### PR TITLE
Improve Enphase connectivity handling

### DIFF
--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -42,6 +42,8 @@ from .const import (
     OPT_FAST_WHILE_STREAMING,
     OPT_NOMINAL_VOLTAGE,
     OPT_SLOW_POLL_INTERVAL,
+    OPT_SESSION_HISTORY_INTERVAL,
+    DEFAULT_SESSION_HISTORY_INTERVAL_MIN,
 )
 
 
@@ -422,6 +424,13 @@ class OptionsFlowHandler(config_entries.OptionsFlow):
                 vol.Optional(
                     OPT_NOMINAL_VOLTAGE,
                     default=self._entry.options.get(OPT_NOMINAL_VOLTAGE, 240),
+                ): int,
+                vol.Optional(
+                    OPT_SESSION_HISTORY_INTERVAL,
+                    default=self._entry.options.get(
+                        OPT_SESSION_HISTORY_INTERVAL,
+                        DEFAULT_SESSION_HISTORY_INTERVAL_MIN,
+                    ),
                 ): int,
                 vol.Optional("reauth", default=False): bool,
                 vol.Optional("forget_password", default=False): bool,

--- a/custom_components/enphase_ev/const.py
+++ b/custom_components/enphase_ev/const.py
@@ -21,12 +21,15 @@ OPT_FAST_POLL_INTERVAL = "fast_poll_interval"
 OPT_SLOW_POLL_INTERVAL = "slow_poll_interval"
 OPT_FAST_WHILE_STREAMING = "fast_while_streaming"
 OPT_NOMINAL_VOLTAGE = "nominal_voltage"
+OPT_API_TIMEOUT = "api_timeout"
+OPT_SESSION_HISTORY_INTERVAL = "session_history_interval"
 ISSUE_NETWORK_UNREACHABLE = "cloud_unreachable"
+ISSUE_DNS_RESOLUTION = "cloud_dns_resolution"
 
 BASE_URL = "https://enlighten.enphaseenergy.com"
 ENTREZ_URL = "https://entrez.enphaseenergy.com"
 LOGIN_URL = f"{BASE_URL}/login/login.json"
 DEFAULT_AUTH_TIMEOUT = 15
 DEFAULT_API_TIMEOUT = 15
-OPT_API_TIMEOUT = "api_timeout"
+DEFAULT_SESSION_HISTORY_INTERVAL_MIN = 15
 DEFAULT_NOMINAL_VOLTAGE = 240

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -138,6 +138,7 @@
           "fast_poll_interval": "Fast poll interval (s)",
           "slow_poll_interval": "Slow poll interval (s)",
           "fast_while_streaming": "Prefer fast polling while cloud stream active",
+          "session_history_interval": "Session history interval (min)",
           "reauth": "Start reauthentication",
           "forget_password": "Forget stored password"
         },
@@ -146,6 +147,7 @@
           "fast_poll_interval": "Interval to use while charging or streaming.",
           "slow_poll_interval": "Interval to use when idle.",
           "fast_while_streaming": "When enabled, fast poll during active cloud streaming.",
+          "session_history_interval": "Minutes to wait between cloud session history fetches.",
           "reauth": "Launch the login flow to refresh credentials without removing the integration.",
           "forget_password": "Removes the stored password. Automatic refresh will no longer be attempted."
         }
@@ -165,6 +167,10 @@
     "cloud_unreachable": {
       "title": "Enphase EV cloud unreachable",
       "description": "Home Assistant cannot reach the Enphase cloud for site {site_id}. Polling slows automatically; verify the service status and your network."
+    },
+    "cloud_dns_resolution": {
+      "title": "Enphase EV DNS resolution failure",
+      "description": "Home Assistant could not resolve enlighten.enphaseenergy.com for site {site_id}. Check your DNS resolver or internet connection."
     }
   }
   ,


### PR DESCRIPTION
## Summary
- add bearer auth and detailed logging for start/stop control calls
- throttle session history with configurable cadence and DNS issue reporting
- expose the new option in the config flow with translations

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"