### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ permissions:
   contents: read
 
 on:
+  push:
     branches:
       - main
       - 'release/**'


### PR DESCRIPTION
Potential fix for [https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/3](https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/3)

The best way to fix this problem is to add a `permissions` block at the workflow root in `.github/workflows/ci.yml`, directly below the top-level keys (e.g., after the `name:` block). This ensures the least-privilege principle is enforced for all jobs in the workflow, unless a specific job overrides it. The minimum recommended is `contents: read` unless a more restrictive or specific permission policy is known to be needed. This change does not affect the workflow's existing steps or functionality but ensures that the default GitHub token permissions are constrained unless explicitly expanded. No imports or additional definitions are needed for this change: it is a pure YAML configuration fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
