### PR TITLE
Refine Enphase EV test fixtures

### DIFF
--- a/tests/components/enphase_ev/conftest.py
+++ b/tests/components/enphase_ev/conftest.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 import json
 import sys
 from collections.abc import Callable
+from contextlib import ExitStack
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from homeassistant.core import HomeAssistant
+from unittest.mock import AsyncMock, patch
 
 try:
     from custom_components.enphase_ev.const import (
@@ -127,3 +130,150 @@ def stub_coordinator_session_history(monkeypatch, request) -> None:
         "_async_fetch_sessions_today",
         _fake_sessions,
     )
+
+
+@pytest.fixture
+def mock_issue_registry(monkeypatch) -> SimpleNamespace:
+    """Capture coordinator issue registry calls without touching HA."""
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    created: list[tuple[str, str, dict[str, Any]]] = []
+    deleted: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        coord_mod.ir,
+        "async_create_issue",
+        lambda hass, domain, issue_id, **kwargs: created.append(
+            (domain, issue_id, kwargs)
+        ),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        coord_mod.ir,
+        "async_delete_issue",
+        lambda hass, domain, issue_id: deleted.append((domain, issue_id)),
+        raising=False,
+    )
+    return SimpleNamespace(created=created, deleted=deleted)
+
+
+@pytest.fixture(autouse=True)
+def mock_clientsession(monkeypatch):
+    """Stub out aiohttp client session factory used by the integration."""
+    session = object()
+    for target in (
+        "custom_components.enphase_ev.coordinator.async_get_clientsession",
+        "custom_components.enphase_ev.config_flow.async_get_clientsession",
+    ):
+        monkeypatch.setattr(
+            target,
+            lambda *args, **kwargs: session,
+            raising=False,
+        )
+    return session
+
+
+@pytest.fixture
+def coordinator_factory(hass, mock_clientsession, mock_issue_registry, monkeypatch):
+    """Return a factory that builds a patched EnphaseCoordinator instance."""
+    from custom_components.enphase_ev import coordinator as coord_mod
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    monkeypatch.setattr(
+        coord_mod,
+        "async_call_later",
+        lambda *_args, **_kwargs: (lambda: None),
+    )
+
+    def _factory(
+        *,
+        config: dict[str, Any] | None = None,
+        serials: list[str] | None = None,
+        client: Any | None = None,
+        data: dict[str, Any] | None = None,
+    ) -> EnphaseCoordinator:
+        active_serials = serials or [RANDOM_SERIAL]
+        cfg = config or {
+            CONF_SITE_ID: RANDOM_SITE_ID,
+            CONF_SERIALS: active_serials,
+            CONF_EAUTH: "EAUTH",
+            CONF_COOKIE: "COOKIE",
+            CONF_SCAN_INTERVAL: 15,
+        }
+        coord = EnphaseCoordinator(hass, cfg)
+        coord.serials = set(active_serials)
+        coord.data = data or {sn: {"sn": sn, "name": f"Charger {sn}"} for sn in coord.serials}
+        coord.last_set_amps = getattr(coord, "last_set_amps", {}) or {}
+        if client is not None:
+            coord.client = client
+        return coord
+
+    return _factory
+
+
+@pytest.fixture
+def setup_integration(
+    hass: HomeAssistant,
+    config_entry: MockConfigEntry,
+    mock_clientsession,
+    mock_issue_registry,
+):
+    """Return helper to fully set up the integration via HA config entries."""
+    from custom_components.enphase_ev.const import DOMAIN
+
+    async def _setup(
+        *,
+        client: Any | None = None,
+        first_refresh_result: Any = None,
+    ) -> dict[str, Any]:
+        forward_calls: list[list[str]] = []
+        unload_mock = AsyncMock(return_value=True)
+        with ExitStack() as stack:
+            if client is not None:
+                stack.enter_context(
+                    patch(
+                        "custom_components.enphase_ev.coordinator.EnphaseEVClient",
+                        return_value=client,
+                    )
+                )
+            stack.enter_context(
+                patch(
+                    "custom_components.enphase_ev.coordinator.EnphaseCoordinator.async_config_entry_first_refresh",
+                    AsyncMock(return_value=first_refresh_result),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    hass.config_entries,
+                    "async_forward_entry_setups",
+                    AsyncMock(
+                        side_effect=lambda entry, platforms: forward_calls.append(
+                            list(platforms)
+                        )
+                    ),
+                )
+            )
+            stack.enter_context(
+                patch.object(
+                    hass.config_entries,
+                    "async_unload_platforms",
+                    unload_mock,
+                )
+            )
+            assert await hass.config_entries.async_setup(config_entry.entry_id)
+            await hass.async_block_till_done()
+        entry_data = hass.data[DOMAIN][config_entry.entry_id]
+        return {
+            "entry_data": entry_data,
+            "forwarded": forward_calls,
+            "unload_mock": unload_mock,
+        }
+
+    return _setup

--- a/tests/components/enphase_ev/test_reconfigure_flow.py
+++ b/tests/components/enphase_ev/test_reconfigure_flow.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from homeassistant import config_entries
@@ -132,10 +132,6 @@ async def test_reconfigure_skips_site_selection(hass) -> None:
             "custom_components.enphase_ev.config_flow.async_fetch_chargers",
             AsyncMock(return_value=chargers),
         ),
-        patch(
-            "custom_components.enphase_ev.config_flow.async_get_clientsession",
-            MagicMock(),
-        ),
     ):
         result = await flow.async_step_reconfigure()
         assert result["type"] is FlowResultType.FORM
@@ -193,10 +189,6 @@ async def test_reconfigure_wrong_account_abort_has_placeholders(hass) -> None:
         patch(
             "custom_components.enphase_ev.config_flow.async_fetch_chargers",
             AsyncMock(return_value=chargers),
-        ),
-        patch(
-            "custom_components.enphase_ev.config_flow.async_get_clientsession",
-            MagicMock(),
         ),
     ):
         # Kick off the reconfigure flow and authenticate
@@ -271,10 +263,6 @@ async def test_reauth_skips_site_selection(hass) -> None:
         patch(
             "custom_components.enphase_ev.config_flow.async_fetch_chargers",
             AsyncMock(return_value=chargers),
-        ),
-        patch(
-            "custom_components.enphase_ev.config_flow.async_get_clientsession",
-            MagicMock(),
         ),
     ):
         result = await flow.async_step_reauth({})


### PR DESCRIPTION
## Summary
- add shared fixtures for full integration setup and coordinator factory
- drive config flow tests through Home Assistant's flow manager
- reuse common clientsession/issue registry stubs across integration and reconfigure tests

## Testing
- ruff check .
- python3 -m pre_commit run --all-files
- pytest tests/components/enphase_ev -q
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"