### PR TITLE
Clamp start charging commands to charger limits

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -255,9 +255,7 @@ def _register_services(hass: HomeAssistant) -> None:
             if not coord:
                 continue
             level = call.data.get("charging_level")
-            if level is None:
-                level = coord.last_set_amps.get(sn, 32)
-            amps = int(level)
+            amps = coord.pick_start_amps(sn, level)
             await coord.client.start_charging(sn, amps, connector_id)
             coord.set_last_set_amps(sn, amps)
             coord.kick_fast(90)

--- a/custom_components/enphase_ev/button.py
+++ b/custom_components/enphase_ev/button.py
@@ -32,8 +32,8 @@ class StartChargeButton(_BaseButton):
         super().__init__(coord, sn, "Start Charging")
         self._attr_translation_key = "start_charging"
     async def async_press(self) -> None:
-        # Use last requested amps or default to 32A
-        amps = int(self._coord.last_set_amps.get(self._sn) or 32)
+        # Coordinator picks a safe amp value within device limits
+        amps = self._coord.pick_start_amps(self._sn)
         await self._coord.client.start_charging(self._sn, amps)
         self._coord.set_last_set_amps(self._sn, amps)
         # Poll quickly for a short window to reflect new state

--- a/custom_components/enphase_ev/device_action.py
+++ b/custom_components/enphase_ev/device_action.py
@@ -55,10 +55,11 @@ async def async_call_action_from_config(hass: HomeAssistant, config: ConfigType,
         return
 
     if typ == ACTION_START:
-        level = int(config.get("charging_level", 32))
+        level = config.get("charging_level")
         connector_id = int(config.get("connector_id", 1))
-        await coord.client.start_charging(sn, level, connector_id)
-        coord.set_last_set_amps(sn, level)
+        amps = coord.pick_start_amps(sn, level)
+        await coord.client.start_charging(sn, amps, connector_id)
+        coord.set_last_set_amps(sn, amps)
         await coord.async_request_refresh()
         return
 

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -35,12 +35,12 @@ class ChargingAmpsNumber(EnphaseBaseEntity, NumberEntity):
         data = self.data
         lvl = data.get("charging_level")
         if lvl is None:
-            # If unknown from API and no prior setpoint, prefer 32A default
-            return float(int(self._coord.last_set_amps.get(self._sn) or 32))
+            # Let coordinator choose a safe default within charger limits
+            return float(self._coord.pick_start_amps(self._sn))
         try:
             return float(int(lvl))
         except Exception:
-            return float(int(self._coord.last_set_amps.get(self._sn) or 32))
+            return float(self._coord.pick_start_amps(self._sn))
 
     @property
     def native_min_value(self) -> float:

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -525,12 +525,12 @@ class EnphaseChargingLevelSensor(EnphaseBaseEntity, SensorEntity):
         data = self.data
         lvl = data.get("charging_level")
         if lvl is None:
-            # Fall back to last set amps; if unknown, prefer 32A default
-            return int(self._coord.last_set_amps.get(self._sn) or 32)
+            # Fall back to coordinator helper which respects charger limits
+            return self._coord.pick_start_amps(self._sn)
         try:
             return int(lvl)
         except Exception:
-            return int(self._coord.last_set_amps.get(self._sn) or 32)
+            return self._coord.pick_start_amps(self._sn)
 
 class EnphaseSessionDurationSensor(EnphaseBaseEntity, SensorEntity):
     _attr_has_entity_name = True

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -36,8 +36,8 @@ class ChargingSwitch(EnphaseBaseEntity, SwitchEntity):
         return bool(self.data.get("charging"))
 
     async def async_turn_on(self, **kwargs) -> None:
-        # Use last requested amps or a sensible default
-        amps = int(self._coord.last_set_amps.get(self._sn) or 32)
+        # Delegate amp selection to coordinator to honor charger limits
+        amps = self._coord.pick_start_amps(self._sn)
         await self._coord.client.start_charging(self._sn, amps)
         self._coord.set_last_set_amps(self._sn, amps)
         self._coord.kick_fast(90)


### PR DESCRIPTION
## Summary
- add coordinator helpers to clamp start amps to per-charger limits
- route switches, buttons, services, and sensors through the shared helper
- refresh unit tests to cover clamping behavior and run black/ruff

## Testing
- python3 -m pre_commit run --all-files
- pytest tests_enphase_ev