### PR TITLE
ci: auto-comment @codex review on PRs (v2)

### DIFF
--- a/.github/workflows/codex_review.yml
+++ b/.github/workflows/codex_review.yml
@@ -1,0 +1,44 @@
+name: Codex Auto Review Comment
+
+on:
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post '@codex review' once
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+
+            // Skip drafts
+            if (pr.draft) {
+              core.info('PR is draft; skipping codex review comment.');
+              return;
+            }
+
+            // Avoid duplicates
+            const comments = await github.paginate(
+              github.rest.issues.listComments,
+              { owner, repo, issue_number: pr.number, per_page: 100 }
+            );
+            const already = comments.some(c => (c.body || '').includes('@codex review'));
+            if (already) {
+              core.info('Codex review comment already present; nothing to do.');
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: pr.number,
+              body: '@codex review',
+            });


### PR DESCRIPTION
Re-adds the Codex auto-review comment workflow without conflicts.\n- Triggers on PR opened/reopened/ready_for_review via pull_request_target\n- Skips draft PRs\n- Checks for existing comment to avoid duplicates\n- Uses issues: write and pull-requests: read only