### PR TITLE
release: v0.2.6 — graceful start/stop no-op + scheduler mode

### DIFF
--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "0.2.5"
+  "version": "0.2.6"
 }

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -171,7 +171,8 @@ class EnphaseChargeModeSensor(EnphaseBaseEntity, SensorEntity):
     @property
     def native_value(self):
         d = (self._coord.data or {}).get(self._sn) or {}
-        return d.get("charge_mode")
+        # Prefer scheduler preference when available for consistency with selector
+        return d.get("charge_mode_pref") or d.get("charge_mode")
 
 class EnphaseLifetimeEnergySensor(EnphaseBaseEntity, SensorEntity):
     _attr_has_entity_name = True

--- a/tests_enphase_ev/test_api_noop_cases.py
+++ b/tests_enphase_ev/test_api_noop_cases.py
@@ -1,0 +1,50 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+pytest.importorskip("pytest_asyncio")
+
+from aiohttp import ClientSession
+from aiohttp.client_exceptions import ClientResponseError
+
+from custom_components.enphase_ev.api import EnphaseEVClient
+
+
+def _cre(status: int, url: str = "https://example.com/") -> ClientResponseError:
+    # Minimal ClientResponseError with mocked RequestInfo
+    req_info = MagicMock()
+    req_info.real_url = url
+    return ClientResponseError(request_info=req_info, history=(), status=status, message=str(status))
+
+
+class ErrorStubClient(EnphaseEVClient):
+    def __init__(self, site_id="3381244"):
+        self.calls = []
+        super().__init__(ClientSession(), site_id, "EAUTH", "COOKIE")
+
+    async def _json(self, method, url, **kwargs):
+        # Record and raise based on action
+        self.calls.append((method, url, kwargs.get("json")))
+        if url.endswith("start_charging"):
+            raise _cre(409, url)
+        if url.endswith("stop_charging"):
+            raise _cre(404, url)
+        return {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_start_charging_noop_when_not_ready():
+    c = ErrorStubClient(site_id="3381244")
+    # Expect no exception; returns a benign payload
+    out = await c.start_charging("482522020944", 32, connector_id=1)
+    assert isinstance(out, dict)
+    assert out.get("status") == "not_ready"
+
+
+@pytest.mark.asyncio
+async def test_stop_charging_noop_when_inactive():
+    c = ErrorStubClient(site_id="3381244")
+    # Expect no exception; returns a benign payload
+    out = await c.stop_charging("482522020944")
+    assert isinstance(out, dict)
+    assert out.get("status") == "not_active"


### PR DESCRIPTION
Summary
- Handle Start/Stop when charger is unplugged or not active without raising errors.
- Prefer scheduler-reported Charge Mode in UI and sensor for consistency.
- Bump manifest to 0.2.6.

Details
- api.py: start_charging treats 409/422 as benign (returns {status: not_ready}); stop_charging treats 400/404/409/422 as benign (returns {status: not_active}).
- select.py/sensor.py: both reflect scheduler preference (charge_mode_pref).
- tests: added test_api_noop_cases.py to validate no-op behavior.

Validation
- Ruff clean; existing tests updated to cover new behavior.
