### PR TITLE
Improve Enphase charger naming

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -378,10 +378,16 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 except Exception:
                     pass
 
+                display_name = obj.get("displayName") or obj.get("name")
+                if display_name is not None:
+                    try:
+                        display_name = str(display_name)
+                    except Exception:
+                        display_name = None
                 out[sn] = {
                     "sn": sn,
                     "name": obj.get("name"),
-                    "display_name": obj.get("displayName") or obj.get("name"),
+                    "display_name": display_name,
                     "connected": _as_bool(obj.get("connected")),
                     "plugged": _as_bool(obj.get("pluggedIn")),
                     "charging": _as_bool(obj.get("charging")),
@@ -537,9 +543,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     val = item.get(key_src)
                     if val is not None and key_dst not in cur:
                         cur[key_dst] = val
-                # Prefer displayName when provided by summary
-                if item.get("displayName") and not cur.get("display_name"):
-                    cur["display_name"] = item.get("displayName")
+                # Prefer displayName from summary v2 for user-facing names
+                if item.get("displayName"):
+                    cur["display_name"] = str(item.get("displayName"))
         # Dynamic poll rate: fast while any charging, within a fast window, or streaming
         if self.config_entry is not None:
             want_fast = any(v.get("charging") for v in out.values()) if out else False

--- a/tests_enphase_ev/test_device_info.py
+++ b/tests_enphase_ev/test_device_info.py
@@ -1,0 +1,26 @@
+from types import SimpleNamespace
+
+
+def test_device_info_uses_display_name_and_model():
+    from custom_components.enphase_ev.entity import EnphaseBaseEntity
+
+    entity = object.__new__(EnphaseBaseEntity)
+    entity._coord = SimpleNamespace(
+        data={
+            "555555555555": {
+                "display_name": "Garage Charger",
+                "model_name": "IQ-EVSE-EU-3032",
+                "hw_version": "2.0",
+                "sw_version": "3.1",
+            }
+        },
+        site_id="1234567",
+    )
+    entity._sn = "555555555555"
+
+    info = entity.device_info
+
+    assert info["name"] == "Garage Charger"
+    assert info["model"] == "Garage Charger (IQ-EVSE-EU-3032)"
+    assert info.get("default_model") == "IQ-EVSE-EU-3032"
+    assert info["serial_number"] == "555555555555"

--- a/tests_enphase_ev/test_entity_wiring.py
+++ b/tests_enphase_ev/test_entity_wiring.py
@@ -55,5 +55,6 @@ def test_device_info_includes_model_name_when_available():
 
     ent = EnphaseEnergyTodaySensor(coord, "482522020944")
     info = ent.device_info
-    assert info["name"] == "IQ EV Charger (IQ-EVSE-EU-3032)"
-    assert info["model"] == "IQ-EVSE-EU-3032"
+    assert info["name"] == "IQ EV Charger"
+    assert info["model"] == "IQ EV Charger (IQ-EVSE-EU-3032)"
+    assert info.get("default_model") == "IQ-EVSE-EU-3032"

--- a/tests_enphase_ev/test_summary_enrichment.py
+++ b/tests_enphase_ev/test_summary_enrichment.py
@@ -49,6 +49,7 @@ async def test_summary_v2_enrichment(hass, monkeypatch):
     summary_list = [
         {
             "serialNumber": "555555555555",
+            "displayName": "Garage Charger",
             "lastReportedAt": "2025-09-08T02:55:30.347Z[UTC]",
             "chargeLevelDetails": {"min": "6", "max": "32", "granularity": "1", "defaultChargeLevel": "disabled"},
             "maxCurrent": 32,
@@ -104,3 +105,4 @@ async def test_summary_v2_enrichment(hass, monkeypatch):
     assert st["hw_version"] == "A.B.C"
     assert st["model_name"] == "MODEL-NAME"
     assert st["model_id"] == "MODEL-SKU-0000"
+    assert st["display_name"] == "Garage Charger"


### PR DESCRIPTION
## Summary
- default charger device names to the summary displayName when available
- format the Device Info model line as displayName (model)
- keep device registry entries in sync and cover with regression tests

## Testing
- pytest -q tests_enphase_ev/test_summary_enrichment.py tests_enphase_ev/test_device_info.py
