### PR TITLE
Improve helper test coverage

### DIFF
--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -150,6 +150,7 @@ def test_site_cloud_reachable_binary_sensor_metadata(
     coord.last_success_utc = now - timedelta(seconds=45)
     coord.update_interval = None
     monkeypatch.setattr(dt_util, "utcnow", lambda: now)
+    assert sensor.available is True
     assert sensor.is_on is True
 
     monkeypatch.setattr(dt_util, "utcnow", lambda: now + timedelta(seconds=61))

--- a/tests/components/enphase_ev/test_entity_base.py
+++ b/tests/components/enphase_ev/test_entity_base.py
@@ -61,3 +61,15 @@ def test_base_entity_logs_transitions(coordinator_factory, caplog):
     entity._handle_coordinator_update()
     assert "data unavailable" in caplog.text
     assert entity._unavailable_logged is True  # type: ignore[attr-defined]
+
+
+def test_base_entity_data_returns_empty_when_source_not_mapping():
+    class NonMappingCoord:
+        def __init__(self) -> None:
+            self.data = ["bad-entry"]
+
+    entity = object.__new__(EnphaseBaseEntity)
+    entity._coord = NonMappingCoord()  # type: ignore[attr-defined]
+    entity._sn = "missing"  # type: ignore[attr-defined]
+
+    assert entity.data == {}


### PR DESCRIPTION
## Summary
- add focused tests covering previously untested helper branches (services, device automation, triggers, numbers, system health)
- refactor API client start/stop candidate builders to unblock error-path coverage and add corresponding tests
- add coordinator init coverage for serial normalization and option fallbacks

## Testing
- pytest -q
