### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/4](https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/4)

To fix this problem, the workflow file `.github/workflows/tests.yml` should include an explicit `permissions` block, either at the workflow root (preferred, to apply to all jobs), or at the job level (if specific jobs need different permissions). Since none of the jobs seem to require write access, and only one uploads coverage (possibly requiring something for pull requests), we follow GitHub's recommendation and set the minimal permissions, starting with `contents: read` globally.

If in the future, any job requires more (for example, write access to pull-requests), then the `permissions` key can be adjusted at either the workflow or job level as needed.

The change:
- Insert at the root of the YAML, immediately after the `name:` line and before `on:`, a `permissions: contents: read` block.
- No further code changes, imports, or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
