### PR TITLE
Fix device automation blocking import

### DIFF
--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -6,6 +6,7 @@
   ],
   "config_flow": true,
   "documentation": "https://github.com/barneyonline/ha-enphase-ev-charger",
+  "import_executor": true,
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/barneyonline/ha-enphase-ev-charger/issues",


### PR DESCRIPTION
## Summary
- enable manifest import_executor so Home Assistant loads device_action via the executor instead of the event loop

## Testing
- pytest -q tests_enphase_ev
