### PR TITLE
release: v0.5.0 — phase mapping, amps precision, current amps, session energy normalization, power estimation

### DIFF
--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -22,6 +22,7 @@ from .const import (
     OPT_API_TIMEOUT,
     OPT_FAST_POLL_INTERVAL,
     OPT_FAST_WHILE_STREAMING,
+    OPT_NOMINAL_VOLTAGE,
     OPT_SLOW_POLL_INTERVAL,
 )
 
@@ -231,6 +232,10 @@ class OptionsFlowHandler(OptionsFlow):
                 vol.Optional(
                     OPT_API_TIMEOUT,
                     default=self.config_entry.options.get(OPT_API_TIMEOUT, 15),
+                ): int,
+                vol.Optional(
+                    OPT_NOMINAL_VOLTAGE,
+                    default=self.config_entry.options.get(OPT_NOMINAL_VOLTAGE, 240),
                 ): int,
             }
         )

--- a/custom_components/enphase_ev/const.py
+++ b/custom_components/enphase_ev/const.py
@@ -12,7 +12,9 @@ DEFAULT_SCAN_INTERVAL = 30
 OPT_FAST_POLL_INTERVAL = "fast_poll_interval"
 OPT_SLOW_POLL_INTERVAL = "slow_poll_interval"
 OPT_FAST_WHILE_STREAMING = "fast_while_streaming"
+OPT_NOMINAL_VOLTAGE = "nominal_voltage"
 
 BASE_URL = "https://enlighten.enphaseenergy.com"
 DEFAULT_API_TIMEOUT = 15
 OPT_API_TIMEOUT = "api_timeout"
+DEFAULT_NOMINAL_VOLTAGE = 240

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "0.4.0"
+  "version": "0.5.0"
 }

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -44,8 +44,8 @@
       "connector_status_reason": { "name": "Connector Reason" },
       "power": { "name": "Power" },
       "charge_mode": { "name": "Charge Mode" },
-      "charging_level": { "name": "Charging Level" },
-      "charging_amps": { "name": "Charging Amps" },
+      "set_amps": { "name": "Set Amps" },
+      "current_amps": { "name": "Current Amps" },
       "min_amp": { "name": "Min Amp" },
       "max_amp": { "name": "Max Amp" },
       "phase_mode": { "name": "Phase Mode" },
@@ -60,13 +60,7 @@
       "schedule_type": { "name": "Schedule Type" },
       "schedule_start": { "name": "Schedule Start" },
       "schedule_end": { "name": "Schedule End" },
-      "lifetime_energy": { "name": "Lifetime Energy" },
-      "connector_status_reason": { "name": "Connector Reason" },
-      "charging_amps": { "name": "Charging Amps" },
-      "min_amp": { "name": "Min Amp" },
-      "max_amp": { "name": "Max Amp" },
-      "phase_mode": { "name": "Phase Mode" },
-      "status": { "name": "Status" }
+      "lifetime_energy": { "name": "Lifetime Energy" }
     },
     "number": {
       "charging_amps": { "name": "Charging Amps" }
@@ -128,11 +122,11 @@
   "issues": {
     "reauth_required": {
       "title": "Enphase EV needs reauthentication",
-      "description": "Site {site_id} requires updated session headers. Please reauthenticate the integration to restore connectivity."
+      "description": "Site {site_id} requires updated session headers. Please reauthenticate."
     },
     "rate_limited": {
       "title": "Enphase EV is rate limited",
-      "description": "The cloud API for site {site_id} returned rate limiting. Polling will slow temporarily. Consider increasing the scan interval."
+      "description": "The cloud API returned rate limiting. Polling will slow temporarily."
     }
   }
   ,

--- a/tests_enphase_ev/test_power_estimate.py
+++ b/tests_enphase_ev/test_power_estimate.py
@@ -1,0 +1,62 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_power_estimates_from_amps_when_missing(monkeypatch):
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+        OPT_NOMINAL_VOLTAGE,
+        OPT_FAST_POLL_INTERVAL,
+        OPT_SLOW_POLL_INTERVAL,
+    )
+
+    cfg = {
+        CONF_SITE_ID: "3381244",
+        CONF_SERIALS: ["482522020944"],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 15,
+    }
+    options = {OPT_NOMINAL_VOLTAGE: 240, OPT_FAST_POLL_INTERVAL: 5, OPT_SLOW_POLL_INTERVAL: 20}
+
+    class DummyEntry:
+        def __init__(self, options):
+            self.options = options
+        def async_on_unload(self, cb):
+            return None
+
+    entry = DummyEntry(options)
+
+    from custom_components.enphase_ev import coordinator as coord_mod
+    monkeypatch.setattr(coord_mod, "async_get_clientsession", lambda *args, **kwargs: object())
+    coord = EnphaseCoordinator(object(), cfg, config_entry=entry)
+
+    class StubClient:
+        def __init__(self, payload):
+            self._payload = payload
+        async def status(self):
+            return self._payload
+
+    payload = {
+        "evChargerData": [
+            {
+                "sn": "482522020944",
+                "name": "Garage EV",
+                "charging": True,
+                "pluggedIn": True,
+                # No power keys here; coordinator should estimate from chargingLevel
+                "chargingLevel": 16,
+            }
+        ],
+        "ts": 1725600423,
+    }
+    coord.client = StubClient(payload)
+    out = await coord._async_update_data()
+    sn = "482522020944"
+    assert out[sn]["power_w"] == 16 * 240
+


### PR DESCRIPTION
Summary
- Phase Mode: add transmission tower icon and map numeric values (1→Single Phase, 3→Three Phase).
- Amps display: show no decimals for Set/Min/Max/Current Amps.
- Charging Amps cleanup: rename original setpoint sensor to "Set Amps"; add new "Current Amps" sensor derived from power.
- Session Energy: normalize e_c when reported in Wh to kWh.
- Power sensor: detect more keys and estimate from amps×nominal_voltage (option, default 240 V) when missing.

Details
- sensor.py:
  - Phase Mode icon and mapping; Set Amps sensor (formerly Charging Amps) with 0-decimal precision; new Current Amps sensor; Min/Max Amp precision set to integer.
- coordinator.py:
  - Session energy normalization; broader power key mapping; estimate power from amps×voltage when charging and power missing.
- config_flow.py/const.py/translations:
  - Add `nominal_voltage` option; label updates for Set/Current Amps; translation cleanup.
- tests:
  - Updated session duration test; added power estimate test.

Breaking changes
- Display names: "Charging Amps" sensor is now "Set Amps"; dashboards may need relabeling. Unique IDs are unchanged.

Validation
- Ruff clean locally. Tests updated to cover new behaviors.
