### PR TITLE
Docs: add Enphase API spec

### DIFF
--- a/Enphase API/api_spec.md
+++ b/Enphase API/api_spec.md
@@ -1,0 +1,242 @@
+# Enphase EV Cloud API Specification
+
+_This reference consolidates everything the integration has learned from reverse‑engineering the Enlighten mobile/web APIs for the IQ EV Charger 2._
+
+---
+
+## 1. Overview
+- **Base URL:** `https://enlighten.enphaseenergy.com`
+- **Auth:** All EV endpoints require the Enlighten `e-auth-token` header and the authenticated session `Cookie` header. Most control endpoints also accept Enlighten bearer tokens when provided; the integration automatically attaches `Authorization: Bearer <token>` when available.
+- **Path Variables:**
+  - `<site_id>` — numeric site identifier (use anonymised examples, e.g., `1000123`)
+  - `<sn>` — charger serial number (use anonymised examples, e.g., `EV1234567890`)
+  - `connectorId` — connector index; currently always `1`
+
+---
+
+## 2. Core EV Controller Endpoints
+
+### 2.1 Status Snapshot
+```
+GET /service/evse_controller/<site_id>/ev_chargers/status
+```
+Returns charger state (plugged, charging, session energy, etc.). Some deployments still respond to `/ev_charger/status`; the integration falls back automatically.
+
+Example payload:
+```json
+{
+  "evChargerData": [
+    {
+      "sn": "EV1234567890",
+      "name": "Sample Charger",
+      "connected": true,
+      "pluggedIn": true,
+      "charging": false,
+      "faulted": false,
+      "connectorStatusType": "AVAILABLE",
+      "connectorStatusReason": "INSUFFICIENT_SOLAR",
+      "chargingLevel": 32,
+      "session_d": {
+        "e_c": 3.52,
+        "start_time": 1700000000,
+        "plg_in_at": 1699999900,
+        "plg_out_at": null
+      },
+      "sch_d": {
+        "enabled": false,
+        "mode": "IMMEDIATE"
+      }
+    }
+  ],
+  "ts": 1700000123
+}
+```
+
+### 2.2 Extended Summary (Metadata)
+```
+GET /service/evse_controller/api/v2/<site_id>/ev_chargers/summary?filter_retired=true
+```
+Provides hardware/software versions, model names, operating voltage, IP addresses, and schedule information.
+
+```json
+{
+  "data": [
+    {
+      "serialNumber": "EV1234567890",
+      "displayName": "Sample Charger",
+      "modelName": "IQ-EVSE-SAMPLE",
+      "maxCurrent": 32,
+      "chargeLevelDetails": { "min": "6", "max": "32", "granularity": "1" },
+      "dlbEnabled": 1,
+      "networkConfig": "[...]",          // JSON or CSV-like string of interfaces
+      "lastReportedAt": "2025-01-15T12:34:56.000Z[UTC]",
+      "operatingVoltage": 240,
+      "firmwareVersion": "25.XX.Y.Z",
+      "processorBoardVersion": "A.B.C"
+    }
+  ]
+}
+```
+
+### 2.3 Start Live Stream
+```
+GET /service/evse_controller/<site_id>/ev_chargers/start_live_stream
+```
+Initiates a short burst of rapid status updates.
+```json
+{ "status": "accepted", "topics": ["evse/<sn>/status"], "duration_s": 60 }
+```
+
+### 2.4 Stop Live Stream
+```
+GET /service/evse_controller/<site_id>/ev_chargers/stop_live_stream
+```
+Ends the fast polling window.
+```json
+{ "status": "accepted" }
+```
+
+---
+
+## 3. Control Operations
+
+The Enlighten backend is inconsistent across regions; the integration tries multiple variants until one succeeds. All payloads shown below are the canonical request. If a 409/422 response is returned (charger unplugged/not ready), the integration treats it as a benign no-op.
+
+### 3.1 Start Charging / Set Amps
+```
+POST /service/evse_controller/<site_id>/ev_chargers/<sn>/start_charging
+Body: { "chargingLevel": 32, "connectorId": 1 }
+```
+Fallback variants observed:
+- `PUT` instead of `POST`
+- Path `/ev_charger/` (singular)
+- Payload keys `charging_level` / `connector_id`
+- No body (uses last stored level)
+
+Typical response:
+```json
+{ "status": "accepted", "chargingLevel": 32 }
+```
+
+### 3.2 Stop Charging
+```
+PUT /service/evse_controller/<site_id>/ev_chargers/<sn>/stop_charging
+```
+Fallbacks: `POST`, singular path `/ev_charger/`.
+```json
+{ "status": "accepted" }
+```
+
+### 3.3 Trigger OCPP Message
+```
+POST /service/evse_controller/<site_id>/ev_charger/<sn>/trigger_message
+Body: { "requestedMessage": "MeterValues" }
+```
+Replies vary by backend. Common shape:
+```json
+{
+  "status": "accepted",
+  "message": "MeterValues",
+  "details": {
+    "initiatedAt": "2025-01-15T12:34:56.000Z",
+    "trackingId": "TICKET-XYZ123"
+  }
+}
+```
+
+---
+
+## 4. Scheduler (Charge Mode) API
+
+Separate Enlighten service requiring bearer tokens in addition to the cookie headers.
+
+### 4.1 Read Preferred Charge Mode
+```
+GET /service/evse_scheduler/api/v1/iqevc/charging-mode/<site_id>/<sn>/preference
+Headers: Authorization: Bearer <token>
+```
+Response:
+```json
+{
+  "data": {
+    "modes": {
+      "manualCharging": { "enabled": true, "chargingMode": "MANUAL_CHARGING" },
+      "scheduledCharging": { "enabled": false },
+      "greenCharging": { "enabled": false }
+    }
+  }
+}
+```
+
+### 4.2 Set Charge Mode
+```
+PUT /service/evse_scheduler/api/v1/iqevc/charging-mode/<site_id>/<sn>/preference
+Body: { "mode": "MANUAL_CHARGING" }
+Headers: Authorization: Bearer <token>
+```
+Success response mirrors the GET payload.
+
+---
+
+## 5. Authentication Flow
+
+### 5.1 Login (Enlighten OAuth)
+1. POST to `https://entrez.enphaseenergy.com/login` with email/password.
+2. Handle MFA challenge (`/login/mfa/verify`) when required.
+3. Retrieve cookies and session ID from the response.
+
+### 5.2 Access Token
+Some sites issue a JWT-like access token via `https://entrez.enphaseenergy.com/access_token`. The integration decodes the `exp` claim to know when to refresh.
+
+### 5.3 Headers Required by API Client
+- `e-auth-token: <token>`
+- `Cookie: <serialized cookie jar>` (must include session cookies like `_enlighten_session`, `X-Requested-With`, etc.)
+- When available: `Authorization: Bearer <token>`
+- Common defaults also send:
+  - `Referer: https://enlighten.enphaseenergy.com/`
+  - `X-Requested-With: XMLHttpRequest`
+
+The integration reuses tokens until expiry or a 401 is encountered, then prompts reauthentication.
+
+---
+
+## 6. Response Field Reference
+
+| Field | Description |
+| --- | --- |
+| `connected` | Charger cloud connection status |
+| `pluggedIn` | Vehicle plugged state |
+| `charging` | Active charging session |
+| `faulted` | Fault present |
+| `connectorStatusType` | ENUM: `AVAILABLE`, `CHARGING`, `FINISHING`, `SUSPENDED`, `FAULTED` |
+| `connectorStatusReason` | Additional enum reason (e.g., `INSUFFICIENT_SOLAR`) |
+| `session_d.e_c` | Session energy (Wh if >200, else kWh) |
+| `session_d.start_time` | Epoch seconds when session started |
+| `chargeLevelDetails.min/max` | Min/max allowed amps |
+| `maxCurrent` | Hardware max amp rating |
+| `operatingVoltage` | Nominal voltage per summary v2 |
+| `dlbEnabled` | Dynamic Load Balancing flag |
+| `networkConfig` | Interfaces with IP/fallback metadata |
+| `firmwareVersion` | Charger firmware |
+| `processorBoardVersion` | Hardware version |
+
+---
+
+## 7. Error Handling & Rate Limiting
+- HTTP 401 — credentials expired; request reauth.
+- HTTP 400/404/409/422 during control operations — charger not ready/not plugged; treated as no-ops.
+- Rate limiting presents as HTTP 429; the integration backs off and logs the event.
+- Recommended polling interval: 30 s (configurable). Live stream can be used for short bursts (60 s)
+
+---
+
+## 8. Known Variations & Open Questions
+- Some deployments omit `displayName` from `/status`; summary v2 is needed for friendly names.
+- Session energy units vary; integration normalizes values >200 as Wh ➜ kWh.
+- Local LAN endpoints (`/ivp/pdm/*`, `/ivp/peb/*`) exist but require installer permissions; not currently accessible with owner accounts.
+
+---
+
+## 9. References
+- Reverse-engineered from Enlighten mobile app network traces (2024–2025).
+- Implemented in `custom_components/enphase_ev/api.py` and `coordinator.py`.

