### PR TITLE
docs: sync with official API status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🔄 Other changes
-- None
+- Document official Enphase API status/error codes and telemetry hints in the EV cloud API spec.
 
 ## v1.3.1 – 2025-10-25
 


### PR DESCRIPTION
## Summary
- capture the partner API's HTTP responses and validation hints in docs/api/api_spec.md
- note telemetry field naming seen in the published v4 endpoints
- log the documentation update in CHANGELOG.md