### PR TITLE
Release 0.8.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## v0.8.6
-- Fix Home Assistant DeviceInfo validation by removing `default_model` from charger device registry entries.
-- Bump manifest version to 0.8.6.
+## v0.8.7
+- Manifest: opt into Home Assistant's `import_executor` to prevent device automation imports from blocking the event loop.
+- Device registry: remove `default_model` from charger entries to satisfy DeviceInfo validation updates.
 
 ## v0.8.4
 - Services: scope start/stop/trigger actions to Enphase charger targets, support multi-device calls, surface OCPP responses, and add advanced field sections.

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "gold",
   "requirements": [],
-  "version": "0.8.6"
+  "version": "0.8.7"
 }


### PR DESCRIPTION
## Summary
- bump manifest version to 0.8.7
- document the import executor change and device registry fix under a consolidated v0.8.7 entry

## Testing
- pytest -q tests_enphase_ev
- DOCKER_HOST=unix:///Users/james/.colima/default/docker.sock docker run --rm -v /tmp-hassfest:/github/workspace ghcr.io/home-assistant/hassfest (clean integration copy)
