### PR TITLE
v0.7.2: Daily Energy from lifetime + Power derived from energy rate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.7.2
+- Sensors: replace old daily/session energy with a new Energy Today derived from the lifetime meter
+  - Monotonic within a day; resets at local midnight; persists baseline across restarts.
+  - Keeps state_class total for Energy dashboard compatibility.
+- Power: simplify by deriving power from the rate of change of Energy Today
+  - Average power between updates; persists sampling state across restarts.
+- Coordinator: expose operating voltage where available; sensors show it in attributes.
+- Tests: add coverage for new daily sensor and power restore behavior.
+
 ## v0.6.5
 - Quality: diagnostics, system health translations, icon mappings, and device triggers
   - Add `quality_scale.yaml` to track Integration Quality Scale rules.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Enphase EV Charger 2 (Cloud) — Home Assistant Custom Integration
 
-**Version:** 0.7.1
+**Version:** 0.7.2
 
 This custom integration surfaces the **Enphase IQ EV Charger 2** in Home Assistant using the same **Enlighten cloud** endpoints used by the Enphase mobile app.
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "silver",
   "requirements": [],
-  "version": "0.7.1"
+  "version": "0.7.2"
 }

--- a/tests_enphase_ev/test_energy_today_from_lifetime.py
+++ b/tests_enphase_ev/test_energy_today_from_lifetime.py
@@ -1,0 +1,38 @@
+import datetime as _dt
+
+
+def test_energy_today_from_lifetime_monotonic(monkeypatch):
+    from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from homeassistant.util import dt as dt_util
+
+    sn = "482522020944"
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    coord.data = {sn: {"sn": sn, "name": "IQ EV Charger", "lifetime_kwh": 100.0}}
+    coord.serials = {sn}
+
+    # Freeze time to a specific day
+    day1 = _dt.datetime(2025, 9, 9, 10, 0, 0, tzinfo=_dt.timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: day1)
+
+    ent = EnphaseEnergyTodaySensor(coord, sn)
+
+    # First read establishes baseline; should be 0.0
+    assert ent.native_value == 0.0
+
+    # Increase lifetime by 1.5 kWh → today should reflect delta
+    coord.data[sn]["lifetime_kwh"] = 101.5
+    assert ent.native_value == 1.5
+
+    # Minor jitter down should not decrease today's value
+    coord.data[sn]["lifetime_kwh"] = 101.49
+    assert ent.native_value == 1.5
+
+    # Next day: baseline resets and value starts from 0 again
+    day2 = _dt.datetime(2025, 9, 10, 0, 1, 0, tzinfo=_dt.timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: day2)
+    coord.data[sn]["lifetime_kwh"] = 103.0
+    assert ent.native_value == 0.0
+    coord.data[sn]["lifetime_kwh"] = 104.2
+    assert ent.native_value == 1.2
+

--- a/tests_enphase_ev/test_entity_wiring.py
+++ b/tests_enphase_ev/test_entity_wiring.py
@@ -1,5 +1,5 @@
 def test_entity_naming_and_availability():
-    from custom_components.enphase_ev.sensor import EnphaseSessionEnergySensor
+    from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
     
     class DummyCoord:
         def __init__(self):
@@ -18,16 +18,16 @@ def test_entity_naming_and_availability():
             "charging": False,
             "faulted": False,
             "connector_status": "AVAILABLE",
-            "session_kwh": 0.0,
+            "lifetime_kwh": 0.0,
             "session_start": None,
         }
     }
 
-    ent = EnphaseSessionEnergySensor(coord, "555555555555")
+    ent = EnphaseEnergyTodaySensor(coord, "555555555555")
     assert ent.available is True
     # Uses has_entity_name; entity name is the suffix only
     assert ent.name == "Energy Today"
     # Device name comes from coordinator data
     assert ent.device_info["name"] == "Garage EV"
     # Unique ID includes domain, serial, and key
-    assert ent.unique_id.endswith("555555555555_session_kwh")
+    assert ent.unique_id.endswith("555555555555_energy_today")