--- a/Enphase API/api_spec.md
+++ b/Enphase API/api_spec.md
@@ -8,8 +8,8 @@ _This reference consolidates everything the integration has learned from reverse
 - **Base URL:** `https://enlighten.enphaseenergy.com`
 - **Auth:** All EV endpoints require the Enlighten `e-auth-token` header and the authenticated session `Cookie` header. Most control endpoints also accept Enlighten bearer tokens when provided; the integration automatically attaches `Authorization: Bearer <token>` when available.
 - **Path Variables:**
-  - `<site_id>` — numeric site identifier (use anonymised examples, e.g., `1000123`)
-  - `<sn>` — charger serial number (use anonymised examples, e.g., `EV1234567890`)
+  - `<site_id>` — numeric site identifier
+  - `<sn>` — charger serial number
   - `connectorId` — connector index; currently always `1`
 
 ---

--- a/Enphase API/local_endpoints.md
+++ b/Enphase API/local_endpoints.md
@@ -54,3 +54,9 @@ _The endpoints below were observed on IQ Gateway firmware 7.6.175 while inspecti
 - Can we obtain a local access token via Enlighten OAuth (similar to solar APIs)?
 
 _These endpoints remain informational until Enphase grants owner-level access. The integration continues to rely on cloud APIs until then._
