### PR TITLE
Stabilize charging state after control actions

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -258,6 +258,7 @@ def _register_services(hass: HomeAssistant) -> None:
             amps = coord.pick_start_amps(sn, level)
             await coord.client.start_charging(sn, amps, connector_id)
             coord.set_last_set_amps(sn, amps)
+            coord.set_charging_expectation(sn, True, hold_for=90)
             coord.kick_fast(90)
             await coord.async_request_refresh()
 
@@ -273,6 +274,7 @@ def _register_services(hass: HomeAssistant) -> None:
             if not coord:
                 continue
             await coord.client.stop_charging(sn)
+            coord.set_charging_expectation(sn, False, hold_for=90)
             coord.kick_fast(60)
             await coord.async_request_refresh()
 

--- a/custom_components/enphase_ev/button.py
+++ b/custom_components/enphase_ev/button.py
@@ -36,6 +36,7 @@ class StartChargeButton(_BaseButton):
         amps = self._coord.pick_start_amps(self._sn)
         await self._coord.client.start_charging(self._sn, amps)
         self._coord.set_last_set_amps(self._sn, amps)
+        self._coord.set_charging_expectation(self._sn, True, hold_for=90)
         # Poll quickly for a short window to reflect new state
         self._coord.kick_fast(90)
         await self._coord.async_request_refresh()
@@ -46,6 +47,7 @@ class StopChargeButton(_BaseButton):
         self._attr_translation_key = "stop_charging"
     async def async_press(self) -> None:
         await self._coord.client.stop_charging(self._sn)
+        self._coord.set_charging_expectation(self._sn, False, hold_for=90)
         # Poll quickly after stop to clear state faster
         self._coord.kick_fast(60)
         await self._coord.async_request_refresh()

--- a/custom_components/enphase_ev/device_action.py
+++ b/custom_components/enphase_ev/device_action.py
@@ -60,11 +60,15 @@ async def async_call_action_from_config(hass: HomeAssistant, config: ConfigType,
         amps = coord.pick_start_amps(sn, level)
         await coord.client.start_charging(sn, amps, connector_id)
         coord.set_last_set_amps(sn, amps)
+        coord.set_charging_expectation(sn, True, hold_for=90)
+        coord.kick_fast(90)
         await coord.async_request_refresh()
         return
 
     if typ == ACTION_STOP:
         await coord.client.stop_charging(sn)
+        coord.set_charging_expectation(sn, False, hold_for=90)
+        coord.kick_fast(60)
         await coord.async_request_refresh()
         return
 

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -40,10 +40,12 @@ class ChargingSwitch(EnphaseBaseEntity, SwitchEntity):
         amps = self._coord.pick_start_amps(self._sn)
         await self._coord.client.start_charging(self._sn, amps)
         self._coord.set_last_set_amps(self._sn, amps)
+        self._coord.set_charging_expectation(self._sn, True, hold_for=90)
         self._coord.kick_fast(90)
         await self._coord.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         await self._coord.client.stop_charging(self._sn)
+        self._coord.set_charging_expectation(self._sn, False, hold_for=90)
         self._coord.kick_fast(60)
         await self._coord.async_request_refresh()

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -269,7 +269,7 @@ The integration reuses tokens until expiry or a 401 is encountered, then prompts
 | `pluggedIn` | Vehicle plugged state |
 | `charging` | Active charging session |
 | `faulted` | Fault present |
-| `connectorStatusType` | ENUM: `AVAILABLE`, `CHARGING`, `FINISHING`, `SUSPENDED`, `FAULTED` |
+| `connectorStatusType` | ENUM: `AVAILABLE`, `CHARGING`, `FINISHING`, `SUSPENDED`, `SUSPENDED_EV`, `SUSPENDED_EVSE`, `FAULTED` |
 | `connectorStatusReason` | Additional enum reason (e.g., `INSUFFICIENT_SOLAR`) |
 | `session_d.e_c` | Session energy (Wh if >200, else kWh) |
 | `session_d.start_time` | Epoch seconds when session started |


### PR DESCRIPTION
## Summary
- hold charging flag for short runway after start/stop so HA switch doesn’t bounce
- treat suspended* connector statuses as active and share expectation helper with services/buttons
- document new enums and add regression coverage for expectation window

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"