### PR TITLE
Improve reconfigure wrong-account UX and auto-assign issues

### DIFF
--- a/.github/workflows/auto_assign_new_issues.yml
+++ b/.github/workflows/auto_assign_new_issues.yml
@@ -1,0 +1,35 @@
+name: Auto Assign New Issues
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  issues: write
+
+jobs:
+  assign_to_author:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const issue = context.payload.issue;
+            const login = "barneyonline";
+
+            if (issue.assignees?.some((assignee) => assignee.login === login)) {
+              return;
+            }
+
+            await github.rest.issues.addAssignees({
+              owner,
+              repo,
+              issue_number: issue.number,
+              assignees: [login],
+            }).catch((error) => {
+              if (error.status !== 422) {
+                throw error;
+              }
+            });

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -1,4 +1,57 @@
 {
+  "config": {
+    "step": {
+      "user": {
+        "title": "Enphase EV Charger 2 (Cloud)",
+        "description": "Sign in with your Enlighten credentials.",
+        "data": {
+          "email": "Email",
+          "password": "Password",
+          "remember_password": "Store password for automatic reauthentication"
+        },
+        "data_description": {
+          "email": "Your Enlighten account email.",
+          "password": "Password is only stored if you enable the checkbox.",
+          "remember_password": "Allows the integration to refresh tokens automatically when they expire."
+        }
+      },
+      "site": {
+        "title": "Select Site",
+        "description": "Pick which Enlighten site to link.",
+        "data": {
+          "site_id": "Site"
+        }
+      },
+      "devices": {
+        "title": "Select Chargers",
+        "description": "Choose one or more chargers to add. All selections share the same polling interval.",
+        "data": {
+          "serials": "Chargers",
+          "scan_interval": "Scan interval (s)"
+        },
+        "data_description": {
+          "serials": "Select chargers from your site or paste serial numbers if none are listed.",
+          "scan_interval": "Seconds between cloud status polls. Default 60s."
+        }
+      }
+    },
+    "error": {
+      "invalid_auth": "Invalid credentials or expired session.",
+      "cannot_connect": "Cannot reach Enphase service.",
+      "service_unavailable": "Enphase temporarily unavailable. Try again later.",
+      "mfa_required": "Account requires multi-factor authentication. Complete MFA in the browser and try again.",
+      "site_required": "Select a site to continue.",
+      "serials_required": "Select or enter at least one charger.",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Already Configured",
+      "reconfigure_successful": "Reconfiguration Successful",
+      "reauth_successful": "Re-Authentication Successful",
+      "manual_mode_removed": "Legacy manual authentication entries are no longer supported. Remove the integration and set it up again using Enlighten login.",
+      "wrong_account": "This entry is already linked to {configured_label}. Remove the integration from Home Assistant and add a new one to link {requested_label}."
+    }
+  },
   "exceptions": {
     "charger_not_plugged": {
       "message": "Cannot start charging because {name} is unplugged from the vehicle."

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -48,7 +48,8 @@
       "already_configured": "Already Configured",
       "reconfigure_successful": "Reconfiguration Successful",
       "reauth_successful": "Re-Authentication Successful",
-      "manual_mode_removed": "Legacy manual authentication entries are no longer supported. Remove the integration and set it up again using Enlighten login."
+      "manual_mode_removed": "Legacy manual authentication entries are no longer supported. Remove the integration and set it up again using Enlighten login.",
+      "wrong_account": "This entry is already linked to {configured_label}. Remove the integration from Home Assistant and add a new one to link {requested_label}."
     }
   }
   ,

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -48,7 +48,8 @@
       "already_configured": "Déjà configuré",
       "reconfigure_successful": "Reconfiguration réussie",
       "reauth_successful": "Réauthentification réussie",
-      "manual_mode_removed": "Les entrées d'authentification manuelle héritées ne sont plus prises en charge. Supprimez l'intégration et reconfigurez-la en utilisant la connexion Enlighten."
+      "manual_mode_removed": "Les entrées d'authentification manuelle héritées ne sont plus prises en charge. Supprimez l'intégration et reconfigurez-la en utilisant la connexion Enlighten.",
+      "wrong_account": "Cette entrée est déjà liée à {configured_label}. Supprimez l'intégration de Home Assistant et ajoutez-en une nouvelle pour associer {requested_label}."
     }
   }
   ,

--- a/tests/components/enphase_ev/test_reconfigure_flow.py
+++ b/tests/components/enphase_ev/test_reconfigure_flow.py
@@ -1,17 +1,23 @@
 from __future__ import annotations
 
+from unittest.mock import AsyncMock, MagicMock, patch
+
 import pytest
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
 
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.enphase_ev.api import AuthTokens, ChargerInfo, SiteInfo
 from custom_components.enphase_ev.config_flow import EnphaseEVConfigFlow
 from custom_components.enphase_ev.const import (
     CONF_EMAIL,
     CONF_PASSWORD,
     CONF_REMEMBER_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_SERIALS,
     CONF_SITE_ID,
+    CONF_SITE_NAME,
     DOMAIN,
 )
 
