### PR TITLE
Release 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,38 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased
-- Charging controls: persist the requested charging state, auto-resume sessions that fall into `SUSPENDED_EVSE` after reconnects, and restore charging automatically after Home Assistant restarts or cloud outages.
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v1.3.1 – 2025-10-25
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
 - Energy sensors: drive the Energy Today reading from the status API session energy (falling back to lifetime deltas) and expose plug timestamps, energy, range, cost, and charge level metadata via attributes.
+
+### 🐛 Bug fixes
+- Charging controls: persist the requested charging state, auto-resume sessions that fall into `SUSPENDED_EVSE` after reconnects, and restore charging automatically after Home Assistant restarts or cloud outages.
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
 
 ## v1.3.0
 - Charger discovery: automatically register new Enlighten chargers at runtime so freshly installed hardware appears without reconfiguring the integration.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ If the login form reports that multi-factor authentication is required, complete
 | `enphase_ev.start_live_stream` | Request faster cloud status updates for a short period. | Advanced fields: `site_id` (optional; stream a specific site) |
 | `enphase_ev.stop_live_stream` | Stop the cloud live stream request. | Advanced fields: `site_id` (optional; stop streaming for a specific site) |
 
-- The `Energy Today` sensor exposes a `sessions_today` attribute containing each charging session completed during the current day (start/end, authentication metadata, active charge time, energy added, miles added, and session cost), supporting multiple sessions per day and trimming cross-midnight sessions to their in-day contribution.
+- The `Energy Today` sensor exposes a `sessions_today` attribute containing each charging session completed during the current day (plug-in/out timestamps, authentication metadata, active charge time, energy added, charge level, miles added, and session cost), supporting multiple sessions per day and trimming cross-midnight sessions to their in-day contribution.
 
 ## Privacy & Rate Limits
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.3.0"
+  "version": "1.3.1"
 }


### PR DESCRIPTION
## Summary

- [x] Includes a concise description of the change and its motivation.
- [ ] References related issues or discussions (e.g., `Fixes #123`).

- Bump the integration to v1.3.1 and promote the Unreleased notes into a dated release section.
- Refresh the README `sessions_today` attribute description for the new metadata surfaced with this release.

## Type of change

- [ ] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release prep for v1.3.1.

## Testing

- [ ] `python -m script.hassfest` (blocked: module not available in the dev container; see additional context)
- [x] `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev"`
- [x] `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"`

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Additional context

- Attempted to run hassfest locally inside the provided dev container, but the `script.hassfest` module is not installed in that environment. Please run hassfest from a Home Assistant Core checkout during review.
