### PR TITLE
Auto-resume charging after EVSE suspension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
+- Charging controls: persist the requested charging state, auto-resume sessions that fall into `SUSPENDED_EVSE` after reconnects, and restore charging automatically after Home Assistant restarts or cloud outages.
 - Energy sensors: drive the Energy Today reading from the status API session energy (falling back to lifetime deltas) and expose plug timestamps, energy, range, cost, and charge level metadata via attributes.
 
 ## v1.3.0

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "p
 - Start/Stop actions now require the EV to be plugged in; unplugged requests raise a translated validation error so the UI tells the user to connect before trying again.
 - Use the `binary_sensor.<charger>_plugged_in` entity in conditional cards or automation conditions to hide/disable start controls until the vehicle is connected.
 - Backend responses that report the charger as “not ready” or “not plugged” are treated as benign no-ops without optimistic state changes, keeping Home Assistant in sync with the hardware.
-- Charging state follows both the `charging` flag and connector status (CHARGING/FINISHING/SUSPENDED\*, covering SUSPENDED_EV and SUSPENDED_EVSE) so restarts quickly recover the correct state.
+- Charging state tracks the backend `charging` flag while EVSE-side suspensions (`SUSPENDED_EVSE`) are treated as paused; when you previously requested charging, the integration automatically re-sends the start command after reconnecting so cloud dropouts and Home Assistant restarts resume charging without manual intervention.
 - The Charge Mode select works with the scheduler API and reflects the service’s active mode.
 
 ### Reconfigure

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -281,7 +281,9 @@ def _register_services(hass: HomeAssistant) -> None:
             result = await coord.client.start_charging(sn, amps, connector_id)
             coord.set_last_set_amps(sn, amps)
             if isinstance(result, dict) and result.get("status") == "not_ready":
+                coord.set_desired_charging(sn, False)
                 continue
+            coord.set_desired_charging(sn, True)
             coord.set_charging_expectation(sn, True, hold_for=90)
             coord.kick_fast(90)
             await coord.async_request_refresh()
@@ -298,6 +300,7 @@ def _register_services(hass: HomeAssistant) -> None:
             if not coord:
                 continue
             await coord.client.stop_charging(sn)
+            coord.set_desired_charging(sn, False)
             coord.set_charging_expectation(sn, False, hold_for=90)
             coord.kick_fast(60)
             await coord.async_request_refresh()

--- a/custom_components/enphase_ev/button.py
+++ b/custom_components/enphase_ev/button.py
@@ -55,7 +55,9 @@ class StartChargeButton(_BaseButton):
         result = await self._coord.client.start_charging(self._sn, amps)
         self._coord.set_last_set_amps(self._sn, amps)
         if isinstance(result, dict) and result.get("status") == "not_ready":
+            self._coord.set_desired_charging(self._sn, False)
             return
+        self._coord.set_desired_charging(self._sn, True)
         self._coord.set_charging_expectation(self._sn, True, hold_for=90)
         # Poll quickly for a short window to reflect new state
         self._coord.kick_fast(90)
@@ -69,6 +71,7 @@ class StopChargeButton(_BaseButton):
 
     async def async_press(self) -> None:
         await self._coord.client.stop_charging(self._sn)
+        self._coord.set_desired_charging(self._sn, False)
         self._coord.set_charging_expectation(self._sn, False, hold_for=90)
         # Poll quickly after stop to clear state faster
         self._coord.kick_fast(60)

