### PR TITLE
Expand Enphase entity coverage

### DIFF
--- a/tests/components/enphase_ev/test_device_info.py
+++ b/tests/components/enphase_ev/test_device_info.py
@@ -23,3 +23,61 @@ def test_device_info_uses_display_name_and_model():
     assert info["name"] == "Garage Charger"
     assert info["model"] == "Garage Charger (IQ-EVSE-EU-3032)"
     assert info["serial_number"] == "555555555555"
+
+
+def test_device_info_falls_back_to_model_name():
+    from custom_components.enphase_ev.entity import EnphaseBaseEntity
+
+    entity = object.__new__(EnphaseBaseEntity)
+    entity._coord = SimpleNamespace(
+        data={
+            "1234": {
+                "model_name": "IQ-EVSE-EU-3032",
+                "hw_version": "2.1",
+            }
+        },
+        site_id="7654321",
+    )
+    entity._sn = "1234"
+
+    info = entity.device_info
+
+    assert info["name"] == "IQ-EVSE-EU-3032"
+    assert info["model"] == "IQ-EVSE-EU-3032"
+    assert info["identifiers"] == {("enphase_ev", "1234")}
+
+
+def test_device_info_defaults_when_metadata_missing():
+    from custom_components.enphase_ev.entity import EnphaseBaseEntity
+
+    entity = object.__new__(EnphaseBaseEntity)
+    entity._coord = SimpleNamespace(
+        data={"321": {}},
+        site_id="site-1",
+    )
+    entity._sn = "321"
+
+    info = entity.device_info
+
+    assert info["name"] == "Enphase EV Charger"
+    assert info.get("model") is None
+
+
+def test_device_info_uses_display_name_when_model_missing():
+    from custom_components.enphase_ev.entity import EnphaseBaseEntity
+
+    entity = object.__new__(EnphaseBaseEntity)
+    entity._coord = SimpleNamespace(
+        data={
+            "999": {
+                "display_name": "Driveway Charger",
+            }
+        },
+        site_id="site-2",
+    )
+    entity._sn = "999"
+
+    info = entity.device_info
+
+    assert info["name"] == "Driveway Charger"
+    assert info["model"] == "Driveway Charger"

--- a/tests/components/enphase_ev/test_entity_base.py
+++ b/tests/components/enphase_ev/test_entity_base.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import logging
+
+from custom_components.enphase_ev.entity import EnphaseBaseEntity
+from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
+
+
+class DummyEntity(EnphaseBaseEntity):
+    """Concrete subclass for exercising base entity logic."""
+
+
+def test_base_entity_data_falls_back_to_coordinator(coordinator_factory):
+    coord = coordinator_factory()
+    entity = DummyEntity(coord, RANDOM_SERIAL)
+    delattr(entity, "_data")
+    coord.data[RANDOM_SERIAL]["hw_version"] = "1.2"
+
+    assert entity.data["hw_version"] == "1.2"
+
+
+def test_base_entity_data_handles_missing_coord():
+    class RaisesAttributeError:
+        @property
+        def data(self):
+            raise AttributeError("boom")
+
+    entity = object.__new__(EnphaseBaseEntity)
+    entity._coord = RaisesAttributeError()  # type: ignore[attr-defined]
+    entity._sn = "nope"  # type: ignore[attr-defined]
+
+    assert entity.data == {}
+
+
+def test_base_entity_logs_transitions(coordinator_factory, caplog):
+    coord = coordinator_factory(data={RANDOM_SERIAL: {"sn": RANDOM_SERIAL, "name": "Garage"}})
+    entity = DummyEntity(coord, RANDOM_SERIAL)
+    entity.async_write_ha_state = lambda *args, **kwargs: None  # type: ignore[attr-defined]
+
+    caplog.set_level(logging.INFO)
+    entity._unavailable_logged = True  # type: ignore[attr-defined]
+    coord.data = {RANDOM_SERIAL: {"sn": RANDOM_SERIAL}}
+    entity._handle_coordinator_update()
+    assert "data available again" in caplog.text
+    assert entity._unavailable_logged is False  # type: ignore[attr-defined]
+
+    caplog.clear()
+    entity._ever_had_data = True  # type: ignore[attr-defined]
+    entity._unavailable_logged = False  # type: ignore[attr-defined]
+    entity._has_data = True  # type: ignore[attr-defined]
+    coord.data = {}
+    coord._last_error = "timeout"  # type: ignore[attr-defined]
+    entity._handle_coordinator_update()
+    assert "data unavailable (timeout)" in caplog.text
+    assert entity._unavailable_logged is True  # type: ignore[attr-defined]
+
+    caplog.clear()
+    entity._unavailable_logged = False  # type: ignore[attr-defined]
+    entity._has_data = True  # type: ignore[attr-defined]
+    coord._last_error = None  # type: ignore[attr-defined]
+    entity._handle_coordinator_update()
+    assert "data unavailable" in caplog.text
+    assert entity._unavailable_logged is True  # type: ignore[attr-defined]

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -51,3 +51,64 @@ async def test_charge_mode_select(hass, monkeypatch):
     await sel.async_select_option("Manual")
     # cache should update immediately
     assert coord._charge_mode_cache[RANDOM_SERIAL][0] == "MANUAL_CHARGING"
