### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,10 @@ jobs:
   pytest:
     runs-on: ubuntu-latest
     needs: quality-scale
+    permissions:
+      contents: read
+      checks: write
+      pull-requests: write
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/6](https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/6)

To remove unnecessary privileges, add a `permissions:` block at the workflow root (near the top, after `name:` and `on:`) or at each job that specifies the minimal required permissions. Since all jobs in this workflow appear to only run checks, validation, and tests, the minimal permission needed is likely `contents: read`. If specific jobs need more, adjust accordingly, but for the code shown, a single block at the top is the most maintainable solution and secures all jobs by default. Insert:

```yaml
permissions:
  contents: read
```

immediately after the `on:` section (after line 17). No modifications to imports, methods, or variables are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