+
+
+## Additional Namespaces
+- `/ivp/ensemble/*`: returns empty arrays (e.g., `{"serial_nums":[]}`); inventory not exposed for owner accounts.
+- `/ivp/ocpp/*`: endpoints exist but respond with `{"error":"404 - Not Found"}` to owner tokens, indicating role gating.
+- `/ivp/pdm/*`: full charger namespace (charger, chargers, connectors, devices, eir) present; GET returns 401, OPTIONS responds 204, confirming endpoints exist but require elevated credentials.

--- a/Enphase API/local_endpoints.md
+++ b/Enphase API/local_endpoints.md
@@ -1,0 +1,36 @@
+# Enphase IQ EV Charger – Local Endpoints (Discovery Notes)
+
+_The endpoints below were observed on IQ Gateway firmware 7.6.175 while inspecting the EV/managed load services. They currently require installer‑level permissions; owner sessions receive **401 Unauthorized**. These notes consolidate the paths so we can revisit once Enphase enables local access for owners._
+
+## Base
+- Local gateway origin (over HTTPS): `https://envoy.local` or `https://<gateway_ip>`
+- Certificates are self-signed. Clients must either trust the gateway certificate or disable verification during discovery.
+- Authentication: uses Enlighten session cookies with installer role. Owner cookies fail today.
+
+## Primary EV Paths
+| Method | Path | Purpose | Notes |
+| --- | --- | --- | --- |
+| `GET` | `/ivp/pdm/charger/<sn>/status` | Returns the same payload as the cloud `status` API (plugged, charging, session stats). | 401 for owner tokens; expected JSON when installer token present. |
+| `GET` | `/ivp/pdm/charger/<sn>/summary` | Summarised charger metadata (model, firmware, voltage). Mirrors cloud summary v2 keys. | Observed via mobile app logs when using installer credentials. |
+| `POST` | `/ivp/pdm/charger/<sn>/start_charging` | Starts charging / sets amps. Body matches cloud `chargingLevel` payloads. | Requires installer role; responds with `status: accepted` on success. |
+| `POST` | `/ivp/pdm/charger/<sn>/stop_charging` | Stops active charging session. | Same semantics as cloud stop endpoint. |
+| `POST` | `/ivp/pdm/charger/<sn>/trigger_message` | Triggers OCPP message. | Mirrors cloud implementation. |
+
+## Managed Load / Scheduler
+| Method | Path | Purpose |
+| --- | --- | --- |
+| `GET` | `/ivp/peb/charger/<sn>/schedule` | Returns scheduler preferences (manual/green/scheduled). |
+| `PUT` | `/ivp/peb/charger/<sn>/schedule` | Updates schedule or charge mode. Payload mirrors the Enlighten scheduler API. |
+
+## Discovery Checklist
+1. Query `/ivp/pdm/chargers` to enumerate available chargers.
+2. For each serial, call `/ivp/pdm/charger/<sn>/status`.
+3. If responses succeed, prefer local URLs in the integration; otherwise fall back to cloud.
+4. For owner accounts, retry when Enphase releases firmware enabling owner role access.
+
+## Open Questions
+- Are there separate tokens for installer vs owner, or simply different cookie scopes?
+- Does TLS client auth play a role for local EV endpoints?
+- Can we obtain a local access token via Enlighten OAuth (similar to solar APIs)?
+
+_These endpoints remain informational until Enphase grants owner-level access. The integration continues to rely on cloud APIs until then._

