### PR TITLE
Release 0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.7.8
+- Sensors: harden the lifetime energy meter so startup zeroes and small API dips no longer reset Energy statistics; added regression coverage.
+- Coordinator: preserve `config_entry` on older Home Assistant cores and reapply fast polling changes via `async_set_update_interval` when available.
+- Config Flow: backport `_get_reconfigure_entry` and `_abort_if_unique_id_mismatch` helpers for legacy cores while retaining reconfigure validation.
+- Tests: silence the frame helper guard for unit tests that instantiate the coordinator outside Home Assistant.
+
 ## v0.7.2
 - Sensors: replace old daily/session energy with a new Energy Today derived from the lifetime meter
   - Monotonic within a day; resets at local midnight; persists baseline across restarts.

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.7.3"
+  "version": "0.7.8"
 }


### PR DESCRIPTION
## Summary
- bump manifest and metadata to version 0.7.8
- document the lifetime energy fixes and compatibility backports in the changelog

## Testing
- not run (doc/version only)
