### PR TITLE
Release v1.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,31 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- Cloud Backoff Ends now exposes the backoff expiry as a timestamp entity and schedules a single refresh when the window finishes, eliminating the per-second state churn that crashed the UI when opening that sensor's history.
-- Removed the stale `backoff_seconds` attribute from Cloud Backoff Ends since the timestamp entity already carries the necessary context and attributes no longer update each second.
+- None
 
 ### 🔧 Improvements
 - None
 
 ### 🔄 Other changes
 - None
+
+## v1.4.3 – 2025-11-12
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Cloud Backoff Ends now exposes the backoff expiry as a timestamp entity and schedules a single refresh when the window finishes, eliminating the per-second state churn that crashed the UI when opening that sensor's history.
+- Removed the stale `backoff_seconds` attribute from Cloud Backoff Ends since the timestamp entity already carries the necessary context and attributes no longer update each second.
+
+### 🔧 Improvements
+- Hold the coordinator in fast polling for a minute whenever a charger toggles between idle and charging so dashboards and automations pick up new states without waiting for the slow interval.
+
+### 🔄 Other changes
+- Split the start/stop API helpers and expand the coordinator/helper/unit test coverage to lock in the fast-poll and diagnostics behaviour.
 
 ## v1.4.2 – 2025-11-09
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If the login form reports that multi-factor authentication is required, complete
 
 | Entity Type | Description |
 | --- | --- |
-| Site sensors | Last Successful Update timestamp, Cloud Latency in milliseconds, Cloud Error Code (with descriptive context), and a Cloud Backoff Ends countdown so you can track active retry windows. |
+| Site sensors | Last Successful Update timestamp, Cloud Latency in milliseconds, Cloud Error Code (with descriptive context), and a Cloud Backoff Ends timestamp so you can see exactly when active retry windows clear. |
 | Site binary sensor | Cloud Reachable indicator (on/off) with attributes for the last success, last failure (status, description, response), and any active backoff window. |
 | Switch | Per-charger charging control (on/off) that stays in sync even if a session is already active. |
 | Button | Start Charging and Stop Charging actions for each charger. |

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.4.2"
+  "version": "1.4.3"
 }


### PR DESCRIPTION
## Summary
- Bump the manifest to 1.4.3 and capture the post-1.4.2 fixes/improvements in CHANGELOG
- Refresh the README Cloud Backoff Ends description now that it is a timestamp entity

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'pytest'
