### PR TITLE
config_flow: add reconfiguration flow (async_step_reconfigure)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,12 @@ When Enphase exposes owner-scope EV endpoints locally, we can add a local client
 - Start/Stop actions treat benign 4xx responses (e.g., unplugged/not active) as no‑ops to avoid errors in HA.
 - The Charge Mode select works with the scheduler API and reflects the service’s active mode.
 
+### Reconfigure
+
+- You can reconfigure the integration (update site ID, serials, or session headers) without removing it.
+- Go to Settings → Devices & Services → Integrations → Enphase EV Charger 2 (Cloud) → Reconfigure.
+- Paste refreshed `e-auth-token` and `Cookie` headers; optionally paste a cURL to auto‑fill.
+
 ### Supported devices
 
 - Supported

--- a/README.md
+++ b/README.md
@@ -16,8 +16,6 @@
 [![Downloads](https://img.shields.io/github/downloads/barneyonline/ha-enphase-ev-charger/total)](https://github.com/barneyonline/ha-enphase-ev-charger/releases)
 [![Open Issues](https://img.shields.io/github/issues/barneyonline/ha-enphase-ev-charger)](https://github.com/barneyonline/ha-enphase-ev-charger/issues)
 
-**Version:** 0.7.2
-
 This custom integration surfaces the **Enphase IQ EV Charger 2** in Home Assistant using the same **Enlighten cloud** endpoints used by the Enphase mobile app.
 
 > ⚠️ Local-only access to EV endpoints is **role-gated** on IQ Gateway firmware 7.6.175. The charger surfaces locally under `/ivp/pdm/*` or `/ivp/peb/*` only with **installer** scope. This integration therefore uses the **cloud API** until owner-scope local endpoints are available.
@@ -123,11 +121,30 @@ Per‑charger entities
 
 Removed (unreliable across deployments): Connector Reason, Schedule Type/Start/End, Session Miles, Session Plug‑in/out timestamps.
 
-**Services**
-- `enphase_ev.start_charging` — fields: `device_id`, optional `charging_level` (A), optional `connector_id` (default 1)
-- `enphase_ev.stop_charging` — fields: `device_id`
-- `enphase_ev.trigger_message` — fields: `device_id`, `requested_message`
-- `enphase_ev.clear_reauth_issue` — optional `site_id`; manually clears the reauth repair issue
+**Services (Actions)**
+- Action: `enphase_ev.start_charging`
+  - Description: Start charging on the selected charger.
+  - Fields:
+    - `device_id` (required)
+    - `charging_level` (optional, A; 6–40)
+    - `connector_id` (optional; usually 1)
+- Action: `enphase_ev.stop_charging`
+  - Description: Stop charging on the selected charger.
+  - Fields:
+    - `device_id` (required)
+- Action: `enphase_ev.trigger_message`
+  - Description: Request the charger to send an OCPP message.
+  - Fields:
+    - `device_id` (required)
+    - `requested_message` (required; e.g., `MeterValues`)
+- Action: `enphase_ev.clear_reauth_issue`
+  - Description: Clear the integration’s reauthentication issue notification.
+  - Fields:
+    - `site_id` (optional)
+- Action: `enphase_ev.start_live_stream`
+  - Description: Request faster cloud status updates for a short period.
+- Action: `enphase_ev.stop_live_stream`
+  - Description: Stop the cloud live stream request.
 
 ## Privacy & Rate Limits
 
@@ -183,3 +200,17 @@ When Enphase exposes owner-scope EV endpoints locally, we can add a local client
 - Charging Amps (number) stores your desired setpoint but does not start charging. The Start button, Charging switch, or start service will use that stored setpoint (default 32 A).
 - Start/Stop actions treat benign 4xx responses (e.g., unplugged/not active) as no‑ops to avoid errors in HA.
 - The Charge Mode select works with the scheduler API and reflects the service’s active mode.
+
+### Supported devices
+
+- Supported
+  - Enphase IQ EV Charger 2 variants (single-connector), as exposed via Enlighten cloud.
+- Unsupported / not tested
+  - Earlier charger generations or models not exposed by the Enlighten EV endpoints.
+  - Multi-connector or region-specific variants not returning compatible status/summary payloads.
+
+### Removing the integration
+
+- Go to Settings → Devices & Services → Integrations.
+- Locate “Enphase EV Charger 2 (Cloud)” and choose “Delete” to remove the integration and its devices.
+- If installed via HACS, you may also remove the repository entry from HACS after removal.

--- a/quality_scale.yaml
+++ b/quality_scale.yaml
@@ -92,8 +92,8 @@ rules:
     status: done
     comment: Structured Actions section in README covers all services and fields.
   reconfiguration_flow:
-    status: todo
-    comment: Implement async_step_reconfigure in config flow.
+    status: done
+    comment: async_step_reconfigure implemented with validation and in-place update.
 
   # Platinum rules (current status)
   dynamic_devices:

--- a/quality_scale.yaml
+++ b/quality_scale.yaml
@@ -83,14 +83,14 @@ rules:
     status: done
     comment: README documents required inputs and options.
   docs_removal_instructions:
-    status: todo
-    comment: Add an explicit removal section to docs.
+    status: done
+    comment: README includes a Removing the integration section with standard steps.
   docs_supported_devices:
-    status: todo
-    comment: List supported/unsupported charger models explicitly.
+    status: done
+    comment: README lists supported and unsupported/not tested devices.
   docs_actions:
-    status: partial
-    comment: Services are described in README; consider adding structured docs/actions section.
+    status: done
+    comment: Structured Actions section in README covers all services and fields.
   reconfiguration_flow:
     status: todo
     comment: Implement async_step_reconfigure in config flow.

--- a/tests_enphase_ev/test_reconfigure_flow.py
+++ b/tests_enphase_ev/test_reconfigure_flow.py
@@ -77,8 +77,9 @@ async def test_reconfigure_updates_entry_on_submit(monkeypatch):
 
     # Monkeypatch helpers inside reconfigure
     monkeypatch.setattr(EnphaseEVConfigFlow, "_get_reconfigure_entry", lambda self: Entry())
+    # Patch the client in its source module, since the flow imports it inside the function
     monkeypatch.setattr(
-        "custom_components.enphase_ev.config_flow.EnphaseEVClient", StubClient
+        "custom_components.enphase_ev.api.EnphaseEVClient", StubClient
     )
     # Bypass unique_id guard in test
     monkeypatch.setattr(EnphaseEVConfigFlow, "async_set_unique_id", lambda *a, **k: None)
@@ -98,4 +99,3 @@ async def test_reconfigure_updates_entry_on_submit(monkeypatch):
 
     res = await flow.async_step_reconfigure(user_input)
     assert res["type"].name in ("ABORT", "CREATE_ENTRY")
-

--- a/tests_enphase_ev/test_reconfigure_flow.py
+++ b/tests_enphase_ev/test_reconfigure_flow.py
@@ -107,3 +107,149 @@ async def test_reconfigure_updates_entry_on_submit(monkeypatch):
 
     res = await flow.async_step_reconfigure(user_input)
     assert res["type"].name in ("ABORT", "CREATE_ENTRY")
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_wrong_account_aborts(monkeypatch):
+    from custom_components.enphase_ev.config_flow import EnphaseEVConfigFlow
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+
+    class Entry:
+        def __init__(self):
+            self.data = {
+                CONF_SITE_ID: "1234567",
+                CONF_SERIALS: ["555555555555"],
+                CONF_SCAN_INTERVAL: 30,
+                CONF_EAUTH: "EAUTH_OLD",
+                CONF_COOKIE: "COOKIE_OLD",
+            }
+            self.entry_id = "entry-id"
+
+    class StubClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def status(self):
+            return {"ok": True}
+
+    flow = EnphaseEVConfigFlow()
+    class Hass:
+        class CEM:
+            def async_update_entry(self, *a, **k):
+                return None
+            async def async_reload(self, *a, **k):
+                return None
+        config_entries = CEM()
+    flow.hass = Hass()
+
+    # Patch environment and helpers
+    import sys, types
+    monkeypatch.setitem(sys.modules, "aiohttp", types.SimpleNamespace(ClientError=Exception))
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.config_flow.async_get_clientsession", lambda hass: object()
+    )
+    monkeypatch.setattr(EnphaseEVConfigFlow, "_get_reconfigure_entry", lambda self: Entry())
+    monkeypatch.setattr("custom_components.enphase_ev.api.EnphaseEVClient", StubClient)
+
+    # Make async_set_unique_id awaitable
+    async def _noop_async(*a, **k):
+        return None
+    monkeypatch.setattr(EnphaseEVConfigFlow, "async_set_unique_id", _noop_async)
+
+    # Force abort when site ID mismatches by raising from mismatch guard
+    def _raise_abort(*a, **k):  # called with reason="wrong_account"
+        raise RuntimeError("wrong_account")
+    monkeypatch.setattr(EnphaseEVConfigFlow, "_abort_if_unique_id_mismatch", _raise_abort)
+
+    user_input = {
+        CONF_SITE_ID: "7654321",  # different from entry (1234567)
+        CONF_SERIALS: "555555555555",
+        CONF_EAUTH: "EAUTH_NEW",
+        CONF_COOKIE: "COOKIE_NEW",
+        CONF_SCAN_INTERVAL: 15,
+    }
+
+    with pytest.raises(RuntimeError):
+        await flow.async_step_reconfigure(user_input)
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_curl_autofill(monkeypatch):
+    from custom_components.enphase_ev.config_flow import EnphaseEVConfigFlow
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+
+    class Entry:
+        def __init__(self):
+            self.data = {
+                CONF_SITE_ID: "1234567",
+                CONF_SERIALS: ["555555555555"],
+                CONF_SCAN_INTERVAL: 30,
+                CONF_EAUTH: "EAUTH_OLD",
+                CONF_COOKIE: "COOKIE_OLD",
+            }
+            self.entry_id = "entry-id"
+
+    class StubClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def status(self):
+            return {"ok": True}
+
+    flow = EnphaseEVConfigFlow()
+    class Hass:
+        class CEM:
+            def async_update_entry(self, *a, **k):
+                return None
+            async def async_reload(self, *a, **k):
+                return None
+        config_entries = CEM()
+    flow.hass = Hass()
+
+    import sys, types
+    monkeypatch.setitem(sys.modules, "aiohttp", types.SimpleNamespace(ClientError=Exception))
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.config_flow.async_get_clientsession", lambda hass: object()
+    )
+    monkeypatch.setattr(EnphaseEVConfigFlow, "_get_reconfigure_entry", lambda self: Entry())
+    monkeypatch.setattr("custom_components.enphase_ev.api.EnphaseEVClient", StubClient)
+
+    async def _noop_async(*a, **k):
+        return None
+    monkeypatch.setattr(EnphaseEVConfigFlow, "async_set_unique_id", _noop_async)
+    monkeypatch.setattr(EnphaseEVConfigFlow, "_abort_if_unique_id_mismatch", lambda *a, **k: None)
+
+    # Provide helper to return a recognizable result
+    flow.async_update_reload_and_abort = lambda entry, data_updates=None: {
+        "type": type("T", (), {"name": "ABORT"})
+    }
+
+    # cURL that includes the same site id as entry to avoid mismatch
+    curl = (
+        "curl 'https://enlighten.enphaseenergy.com/service/evse_controller/1234567/ev_chargers/status' "
+        "-H 'e-auth-token: TOKEN123' -H 'Cookie: COOKIE123'"
+    )
+
+    user_input = {
+        CONF_SITE_ID: "1234567",  # will be set from curl anyway
+        CONF_SERIALS: "555555555555",
+        CONF_EAUTH: "",
+        CONF_COOKIE: "",
+        CONF_SCAN_INTERVAL: 20,
+        "curl": curl,
+    }
+
+    res = await flow.async_step_reconfigure(user_input)
+    assert res["type"].name in ("ABORT", "CREATE_ENTRY")

--- a/tests_enphase_ev/test_reconfigure_flow.py
+++ b/tests_enphase_ev/test_reconfigure_flow.py
@@ -1,0 +1,101 @@
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_shows_form(monkeypatch):
+    from custom_components.enphase_ev.config_flow import EnphaseEVConfigFlow
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+
+    class Entry:
+        def __init__(self):
+            self.data = {
+                CONF_SITE_ID: "1234567",
+                CONF_SERIALS: ["555555555555"],
+                CONF_SCAN_INTERVAL: 30,
+                CONF_EAUTH: "EAUTH",
+                CONF_COOKIE: "COOKIE",
+            }
+
+    flow = EnphaseEVConfigFlow()
+    # Hass object not used for the display path
+    flow.hass = object()
+    monkeypatch.setattr(EnphaseEVConfigFlow, "_get_reconfigure_entry", lambda self: Entry())
+
+    res = await flow.async_step_reconfigure()
+    assert res["type"].name == "FORM"
+    assert res["step_id"] == "reconfigure"
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_updates_entry_on_submit(monkeypatch):
+    from custom_components.enphase_ev.config_flow import EnphaseEVConfigFlow
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+
+    class Entry:
+        def __init__(self):
+            self.data = {
+                CONF_SITE_ID: "1234567",
+                CONF_SERIALS: ["555555555555"],
+                CONF_SCAN_INTERVAL: 30,
+                CONF_EAUTH: "EAUTH_OLD",
+                CONF_COOKIE: "COOKIE_OLD",
+            }
+            self.entry_id = "entry-id"
+
+    class StubClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def status(self):
+            return {"ok": True}
+
+    flow = EnphaseEVConfigFlow()
+    # Provide a minimal hass with config_entries manager used in fallback path
+    class CEM:
+        def async_update_entry(self, *a, **k):
+            return None
+
+        async def async_reload(self, *a, **k):
+            return None
+
+    class Hass:
+        config_entries = CEM()
+
+    flow.hass = Hass()
+
+    # Monkeypatch helpers inside reconfigure
+    monkeypatch.setattr(EnphaseEVConfigFlow, "_get_reconfigure_entry", lambda self: Entry())
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.config_flow.EnphaseEVClient", StubClient
+    )
+    # Bypass unique_id guard in test
+    monkeypatch.setattr(EnphaseEVConfigFlow, "async_set_unique_id", lambda *a, **k: None)
+    monkeypatch.setattr(EnphaseEVConfigFlow, "_abort_if_unique_id_mismatch", lambda *a, **k: None)
+    # Prefer the helper if present to return a result with a type name
+    flow.async_update_reload_and_abort = lambda entry, data_updates=None: {
+        "type": type("T", (), {"name": "ABORT"})
+    }
+
+    user_input = {
+        CONF_SITE_ID: "1234567",
+        CONF_SERIALS: "555555555555",
+        CONF_EAUTH: "EAUTH_NEW",
+        CONF_COOKIE: "COOKIE_NEW",
+        CONF_SCAN_INTERVAL: 15,
+    }
+
+    res = await flow.async_step_reconfigure(user_input)
+    assert res["type"].name in ("ABORT", "CREATE_ENTRY")
+


### PR DESCRIPTION
Implements reconfiguration flow to meet the Gold rule `reconfiguration_flow`:

- config_flow.py
  - Adds `async_step_reconfigure` with:
    - Optional cURL parsing (like initial setup) to speed up reconfigure.
    - Normalization of serial inputs.
    - Validation by probing `/status` with provided headers.
    - Unique ID safeguard (site ID mismatch aborts with `wrong_account`).
    - In-place update of entry using `async_update_reload_and_abort` when available, falling back to manual update+reload otherwise.
- quality_scale.yaml
  - Marks `reconfiguration_flow` as done.

No runtime behavior change unless the user chooses Reconfigure in the UI.
