### PR TITLE
Auto-discover site list during onboarding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
-AGENTS.md
+__pycache__/
+.pytest_cache/
+.ruff_cache/
+.venv*/
+Enphase API/ocpp_messages.md
+enphase_ev_custom_docs/

--- a/Enphase API/api_spec.md
+++ b/Enphase API/api_spec.md
@@ -11,6 +11,7 @@ _This reference consolidates everything the integration has learned from reverse
   - `<site_id>` — numeric site identifier
   - `<sn>` — charger serial number
   - `connectorId` — connector index; currently always `1`
+- **Discovery:** `GET /service/evse_controller/sites` (fallbacks: `/api/v1/sites`, `/sites.json`) enumerates the account's accessible sites, returning `site_id` and optional `name` fields that the config flow can surface without manual entry.
 
 ---
 

--- a/tests_enphase_ev/test_auth_site_discovery.py
+++ b/tests_enphase_ev/test_auth_site_discovery.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import aiohttp
+import pytest
+from yarl import URL
+
+from custom_components.enphase_ev import api
+
+
+@pytest.mark.asyncio
+async def test_async_authenticate_populates_site_headers(monkeypatch):
+    site_headers: list[dict[str, str]] = []
+
+    async def _fake_request_json(
+        session: aiohttp.ClientSession,
+        method: str,
+        url: str,
+        *,
+        timeout: int,
+        headers: dict[str, str] | None = None,
+        data=None,
+        json_data=None,
+    ):
+        if url == api.LOGIN_URL:
+            session.cookie_jar.update_cookies(
+                {
+                    "XSRF-TOKEN": "xsrf123",
+                    "enlighten_session": "sess123",
+                },
+                response_url=URL(api.BASE_URL),
+            )
+            return {"session_id": "sid123"}
+        if url == f"{api.ENTREZ_URL}/tokens":
+            return {"token": "token123", "expires_at": 1700000000}
+        if url.endswith("/service/evse_controller/sites"):
+            site_headers.append(headers or {})
+            return {"data": [{"site_id": 3381244, "name": "Garage"}]}
+        raise AssertionError(f"Unexpected URL: {url}")
+
+    monkeypatch.setattr(api, "_request_json", _fake_request_json)
+
+    async with aiohttp.ClientSession() as session:
+        tokens, sites = await api.async_authenticate(session, "user@example.com", "secret")
+
+    assert tokens.access_token == "token123"
+    assert sites and sites[0].site_id == "3381244"
+    assert site_headers, "Site discovery request headers were not captured"
+
+    captured = site_headers[0]
+    assert captured["X-CSRF-Token"] == "xsrf123"
+    assert captured["X-Requested-With"] == "XMLHttpRequest"
+    assert captured["Referer"] == f"{api.BASE_URL}/"
+    assert captured["Authorization"] == "Bearer token123"
+    assert captured["e-auth-token"] == "token123"
+    # Ensure the caller explicitly sets Cookie so the request works without relying on session defaults
+    assert "Cookie" in captured and "enlighten_session" in captured["Cookie"]


### PR DESCRIPTION
## Summary
- send Enlighten cookies, bearer token, and XSRF header when calling /service/evse_controller/sites so the config flow can auto-populate site IDs
- document the cloud site discovery endpoint and add Docker-based testing instructions for agents
- add a regression test covering async_authenticate site discovery headers

## Testing
- docker-compose run --rm ha-dev bash -lc 'pip install pre-commit && git config --global --add safe.directory /workspace && pre-commit run --all-files'
- pytest tests_enphase_ev/test_auth_site_discovery.py