### PR TITLE
Release 0.8.0b1 beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.8.0b1
+- Config Flow: add Enlighten email/password login with MFA prompts, site & charger selection, automatic token refresh, and a manual header fallback for advanced users.
+- API & Coordinator: rewrite the client stack to handle the wider Enlighten variants, cache summary metadata, smooth rate limiting, and persist last set amps/session data after restarts.
+- Diagnostics & Tests: expand diagnostics redaction and add extensive regression coverage for the new flow, API variations, and polling behavior.
+
 ## v0.7.8
 - Sensors: harden the lifetime energy meter so startup zeroes and small API dips no longer reset Energy statistics; added regression coverage.
 - Coordinator: preserve `config_entry` on older Home Assistant cores and reapply fast polling changes via `async_set_update_interval` when available.

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.7.8"
+  "version": "0.8.0b1"
 }


### PR DESCRIPTION
## Summary
- bump manifest version to 0.8.0b1 for the beta release
- document the Enlighten login flow and API refactor changes in the changelog

## Testing
- not run (docs only)