### PR TITLE
Enrich Energy Today with session history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+- Session history: document the Enlighten session history endpoint, cache daily results, expose per-session energy/cost metadata via the Energy Today sensor, and trim cross-midnight sessions so only the in-day energy is counted.
+
 ## v1.1.0
 - Authentication: auto-populate Enlighten site discovery headers (XSRF, cookies, bearer tokens) so account sites load reliably without manual header capture.
 - Services: allow targeting Start/Stop Live Stream calls by site, wiring the service schema up with site-aware selectors.

--- a/Enphase API/api_spec.md
+++ b/Enphase API/api_spec.md
@@ -97,6 +97,66 @@ Ends the fast polling window.
 { "status": "accepted" }
 ```
 
+### 2.5 Session History
+```
+POST /service/enho_historical_events_ms/<site_id>/sessions/<sn>/history
+Body: {
+  "startDate": "16-10-2025",
+  "endDate": "16-10-2025",
+  "offset": 0,
+  "limit": 20
+}
+Headers:
+  Accept: application/json, text/javascript, */*; q=0.01
+  Authorization: Bearer <jwt>
+  Cookie: ...; XSRF-TOKEN=<token>; ...
+  e-auth-token: <token>
+  X-Requested-With: XMLHttpRequest
+```
+Returns a list of recent charging sessions for the requested charger. `startDate`/`endDate` are `DD-MM-YYYY` in the site's local timezone. The response indicates whether more pages are available via `hasMore`.
+
+Example response:
+```json
+{
+  "source": "evse",
+  "timestamp": "2025-10-16T08:45:14.230924038Z",
+  "data": {
+    "result": [
+      {
+        "id": "123456789012:1700000001",
+        "sessionId": 1700000001,
+        "startTime": "2025-10-16T00:02:08.826Z[UTC]",
+        "endTime": "2025-10-16T04:39:50.618Z[UTC]",
+        "authType": null,
+        "authIdentifier": null,
+        "authToken": null,
+        "aggEnergyValue": 29.94,
+        "activeChargeTime": 15284,
+        "milesAdded": 120.7,
+        "sessionCost": 0.77,
+        "costCalculated": true,
+        "manualOverridden": true,
+        "avgCostPerUnitEnergy": 0.03,
+        "sessionCostState": "COST_CALCULATED",
+        "chargeProfileStackLevel": 4
+      }
+    ],
+    "hasMore": true,
+    "startDate": "10-08-2022",
+    "endDate": "16-10-2025",
+    "offset": 0,
+    "limit": 20
+  }
+}
+```
+Fields of interest:
+- `aggEnergyValue` — energy delivered in kWh for the session.
+- `activeChargeTime` — session duration in seconds while actively charging.
+- `milesAdded` — range added in miles (region-specific; may be `null`).
+- `sessionCost`/`avgCostPerUnitEnergy` — cost metadata when tariffs are configured.
+- `authType`/`authIdentifier`/`authToken` — authentication metadata recorded by Enlighten (often `null` for residential accounts).
+- `sessionCostState` — cost calculation status such as `COST_CALCULATED`.
+
 ---
 
 ## 3. Control Operations

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ If the login form reports that multi-factor authentication is required, complete
 | `enphase_ev.start_live_stream` | Request faster cloud status updates for a short period. | Advanced fields: `site_id` (optional; stream a specific site) |
 | `enphase_ev.stop_live_stream` | Stop the cloud live stream request. | Advanced fields: `site_id` (optional; stop streaming for a specific site) |
 
+- The `Energy Today` sensor exposes a `sessions_today` attribute containing each charging session completed during the current day (start/end, authentication metadata, active charge time, energy added, miles added, and session cost), supporting multiple sessions per day and trimming cross-midnight sessions to their in-day contribution.
+
 ## Privacy & Rate Limits
 
 - Credentials are stored in HA’s config entries and redacted from diagnostics.

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -692,3 +692,30 @@ class EnphaseEVClient:
             return data.get("data") or []
         except Exception:
             return None
+
+    async def session_history(
+        self,
+        sn: str,
+        *,
+        start_date: str,
+        end_date: str | None = None,
+        offset: int = 0,
+        limit: int = 20,
+    ) -> dict:
+        """Fetch charging sessions for a charger between the provided dates.
+
+        POST /service/enho_historical_events_ms/<site_id>/sessions/<sn>/history
+        Dates must be formatted as DD-MM-YYYY in the site locale.
+        """
+        url = f"{BASE_URL}/service/enho_historical_events_ms/{self._site}/sessions/{sn}/history"
+        payload = {
+            "startDate": start_date,
+            "endDate": end_date or start_date,
+            "offset": int(offset),
+            "limit": int(limit),
+        }
+        headers = dict(self._h)
+        bearer = self._bearer() or self._eauth
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
+        return await self._json("POST", url, json=payload, headers=headers)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    session_history_real: enable real session history calls in coordinator tests

--- a/tests_enphase_ev/conftest.py
+++ b/tests_enphase_ev/conftest.py
@@ -143,6 +143,27 @@ def stub_issue_registry(monkeypatch):
     )
 
 
+@pytest.fixture(autouse=True)
+def stub_session_history(monkeypatch, request):
+    try:
+        from custom_components.enphase_ev import coordinator as coord_mod
+    except Exception:
+        return
+
+    if request.node.get_closest_marker("session_history_real"):
+        return
+
+    async def _fake_sessions(self, sn, *, day_local=None):
+        return []
+
+    monkeypatch.setattr(
+        coord_mod.EnphaseCoordinator,
+        "_async_fetch_sessions_today",
+        _fake_sessions,
+        raising=False,
+    )
+
+
 class _DummyResponse:
     def __init__(self, *, json_data=None, status=200):
         self._json = json_data or {}

--- a/tests_enphase_ev/test_coordinator_behavior.py
+++ b/tests_enphase_ev/test_coordinator_behavior.py
@@ -1,4 +1,5 @@
 import asyncio
+from datetime import datetime, timezone
 import aiohttp
 import pytest
 
@@ -202,6 +203,382 @@ async def test_streaming_prefers_fast(hass, monkeypatch):
     coord._streaming = True
     await coord._async_update_data()
     assert int(coord.update_interval.total_seconds()) == 6
+
+
+@pytest.mark.asyncio
+async def test_session_history_enrichment(hass, monkeypatch):
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+    from custom_components.enphase_ev import coordinator as coord_mod
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    cfg = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 15,
+    }
+
+    class DummyEntry:
+        def __init__(self):
+            self.options = {}
+
+        def async_on_unload(self, cb):
+            return None
+
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    coord = EnphaseCoordinator(hass, cfg, config_entry=DummyEntry())
+
+    class StubClient:
+        async def status(self):
+            return {
+                "evChargerData": [
+                    {
+                        "sn": RANDOM_SERIAL,
+                        "name": "Garage EV",
+                        "charging": False,
+                        "pluggedIn": True,
+                    }
+                ]
+            }
+
+        async def summary_v2(self):
+            return []
+
+        async def charge_mode(self, sn):
+            return None
+
+    coord.client = StubClient()
+
+    async def _fake_sessions(self, sn, *, day_local=None):
+        return [
+            {
+                "session_id": "stub-1",
+                "start": "2025-10-16T00:00:00+00:00",
+                "end": "2025-10-16T01:00:00+00:00",
+                "energy_kwh_total": 4.5,
+                "energy_kwh": 4.5,
+                "active_charge_time_s": 3600,
+                "auth_type": None,
+                "auth_identifier": None,
+                "auth_token": None,
+                "miles_added": 15.0,
+                "session_cost": 1.1,
+                "avg_cost_per_kwh": 0.24,
+                "cost_calculated": True,
+                "manual_override": False,
+                "session_cost_state": "COST_CALCULATED",
+                "charge_profile_stack_level": 0,
+            },
+            {
+                "session_id": "stub-2",
+                "start": "2025-10-16T04:00:00+00:00",
+                "end": "2025-10-16T05:30:00+00:00",
+                "energy_kwh_total": 2.0,
+                "energy_kwh": 2.0,
+                "active_charge_time_s": 5400,
+                "auth_type": "RFID",
+                "auth_identifier": "user",
+                "auth_token": "token",
+                "miles_added": 8.0,
+                "session_cost": 0.6,
+                "avg_cost_per_kwh": 0.3,
+                "cost_calculated": True,
+                "manual_override": True,
+                "session_cost_state": "COST_CALCULATED",
+                "charge_profile_stack_level": 4,
+            },
+            {
+                "session_id": "stub-3",
+                "start": "2025-10-15T23:30:00+00:00",
+                "end": "2025-10-16T00:30:00+00:00",
+                "energy_kwh_total": 4.0,
+                "energy_kwh": 2.0,
+                "active_charge_time_s": 3600,
+                "auth_type": None,
+                "auth_identifier": None,
+                "auth_token": None,
+                "miles_added": 10.0,
+                "session_cost": 0.5,
+                "avg_cost_per_kwh": 0.25,
+                "cost_calculated": True,
+                "manual_override": False,
+                "session_cost_state": "COST_CALCULATED",
+                "charge_profile_stack_level": 2,
+            },
+        ]
+
+    coord._async_fetch_sessions_today = _fake_sessions.__get__(coord, coord.__class__)
+
+    data = await coord._async_update_data()
+    st = data[RANDOM_SERIAL]
+    assert st["energy_today_sessions_kwh"] == pytest.approx(8.5, abs=1e-3)
+    assert len(st["energy_today_sessions"]) == 3
+    cross_midnight = st["energy_today_sessions"][2]
+    assert cross_midnight["energy_kwh_total"] == pytest.approx(4.0)
+    assert cross_midnight["energy_kwh"] == pytest.approx(2.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.session_history_real
+async def test_session_history_cross_midnight_split(hass, monkeypatch):
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+    from custom_components.enphase_ev import coordinator as coord_mod
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from homeassistant.util import dt as dt_util
+
+    cfg = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 15,
+    }
+
+    class DummyEntry:
+        def __init__(self):
+            self.options = {}
+
+        def async_on_unload(self, cb):
+            return None
+
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    coord = EnphaseCoordinator(hass, cfg, config_entry=DummyEntry())
+
+    day_now = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: day_now)
+
+    client = coord.client
+    calls: list[dict] = []
+
+    async def fake_session_history(self, sn, *, start_date, end_date, offset, limit):
+        calls.append(
+            {
+                "sn": sn,
+                "start_date": start_date,
+                "end_date": end_date,
+                "offset": offset,
+                "limit": limit,
+            }
+        )
+        return {
+            "data": {
+                "result": [
+                    {
+                        "sessionId": 1,
+                        "startTime": "2025-10-15T23:30:00Z[UTC]",
+                        "endTime": "2025-10-16T01:30:00Z[UTC]",
+                        "aggEnergyValue": 6.0,
+                        "activeChargeTime": 7200,
+                    },
+                    {
+                        "sessionId": 2,
+                        "startTime": "2025-10-16T04:00:00Z[UTC]",
+                        "endTime": "2025-10-16T05:00:00Z[UTC]",
+                        "aggEnergyValue": 3.0,
+                        "activeChargeTime": 3600,
+                    },
+                ],
+                "hasMore": False,
+                "startDate": start_date,
+                "endDate": end_date,
+            }
+        }
+
+    monkeypatch.setattr(
+        client,
+        "session_history",
+        fake_session_history.__get__(client, client.__class__),
+        raising=False,
+    )
+
+    sessions = await coord._async_fetch_sessions_today(RANDOM_SERIAL, day_local=day_now)
+    assert calls, "session_history should have been called"
+    assert len(sessions) == 2
+    assert len(calls) == 1
+
+    first = sessions[0]
+    assert first["energy_kwh_total"] == pytest.approx(6.0)
+    # Only 1.5 hours of a 2 hour session occur within the day -> 75%
+    assert first["energy_kwh"] == pytest.approx(4.5)
+    assert first["active_charge_time_overlap_s"] == 5400
+
+    second = sessions[1]
+    assert second["energy_kwh"] == pytest.approx(3.0)
+
+    # Cached result should be reused
+    calls.clear()
+    again = await coord._async_fetch_sessions_today(RANDOM_SERIAL, day_local=day_now)
+    assert not calls
+    assert again == sessions
+
+
+@pytest.mark.asyncio
+@pytest.mark.session_history_real
+async def test_session_history_unauthorized_falls_back(hass, monkeypatch):
+    from custom_components.enphase_ev.api import Unauthorized
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+    from custom_components.enphase_ev import coordinator as coord_mod
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    cfg = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 15,
+    }
+
+    class DummyEntry:
+        def __init__(self):
+            self.options = {}
+
+        def async_on_unload(self, cb):
+            return None
+
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    coord = EnphaseCoordinator(hass, cfg, config_entry=DummyEntry())
+
+    class StubClient:
+        async def status(self):
+            return {
+                "evChargerData": [
+                    {
+                        "sn": RANDOM_SERIAL,
+                        "name": "Garage EV",
+                        "charging": False,
+                        "pluggedIn": True,
+                    }
+                ],
+                "ts": 1757299870275,
+            }
+
+        async def summary_v2(self):
+            return []
+
+        async def charge_mode(self, sn):
+            return None
+
+        async def session_history(self, *args, **kwargs):
+            raise Unauthorized()
+
+    coord.client = StubClient()
+
+    data = await coord._async_update_data()
+    st = data[RANDOM_SERIAL]
+    assert st["energy_today_sessions"] == []
+    assert st["energy_today_sessions_kwh"] == 0.0
+
+
+@pytest.mark.asyncio
+@pytest.mark.session_history_real
+async def test_session_history_inflight_session_counts_energy(hass, monkeypatch):
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+    from custom_components.enphase_ev import coordinator as coord_mod
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from homeassistant.util import dt as dt_util
+
+    cfg = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 15,
+    }
+
+    class DummyEntry:
+        def __init__(self):
+            self.options = {}
+
+        def async_on_unload(self, cb):
+            return None
+
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    coord = EnphaseCoordinator(hass, cfg, config_entry=DummyEntry())
+
+    # Fix "now" for the coordinator so the ongoing session overlaps the day
+    now_local = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: now_local)
+
+    class StubClient:
+        async def status(self):
+            return {
+                "evChargerData": [
+                    {
+                        "sn": RANDOM_SERIAL,
+                        "name": "Garage EV",
+                        "charging": True,
+                        "pluggedIn": True,
+                    }
+                ],
+                "ts": 1757299870275,
+            }
+
+        async def summary_v2(self):
+            return []
+
+        async def charge_mode(self, sn):
+            return None
+
+        async def session_history(self, *args, **kwargs):
+            return {
+                "data": {
+                    "result": [
+                        {
+                            "sessionId": 99,
+                            "startTime": "2025-10-16T09:30:00Z[UTC]",
+                            "endTime": None,
+                            "aggEnergyValue": 4.0,
+                            "activeChargeTime": 7200,
+                        }
+                    ],
+                    "hasMore": False,
+                }
+            }
+
+    coord.client = StubClient()
+
+    data = await coord._async_update_data()
+    st = data[RANDOM_SERIAL]
+    sessions = st["energy_today_sessions"]
+    assert sessions and len(sessions) == 1
+    inflight = sessions[0]
+    assert inflight["energy_kwh_total"] == pytest.approx(4.0)
+    assert inflight["energy_kwh"] == pytest.approx(4.0)
+    assert inflight["active_charge_time_overlap_s"] > 0
+    assert st["energy_today_sessions_kwh"] == pytest.approx(4.0)
 
 
 @pytest.mark.asyncio

--- a/tests_enphase_ev/test_summary_enrichment.py
+++ b/tests_enphase_ev/test_summary_enrichment.py
@@ -106,3 +106,5 @@ async def test_summary_v2_enrichment(hass, monkeypatch):
     assert st["model_name"] == "MODEL-NAME"
     assert st["model_id"] == "MODEL-SKU-0000"
     assert st["display_name"] == "Garage Charger"
+    assert st["energy_today_sessions"] == []
+    assert st["energy_today_sessions_kwh"] == 0.0


### PR DESCRIPTION
## Summary
- document the Enlighten session-history endpoint and add a client helper for it
- cache per-day session history in the coordinator and expose session totals in data dicts
- update the Energy Today sensor/docs/tests so daily totals come from session history with detailed attributes

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"