### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -1,4 +1,6 @@
 name: Validate with hassfest
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/2](https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/2)

To fix this issue, we should add a minimal `permissions:` block to the workflow at either the workflow root (applies to all jobs) or at the `validate` job level. Since this is a single-job workflow, applying it at the root is simplest and most maintainable. The least privileges required should be set, starting with `contents: read`, which allows the job to check out the repository but does not provide unnecessary write access. Edit `.github/workflows/hassfest.yml` and insert a `permissions:` block immediately after the `name` field (before `on:`), setting `contents: read`. No additional imports or methods are needed; this is purely a configuration change in YAML.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
