### PR TITLE
Fix Ruff lint issues in tests

### DIFF
--- a/tests/components/enphase_ev/test_coordinator_edge_cases.py
+++ b/tests/components/enphase_ev/test_coordinator_edge_cases.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import asyncio
-import asyncio
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -429,7 +429,7 @@ async def test_service_helper_resolve_functions_cover_none_branches(
     assert await resolve_sn(child_no_parent.id) is None
     assert await resolve_site(child_no_parent.id) is None
 
-    parent_site = dev_reg.async_get_or_create(
+    dev_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, "site:PARENT")},
         manufacturer="Enphase",


### PR DESCRIPTION
## Summary
- remove duplicate asyncio import in coordinator edge case tests to clear Ruff F811
- drop unused parent_site assignment in init module tests to satisfy Ruff F841

## Testing
- ruff check .
- pytest tests/components/enphase_ev -q
- python3 -m pre_commit run --all-files