### PR TITLE
release: v0.2.5 — fix Charge Mode headers and display scheduler mode

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -207,7 +207,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     commissioned_val = obj.get("isCommissioned") or conn0.get("commissioned")
 
                 # Charge mode: fetch from scheduler API (cached); fall back to derived
-                charge_mode = await self._get_charge_mode(sn)
+                charge_mode_pref = await self._get_charge_mode(sn)
+                charge_mode = charge_mode_pref
                 if not charge_mode:
                     charge_mode = (
                         obj.get("chargeMode")
@@ -244,6 +245,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     "schedule_start": sch_info0.get("startTime"),
                     "schedule_end": sch_info0.get("endTime"),
                     "charge_mode": charge_mode,
+                    # Expose scheduler preference explicitly for entities that care
+                    "charge_mode_pref": charge_mode_pref,
                     "charging_level": charging_level,
                     "power_w": power_w,
                 }

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "0.2.4"
+  "version": "0.2.5"
 }

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -43,7 +43,8 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
     @property
     def current_option(self) -> str | None:
         d = (self._coord.data or {}).get(self._sn) or {}
-        val = d.get("charge_mode")
+        # Prefer scheduler-reported charge mode when available
+        val = d.get("charge_mode_pref") or d.get("charge_mode")
         if not val:
             return None
         return LABELS.get(str(val), str(val).title())


### PR DESCRIPTION
Summary
- Fix TypeError when selecting Charge Mode by merging per-call headers in api._json() so aiohttp gets a single headers dict.
- Charge Mode selector now shows the Enphase scheduler preference (MANUAL/SCHEDULED/GREEN) via coordinator's charge_mode_pref.
- Bump manifest version to 0.2.5.

Details
- api.py: merge default headers with caller-provided ones (e.g., Authorization Bearer) and pass a single headers kwarg.
- coordinator.py: cache and expose scheduler preference as charge_mode_pref alongside charge_mode fallback.
- select.py: prefer charge_mode_pref for current_option display.

Validation
- Local tests passed (pytest tests_enphase_ev), ruff clean.
