### PR TITLE
release: v0.6.0 — session duration fix, sensor cleanup, wording + icons, setpoint behavior

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -105,11 +105,10 @@ def _register_services(hass: HomeAssistant) -> None:
         coord = await _get_coordinator_for_sn(sn)
         if not coord:
             return
-        await coord.client.start_charging(
-            sn,
-            int(call.data.get("charging_level", 32)),
-            int(call.data.get("connector_id", 1)),
-        )
+        level = call.data.get("charging_level")
+        if level is None:
+            level = coord.last_set_amps.get(sn, 32)
+        await coord.client.start_charging(sn, int(level), int(call.data.get("connector_id", 1)))
         coord.kick_fast(90)
         await coord.async_request_refresh()
 

--- a/custom_components/enphase_ev/button.py
+++ b/custom_components/enphase_ev/button.py
@@ -30,9 +30,10 @@ class StartChargeButton(_BaseButton):
         super().__init__(coord, sn, "Start Charging")
         self._attr_translation_key = "start_charging"
     async def async_press(self) -> None:
-        # Default to 32A when started via button
-        await self._coord.client.start_charging(self._sn, 32)
-        self._coord.set_last_set_amps(self._sn, 32)
+        # Use last requested amps or default to 32A
+        amps = int(self._coord.last_set_amps.get(self._sn) or 32)
+        await self._coord.client.start_charging(self._sn, amps)
+        self._coord.set_last_set_amps(self._sn, amps)
         # Poll quickly for a short window to reflect new state
         self._coord.kick_fast(90)
         await self._coord.async_request_refresh()

--- a/custom_components/enphase_ev/entity.py
+++ b/custom_components/enphase_ev/entity.py
@@ -27,6 +27,7 @@ class EnphaseBaseEntity(CoordinatorEntity[EnphaseCoordinator]):
             identifiers={(DOMAIN, self._sn)},
             manufacturer="Enphase",
             model="IQ EV Charger 2",
+            serial_number=str(self._sn),
             name=dev_name,
             via_device=(DOMAIN, f"site:{self._coord.site_id}"),
         )

--- a/custom_components/enphase_ev/icons.json
+++ b/custom_components/enphase_ev/icons.json
@@ -12,7 +12,9 @@
       "connector_status": { "default": "mdi:ev-station" },
       "power": { "default": "mdi:flash" },
       "session_energy": { "default": "mdi:gauge" },
