### PR TITLE
release: v0.3.0 — charging amps, fast polling window, remove unreliable sensors

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -110,6 +110,7 @@ def _register_services(hass: HomeAssistant) -> None:
             int(call.data.get("charging_level", 32)),
             int(call.data.get("connector_id", 1)),
         )
+        coord.kick_fast(90)
         await coord.async_request_refresh()
 
     async def _svc_stop(call):
@@ -120,6 +121,7 @@ def _register_services(hass: HomeAssistant) -> None:
         if not coord:
             return
         await coord.client.stop_charging(sn)
+        coord.kick_fast(60)
         await coord.async_request_refresh()
 
     async def _svc_trigger(call):

--- a/custom_components/enphase_ev/button.py
+++ b/custom_components/enphase_ev/button.py
@@ -33,6 +33,8 @@ class StartChargeButton(_BaseButton):
         # Default to 32A when started via button
         await self._coord.client.start_charging(self._sn, 32)
         self._coord.set_last_set_amps(self._sn, 32)
+        # Poll quickly for a short window to reflect new state
+        self._coord.kick_fast(90)
         await self._coord.async_request_refresh()
 
 class StopChargeButton(_BaseButton):
@@ -41,4 +43,6 @@ class StopChargeButton(_BaseButton):
         self._attr_translation_key = "stop_charging"
     async def async_press(self) -> None:
         await self._coord.client.stop_charging(self._sn)
+        # Poll quickly after stop to clear state faster
+        self._coord.kick_fast(60)
         await self._coord.async_request_refresh()

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "0.2.6"
+  "version": "0.3.0"
 }


### PR DESCRIPTION
Summary
- Charging Level sensor updated to "Charging Amps" with proper units and device class; unknown values now show 0.
- Add a temporary fast-poll window after Start/Stop actions to reflect state changes quickly.
- Remove unreliable sensors that rarely return data across deployments.

Details
- sensor.py:
  - Charging Level -> Charging Amps: device_class=current, unit=A; value coerced to int; fallback to last_set_amps; unknown=0.
  - Removed entities: Connector Reason, Schedule Type, Schedule Start, Schedule End, Session Miles, Session Plug-in At, Session Plug-out At.
- coordinator.py/button.py/__init__.py:
  - New `kick_fast()` on coordinator; called after start/stop to poll faster for a short window.

Breaking changes
- The following sensors were removed due to consistently missing or unreliable values in most regions:
  - sensor.<device>_connector_reason
  - sensor.<device>_schedule_type
  - sensor.<device>_schedule_start
  - sensor.<device>_schedule_end
  - sensor.<device>_session_miles
  - sensor.<device>_session_plug_in_at
  - sensor.<device>_session_plug_out_at
- Charging Level sensor was renamed and its unique_id changed to represent amps; dashboards/automations referencing the old entity may need to be updated to the new "Charging Amps" sensor.

Context
- v0.2.6 handled benign 4xx on Start/Stop and aligned Charge Mode sensor/select with the scheduler preference.
- v0.3.0 builds on that with better responsiveness during state transitions and clearer/current-focused amperage reporting.

Validation
- Lint clean with ruff. Local tests updated in prior PRs.
