### PR TITLE
Release 1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 - No unreleased changes.
 
+## v1.2.5
+- Coordinator: anchor HTTP and network backoff windows to the configured slow polling interval (and any dynamic interval overrides) so recovery pacing always respects user settings.
+- Coordinator: surface the last successful sync, last failure metadata, and the current backoff end as tracked fields and keep site-level diagnostics entities available during cloud outages.
+- Diagnostics: add dedicated site sensors for the last error code/message and the active backoff expiry timestamp, and expose the same metadata as attributes on the site cloud reachability binary sensor and existing site latency sensor.
+
 ## v1.2.4
 - Coordinator: expand HTTP error handling to apply exponential backoff to every response while respecting `Retry-After`, improving stability during cloud outages and throttling.
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ If the login form reports that multi-factor authentication is required, complete
 
 | Entity Type | Description |
 | --- | --- |
-| Site sensor | Last Successful Update timestamp and Cloud Latency in milliseconds. |
-| Site binary sensor | Cloud Reachable indicator (on/off). |
+| Site sensors | Last Successful Update timestamp, Cloud Latency in milliseconds, Cloud Last Error Code/Message, and Cloud Backoff Ends timestamp so you can track outages. |
+| Site binary sensor | Cloud Reachable indicator (on/off) with attributes for the last success, last failure, and any active backoff window. |
 | Switch | Per-charger charging control (on/off) that stays in sync even if a session is already active. |
 | Button | Start Charging and Stop Charging actions for each charger. |
 | Select | Charge Mode selector (Manual, Scheduled, Green) backed by the cloud scheduler. |

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "gold",
   "requirements": [],
-  "version": "1.2.4"
+  "version": "1.2.5"
 }


### PR DESCRIPTION
## Summary
- bump manifest to 1.2.5
- document new cloud diagnostics in changelog
- refresh README entities table for the added site sensors

## Testing
- not run