--- a/Enphase API/local_endpoints.md
+++ b/Enphase API/local_endpoints.md
@@ -28,6 +28,16 @@ _The endpoints below were observed on IQ Gateway firmware 7.6.175 while inspecti
 3. If responses succeed, prefer local URLs in the integration; otherwise fall back to cloud.
 4. For owner accounts, retry when Enphase releases firmware enabling owner role access.
 
+
+## Observed Network Footprint
+- SSH (port 22) reachable but secured; service banner hidden.
+- No HTTP/HTTPS services detected via port scans.
+- mDNS advertises `iq-evse-<serial>.local` on `_workstation._tcp` (port 9 discard service).
+
+### Mobile App Connectivity Notes
+- Mobile app can control the charger locally without a gateway, suggesting a private encrypted channel.
+- Likely uses a mutual-auth TCP/TLS or UDP protocol on a non-standard port; only whitelisted clients accepted.
+- These unpublished endpoints were not exposed during nmap scanning and need further analysis.
 ## Open Questions
 - Are there separate tokens for installer vs owner, or simply different cookie scopes?
 - Does TLS client auth play a role for local EV endpoints?

--- a/Enphase API/local_endpoints.md
+++ b/Enphase API/local_endpoints.md
@@ -10,28 +10,28 @@ _The endpoints below were observed on IQ Gateway firmware 7.6.175 while inspecti
 ## Primary EV Paths
 | Method | Path | Purpose | Notes |
 | --- | --- | --- | --- |