@@ -82,3 +88,206 @@ async def test_reauth_manual_entry_aborts(hass) -> None:
 
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "manual_mode_removed"
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_skips_site_selection(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SITE_ID: "site-123",
+            CONF_SITE_NAME: "Garage Site",
+            CONF_EMAIL: "user@example.com",
+            CONF_REMEMBER_PASSWORD: True,
+            CONF_PASSWORD: "secret",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = EnphaseEVConfigFlow()
+    flow.hass = hass
+    flow.context = {
+        "source": config_entries.SOURCE_RECONFIGURE,
+        "entry_id": entry.entry_id,
+    }
+
+    tokens = AuthTokens(
+        cookie="jar=1",
+        session_id="sid123",
+        access_token="token123",
+        token_expires_at=1_700_000_000,
+    )
+    sites = [
+        SiteInfo(site_id="site-123", name="Garage Site"),
+        SiteInfo(site_id="site-456", name="Backup Site"),
+    ]
+    chargers = [ChargerInfo(serial="EV123", name="Driveway Charger")]
+
+    with (
+        patch(
+            "custom_components.enphase_ev.config_flow.async_authenticate",
+            AsyncMock(return_value=(tokens, sites)),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_chargers",
+            AsyncMock(return_value=chargers),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_get_clientsession",
+            MagicMock(),
+        ),
+    ):
+        result = await flow.async_step_reconfigure()
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        result = await flow.async_step_user(
+            {
+                CONF_EMAIL: "user@example.com",
+                CONF_PASSWORD: "secret",
+                CONF_REMEMBER_PASSWORD: True,
+            }
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "devices"
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_wrong_account_abort_has_placeholders(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SITE_ID: "site-123",
+            CONF_SITE_NAME: "Garage Site",
+            CONF_EMAIL: "user@example.com",
+            CONF_REMEMBER_PASSWORD: True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = EnphaseEVConfigFlow()
+    flow.hass = hass
+    flow.context = {
+        "source": config_entries.SOURCE_RECONFIGURE,
+        "entry_id": entry.entry_id,
+    }
+
+    tokens = AuthTokens(
+        cookie="jar=1",
+        session_id="sid123",
+        access_token="token123",
+        token_expires_at=1_700_000_000,
+    )
+    sites = [
+        SiteInfo(site_id="site-123", name="Garage Site"),
+        SiteInfo(site_id="site-456", name="Backup Site"),
+    ]
+    chargers = [ChargerInfo(serial="EV999", name="Workshop Charger")]
+
+    with (
+        patch(
+            "custom_components.enphase_ev.config_flow.async_authenticate",
+            AsyncMock(return_value=(tokens, sites)),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_chargers",
+            AsyncMock(return_value=chargers),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_get_clientsession",
+            MagicMock(),
+        ),
+    ):
+        # Kick off the reconfigure flow and authenticate
+        result = await flow.async_step_reconfigure()
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        result = await flow.async_step_user(
+            {
+                CONF_EMAIL: "user@example.com",
+                CONF_PASSWORD: "secret",
+                CONF_REMEMBER_PASSWORD: True,
+            }
+        )
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "devices"
+
+        # Simulate selecting a different site before finalizing
+        flow._selected_site_id = "site-456"
+
+        result = await flow.async_step_devices(
+            {CONF_SERIALS: ["EV999"], CONF_SCAN_INTERVAL: 60}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "wrong_account"
+    placeholders = result.get("description_placeholders")
+    assert placeholders == {
+        "configured_label": "Garage Site (site-123)",
+        "requested_label": "Backup Site (site-456)",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reauth_skips_site_selection(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SITE_ID: "site-123",
+            CONF_SITE_NAME: "Garage Site",
+            CONF_EMAIL: "user@example.com",
+            CONF_REMEMBER_PASSWORD: True,
+            CONF_PASSWORD: "secret",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = EnphaseEVConfigFlow()
+    flow.hass = hass
+    flow.context = {
+        "source": config_entries.SOURCE_REAUTH,
+        "entry_id": entry.entry_id,
+    }
+
+    tokens = AuthTokens(
+        cookie="jar=1",
+        session_id="sid123",
+        access_token="token123",
+        token_expires_at=1_700_000_000,
+    )
+    sites = [
+        SiteInfo(site_id="site-123", name="Garage Site"),
+        SiteInfo(site_id="site-456", name="Backup Site"),
+    ]
+    chargers = [ChargerInfo(serial="EV123", name="Driveway Charger")]
+
+    with (
+        patch(
+            "custom_components.enphase_ev.config_flow.async_authenticate",
+            AsyncMock(return_value=(tokens, sites)),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_chargers",
+            AsyncMock(return_value=chargers),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_get_clientsession",
+            MagicMock(),
+        ),
+    ):
+        result = await flow.async_step_reauth({})
+        assert result["type"] is FlowResultType.FORM
+        assert result["step_id"] == "user"
+
+        result = await flow.async_step_user(
+            {
+                CONF_EMAIL: "user@example.com",
+                CONF_PASSWORD: "secret",
+                CONF_REMEMBER_PASSWORD: True,
+            }
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "devices"


### PR DESCRIPTION
## Summary
- lock reconfigure and reauth flows to the existing site and return a descriptive wrong_account abort
- add base strings and translations for the wrong_account message
- add regression coverage for reconfigure/reauth and the abort placeholders
- add a GitHub Actions workflow to auto-assign new issues to barneyonline

## Testing
- pytest tests/components/enphase_ev/test_reconfigure_flow.py

## Issues
- improves handling for https://github.com/barneyonline/ha-enphase-ev-charger/issues/135