### PR TITLE
Prevent concurrency deadlock in Tests workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ on:
         required: false
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ format('{0}-{1}', github.workflow_ref || github.workflow, github.ref) }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary

Adjust reusable workflow concurrency to use `workflow_ref` when available, preventing deadlocks between the top-level `CI` workflow and the called `checks` job.

## Type of change

- [ ] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Other: Workflow reliability

## Testing

Tick all commands you ran locally (remove lines that do not apply):

- [ ] `ruff check .`
- [ ] `black custom_components/enphase_ev`
- [ ] `pytest -q tests_enphase_ev`
- [ ] `python scripts/validate_quality_scale.py`
- [ ] `python -m script.hassfest`
- [ ] `pre-commit run --all-files`
- [ ] Other (describe below)

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Additional context

Aligns concurrency strategy with GitHub guidance by using `workflow_ref` (when defined) and falling back to `workflow`, so direct runs keep serialization while reusable invocations get unique keys.
