### PR TITLE
device: drop default_model for chargers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.8.6
+- Fix Home Assistant DeviceInfo validation by removing `default_model` from charger device registry entries.
+- Bump manifest version to 0.8.6.
+
 ## v0.8.4
 - Sensors: rename Dynamic Load Balancing status, add enabled/disabled icons, and update translations.
 - Cleanup: remove the deprecated `binary_sensor.iq_ev_charger_dlb_active` and its coordinator payload.

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -85,8 +85,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             model_display = dev_name
         if model_display:
             kwargs["model"] = model_display
-            if model_name:
-                kwargs.setdefault("default_model", model_name)
         model_id = d.get("model_id")
         # Device registry does not support a separate model_id field; ignore it
         hw = d.get("hw_version")

--- a/custom_components/enphase_ev/entity.py
+++ b/custom_components/enphase_ev/entity.py
@@ -52,8 +52,6 @@ class EnphaseBaseEntity(CoordinatorEntity[EnphaseCoordinator]):
         # Optional enrichment when available
         if model_display:
             info_kwargs["model"] = model_display
-            if model_name:
-                info_kwargs.setdefault("default_model", model_name)
         if d.get("hw_version"):
             info_kwargs["hw_version"] = str(d.get("hw_version"))
         if d.get("sw_version"):

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -14,5 +14,5 @@
   ],
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.8.4"
+  "version": "0.8.6"
 }

--- a/tests_enphase_ev/test_device_info.py
+++ b/tests_enphase_ev/test_device_info.py
@@ -22,5 +22,4 @@ def test_device_info_uses_display_name_and_model():
 
     assert info["name"] == "Garage Charger"
     assert info["model"] == "Garage Charger (IQ-EVSE-EU-3032)"
-    assert info.get("default_model") == "IQ-EVSE-EU-3032"
     assert info["serial_number"] == "555555555555"

--- a/tests_enphase_ev/test_entity_wiring.py
+++ b/tests_enphase_ev/test_entity_wiring.py
@@ -57,4 +57,3 @@ def test_device_info_includes_model_name_when_available():
     info = ent.device_info
     assert info["name"] == "IQ EV Charger"
     assert info["model"] == "IQ EV Charger (IQ-EVSE-EU-3032)"
-    assert info.get("default_model") == "IQ-EVSE-EU-3032"


### PR DESCRIPTION
## Summary
- remove  from charger device registry entries to satisfy HA DeviceInfo validation

## Testing
- pytest -q