-      "charging_level": { "default": "mdi:current-ac" },
+      "set_amps": { "default": "mdi:current-ac" },
+      "charge_mode": { "default": "mdi:car-electric" },
+      "status": { "default": "mdi:information-outline" },
       "session_duration": { "default": "mdi:timer-outline" },
       "last_successful_update": { "default": "mdi:clock-check-outline" },
       "cloud_latency": { "default": "mdi:timer-sand" }

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "0.5.0"
+  "version": "0.6.0"
 }

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -63,10 +63,7 @@ class ChargingAmpsNumber(EnphaseBaseEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         amps = int(value)
-        # Attempt to set/start charging at the requested amps
-        await self._coord.client.start_charging(self._sn, amps)
-        # Record last requested amps and poll quickly to reflect changes
+        # Store desired setpoint locally; do not start charging here.
+        # Start actions (switch/button/service) will use this setpoint.
         self._coord.set_last_set_amps(self._sn, amps)
-        self._coord.kick_fast(90)
         await self._coord.async_request_refresh()
-

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -27,7 +27,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         entities.append(EnphaseConnectorStatusSensor(coord, sn))
         entities.append(EnphasePowerSensor(coord, sn))
         entities.append(EnphaseChargingLevelSensor(coord, sn))
-        entities.append(EnphaseCurrentAmpsSensor(coord, sn))
         entities.append(EnphaseSessionDurationSensor(coord, sn))
         entities.append(EnphaseLastReportedSensor(coord, sn))
         entities.append(EnphaseChargeModeSensor(coord, sn))
@@ -283,38 +282,7 @@ class EnphaseStatusSensor(EnphaseBaseEntity, SensorEntity):
         return d.get("status")
 
 
-class EnphaseCurrentAmpsSensor(EnphaseBaseEntity, SensorEntity):
-    _attr_has_entity_name = True
-    _attr_translation_key = "current_amps"
-    _attr_state_class = SensorStateClass.MEASUREMENT
-    _attr_device_class = SensorDeviceClass.CURRENT
-    _attr_native_unit_of_measurement = "A"
-    _attr_suggested_display_precision = 0
-
-    def __init__(self, coord: EnphaseCoordinator, sn: str):
-        super().__init__(coord, sn)
-        self._attr_unique_id = f"{DOMAIN}_{sn}_current_amps"
-
-    @property
-    def native_value(self):
-        d = (self._coord.data or {}).get(self._sn) or {}
-        power = d.get("power_w")
-        if isinstance(power, (int, float)) and power > 0:
-            # Use coordinator nominal voltage if available; default to 240
-            try:
-                v = int(getattr(self._coord, "_nominal_v", 240))
-            except Exception:
-                v = 240
-            try:
-                return int(round(float(power) / float(v)))
-            except Exception:
-                return None
-        # Fallback: show setpoint if available
-        lvl = d.get("charging_level")
-        try:
-            return int(lvl) if lvl is not None else 0
-        except Exception:
-            return 0
+## Removed duplicate Current Amps sensor to avoid confusion with Set Amps
 
 
 ## Removed unreliable sensors: Session Miles

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -45,7 +45,6 @@
       "power": { "name": "Power" },
       "charge_mode": { "name": "Charge Mode" },
       "set_amps": { "name": "Set Amps" },
-      "current_amps": { "name": "Current Amps" },
       "min_amp": { "name": "Min Amp" },
       "max_amp": { "name": "Max Amp" },
       "phase_mode": { "name": "Phase Mode" },
@@ -68,9 +67,9 @@
     "binary_sensor": {
       "plugged_in": { "name": "Plugged In" },
       "charging": { "name": "Charging" },
-      "faulted": { "name": "Faulted" },
+      "faulted": { "name": "Charger Problem" },
       "cloud_reachable": { "name": "Cloud Reachable" },
-      "dlb_active": { "name": "DLB Active" },
+      "dlb_active": { "name": "Load Balancing Active" },
       "commissioned": { "name": "Commissioned" }
     },
     "switch": {

--- a/tests_enphase_ev/test_entities_and_flow.py
+++ b/tests_enphase_ev/test_entities_and_flow.py
@@ -10,11 +10,10 @@ def test_power_sensor_device_class():
 
 
 @pytest.mark.asyncio
-async def test_config_flow_form(hass):
+async def test_config_flow_form():
     from custom_components.enphase_ev.config_flow import EnphaseEVConfigFlow
     flow = EnphaseEVConfigFlow()
-    flow.hass = hass
+    flow.hass = object()
     res = await flow.async_step_user()
     assert res["type"].name == "FORM"
     assert res["step_id"] == "user"
-

--- a/tests_enphase_ev/test_select_charge_mode.py
+++ b/tests_enphase_ev/test_select_charge_mode.py
@@ -2,9 +2,7 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_charge_mode_select(hass, monkeypatch):
-    from custom_components.enphase_ev.select import ChargeModeSelect
-    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+async def test_charge_mode_select(monkeypatch):
     from custom_components.enphase_ev.const import (
         CONF_COOKIE,
         CONF_EAUTH,
@@ -12,6 +10,8 @@ async def test_charge_mode_select(hass, monkeypatch):
         CONF_SERIALS,
         CONF_SITE_ID,
     )
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from custom_components.enphase_ev.select import ChargeModeSelect
 
     cfg = {
         CONF_SITE_ID: "3381244",
@@ -22,7 +22,7 @@ async def test_charge_mode_select(hass, monkeypatch):
     }
     from custom_components.enphase_ev import coordinator as coord_mod
     monkeypatch.setattr(coord_mod, "async_get_clientsession", lambda *args, **kwargs: object())
-    coord = EnphaseCoordinator(hass, cfg)
+    coord = EnphaseCoordinator(object(), cfg)
 
     # preload coordinator state
     coord.data = {"482522020944": {"charge_mode": "SCHEDULED_CHARGING"}}


### PR DESCRIPTION
Summary
- Session Duration: normalize timestamps (ms→s), record a fixed end on stop, and prevent duration from growing after stop.
- Charging Amps: remove duplicate "Current Amps" sensor; keep a single "Set Amps" sensor.
- Binary sensors: rename Faulted → "Charger Problem"; DLB Active → "Load Balancing Active".
- Icons: add icons for Status (information) and Charge Mode (car-electric); Set Amps uses current-ac.
- Device info: include charger serial to distinguish multiple units.
- Number behavior: Charging Amps control now only stores the desired amps; it does not start charging. Start button/switch/service use the stored setpoint.
- Tests: remove dependency on hass fixture in two tests to silence deprecation warnings.

Details
- coordinator.py: unify ms/seconds; capture session_end on charging→not charging; normalize plug-out fallback; freeze duration.
- sensor.py/icons.json/translations: removed Current Amps; labels and icons updated; wording improved.
- entity.py: add serial_number to DeviceInfo.
- number.py/button.py/__init__.py: setpoint-only number; start uses last_set_amps (or 32 A default).
- tests: updated to avoid hass fixture warnings.

Breaking changes
- Current Amps sensor removed to avoid duplication. Set Amps remains with same unique_id; dashboards may need relabeling only.

Validation
- Ruff checks clean locally; tests adjusted.
