### PR TITLE
chore: release 1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 - No unreleased changes.
 
+## v1.3.0
+- Charger discovery: automatically register new Enlighten chargers at runtime so freshly installed hardware appears without reconfiguring the integration.
+- Coordinator & diagnostics: streamline the first refresh, record backend phase timings, and surface additional error/backoff counters through diagnostics and System Health.
+- Charging safeguards: block start requests while the EV is unplugged, raise translated validation errors, and keep switches/buttons in sync with charger reality.
+- Testing & tooling: migrate the integration tests under `tests/components/enphase_ev`, refresh fixtures, and align the Docker dev image with Home Assistant’s test harness.
+
 ## v1.2.6
 - Localisation: add full French translations for the integration strings.
 - Docs: note supported languages and bump the integration manifest version.

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.2.6"
+  "version": "1.3.0"
 }


### PR DESCRIPTION
## Summary
- release Enphase EV Charger 2 (Cloud) version 1.3.0
- document highlights in CHANGELOG for discovery, diagnostics, and safeguards
- bump integration manifest to 1.3.0

## Testing
- python3 -m script.hassfest *(fails: ModuleNotFoundError: No module named 'script' – Home Assistant Core tooling not available locally)*
- python3 -m pytest tests/components/enphase_ev -q *(fails: local Python 3.9 lacks typing unions and Home Assistant raises ImportError)*
- pre-commit run --all-files *(fails: pre-commit points to missing Python 3.10 interpreter)*