### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.1.0
+- Authentication: auto-populate Enlighten site discovery headers (XSRF, cookies, bearer tokens) so account sites load reliably without manual header capture.
+- Services: allow targeting Start/Stop Live Stream calls by site, wiring the service schema up with site-aware selectors.
+- Coordinator: tolerate the new `charginglevel` payload casing and normalise operating voltage parsing so set amps and power math stay accurate.
+- Bug fixes & performance: resolve the zero-amp charging state regression, keep live stream refreshes scoped to the requested site, and stabilise power calculations by smoothing voltage updates.
+- Tooling & Docs: add a Docker-based dev environment, document its usage, and extend tests for the refreshed authentication flow.
+
 ## v1.0.0
 - Coordinator & options: harden API retries with exponential backoff, raise Home Assistant Repairs issues when the cloud is unreachable or rate limited, and expose an adjustable API timeout in the options flow.
 - Power sensor: derive each charger's max watt throughput from the reported amps/voltage so gauges and attributes scale to the installation.

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ If the login form reports that multi-factor authentication is required, complete
 | `enphase_ev.stop_charging` | Stop charging on the charger(s) selected via the service target. | None |
 | `enphase_ev.trigger_message` | Request the selected charger(s) to send an OCPP message and return the cloud response. | `requested_message` (required; e.g. `MeterValues`). Advanced: `site_id` (optional override) |
 | `enphase_ev.clear_reauth_issue` | Clear the integration’s reauthentication repair for the chosen site device(s). | `site_id` (optional override) |
-| `enphase_ev.start_live_stream` | Request faster cloud status updates for a short period. | None |
-| `enphase_ev.stop_live_stream` | Stop the cloud live stream request. | None |
+| `enphase_ev.start_live_stream` | Request faster cloud status updates for a short period. | Advanced fields: `site_id` (optional; stream a specific site) |
+| `enphase_ev.stop_live_stream` | Stop the cloud live stream request. | Advanced fields: `site_id` (optional; stop streaming for a specific site) |
 
 ## Privacy & Rate Limits
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "gold",
   "requirements": [],
-  "version": "1.0.0"
+  "version": "1.1.0"
 }


### PR DESCRIPTION
## Summary
- bump the manifest version to 1.1.0
- document the 1.1.0 changes in the changelog
- refresh README service docs to match the new site targeting fields

## Testing
- not run