### PR TITLE
Add Codecov test analytics uploads

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,11 +83,22 @@ jobs:
           python -m pip install --upgrade pip
           pip install --upgrade pytest pytest-asyncio pytest-cov pytest-homeassistant-custom-component homeassistant aiohttp async-timeout voluptuous
       - name: Run tests
-        run: pytest --cov=custom_components.enphase_ev --cov-report=term-missing --cov-report=xml
+        id: pytest
+        continue-on-error: true
+        run: pytest --cov=custom_components.enphase_ev --cov-report=term-missing --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
       - name: Upload coverage to Codecov
-        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
+        if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) }}
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml
           fail_ci_if_error: true
+      - name: Upload test results to Codecov
+        if: ${{ always() && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./junit.xml
+      - name: Fail if tests failed
+        if: ${{ steps.pytest.outcome == 'failure' }}
+        run: exit 1


### PR DESCRIPTION
## Summary

- Generate JUnit test results during pytest runs and upload them to Codecov Test Analytics alongside coverage.
- Ensure coverage and test result uploads run even when pytest fails so diagnostics reach Codecov.

## Type of change

- [ ] Bugfix
- [x] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Tick all commands you ran locally (remove lines that do not apply):

- [ ] (CI-only change; no local commands executed)

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Additional context

- No local commands run; relying on CI to validate workflow changes.
