### PR TITLE
release: 0.8.4 dynamic load balancing cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.8.4
+- Sensors: rename Dynamic Load Balancing status, add enabled/disabled icons, and update translations.
+- Cleanup: remove the deprecated `binary_sensor.iq_ev_charger_dlb_active` and its coordinator payload.
+- Tests: extend regression coverage for the updated sensor states.
+
 ## v0.8.3
 - Remove legacy manual header flow from config/reauth paths and translations
 - Update documentation and tests for login-only setup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 - Sensors: rename Dynamic Load Balancing status, add enabled/disabled icons, and update translations.
 - Cleanup: remove the deprecated `binary_sensor.iq_ev_charger_dlb_active` and its coordinator payload.
 - Tests: extend regression coverage for the updated sensor states.
+- Docs: mention the Dynamic Load Balancing sensor in the README entities table.
 
 ## v0.8.3
 - Remove legacy manual header flow from config/reauth paths and translations

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If the login form reports that multi-factor authentication is required, complete
 | Select | Charge Mode selector (Manual, Scheduled, Green) backed by the cloud scheduler. |
 | Number | Charging Amps setpoint (6-40 A) without initiating a session. |
 | Sensor (charging metrics) | Power, Session Energy, Session Duration, Set Amps, Min/Max Amps, Charge Mode, Phase Mode, and Status. |
-| Sensor (diagnostics) | Connector Status, Connection interface, IP Address, and Reporting Interval sourced from the cloud API. |
+| Sensor (diagnostics) | Connector Status, Dynamic Load Balancing status, Connection interface, IP Address, and Reporting Interval sourced from the cloud API. |
 
 **Services (Actions)**
 

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -25,7 +25,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         entities.append(ChargingBinarySensor(coord, sn))
         entities.append(FaultedBinarySensor(coord, sn))
         entities.append(ConnectedBinarySensor(coord, sn))
-        entities.append(DlbActiveBinarySensor(coord, sn))
         entities.append(CommissionedBinarySensor(coord, sn))
     async_add_entities(entities)
 
@@ -74,12 +73,6 @@ class ConnectedBinarySensor(_EVBoolSensor):
     def __init__(self, coord: EnphaseCoordinator, sn: str):
         super().__init__(coord, sn, "connected", "connected")
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
-        self._attr_entity_category = EntityCategory.DIAGNOSTIC
-
-
-class DlbActiveBinarySensor(_EVBoolSensor):
-    def __init__(self, coord: EnphaseCoordinator, sn: str):
-        super().__init__(coord, sn, "dlb_active", "dlb_active")
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -388,7 +388,6 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     "faulted": _as_bool(obj.get("faulted")),
                     "connector_status": obj.get("connectorStatusType") or conn0.get("connectorStatusType"),
                     "connector_reason": conn0.get("connectorStatusReason"),
-                    "dlb_active": _as_bool(conn0.get("dlbActive")),
                     "session_kwh": ses_kwh,
                     "session_miles": sess.get("miles"),
                     # Normalize session start epoch if needed

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.8.3"
+  "version": "0.8.4"
 }

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -217,7 +217,7 @@ class EnphaseDynamicLoadBalancingSensor(_BaseEVSensor):
     _attr_translation_key = "dlb_status"
 
     def __init__(self, coord: EnphaseCoordinator, sn: str):
-        super().__init__(coord, sn, "Dynamic Loan Balancing", "dlb_enabled")
+        super().__init__(coord, sn, "Dynamic Load Balancing", "dlb_enabled")
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
@@ -226,6 +226,13 @@ class EnphaseDynamicLoadBalancingSensor(_BaseEVSensor):
         if raw is None:
             return None
         return "enabled" if bool(raw) else "disabled"
+
+    @property
+    def icon(self) -> str | None:
+        raw = super().native_value
+        if raw is None:
+            return "mdi:lightning-bolt-outline"
+        return "mdi:lightning-bolt" if bool(raw) else "mdi:lightning-bolt-outline"
 
 class EnphasePowerSensor(EnphaseBaseEntity, SensorEntity, RestoreEntity):
     _attr_has_entity_name = True

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -94,7 +94,6 @@
       "charging": { "name": "Charging" },
       "faulted": { "name": "Charger Problem" },
       "cloud_reachable": { "name": "Cloud Reachable" },
-      "dlb_active": { "name": "Load Balancing Active" },
       "commissioned": { "name": "Commissioned" }
     },
     "switch": {

--- a/tests_enphase_ev/test_sensors.py
+++ b/tests_enphase_ev/test_sensors.py
@@ -102,11 +102,13 @@ def test_dlb_sensor_state_mapping():
     )
 
     sensor = EnphaseDynamicLoadBalancingSensor(coord, sn)
-    assert sensor.name == "Dynamic Loan Balancing"
+    assert sensor.name == "Dynamic Load Balancing"
     assert sensor.native_value == "enabled"
+    assert sensor.icon == "mdi:lightning-bolt"
 
     coord.data[sn]["dlb_enabled"] = False
     assert sensor.native_value == "disabled"
+    assert sensor.icon == "mdi:lightning-bolt-outline"
 
     coord.data[sn].pop("dlb_enabled")
     assert sensor.native_value is None


### PR DESCRIPTION
## Summary
- rename the Dynamic Load Balancing sensor label and add state-driven icons
- remove the deprecated load-balancing binary sensor and coordinator payload
- bump the manifest to 0.8.4 and document the changes in the changelog

## Testing
- pytest -q tests_enphase_ev