+
+
+def test_charge_mode_select_current_option_paths(coordinator_factory):
+    from custom_components.enphase_ev.select import ChargeModeSelect
+
+    coord = coordinator_factory()
+    coord.data[RANDOM_SERIAL]["charge_mode_pref"] = "GREEN_CHARGING"
+    coord.data[RANDOM_SERIAL]["charge_mode"] = "MANUAL_CHARGING"
+
+    sel = ChargeModeSelect(coord, RANDOM_SERIAL)
+    assert sel.current_option == "Green"
+
+    coord.data[RANDOM_SERIAL]["charge_mode_pref"] = ""
+    coord.data[RANDOM_SERIAL]["charge_mode"] = "experimental_mode"
+    assert sel.current_option == "Experimental_Mode"
+
+    coord.data[RANDOM_SERIAL]["charge_mode"] = ""
+    assert sel.current_option is None
+
+
+@pytest.mark.asyncio
+async def test_select_platform_async_setup_entry_filters_known_serials(
+    hass, config_entry, coordinator_factory
+):
+    from custom_components.enphase_ev.const import DOMAIN
+    from custom_components.enphase_ev.select import ChargeModeSelect, async_setup_entry
+
+    coord = coordinator_factory(serials=["1111"])
+    added: list[list[ChargeModeSelect]] = []
+    listeners: list[object] = []
+
+    def capture_add(entities, update_before_add=False):
+        added.append(list(entities))
+
+    def capture_listener(callback, *, context=None):
+        listeners.append(callback)
+
+        def _remove():
+            listeners.remove(callback)
+
+        return _remove
+
+    coord.async_add_listener = capture_listener  # type: ignore[attr-defined]
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+
+    await async_setup_entry(hass, config_entry, capture_add)
+    assert len(added) == 1
+    assert isinstance(added[0][0], ChargeModeSelect)
+    assert added[0][0]._sn == "1111"
+    assert len(listeners) == 1
+
+    added.clear()
+    listeners[0]()
+    assert added == []
+
+    coord._ensure_serial_tracked("2222")
+    coord.data["2222"] = {"sn": "2222", "name": "Driveway"}
+    listeners[0]()
+
+    assert len(added) == 1
+    assert {entity._sn for entity in added[0]} == {"2222"}


### PR DESCRIPTION
## Summary
- add tests for button/select platform serial sync coverage
- cover EnphaseBaseEntity data fallbacks and logging
- expand device info fallback tests for full branch coverage

## Testing
- pytest tests/components/enphase_ev -q
- ruff check .
- python3 -m pre_commit run --all-files
