### PR TITLE
number/sensor: default Set Amps to 32A when unknown on startup

### DIFF
--- a/PR_BODY_0_6_2.md
+++ b/PR_BODY_0_6_2.md
@@ -1,0 +1,17 @@
+Title: number/sensor: default Set Amps to 32A when unknown on startup
+
+Summary
+- Align initial value of both the Set Amps sensor and the charging amps number control to 32A when the API does not report a `chargingLevel` on first refresh.
+- Prevents the control from showing 0 A (or min) after re-install/restart until the first user action.
+
+Details
+- `EnphaseChargingLevelSensor` and `ChargingAmpsNumber` now fall back to the coordinator’s `last_set_amps[sn]` or 32A if missing.
+- The coordinator still seeds `last_set_amps` from `chargingLevel` when provided by the API.
+- Start/stop actions remain unchanged; they already default to 32A when unset.
+
+Notes on duplicate sensors
+- This integration creates `sensor.iq_ev_charger_set_amps`. If you also see `sensor.set_amp`, that entity is not created by this integration and likely comes from an older/other integration or a leftover helper. You can safely remove/disable it.
+
+Version
+- Bump to 0.6.2
+

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "0.6.1"
+  "version": "0.6.2"
 }

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -33,11 +33,12 @@ class ChargingAmpsNumber(EnphaseBaseEntity, NumberEntity):
         d = (self._coord.data or {}).get(self._sn) or {}
         lvl = d.get("charging_level")
         if lvl is None:
-            return float(int(self._coord.last_set_amps.get(self._sn) or 0))
+            # If unknown from API and no prior setpoint, prefer 32A default
+            return float(int(self._coord.last_set_amps.get(self._sn) or 32))
         try:
             return float(int(lvl))
         except Exception:
-            return 0.0
+            return float(int(self._coord.last_set_amps.get(self._sn) or 32))
 
     @property
     def native_min_value(self) -> float:

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -101,12 +101,12 @@ class EnphaseChargingLevelSensor(EnphaseBaseEntity, SensorEntity):
         d = (self._coord.data or {}).get(self._sn) or {}
         lvl = d.get("charging_level")
         if lvl is None:
-            # Fall back to last set amps; if unknown, show 0 per request
-            return int(self._coord.last_set_amps.get(self._sn) or 0)
+            # Fall back to last set amps; if unknown, prefer 32A default
+            return int(self._coord.last_set_amps.get(self._sn) or 32)
         try:
             return int(lvl)
         except Exception:
-            return 0
+            return int(self._coord.last_set_amps.get(self._sn) or 32)
 
 class EnphaseSessionDurationSensor(EnphaseBaseEntity, SensorEntity):
     _attr_has_entity_name = True

--- a/tests_enphase_ev/test_number_and_switch.py
+++ b/tests_enphase_ev/test_number_and_switch.py
@@ -43,8 +43,8 @@ async def test_charging_amps_number_reads_and_sets(monkeypatch):
     coord.async_request_refresh = _noop  # type: ignore
 
     ent = ChargingAmpsNumber(coord, sn)
-    # Unknown -> uses last_set_amps (0)
-    assert ent.native_value == 0.0
+    # Unknown -> uses default of 32A for initial display
+    assert ent.native_value == 32.0
     assert ent.native_min_value == 6.0
     assert ent.native_max_value == 40.0
 


### PR DESCRIPTION
Title: number/sensor: default Set Amps to 32A when unknown on startup

Summary
- Align initial value of both the Set Amps sensor and the charging amps number control to 32A when the API does not report a `chargingLevel` on first refresh.
- Prevents the control from showing 0 A (or min) after re-install/restart until the first user action.

Details
- `EnphaseChargingLevelSensor` and `ChargingAmpsNumber` now fall back to the coordinator’s `last_set_amps[sn]` or 32A if missing.
- The coordinator still seeds `last_set_amps` from `chargingLevel` when provided by the API.
- Start/stop actions remain unchanged; they already default to 32A when unset.

Notes on duplicate sensors
- This integration creates `sensor.iq_ev_charger_set_amps`. If you also see `sensor.set_amp`, that entity is not created by this integration and likely comes from an older/other integration or a leftover helper. You can safely remove/disable it.

Version
- Bump to 0.6.2

