### PR TITLE
tests: align Energy Today + kWh normalization; update IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enphase EV Charger 2 (Cloud) — Home Assistant Custom Integration
 
-**Version:** 0.6.0 (beta)
+**Version:** 0.7.1
 
 This custom integration surfaces the **Enphase IQ EV Charger 2** in Home Assistant using the same **Enlighten cloud** endpoints used by the Enphase mobile app.
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "0.6.5"
+  "version": "0.7.1"
 }

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -56,9 +56,9 @@ class EnphaseSessionEnergySensor(_BaseEVSensor):
     _attr_device_class = "energy"
     _attr_native_unit_of_measurement = "kWh"
     _attr_state_class = SensorStateClass.TOTAL
-    _attr_translation_key = "session_energy"
+    _attr_translation_key = "energy_today"
     def __init__(self, coord, sn):
-        super().__init__(coord, sn, "Session Energy", "session_kwh")
+        super().__init__(coord, sn, "Energy Today", "session_kwh")
 
 class EnphaseConnectorStatusSensor(_BaseEVSensor):
     _attr_translation_key = "connector_status"

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -39,7 +39,7 @@
   ,
   "entity": {
     "sensor": {
-      "session_energy": { "name": "Session Energy" },
+      "energy_today": { "name": "Energy Today" },
       "connector_status": { "name": "Connector Status" },
       "connector_status_reason": { "name": "Connector Reason" },
       "power": { "name": "Power" },

--- a/tests_enphase_ev/test_entity_wiring.py
+++ b/tests_enphase_ev/test_entity_wiring.py
@@ -4,14 +4,14 @@ def test_entity_naming_and_availability():
     class DummyCoord:
         def __init__(self):
             self.data = {}
-            self.serials = {"482522020944"}
-            self.site_id = "3381244"
+            self.serials = {"555555555555"}
+            self.site_id = "1234567"
             self.last_update_success = True
     
     coord = DummyCoord()
     coord.data = {
-        "482522020944": {
-            "sn": "482522020944",
+        "555555555555": {
+            "sn": "555555555555",
             "name": "Garage EV",
             "connected": True,
             "plugged": True,
@@ -23,11 +23,11 @@ def test_entity_naming_and_availability():
         }
     }
 
-    ent = EnphaseSessionEnergySensor(coord, "482522020944")
+    ent = EnphaseSessionEnergySensor(coord, "555555555555")
     assert ent.available is True
     # Uses has_entity_name; entity name is the suffix only
-    assert ent.name == "Session Energy"
+    assert ent.name == "Energy Today"
     # Device name comes from coordinator data
     assert ent.device_info["name"] == "Garage EV"
     # Unique ID includes domain, serial, and key
-    assert ent.unique_id.endswith("482522020944_session_kwh")
+    assert ent.unique_id.endswith("555555555555_session_kwh")

--- a/tests_enphase_ev/test_summary_enrichment.py
+++ b/tests_enphase_ev/test_summary_enrichment.py
@@ -13,8 +13,8 @@ async def test_summary_v2_enrichment(monkeypatch):
     )
 
     cfg = {
-        CONF_SITE_ID: "3381244",
-        CONF_SERIALS: ["482522020944"],
+        CONF_SITE_ID: "1234567",
+        CONF_SERIALS: ["555555555555"],
         CONF_EAUTH: "EAUTH",
         CONF_COOKIE: "COOKIE",
         CONF_SCAN_INTERVAL: 30,
@@ -26,7 +26,7 @@ async def test_summary_v2_enrichment(monkeypatch):
     status_payload = {
         "evChargerData": [
             {
-                "sn": "482522020944",
+                "sn": "555555555555",
                 "name": "IQ EV Charger",
                 "connected": True,
                 "pluggedIn": False,
@@ -48,7 +48,7 @@ async def test_summary_v2_enrichment(monkeypatch):
 
     summary_list = [
         {
-            "serialNumber": "482522020944",
+            "serialNumber": "555555555555",
             "lastReportedAt": "2025-09-08T02:55:30.347Z[UTC]",
             "chargeLevelDetails": {"min": "6", "max": "32", "granularity": "1", "defaultChargeLevel": "disabled"},
             "maxCurrent": 32,
@@ -72,7 +72,7 @@ async def test_summary_v2_enrichment(monkeypatch):
     coord.client = StubClient()
 
     data = await coord._async_update_data()
-    st = data["482522020944"]
+    st = data["555555555555"]
 
     assert st["min_amp"] == 6
     assert st["max_amp"] == 32
@@ -80,9 +80,9 @@ async def test_summary_v2_enrichment(monkeypatch):
     assert st["phase_mode"] == 1
     assert st["status"] == "NORMAL"
     assert st["commissioned"] is True
-    assert st["lifetime_kwh"] == pytest.approx(39153.87)
+    # lifetime consumption normalized to kWh if backend returns Wh-like values
+    assert st["lifetime_kwh"] == pytest.approx(39.154, abs=1e-3)
     # last_reported_at should come from summary
     assert "last_reported_at" in st and st["last_reported_at"].startswith("2025-09-08")
     # charge mode cached/derived value
     assert st["charge_mode"] == "MANUAL_CHARGING"
-

--- a/tests_enphase_ev/test_voltage_and_daily_energy.py
+++ b/tests_enphase_ev/test_voltage_and_daily_energy.py
@@ -1,0 +1,81 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_power_uses_operating_voltage_when_present(monkeypatch):
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+        OPT_NOMINAL_VOLTAGE,
+    )
+
+    cfg = {
+        CONF_SITE_ID: "1234567",
+        CONF_SERIALS: ["555555555555"],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 30,
+    }
+    from custom_components.enphase_ev import coordinator as coord_mod
+    monkeypatch.setattr(coord_mod, "async_get_clientsession", lambda *args, **kwargs: object())
+    coord = EnphaseCoordinator(object(), cfg)
+
+    sn = "555555555555"
+
+    status_payload = {
+        "evChargerData": [
+            {
+                "sn": sn,
+                "name": "Garage EV",
+                "connected": True,
+                "pluggedIn": True,
+                "charging": True,
+                # Estimate from amps when power missing
+                "chargingLevel": 16,
+                "connectors": [{"connectorStatusType": "CHARGING", "dlbActive": False}],
+            }
+        ],
+        "ts": 1725600423,
+    }
+
+    summary_list = [
+        {
+            "serialNumber": sn,
+            "operatingVoltage": "230",
+            "lifeTimeConsumption": 10000,
+        }
+    ]
+
+    class StubClient:
+        async def status(self):
+            return status_payload
+
+        async def summary_v2(self):
+            return summary_list
+
+        async def charge_mode(self, sn: str):
+            return None
+
+    coord.client = StubClient()
+
+    data = await coord._async_update_data()
+    assert data[sn]["power_w"] == 16 * 230
+
+
+def test_energy_today_sensor_name_and_value():
+    from custom_components.enphase_ev.sensor import EnphaseSessionEnergySensor
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    # Minimal coordinator stub with daily kWh present
+    sn = "482522020944"
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    coord.data = {sn: {"sn": sn, "name": "IQ EV Charger", "session_kwh": 3.25}}
+    coord.serials = {sn}
+
+    ent = EnphaseSessionEnergySensor(coord, sn)
+    assert ent.name == "Energy Today"
+    assert ent.native_value == 3.25


### PR DESCRIPTION
- Update test expectations for renamed 'Energy Today' sensor\n- Adjust lifetime energy to normalized kWh (39.154 vs 39153.87)\n- Add operatingVoltage-based power estimation test\n- Switch tests to placeholder serial/site IDs