### PR TITLE
Guard Codecov upload on forked PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,5 +21,4 @@ concurrency:
 jobs:
   checks:
     uses: ./.github/workflows/tests.yml
-    with:
-      codecov_token: ${{ secrets.CODECOV_TOKEN }}
+    secrets: inherit

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,10 +11,9 @@ on:
       - '.github/workflows/tests.yml'
   workflow_dispatch:
   workflow_call:
-    inputs:
-      codecov_token:
+    secrets:
+      CODECOV_TOKEN:
         required: false
-        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -69,8 +68,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.13']
-    env:
-      CODECOV_TOKEN: ${{ (github.event_name == 'workflow_call' && inputs.codecov_token) || (github.event_name != 'workflow_call' && secrets.CODECOV_TOKEN) || '' }}
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -88,9 +85,9 @@ jobs:
       - name: Run tests
         run: pytest --cov=custom_components.enphase_ev --cov-report=term-missing --cov-report=xml
       - name: Upload coverage to Codecov
-        if: ${{ env.CODECOV_TOKEN != '' }}
+        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
         uses: codecov/codecov-action@v5
         with:
-          token: ${{ env.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true


### PR DESCRIPTION
## Summary

Guard Codecov uploads in the reusable `tests.yml` workflow so forked pull requests don’t fail validation, and have the wrapper workflow inherit secrets just like Home Assistant Core.

## Type of change

- [ ] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Other: CI workflow resilience

## Testing

Tick all commands you ran locally (remove lines that do not apply):

- [ ] `ruff check .`
- [ ] `black custom_components/enphase_ev`
- [ ] `pytest -q tests_enphase_ev`
- [ ] `python scripts/validate_quality_scale.py`
- [ ] `python -m script.hassfest`
- [ ] `pre-commit run --all-files`
- [ ] Other (describe below)

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Additional context

The reusable workflow now aligns with Home Assistant Core: Codecov uploads are skipped on forked PRs, while trusted callers inherit secrets to keep coverage reporting.
