### PR TITLE
release: v0.4.0 — Charging Amps number and Charging switch

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -22,7 +22,7 @@ from .const import DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
 
-PLATFORMS: list[str] = ["sensor", "binary_sensor", "button", "select"]
+PLATFORMS: list[str] = ["sensor", "binary_sensor", "button", "select", "number", "switch"]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     data = hass.data.setdefault(DOMAIN, {})

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "0.3.0"
+  "version": "0.4.0"
 }

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import EnphaseCoordinator
+from .entity import EnphaseBaseEntity
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
+    coord: EnphaseCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    entities: list[NumberEntity] = []
+    serials = list(coord.serials or coord.data.keys())
+    for sn in serials:
+        entities.append(ChargingAmpsNumber(coord, sn))
+    async_add_entities(entities)
+
+
+class ChargingAmpsNumber(EnphaseBaseEntity, NumberEntity):
+    _attr_has_entity_name = True
+    _attr_translation_key = "charging_amps"
+    _attr_native_unit_of_measurement = "A"
+
+    def __init__(self, coord: EnphaseCoordinator, sn: str):
+        super().__init__(coord, sn)
+        self._attr_unique_id = f"{DOMAIN}_{sn}_amps_number"
+
+    @property
+    def native_value(self) -> float | None:
+        d = (self._coord.data or {}).get(self._sn) or {}
+        lvl = d.get("charging_level")
+        if lvl is None:
+            return float(int(self._coord.last_set_amps.get(self._sn) or 0))
+        try:
+            return float(int(lvl))
+        except Exception:
+            return 0.0
+
+    @property
+    def native_min_value(self) -> float:
+        d = (self._coord.data or {}).get(self._sn) or {}
+        v = d.get("min_amp")
+        try:
+            return float(int(v)) if v is not None else 6.0
+        except Exception:
+            return 6.0
+
+    @property
+    def native_max_value(self) -> float:
+        d = (self._coord.data or {}).get(self._sn) or {}
+        v = d.get("max_amp")
+        try:
+            return float(int(v)) if v is not None else 40.0
+        except Exception:
+            return 40.0
+
+    @property
+    def native_step(self) -> float:
+        return 1.0
+
+    async def async_set_native_value(self, value: float) -> None:
+        amps = int(value)
+        # Attempt to set/start charging at the requested amps
+        await self._coord.client.start_charging(self._sn, amps)
+        # Record last requested amps and poll quickly to reflect changes
+        self._coord.set_last_set_amps(self._sn, amps)
+        self._coord.kick_fast(90)
+        await self._coord.async_request_refresh()
+

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import EnphaseCoordinator
+from .entity import EnphaseBaseEntity
+
+
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback):
+    coord: EnphaseCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    entities: list[SwitchEntity] = []
+    serials = list(coord.serials or coord.data.keys())
+    for sn in serials:
+        entities.append(ChargingSwitch(coord, sn))
+    async_add_entities(entities)
+
+
+class ChargingSwitch(EnphaseBaseEntity, SwitchEntity):
+    _attr_has_entity_name = True
+    _attr_translation_key = "charging"
+
+    def __init__(self, coord: EnphaseCoordinator, sn: str):
+        super().__init__(coord, sn)
+        self._attr_unique_id = f"{DOMAIN}_{sn}_charging_switch"
+
+    @property
+    def is_on(self) -> bool:
+        d = (self._coord.data or {}).get(self._sn) or {}
+        return bool(d.get("charging"))
+
+    async def async_turn_on(self, **kwargs) -> None:
+        # Use last requested amps or a sensible default
+        amps = int(self._coord.last_set_amps.get(self._sn) or 32)
+        await self._coord.client.start_charging(self._sn, amps)
+        self._coord.set_last_set_amps(self._sn, amps)
+        self._coord.kick_fast(90)
+        await self._coord.async_request_refresh()
+
+    async def async_turn_off(self, **kwargs) -> None:
+        await self._coord.client.stop_charging(self._sn)
+        self._coord.kick_fast(60)
+        await self._coord.async_request_refresh()
+

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -68,6 +68,9 @@
       "phase_mode": { "name": "Phase Mode" },
       "status": { "name": "Status" }
     },
