### PR TITLE
Refine device info presentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.8.2
+- Diagnostics: add Connection, IP Address, and Reporting Interval sensors with translation strings and icons sourced from the Enlighten summary metadata.
+- Device info: surface the charger display name alongside the model (e.g., `IQ EV Charger (IQ-EVSE-EU-3032)`).
+- Maintenance: remove redundant `custom_components/__init__.py`, bump manifest version to 0.8.2, and refresh README documentation.
+
 ## v0.8.1
 - Sensors: derive IQ charger power from lifetime energy deltas with 5 minute smoothing, throughput capping, and legacy state restore support to eliminate transient spikes.
 - Coordinator: drop estimated `power_w` fields so sensors own the calculation and keep cross-restart continuity.

--- a/README.md
+++ b/README.md
@@ -13,10 +13,15 @@
 [![Integration Version](https://img.shields.io/badge/dynamic/json?url=https%3A%2F%2Fraw.githubusercontent.com%2Fbarneyonline%2Fha-enphase-ev-charger%2Fmain%2Fcustom_components%2Fenphase_ev%2Fmanifest.json&query=%24.version&label=integration%20version&cacheSeconds=3600)](custom_components/enphase_ev/manifest.json)
 [![HACS](https://img.shields.io/badge/HACS-Custom-41BDF5.svg)](https://hacs.xyz)
 
-[![Downloads](https://img.shields.io/github/downloads/barneyonline/ha-enphase-ev-charger/total)](https://github.com/barneyonline/ha-enphase-ev-charger/releases)
 [![Open Issues](https://img.shields.io/github/issues/barneyonline/ha-enphase-ev-charger)](https://github.com/barneyonline/ha-enphase-ev-charger/issues)
 
-This custom integration surfaces the **Enphase IQ EV Charger 2** in Home Assistant using the same **Enlighten cloud** endpoints used by the Enphase mobile app.
+This custom integration surfaces the **Enphase IQ EV Charger 2** in Home Assistant using the same **Enlighten cloud** endpoints used by the Enphase mobile app and adds:
+
+- Start/stop charging directly from Home Assistant
+- Set and persist the charger’s current limit (6–40 A)
+- View plugged-in, charging, and fault status in real time
+- Track live power, session energy, session duration, and daily energy totals
+- Inspect connection diagnostics including active interface, IP address, and reporting interval
 
 > ⚠️ Local-only access to EV endpoints is **role-gated** on IQ Gateway firmware 7.6.175. The charger surfaces locally under `/ivp/pdm/*` or `/ivp/peb/*` only with **installer** scope. This integration therefore uses the **cloud API** until owner-scope local endpoints are available.
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,11 @@ Per‑charger entities
   - Phase Mode — 1→Single Phase, 3→Three Phase
   - Status — cloud summary status
   - Connector Status — AVAILABLE/CHARGING/etc. (diagnostic)
+  - Connection — active interface reported by the charger (diagnostic)
+  - IP Address — current LAN address from the latest summary (diagnostic)
+  - Reporting Interval (s) — current cloud reporting cadence (diagnostic)
+
+Device registry entries combine both the charger display name and model, e.g., `IQ EV Charger (IQ-EVSE-EU-3032)`.
 
 Removed (unreliable across deployments): Connector Reason, Schedule Type/Start/End, Session Miles, Session Plug‑in/out timestamps.
 

--- a/custom_components/__init__.py
+++ b/custom_components/__init__.py
@@ -1,2 +1,0 @@
-"""Namespace package for custom Home Assistant integrations used in tests."""
-

--- a/custom_components/enphase_ev/entity.py
+++ b/custom_components/enphase_ev/entity.py
@@ -22,7 +22,16 @@ class EnphaseBaseEntity(CoordinatorEntity[EnphaseCoordinator]):
     @property
     def device_info(self) -> DeviceInfo:
         d = (self._coord.data or {}).get(self._sn) or {}
-        dev_name = d.get("display_name") or d.get("name") or "Enphase EV Charger"
+        display_name = d.get("display_name") or d.get("name")
+        model_name = d.get("model_name")
+        if display_name and model_name:
+            dev_name = f"{display_name} ({model_name})"
+        elif display_name:
+            dev_name = display_name
+        elif model_name:
+            dev_name = str(model_name)
+        else:
+            dev_name = "Enphase EV Charger"
         # Build DeviceInfo using keyword arguments as per HA dev docs
         info_kwargs: dict[str, object] = {
             "identifiers": {(DOMAIN, self._sn)},

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.8.1"
+  "version": "0.8.2"
 }

--- a/tests_enphase_ev/test_entity_wiring.py
+++ b/tests_enphase_ev/test_entity_wiring.py
@@ -31,3 +31,29 @@ def test_entity_naming_and_availability():
     assert ent.device_info["name"] == "Garage EV"
     # Unique ID includes domain, serial, and key
     assert ent.unique_id.endswith("555555555555_energy_today")
+
+
+def test_device_info_includes_model_name_when_available():
+    from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
+
+    class DummyCoord:
+        def __init__(self):
+            self.data = {}
+            self.serials = {"482522020944"}
+            self.site_id = "3381244"
+            self.last_update_success = True
+
+    coord = DummyCoord()
+    coord.data = {
+        "482522020944": {
+            "sn": "482522020944",
+            "display_name": "IQ EV Charger",
+            "model_name": "IQ-EVSE-EU-3032",
+            "connected": True,
+        }
+    }
+
+    ent = EnphaseEnergyTodaySensor(coord, "482522020944")
+    info = ent.device_info
+    assert info["name"] == "IQ EV Charger (IQ-EVSE-EU-3032)"
+    assert info["model"] == "IQ-EVSE-EU-3032"


### PR DESCRIPTION
## Summary
- show the charger display name together with the model in device info
- bump the manifest to 0.8.2, drop unused root __init__, and update docs
- document new diagnostic sensors and changelog entries

## Testing
- . .venv313/bin/activate && pytest tests_enphase_ev/test_entity_wiring.py
- . .venv313/bin/activate && pytest tests_enphase_ev

