### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/7](https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/7)

The best fix is to add an explicit `permissions` block with the least privilege required for the jobs in this workflow. Given that almost all jobs only read repository code, a workflow-global `permissions: contents: read` block at the top is suitable for the majority of the workflow. If any job (or step) needs elevated write access (e.g., if `codecov-action` needs to create a status check or write to pull requests), a job-level permissions override (e.g., `pull-requests: write`) can be added for that job only. For now, a minimal global `permissions: contents: read` block should be inserted after the `name:` and before the `on:` trigger, ensuring least privilege by default.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
