### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,6 +19,8 @@ concurrency:
   group: ${{ format('{0}-{1}', github.workflow_ref || github.workflow, github.ref) }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/5](https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/5)

To fix the problem, the best general approach is to add a `permissions` block specifying the minimal required permissions, either at the workflow root level (before the `jobs:` key, which affects all jobs) or individually inside jobs if some require different permissions. In this workflow, none of the jobs seem to require write access (they mainly check out code, run tests, upload results), so setting `contents: read` at the workflow root is sufficient and safest, unless a job specifically requires an elevated permission (e.g., writing a PR comment or issue). The codecov action with a token does not require extra permissions since the uploading is done via the Codecov token. Therefore, add the following block just before the `jobs:` key:

```yaml
permissions:
  contents: read
```

No new imports or external changes are needed; just the single block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