--- a/custom_components/enphase_ev/device_action.py
+++ b/custom_components/enphase_ev/device_action.py
@@ -67,7 +67,9 @@ async def async_call_action_from_config(
         result = await coord.client.start_charging(sn, amps, connector_id)
         coord.set_last_set_amps(sn, amps)
         if isinstance(result, dict) and result.get("status") == "not_ready":
+            coord.set_desired_charging(sn, False)
             return
+        coord.set_desired_charging(sn, True)
         coord.set_charging_expectation(sn, True, hold_for=90)
         coord.kick_fast(90)
         await coord.async_request_refresh()
@@ -75,6 +77,7 @@ async def async_call_action_from_config(
 
     if typ == ACTION_STOP:
         await coord.client.stop_charging(sn)
+        coord.set_desired_charging(sn, False)
         coord.set_charging_expectation(sn, False, hold_for=90)
         coord.kick_fast(60)
         await coord.async_request_refresh()

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.restore_state import RestoreEntity
 
 from .const import DOMAIN
 from .coordinator import EnphaseCoordinator
@@ -34,7 +36,7 @@ async def async_setup_entry(
     _async_sync_chargers()
 
 
-class ChargingSwitch(EnphaseBaseEntity, SwitchEntity):
+class ChargingSwitch(EnphaseBaseEntity, RestoreEntity, SwitchEntity):
     _attr_has_entity_name = True
     _attr_translation_key = "charging"
     # Main feature of the device; let entity name equal device name
@@ -43,9 +45,31 @@ class ChargingSwitch(EnphaseBaseEntity, SwitchEntity):
     def __init__(self, coord: EnphaseCoordinator, sn: str):
         super().__init__(coord, sn)
         self._attr_unique_id = f"{DOMAIN}_{sn}_charging_switch"
+        self._restored_state: bool | None = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last_state = await self.async_get_last_state()
+        if last_state is not None:
+            desired = last_state.state == STATE_ON
+            self._restored_state = desired
+            self._coord.set_desired_charging(self._sn, desired)
+            if desired and not self.is_on:
+                self._coord.kick_fast(60)
+                try:
+                    await self._coord.async_request_refresh()
+                except Exception:  # noqa: BLE001
+                    return
+            self.async_write_ha_state()
+        else:
+            if self.available:
+                self._coord.set_desired_charging(self._sn, self.is_on)
+                self._restored_state = self.is_on
 
     @property
     def is_on(self) -> bool:
+        if not self.available and self._restored_state is not None:
+            return self._restored_state
         return bool(self.data.get("charging"))
 
     async def async_turn_on(self, **kwargs) -> None:
@@ -55,13 +79,21 @@ class ChargingSwitch(EnphaseBaseEntity, SwitchEntity):
         result = await self._coord.client.start_charging(self._sn, amps)
         self._coord.set_last_set_amps(self._sn, amps)
         if isinstance(result, dict) and result.get("status") == "not_ready":
+            self._coord.set_desired_charging(self._sn, False)
             return
+        self._coord.set_desired_charging(self._sn, True)
         self._coord.set_charging_expectation(self._sn, True, hold_for=90)
         self._coord.kick_fast(90)
         await self._coord.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         await self._coord.client.stop_charging(self._sn)
+        self._coord.set_desired_charging(self._sn, False)
         self._coord.set_charging_expectation(self._sn, False, hold_for=90)
         self._coord.kick_fast(60)
         await self._coord.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._restored_state = None
+        super()._handle_coordinator_update()

--- a/tests/components/enphase_ev/test_number_and_switch.py
+++ b/tests/components/enphase_ev/test_number_and_switch.py
@@ -124,13 +124,16 @@ async def test_charging_switch_turn_on_off(hass, monkeypatch):
 
     sw = ChargingSwitch(coord, sn)
     assert sw.is_on is False
+    assert coord.get_desired_charging(sn) is None
 
     await sw.async_turn_on()
     assert coord.client.start_calls[-1] == (sn, 16, 1)
     assert coord.last_set_amps[sn] == 16
+    assert coord.get_desired_charging(sn) is True
 
     await sw.async_turn_off()
     assert coord.client.stop_calls[-1] == sn
+    assert coord.get_desired_charging(sn) is False
 
 
 @pytest.mark.asyncio
@@ -190,3 +193,4 @@ async def test_charging_switch_requires_plugged(hass, monkeypatch):
     with pytest.raises(ServiceValidationError):
         await sw.async_turn_on()
     assert coord.client.start_calls == []
+    assert coord.get_desired_charging(sn) is None


### PR DESCRIPTION
## Summary

- [x] Persist the user-requested charging state so UI controls survive restarts.
- [x] Detect EVSE-side suspensions and automatically reissue `start_charging` when the charger is plugged in and should be running.
- [x] Document the behaviour change and add regression coverage.

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Tick all commands you ran locally (remove lines that do not apply):

- [ ] `ruff check .`
- [ ] `black custom_components/enphase_ev`
- [ ] `pytest -q tests_enphase_ev`
- [ ] `python scripts/validate_quality_scale.py`
- [ ] `python -m script.hassfest`
- [x] `pre-commit run --all-files`
- [x] Other (describe below)

Other commands:
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_number_and_switch.py"`

`python -m script.hassfest` is unavailable in this repository; please run from a Home Assistant Core checkout if required.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Additional context

- Automatic restart avoids users needing to toggle charging after temporary cloud outages or Home Assistant restarts.
- Hassfest cannot be run from this repository; the command is noted above.
