### PR TITLE
Update service translations and redact email

### DIFF
--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -5,7 +5,7 @@ from typing import Any
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.helpers import device_registry as dr
 
-from .const import DOMAIN
+from .const import CONF_EMAIL, DOMAIN
 
 TO_REDACT = [
     "e_auth_token",
@@ -14,6 +14,7 @@ TO_REDACT = [
     "session_id",
     "enlighten_manager_token_production",
     "password",
+    CONF_EMAIL,
 ]
 
 

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -249,6 +249,10 @@
       "name": "Clear Reauth Issue",
       "description": "Select an Enphase site device to clear its reauthentication repair issue.",
       "fields": {
+        "device_id": {
+          "name": "Chargers",
+          "description": "Select Enphase chargers whose reauthentication repair issue should be cleared."
+        },
         "site_id": {
           "name": "Site ID",
           "description": "Optional site identifier; detected automatically when a site device is selected."

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -242,6 +242,10 @@
       "name": "Effacer le problème de réauth",
       "description": "Sélectionnez un périphérique de site Enphase pour effacer son problème de réparation de réauthentification.",
       "fields": {
+        "device_id": {
+          "name": "Bornes de recharge",
+          "description": "Sélectionnez les bornes Enphase dont l'alerte de réauthentification doit être effacée."
+        },
         "site_id": {
           "name": "ID du site",
           "description": "Identifiant de site optionnel ; détecté automatiquement lorsqu'un périphérique de site est sélectionné."

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -54,6 +54,7 @@ async def test_config_entry_diagnostics_includes_coordinator(hass, config_entry)
     diag = await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
 
     assert diag["entry_data"]["cookie"] == "**REDACTED**"
+    assert diag["entry_data"]["email"] == "**REDACTED**"
     assert diag["coordinator"]["site_id"] == RANDOM_SITE_ID
     assert diag["coordinator"]["headers_info"]["base_header_names"] == [
         "Authorization",

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import json
+import pathlib
+
+
+def test_clear_reauth_issue_device_field_translated() -> None:
+    """Ensure device selector metadata is translated for all locales."""
+
+    translations_dir = (
+        pathlib.Path(__file__).resolve().parents[3]
+        / "custom_components"
+        / "enphase_ev"
+        / "translations"
+    )
+    for lang in ("en", "fr"):
+        data = json.loads((translations_dir / f"{lang}.json").read_text())
+        fields = data["services"]["clear_reauth_issue"]["fields"]
+        assert "device_id" in fields, f"{lang} missing device_id translation"
+        entry = fields["device_id"]
+        assert entry.get("name"), f"{lang} device_id name empty"
+        assert entry.get("description"), f"{lang} device_id description empty"


### PR DESCRIPTION
## Summary
- localize the new clear_reauth_issue device selector in all shipped locales
- redact stored account email from diagnostics output for privacy
- add regression tests covering translations and redaction

## Testing
- pytest