+    "number": {
+      "charging_amps": { "name": "Charging Amps" }
+    },
     "binary_sensor": {
       "plugged_in": { "name": "Plugged In" },
       "charging": { "name": "Charging" },
@@ -75,6 +78,9 @@
       "cloud_reachable": { "name": "Cloud Reachable" },
       "dlb_active": { "name": "DLB Active" },
       "commissioned": { "name": "Commissioned" }
+    },
+    "switch": {
+      "charging": { "name": "Charging" }
     },
     "select": {
       "charge_mode": { "name": "Charge Mode" }

--- a/tests_enphase_ev/test_number_and_switch.py
+++ b/tests_enphase_ev/test_number_and_switch.py
@@ -1,0 +1,108 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_charging_amps_number_reads_and_sets(monkeypatch):
+    from custom_components.enphase_ev.number import ChargingAmpsNumber
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+
+    cfg = {
+        CONF_SITE_ID: "3381244",
+        CONF_SERIALS: ["482522020944"],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 30,
+    }
+    from custom_components.enphase_ev import coordinator as coord_mod
+    monkeypatch.setattr(coord_mod, "async_get_clientsession", lambda *args, **kwargs: object())
+    coord = EnphaseCoordinator(object(), cfg)
+    sn = "482522020944"
+    # Populate coordinator data with min/max
+    coord.data = {sn: {"name": "Garage EV", "charging_level": None, "min_amp": 6, "max_amp": 40}}
+    coord.last_set_amps = {}
+
+    class StubClient:
+        def __init__(self):
+            self.calls = []
+        async def start_charging(self, s, amps, connector_id=1):
+            self.calls.append((s, amps, connector_id))
+            return {"status": "ok"}
+
+    coord.client = StubClient()
+
+    # Avoid debouncer refresh
+    async def _noop():
+        return None
+    coord.async_request_refresh = _noop  # type: ignore
+
+    ent = ChargingAmpsNumber(coord, sn)
+    # Unknown -> uses last_set_amps (0)
+    assert ent.native_value == 0.0
+    assert ent.native_min_value == 6.0
+    assert ent.native_max_value == 40.0
+
+    await ent.async_set_native_value(24)
+    assert coord.client.calls[-1] == (sn, 24, 1)
+    # Last set amps updated
+    assert coord.last_set_amps[sn] == 24
+
+
+@pytest.mark.asyncio
+async def test_charging_switch_turn_on_off(monkeypatch):
+    from custom_components.enphase_ev.switch import ChargingSwitch
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+
+    cfg = {
+        CONF_SITE_ID: "3381244",
+        CONF_SERIALS: ["482522020944"],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 30,
+    }
+    from custom_components.enphase_ev import coordinator as coord_mod
+    monkeypatch.setattr(coord_mod, "async_get_clientsession", lambda *args, **kwargs: object())
+    coord = EnphaseCoordinator(object(), cfg)
+    sn = "482522020944"
+    coord.data = {sn: {"name": "Garage EV", "charging": False}}
+    coord.last_set_amps = {sn: 32}
+
+    class StubClient:
+        def __init__(self):
+            self.start_calls = []
+            self.stop_calls = []
+        async def start_charging(self, s, amps, connector_id=1):
+            self.start_calls.append((s, amps, connector_id))
+            return {"status": "ok"}
+        async def stop_charging(self, s):
+            self.stop_calls.append(s)
+            return {"status": "ok"}
+
+    coord.client = StubClient()
+
+    async def _noop():
+        return None
+    coord.async_request_refresh = _noop  # type: ignore
+
+    sw = ChargingSwitch(coord, sn)
+    assert sw.is_on is False
+
+    await sw.async_turn_on()
+    assert coord.client.start_calls[-1] == (sn, 32, 1)
+
+    await sw.async_turn_off()
+    assert coord.client.stop_calls[-1] == sn
+


### PR DESCRIPTION
Summary
- Add Charging Amps number entity to view/set amps (A) per charger.
- Add Charging switch entity to toggle charging on/off.
- Include tests and translations; register new platforms.

Details
- number.py: `ChargingAmpsNumber`
  - Reads amps from `charging_level`, falls back to `last_set_amps`, else 0.
  - min/max from `summary_v2.chargeLevelDetails` via coordinator (`min_amp`/`max_amp`), defaults 6–40 A.
  - `async_set_native_value(amps)` calls `start_charging(sn, amps)`, updates `last_set_amps`, kicks fast polling, refreshes.
- switch.py: `ChargingSwitch`
  - `is_on` reflects `coordinator.data[sn]["charging"]`.
  - `turn_on` calls `start_charging(sn, last_set_amps or 32)`, kicks fast polling, refreshes.
  - `turn_off` calls `stop_charging(sn)`, kicks fast polling, refreshes.
- __init__.py: add `number` and `switch` to `PLATFORMS`.
- translations: add names for number/switch entities.
- tests: verify number read/set behavior and switch on/off calls.

Behavior notes
- Uses the existing start endpoint to adjust amps while charging or to start at the requested amps when idle.
- Gracefully handles unplugged/not-ready/idle cases thanks to prior no-op handling for 4xx responses in start/stop.
- Fast polling window after actions ensures the UI updates promptly.

Breaking changes
- None.

Validation
- Ruff clean.
- Tests for new entities added.