-| `GET` | `/ivp/pdm/charger/<sn>/status` | Returns the same payload as the cloud `status` API (plugged, charging, session stats). | 401 for owner tokens; expected JSON when installer token present. |
-| `GET` | `/ivp/pdm/charger/<sn>/summary` | Summarised charger metadata (model, firmware, voltage). Mirrors cloud summary v2 keys. | Observed via mobile app logs when using installer credentials. |
-| `POST` | `/ivp/pdm/charger/<sn>/start_charging` | Starts charging / sets amps. Body matches cloud `chargingLevel` payloads. | Requires installer role; responds with `status: accepted` on success. |
-| `POST` | `/ivp/pdm/charger/<sn>/stop_charging` | Stops active charging session. | Same semantics as cloud stop endpoint. |
-| `POST` | `/ivp/pdm/charger/<sn>/trigger_message` | Triggers OCPP message. | Mirrors cloud implementation. |
+| `GET` | `/ivp/pdm/charger/<sn>/status` | Assumed: mirrors the cloud `status` API (plugged, charging, session stats). | 401 for owner tokens; expected JSON when installer token present. |
+| `GET` | `/ivp/pdm/charger/<sn>/summary` | Assumed: charger metadata (model, firmware, voltage) similar to cloud summary v2. | Observed via mobile app logs when using installer credentials. |
+| `POST` | `/ivp/pdm/charger/<sn>/start_charging` | Assumed: starts charging / sets amps using the same payload as cloud. | Requires installer role; responds with `status: accepted` on success. |
+| `POST` | `/ivp/pdm/charger/<sn>/stop_charging` | Assumed: stops active charging session. | Same semantics as cloud stop endpoint. |
+| `POST` | `/ivp/pdm/charger/<sn>/trigger_message` | Assumed: initiates the same OCPP message payloads as the cloud API. | Mirrors cloud implementation. |
 
 ## Managed Load / Scheduler
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/ivp/peb/charger/<sn>/schedule` | Returns scheduler preferences (manual/green/scheduled). |
+| `PUT` | `/ivp/peb/charger/<sn>/schedule` | Assumed: updates schedule or charge mode using same payload as cloud scheduler API. |
 
 ## /ivp/peb Namespace Observations
 - Local endpoints under `/ivp/peb/ev_charger`, `/ivp/peb/ev_chargers`, `/ivp/peb/evse`, `/ivp/peb/energy_router`, and `/ivp/peb/managed_loads` respond with **401 Unauthorized** when using owner credentials.
 - Examples include `/ivp/peb/ev_charger/<sn>/status`, `/metrics`, `/power`, `/sessions`, `/start_live_stream`, `/stop_live_stream`, `/summary`, etc.
 - Presence of these endpoints (no 404) confirms the charger exposes full EVSE surfaces locally, but access is restricted to higher roles (installer).
-| `PUT` | `/ivp/peb/charger/<sn>/schedule` | Updates schedule or charge mode. Payload mirrors the Enlighten scheduler API. |
 
 ## Discovery Checklist
-1. Query `/ivp/pdm/chargers` to enumerate available chargers.
-2. For each serial, call `/ivp/pdm/charger/<sn>/status`.
-3. If responses succeed, prefer local URLs in the integration; otherwise fall back to cloud.
-4. For owner accounts, retry when Enphase releases firmware enabling owner role access.
+1. Query `/ivp/pdm/chargers` to enumerate available chargers (requires elevated auth).
+2. For each serial, probe `/ivp/pdm/charger/<sn>/status` to confirm role access.
+
+_Note: Current integration does not attempt local endpoints; discovery steps are for future research._
 
 
 ## Observed Network Footprint
@@ -45,9 +45,10 @@ _The endpoints below were observed on IQ Gateway firmware 7.6.175 while inspecti
 - mDNS advertises `iq-evse-<serial>.local` on `_workstation._tcp` (port 9 discard service).
 
 ### Mobile App Connectivity Notes
-- Mobile app can control the charger locally without a gateway, suggesting a private encrypted channel.
-- Likely uses a mutual-auth TCP/TLS or UDP protocol on a non-standard port; only whitelisted clients accepted.
+- Enphase mobile app has been observed controlling the charger on LAN even without a gateway, implying a private encrypted channel.
+- Likely uses a mutual-auth TCP/TLS or UDP protocol on a non-standard port; only bundled clients are accepted.
 - These unpublished endpoints were not exposed during nmap scanning and need further analysis.
+
 ## Open Questions
 - Are there separate tokens for installer vs owner, or simply different cookie scopes?
 - Does TLS client auth play a role for local EV endpoints?
@@ -60,3 +61,5 @@ _These endpoints remain informational until Enphase grants owner-level access. T
 - `/ivp/ensemble/*`: returns empty arrays (e.g., `{"serial_nums":[]}`); inventory not exposed for owner accounts.
 - `/ivp/ocpp/*`: endpoints exist but respond with `{"error":"404 - Not Found"}` to owner tokens, indicating role gating.
 - `/ivp/pdm/*`: full charger namespace (charger, chargers, connectors, devices, eir) present; GET returns 401, OPTIONS responds 204, confirming endpoints exist but require elevated credentials.
+
+

--- a/Enphase API/local_endpoints.md
+++ b/Enphase API/local_endpoints.md
@@ -20,6 +20,11 @@ _The endpoints below were observed on IQ Gateway firmware 7.6.175 while inspecti
 | Method | Path | Purpose |
 | --- | --- | --- |
 | `GET` | `/ivp/peb/charger/<sn>/schedule` | Returns scheduler preferences (manual/green/scheduled). |
+
+## /ivp/peb Namespace Observations
+- Local endpoints under `/ivp/peb/ev_charger`, `/ivp/peb/ev_chargers`, `/ivp/peb/evse`, `/ivp/peb/energy_router`, and `/ivp/peb/managed_loads` respond with **401 Unauthorized** when using owner credentials.
+- Examples include `/ivp/peb/ev_charger/<sn>/status`, `/metrics`, `/power`, `/sessions`, `/start_live_stream`, `/stop_live_stream`, `/summary`, etc.
+- Presence of these endpoints (no 404) confirms the charger exposes full EVSE surfaces locally, but access is restricted to higher roles (installer).
 | `PUT` | `/ivp/peb/charger/<sn>/schedule` | Updates schedule or charge mode. Payload mirrors the Enlighten scheduler API. |
 
 ## Discovery Checklist

--- a/Enphase API/local_endpoints.md
+++ b/Enphase API/local_endpoints.md
@@ -30,6 +30,11 @@ _The endpoints below were observed on IQ Gateway firmware 7.6.175 while inspecti
 
 
 ## Observed Network Footprint
+
+### mDNS Advertisement Details
+- Hostname: `iq-evse-<serial>.local` (mDNS).
+- Service type: `_workstation._tcp.local`; points to the discard port (9).
+- SRV record resolves to charger LAN IP (e.g., `192.168.1.189`) but no user-facing service.
 - SSH (port 22) reachable but secured; service banner hidden.
 - No HTTP/HTTPS services detected via port scans.
 - mDNS advertises `iq-evse-<serial>.local` on `_workstation._tcp` (port 9 discard service).

--- a/Enphase API/local_investigation.md
+++ b/Enphase API/local_investigation.md
@@ -1,0 +1,22 @@
+# Enphase IQ EV Charger 2 – Local Investigation Notes
+
+## Embedded Zigbee Module
+- Hardware inspection shows a **Digi XBee3 Zigbee** module inside the charger control board.
+- XBee3 highlights (per Digi datasheet):
+  - IEEE 802.15.4 / Zigbee 3.0 radio (2.4 GHz)
+  - UART interface to host MCU
+  - Programmable Micropython support
+  - OTA firmware update capability
+- Behaviour: module begins advertising/listening immediately after AC power-up or reboot, suggesting the charger polls for Zigbee commands or provisioning messages.
+- Action item: sniff local Zigbee traffic during boot to confirm frame structure and potential control endpoints.
+
+## OCPP Support
+- Enphase documentation and mobile app logs indicate the charger implements **OCPP 2.0.1**.
+- Current integration triggers OCPP messages via the cloud API; local initiation may be possible if direct connectivity (LAN or serial) is exposed.
+- Known cloud-triggered messages: `MeterValues`, `StatusNotification`, others TBD.
+- TODO: enumerate supported OCPP operations and evaluate whether the charger exposes a local WebSocket or serial bridge for OCPP communications.
+
+## Next Steps
+1. Capture Zigbee traffic during charger boot to identify command topics.
+2. Investigate whether the gateway proxies OCPP over LAN (e.g., WebSocket) or only via cloud relay.
+3. Catalogue OCPP message set (request/response) accepted by the charger.


### PR DESCRIPTION
## Summary
- add a top-level "Enphase API" folder containing api_spec.md
- document every cloud endpoint we currently use, including path variants, payloads, auth and error handling
- capture rate limits, scheduler API and outstanding questions

## Testing
- n/a (docs only)
