### PR TITLE
Improve Enphase EV test coverage

### DIFF
--- a/tests/components/enphase_ev/test_api_helpers.py
+++ b/tests/components/enphase_ev/test_api_helpers.py
@@ -1,0 +1,80 @@
+"""Tests for helper utilities in the API module."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+from aiohttp import CookieJar
+from yarl import URL
+
+from custom_components.enphase_ev import api
+
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_serialize_cookie_jar() -> None:
+    """Cookie jar serialization should extract cookies for provided URLs."""
+    jar = CookieJar()
+    jar.update_cookies({"session": "abc123"}, URL("https://enphase.test"))
+    header, mapping = api._serialize_cookie_jar(
+        jar, ["https://enphase.test", "https://ignored.invalid"]
+    )
+    assert header == "session=abc123"
+    assert mapping == {"session": "abc123"}
+
+
+def test_decode_jwt_exp_success() -> None:
+    """Successfully decode the exp claim from a JWT payload."""
+    payload = {"exp": 1_700_000_000}
+    payload_b64 = base64.urlsafe_b64encode(json.dumps(payload).encode()).decode()
+    payload_b64 = payload_b64.rstrip("=")
+    token = f"header.{payload_b64}.sig"
+    assert api._decode_jwt_exp(token) == 1_700_000_000
+
+
+def test_decode_jwt_exp_failure() -> None:
+    """Non-JWT strings should produce None."""
+    assert api._decode_jwt_exp("not-a-token") is None
+
+
+def test_extract_xsrf_token() -> None:
+    """XSRF token is located case-insensitively."""
+    cookies = {"session": "abc", "XSRF-TOKEN": "xsrf-value"}
+    assert api._extract_xsrf_token(cookies) == "xsrf-value"
+
+
+def test_normalize_sites_handles_nested_structures() -> None:
+    """Site normalization should handle nested dict responses."""
+    payload = {
+        "data": [
+            {"site_id": 1234, "name": "Garage"},
+            {"siteId": "5678", "siteName": "Backup"},
+            {"id": 9},
+        ]
+    }
+    sites = api._normalize_sites(payload)
+    assert [site.site_id for site in sites] == ["1234", "5678", "9"]
+    assert sites[0].name == "Garage"
+    assert sites[1].name == "Backup"
+    assert sites[2].name is None
+
+
+def test_normalize_chargers_handles_varied_keys() -> None:
+    """Charger normalization should account for different payload keys."""
+    payload = {
+        "data": {
+            "chargers": [
+                {"serial": "EV123", "name": "Garage"},
+                {"serialNumber": "EV456", "displayName": "Driveway"},
+                {"sn": "EV789"},
+            ]
+        }
+    }
+    chargers = api._normalize_chargers(payload)
+    assert [charger.serial for charger in chargers] == ["EV123", "EV456", "EV789"]
+    assert chargers[0].name == "Garage"
+    assert chargers[1].name == "Driveway"
+    assert chargers[2].name is None

--- a/tests/components/enphase_ev/test_device_action.py
+++ b/tests/components/enphase_ev/test_device_action.py
@@ -1,0 +1,170 @@
+"""Tests for the device action helpers."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from types import ModuleType, SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import sys
+
+# Provide a lightweight shim for the device automation constants to avoid
+# importing the full Home Assistant stack during unit tests.
+shim = ModuleType("homeassistant.components.device_automation.const")
+shim.CONF_TYPE = "type"
+sys.modules["homeassistant.components.device_automation.const"] = shim
+
+from homeassistant.const import CONF_DEVICE_ID
+from homeassistant.helpers import device_registry as dr
+
+from custom_components.enphase_ev import device_action
+from custom_components.enphase_ev.const import DOMAIN
+from tests.components.enphase_ev.random_ids import RANDOM_SERIAL, RANDOM_SITE_ID
+
+CONF_TYPE = "type"
+
+
+@pytest.fixture
+def device_id(hass, config_entry) -> str:
+    """Create a charger device linked to the config entry."""
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, RANDOM_SERIAL), (DOMAIN, f"site:{RANDOM_SITE_ID}")},
+        manufacturer="Enphase",
+        name="Garage Charger",
+    )
+    return device.id
+
+
+def _make_coordinator() -> SimpleNamespace:
+    """Return a coordinator stub with the attributes device actions rely on."""
+
+    class DummyCoord(SimpleNamespace):
+        pass
+
+    coord = DummyCoord()
+    coord.serials = {RANDOM_SERIAL}
+    coord.data = {RANDOM_SERIAL: {}}
+    coord.site_id = RANDOM_SITE_ID
+    coord.update_interval = timedelta(seconds=30)
+    coord.phase_timings = {}
+
+    coord.require_plugged = MagicMock()
+    coord.pick_start_amps = MagicMock(return_value=32)
+    coord.set_last_set_amps = MagicMock()
+    coord.set_desired_charging = MagicMock()
+    coord.set_charging_expectation = MagicMock()
+    coord.kick_fast = MagicMock()
+    coord.async_request_refresh = AsyncMock()
+
+    client = SimpleNamespace()
+    client.start_charging = AsyncMock(return_value={"status": "ok"})
+    client.stop_charging = AsyncMock(return_value=None)
+    coord.client = client
+
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_async_get_actions_returns_start_stop(hass, config_entry, device_id) -> None:
+    """Device actions should expose start/stop toggles for charger devices."""
+    actions = await device_action.async_get_actions(hass, device_id)
+    assert len(actions) == 2
+    assert {
+        (action[CONF_DEVICE_ID], action[CONF_TYPE])
+        for action in actions
+    } == {(device_id, device_action.ACTION_START), (device_id, device_action.ACTION_STOP)}
+
+
+@pytest.mark.asyncio
+async def test_async_call_action_start_success(
+    hass, config_entry, device_id, monkeypatch
+) -> None:
+    """Starting a charge session should invoke the coordinator helpers."""
+    coord = _make_coordinator()
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+
+    config = {
+        CONF_DEVICE_ID: device_id,
+        CONF_TYPE: device_action.ACTION_START,
+        "charging_level": 30,
+        "connector_id": 2,
+    }
+
+    await device_action.async_call_action_from_config(hass, config, {}, None)
+
+    coord.require_plugged.assert_called_once_with(RANDOM_SERIAL)
+    coord.pick_start_amps.assert_called_once_with(RANDOM_SERIAL, 30)
+    coord.client.start_charging.assert_awaited_once_with(RANDOM_SERIAL, 32, 2)
+    coord.set_last_set_amps.assert_called_once_with(RANDOM_SERIAL, 32)
+    coord.set_desired_charging.assert_called_with(RANDOM_SERIAL, True)
+    coord.set_charging_expectation.assert_called_with(RANDOM_SERIAL, True, hold_for=90)
+    coord.kick_fast.assert_called_with(90)
+    coord.async_request_refresh.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_call_action_start_handles_not_ready(
+    hass, config_entry, device_id
+) -> None:
+    """A not_ready response should flip desired charging back to False."""
+    coord = _make_coordinator()
+    coord.client.start_charging.return_value = {"status": "not_ready"}
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+
+    await device_action.async_call_action_from_config(
+        hass,
+        {
+            CONF_DEVICE_ID: device_id,
+            CONF_TYPE: device_action.ACTION_START,
+        },
+        {},
+        None,
+    )
+
+    coord.set_desired_charging.assert_called_with(RANDOM_SERIAL, False)
+
+
+@pytest.mark.asyncio
+async def test_async_call_action_stop(hass, config_entry, device_id) -> None:
+    """Stopping a charge session should invoke the coordinator client."""
+    coord = _make_coordinator()
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+
+    await device_action.async_call_action_from_config(
+        hass,
+        {
+            CONF_DEVICE_ID: device_id,
+            CONF_TYPE: device_action.ACTION_STOP,
+        },
+        {},
+        None,
+    )
+
+    coord.client.stop_charging.assert_awaited_once_with(RANDOM_SERIAL)
+    coord.set_desired_charging.assert_called_with(RANDOM_SERIAL, False)
+    coord.set_charging_expectation.assert_called_with(RANDOM_SERIAL, False, hold_for=90)
+    coord.kick_fast.assert_called_with(60)
+
+
+@pytest.mark.asyncio
+async def test_async_get_action_capabilities() -> None:
+    """Capabilities schema should expose optional fields for start action."""
+    result = await device_action.async_get_action_capabilities(
+        None,
+        {
+            CONF_TYPE: device_action.ACTION_START,
+        },
+    )
+    schema = result["extra_fields"]
+    validated = schema(
+        {
+            "charging_level": 24,
+            "connector_id": 1,
+        }
+    )
+    assert validated["charging_level"] == 24
+    assert validated["connector_id"] == 1