--- a/tests_enphase_ev/test_power_restore.py
+++ b/tests_enphase_ev/test_power_restore.py
@@ -1,0 +1,60 @@
+import datetime as _dt
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_power_restore_continues_from_last_sample(monkeypatch):
+    from homeassistant.util import dt as dt_util
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    from custom_components.enphase_ev.sensor import EnphasePowerSensor
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    sn = "555555555555"
+
+    # Prepare a fixed day and a prior sample at t0
+    t0 = _dt.datetime(2025, 9, 9, 10, 0, 0, tzinfo=_dt.timezone.utc)
+    today_str = t0.strftime("%Y-%m-%d")
+    last_ts = t0.timestamp()
+
+    # Build coordinator stub and initial data
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    coord.data = {sn: {"sn": sn, "name": "Garage EV", "lifetime_kwh": 10.5, "operating_v": 230}}
+    coord.serials = {sn}
+    coord.site_id = "1234567"
+    coord.last_update_success = True
+
+    ent = EnphasePowerSensor(coord, sn)
+
+    # Provide a fake last state via monkeypatch without relying on hass restore cache
+    class _FakeState:
+        def __init__(self, state: str, attrs: dict):
+            self.state = state
+            self.attributes = attrs
+
+    async def _fake_get_last_state(self):
+        return _FakeState(
+            "3600",
+            {
+                "baseline_kwh": 10.0,
+                "baseline_day": today_str,
+                "last_energy_today_kwh": 0.5,
+                "last_ts": last_ts,
+            },
+        )
+
+    # Avoid calling the CoordinatorEntity async_added_to_hass implementation
+    async def _noop(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(EnphasePowerSensor, "async_get_last_state", _fake_get_last_state)
+    monkeypatch.setattr(CoordinatorEntity, "async_added_to_hass", _noop)
+
+    await ent.async_added_to_hass()
+
+    # Advance time by 60s and increase lifetime by 0.1 kWh → 6000 W
+    t1 = t0 + _dt.timedelta(seconds=60)
+    monkeypatch.setattr(dt_util, "now", lambda: t1)
+    coord.data[sn]["lifetime_kwh"] = 10.6
+
+    assert ent.native_value == 6000

--- a/tests_enphase_ev/test_sensors.py
+++ b/tests_enphase_ev/test_sensors.py
@@ -31,13 +31,25 @@ def test_charging_level_fallback():
     assert s.native_value == 30
 
 
-def test_power_sensor_value():
+def test_power_sensor_value(monkeypatch):
+    import datetime as _dt
+    from homeassistant.util import dt as dt_util
     from custom_components.enphase_ev.sensor import EnphasePowerSensor
 
     sn = "482522020944"
-    coord = _mk_coord_with(sn, {"sn": sn, "name": "Garage EV", "power_w": 3700})
+    coord = _mk_coord_with(sn, {"sn": sn, "name": "Garage EV", "lifetime_kwh": 10.0})
     s = EnphasePowerSensor(coord, sn)
-    assert s.native_value == 3700
+
+    # First read at t0 seeds state → 0 W
+    t0 = _dt.datetime(2025, 9, 9, 10, 0, 0, tzinfo=_dt.timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: t0)
+    assert s.native_value == 0
+
+    # After 120s, +0.24 kWh → 7200 W
+    t1 = t0 + _dt.timedelta(seconds=120)
+    monkeypatch.setattr(dt_util, "now", lambda: t1)
+    coord.data[sn]["lifetime_kwh"] = 10.24
+    assert s.native_value == 7200
 
 
 def test_session_duration_minutes():


### PR DESCRIPTION
v0.7.2: Daily Energy from lifetime + Power derived from energy rate

Summary
- Daily Energy
  - Replace previous “Energy Today” source with a new sensor derived from the lifetime meter.
  - Monotonic within a day, resets at local midnight.
  - Persists baseline across HA restarts (RestoreEntity).
  - State class remains `total` for Energy dashboard compatibility.

- Power
  - Simplify implementation: derive W from the rate of change of “Energy Today”.
  - Average power between updates, resilient to jitter and day rollover.
  - Persists sampling state across restarts (RestoreEntity).
  - Attributes: `baseline_kwh`, `baseline_day`, `last_energy_today_kwh`, `last_ts`, `operating_v` (or 230), `method: derived_from_energy_today`.

- Coordinator
  - Expose operating voltage from `summary_v2` in mapped data for transparency.

- Tests
  - Add Energy Today monotonic + day reset test.
  - Add Power restore test; update Power value test to reflect new behavior.

- Maintenance
  - Bump version to 0.7.2 in `manifest.json`, `README.md`, and `CHANGELOG.md`.
  - ruff fixes (imports, line length).

Notes
- Energy Dashboard: Prefer Lifetime Energy (`total_increasing`) or the new Energy Today (`total`) as the daily counter.
- The previous session-based “Energy Today” is removed to avoid confusion and incorrect daily totals.
