### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/quality_scale.yml
+++ b/.github/workflows/quality_scale.yml
@@ -1,4 +1,6 @@
 name: Quality Scale
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/1](https://github.com/barneyonline/ha-enphase-ev-charger/security/code-scanning/1)

To resolve the problem, the workflow file `.github/workflows/quality_scale.yml` needs to be updated to include a `permissions` block. As the workflow steps only require source code read access (checkout, install, scripting), and do not interact with issues, pull requests, or other resources requiring write permissions, you can grant only `contents: read` permission. The `permissions` block should be added at the top level in the workflow (right after `name:` is a common convention), applying to all jobs in the workflow (unless overridden by job-level permissions blocks). This single addition will restrict the GITHUB_TOKEN for all jobs and greatly improve security hygiene.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