--- a/tests/components/enphase_ev/test_device_trigger.py
+++ b/tests/components/enphase_ev/test_device_trigger.py
@@ -1,0 +1,119 @@
+"""Tests for device triggers."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+
+triggers_pkg = ModuleType("homeassistant.components.automation.triggers")
+state_mod = ModuleType("homeassistant.components.automation.triggers.state")
+
+
+async def _placeholder_async_attach_trigger(*args, **kwargs):
+    raise NotImplementedError
+
+
+state_mod.async_attach_trigger = _placeholder_async_attach_trigger
+triggers_pkg.state = state_mod
+sys.modules.setdefault("homeassistant.components.automation", ModuleType("homeassistant.components.automation"))
+sys.modules["homeassistant.components.automation.triggers"] = triggers_pkg
+sys.modules["homeassistant.components.automation.triggers.state"] = state_mod
+sys.modules["homeassistant.components.automation"].triggers = triggers_pkg
+
+from custom_components.enphase_ev import device_trigger
+from custom_components.enphase_ev.const import DOMAIN
+from tests.components.enphase_ev.random_ids import RANDOM_SERIAL, RANDOM_SITE_ID
+
+
+@pytest.fixture
+def device_entry(hass, config_entry):
+    """Create a device and matching binary sensors for trigger discovery."""
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, RANDOM_SERIAL), (DOMAIN, f"site:{RANDOM_SITE_ID}")},
+        manufacturer="Enphase",
+        name="Garage Charger",
+    )
+
+    ent_reg = er.async_get(hass)
+    entity_ids: list[str] = []
+    for tkey, unique in (
+        ("charging", "charging-bin"),
+        ("plugged_in", "plug-bin"),
+        ("faulted", "fault-bin"),
+    ):
+        entry = ent_reg.async_get_or_create(
+            domain="binary_sensor",
+            platform="enphase_ev",
+            unique_id=unique,
+            device_id=device.id,
+            config_entry=config_entry,
+            translation_key=tkey,
+        )
+        entity_ids.append(entry.entity_id)
+    return device, entity_ids
+
+
+@pytest.mark.asyncio
+async def test_async_get_triggers_exposes_device_triggers(hass, device_entry):
+    """All known triggers for the device should be discovered."""
+    device, _ = device_entry
+    triggers = await device_trigger.async_get_triggers(hass, device.id)
+    assert {trigger["type"] for trigger in triggers} == {
+        "charging_started",
+        "charging_stopped",
+        "plugged_in",
+        "unplugged",
+        "faulted",
+    }
+    assert all(trigger["entity_id"].startswith("binary_sensor.") for trigger in triggers)
+
+
+@pytest.mark.asyncio
+async def test_async_attach_trigger_wraps_state_trigger(
+    hass, device_entry, monkeypatch
+):
+    """Attaching a trigger should delegate to the state trigger helper."""
+    async_mock = AsyncMock(return_value="unsubscribe")
+    monkeypatch.setattr(
+        device_trigger.state_trigger, "async_attach_trigger", async_mock
+    )
+
+    action = MagicMock()
+    automation_info = {"name": "automation"}
+
+    device, _ = device_entry
+    unsubscribe = await device_trigger.async_attach_trigger(
+        hass,
+        {"device_id": device.id, "type": "charging_started"},
+        action,
+        automation_info,
+    )
+
+    async_mock.assert_awaited_once()
+    state_cfg = async_mock.await_args.args[1]
+    assert state_cfg["entity_id"].startswith("binary_sensor.")
+    assert state_cfg["to"] == "on"
+    assert state_cfg["from"] == "off"
+    assert unsubscribe == "unsubscribe"
+
+
+@pytest.mark.asyncio
+async def test_async_attach_trigger_handles_missing_entity(hass, device_entry):
+    """If the entity is missing, the helper should return a no-op."""
+    device, entity_ids = device_entry
+    ent_reg = er.async_get(hass)
+    for entity_id in entity_ids:
+        ent_reg.async_remove(entity_id)
+
+    detach = await device_trigger.async_attach_trigger(
+        hass, {"device_id": device.id, "type": "charging_started"}, None, {}
+    )
+    assert callable(detach)
+    assert detach() is None

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -1,0 +1,107 @@
+"""Tests for integration diagnostics."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from homeassistant.helpers import device_registry as dr
+
+from custom_components.enphase_ev import diagnostics
+from custom_components.enphase_ev.const import DOMAIN
+from tests.components.enphase_ev.random_ids import RANDOM_SERIAL, RANDOM_SITE_ID
+
+
+class DummyClient(SimpleNamespace):
+    def __init__(self) -> None:
+        super().__init__()
+        self._h = {"Authorization": "REDACTED", "X-Test": "value"}
+
+    def _bearer(self):
+        return "token"
+
+
+class DummyCoordinator(SimpleNamespace):
+    """Coordinator stub exposing diagnostics attributes."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.client = DummyClient()
+        self.update_interval = timedelta(seconds=45)
+        self._charge_mode_cache = {RANDOM_SERIAL: ("FAST", 0)}
+        self.site_id = RANDOM_SITE_ID
+        self.serials = {RANDOM_SERIAL}
+        self.data = {RANDOM_SERIAL: {"sn": RANDOM_SERIAL, "status": "idle"}}
+        self._network_errors = 2
+        self._http_errors = 1
+        self._backoff_until = 120.0
+        self._last_error = "timeout"
+        self.phase_timings = {"fast": 0.6}
+        self._session_history_cache_ttl = 300
+        self._session_history_cache = {"key": []}
+        self._session_history_interval_min = 15
+        self._session_refresh_in_progress = {"key"}
+
+
+@pytest.mark.asyncio
+async def test_config_entry_diagnostics_includes_coordinator(hass, config_entry) -> None:
+    """Validate coordinator diagnostics payload and redaction logic."""
+    coord = DummyCoordinator()
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+
+    diag = await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
+
+    assert diag["entry_data"]["cookie"] == "**REDACTED**"
+    assert diag["coordinator"]["site_id"] == RANDOM_SITE_ID
+    assert diag["coordinator"]["headers_info"]["base_header_names"] == [
+        "Authorization",
+        "X-Test",
+    ]
+    assert diag["coordinator"]["headers_info"]["has_scheduler_bearer"] is True
+    assert diag["coordinator"]["last_scheduler_modes"] == {RANDOM_SERIAL: "FAST"}
+    assert diag["coordinator"]["session_history"]["cache_keys"] == 1
+
+
+@pytest.mark.asyncio
+async def test_device_diagnostics_returns_snapshot(
+    hass, config_entry
+) -> None:
+    """Device diagnostics should resolve a serial and return cached data."""
+    coord = DummyCoordinator()
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, RANDOM_SERIAL), (DOMAIN, f"site:{RANDOM_SITE_ID}")},
+        manufacturer="Enphase",
+        name="Garage Charger",
+    )
+
+    result = await diagnostics.async_get_device_diagnostics(
+        hass, config_entry, device
+    )
+    assert result["serial"] == RANDOM_SERIAL
+    assert result["snapshot"] == coord.data[RANDOM_SERIAL]
+
+
+@pytest.mark.asyncio
+async def test_device_diagnostics_handles_missing_serial(
+    hass, config_entry
+) -> None:
+    """If a device has no serial identifier, report the error."""
+    coord = DummyCoordinator()
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"site:{RANDOM_SITE_ID}")},
+        manufacturer="Enphase",
+    )
+
+    result = await diagnostics.async_get_device_diagnostics(
+        hass, config_entry, device
+    )
+    assert result == {"error": "serial_not_resolved"}

--- a/tests/components/enphase_ev/test_system_health.py
+++ b/tests/components/enphase_ev/test_system_health.py
@@ -1,0 +1,63 @@
+"""Tests for the system health helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.enphase_ev import system_health
+from custom_components.enphase_ev.const import BASE_URL, DOMAIN
+from tests.components.enphase_ev.random_ids import RANDOM_SITE_ID
+
+
+@pytest.mark.asyncio
+async def test_async_register_binds_handler(hass) -> None:
+    """Ensure the system health handler is registered."""
+
+    class DummyRegister:
+        def __init__(self) -> None:
+            self.handler = None
+
+        def async_register_info(self, handler):
+            self.handler = handler
+
+    register = DummyRegister()
+    system_health.async_register(hass, register)
+    assert register.handler is system_health.system_health_info
+
+
+@pytest.mark.asyncio
+async def test_system_health_info_reports_state(hass, config_entry, monkeypatch) -> None:
+    """The info payload should reflect coordinator attributes."""
+    coord = SimpleNamespace()
+    coord.last_success_utc = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    coord.latency_ms = 120
+    coord._last_error = "timeout"
+    coord._backoff_until = 42.0
+    coord._network_errors = 3
+    coord._http_errors = 1
+    coord.phase_timings = {"fast": 0.5}
+    coord._session_history_cache_ttl = 300
+
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+
+    monkeypatch.setattr(
+        system_health.system_health,
+        "async_check_can_reach_url",
+        lambda hass, url: url == BASE_URL,
+    )
+
+    info = await system_health.system_health_info(hass)
+
+    assert info["site_id"] == config_entry.data["site_id"]
+    assert info["can_reach_server"] is True
+    assert info["last_success"] == coord.last_success_utc.isoformat()
+    assert info["latency_ms"] == 120
+    assert info["last_error"] == "timeout"
+    assert info["backoff_active"] is True
+    assert info["network_errors"] == 3
+    assert info["http_errors"] == 1
+    assert info["phase_timings"] == {"fast": 0.5}
+    assert info["session_cache_ttl_s"] == 300


### PR DESCRIPTION
## Summary

Add targeted tests for device actions, triggers, diagnostics, system health, and API helper utilities to boost Codecov coverage for the Enphase EV integration.

## Type of change

- [ ] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [x] Other (describe below)

Other: Test coverage improvements

## Testing

Tick all commands you ran locally (remove lines that do not apply):

- [x] `pytest --cov=custom_components.enphase_ev --cov-report=term`
- [ ] `ruff check .`
- [ ] `black custom_components/enphase_ev`
- [ ] `pytest -q tests_enphase_ev`
- [ ] `python scripts/validate_quality_scale.py`
- [ ] `python -m script.hassfest`
- [ ] `pre-commit run --all-files`
- [x] Other (describe below)

Other: `pre-commit run --all-files` (fails: /opt/homebrew/opt/python@3.10/bin/python3.10: bad interpreter - local env lacks python3.10)

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Additional context

Coverage now reports ~67% (up from ~63%) for `custom_components.enphase_ev`.
