### PR TITLE
Improve coordinator+sensor coverage

### DIFF
--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -1,0 +1,466 @@
+"""Focused coverage tests for EnphaseCoordinator edge branches."""
+
+from __future__ import annotations
+
+from collections import deque
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+from aiohttp.client_reqrep import RequestInfo
+from homeassistant.helpers.update_coordinator import UpdateFailed
+from multidict import CIMultiDict, CIMultiDictProxy
+from yarl import URL
+
+from custom_components.enphase_ev import coordinator as coord_mod
+from custom_components.enphase_ev.coordinator import (
+    FAST_TOGGLE_POLL_HOLD_S,
+    EnphaseCoordinator,
+    ServiceValidationError,
+)
+from custom_components.enphase_ev.const import (
+    ISSUE_CLOUD_ERRORS,
+    ISSUE_DNS_RESOLUTION,
+    ISSUE_NETWORK_UNREACHABLE,
+)
+from custom_components.enphase_ev.session_history import MIN_SESSION_HISTORY_CACHE_TTL
+from tests.components.enphase_ev.random_ids import RANDOM_SERIAL as SERIAL_ONE
+
+pytestmark = pytest.mark.session_history_real
+
+pytest.importorskip("homeassistant")
+
+
+def _request_info() -> RequestInfo:
+    """Build a minimal RequestInfo for ClientResponseError."""
+    return RequestInfo(
+        url=URL("https://enphase.example/status"),
+        method="GET",
+        headers=CIMultiDictProxy(CIMultiDict()),
+        real_url=URL("https://enphase.example/status"),
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_enrich_sessions_invokes_history(coordinator_factory):
+    coord = coordinator_factory()
+    serials = [SERIAL_ONE]
+    fake_history = SimpleNamespace(
+        async_enrich=AsyncMock(return_value={"123": []}),
+        cache_ttl=MIN_SESSION_HISTORY_CACHE_TTL,
+    )
+    coord.session_history = fake_history
+
+    day = datetime(2025, 5, 1, tzinfo=timezone.utc)
+    result = await coord._async_enrich_sessions(serials, day, in_background=False)
+
+    assert result == {"123": []}
+    fake_history.async_enrich.assert_awaited_once_with(
+        serials, day, in_background=False
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_sessions_today_handles_timezone_error(monkeypatch, coordinator_factory):
+    coord = coordinator_factory()
+    sn = next(iter(coord.serials))
+
+    original = coord_mod.dt_util.as_local
+    calls = {"count": 0}
+
+    def fake_as_local(value):
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise ValueError("boom")
+        return original(value)
+
+    monkeypatch.setattr(coord_mod.dt_util, "as_local", fake_as_local)
+    coord.session_history = SimpleNamespace(
+        cache_ttl=MIN_SESSION_HISTORY_CACHE_TTL,
+        _async_fetch_sessions_today=AsyncMock(return_value=[{"energy_kwh": 1.2}]),
+    )
+
+    naive_day = datetime(2025, 1, 1, 12, 0, 0)
+    first = await coord._async_fetch_sessions_today(sn, day_local=naive_day)
+    assert first == [{"energy_kwh": 1.2}]
+
+    # Immediate second call should reuse cache without invoking session history again.
+    second = await coord._async_fetch_sessions_today(sn, day_local=naive_day)
+    assert second == first
+    coord.session_history._async_fetch_sessions_today.assert_awaited_once()
+
+
+def test_collect_site_metrics_serializes_dates(coordinator_factory):
+    coord = coordinator_factory()
+
+    class BadDate:
+        def __init__(self, label: str) -> None:
+            self._label = label
+
+        def isoformat(self) -> str:
+            raise ValueError("fail")
+
+        def __str__(self) -> str:
+            return self._label
+
+    coord.site_name = "Garage"
+    coord.last_success_utc = BadDate("success")
+    coord.last_failure_utc = BadDate("failure")
+    coord.backoff_ends_utc = BadDate("backoff")
+    coord.last_failure_status = 500
+    coord.last_failure_description = "boom"
+    coord.last_failure_source = "http"
+    coord.last_failure_response = '{"error":"boom"}'
+    coord._backoff_until = coord_mod.time.monotonic() + 10
+
+    metrics = coord.collect_site_metrics()
+    assert metrics["last_success"] == "success"
+    assert metrics["last_failure"] == "failure"
+    assert metrics["backoff_ends_utc"] == "backoff"
+
+    placeholders = coord._issue_translation_placeholders(metrics)
+    assert placeholders == {
+        "site_id": coord.site_id,
+        "site_name": "Garage",
+        "last_error": "boom",
+        "last_status": "500",
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_http_error_creates_cloud_issue(
+    coordinator_factory, mock_issue_registry, monkeypatch
+):
+    coord = coordinator_factory()
+    headers = CIMultiDictProxy(CIMultiDict({"Retry-After": "Wed, 21 Oct 2015 07:28:00 GMT"}))
+    err = aiohttp.ClientResponseError(
+        _request_info(),
+        (),
+        status=503,
+        message='{"error":{"displayMessage":"scheduled maintenance"}}',
+        headers=headers,
+    )
+    coord.client.status = AsyncMock(side_effect=err)
+    coord._http_errors = 2
+    coord._schedule_backoff_timer = MagicMock()
+
+    with pytest.raises(UpdateFailed):
+        await coord._async_update_data()
+
+    assert coord._backoff_until is not None
+    assert coord.last_failure_description == "scheduled maintenance"
+    assert any(issue[1] == ISSUE_CLOUD_ERRORS for issue in mock_issue_registry.created)
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_network_dns_issue(
+    coordinator_factory, mock_issue_registry, monkeypatch
+):
+    coord = coordinator_factory()
+    coord.client.status = AsyncMock(
+        side_effect=aiohttp.ClientError("dns failure in name resolution")
+    )
+    coord._network_errors = 2
+    coord._dns_failures = 1
+    coord._schedule_backoff_timer = MagicMock()
+    monkeypatch.setattr(coord, "_slow_interval_floor", lambda: 30)
+
+    with pytest.raises(UpdateFailed):
+        await coord._async_update_data()
+
+    assert coord._backoff_until is not None
+    assert any(issue[1] == ISSUE_NETWORK_UNREACHABLE for issue in mock_issue_registry.created)
+    assert any(issue[1] == ISSUE_DNS_RESOLUTION for issue in mock_issue_registry.created)
+
+
+def test_sync_desired_charging_schedules_auto_resume(coordinator_factory, monkeypatch):
+    coord = coordinator_factory()
+    sn = next(iter(coord.serials))
+    now = coord_mod.time.monotonic()
+    coord._desired_charging = {sn: True}
+    coord._auto_resume_attempts = {}
+    coord.data = {
+        sn: {
+            "sn": sn,
+            "charging": False,
+            "plugged": True,
+            "connector_status": coord_mod.SUSPENDED_EVSE_STATUS,
+        }
+    }
+    created = []
+
+    def fake_create_task(coro, *, name=None):
+        created.append((coro, name))
+        return None
+
+    monkeypatch.setattr(coord.hass, "async_create_task", fake_create_task)
+
+    coord._sync_desired_charging(coord.data)
+
+    assert len(created) == 1
+    coro, name = created[0]
+    assert name == f"enphase_ev_auto_resume_{sn}"
+    coro.close()
+    assert coord._auto_resume_attempts[sn] >= now
+
+
+def test_apply_lifetime_guard_confirms_resets(monkeypatch):
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    coord.summary = SimpleNamespace(invalidate=MagicMock())
+    coord._lifetime_guard = {}
+
+    sn = "EV1"
+    first = coord._apply_lifetime_guard(sn, 15000, {"lifetime_kwh": 12.0})
+    assert first == pytest.approx(15.0)
+
+    # Drop to trigger pending reset detection
+    with monkeypatch.context() as ctx:
+        ticker = deque([1_000.0, 1_005.0, 1_020.0])
+        ctx.setattr(coord_mod.time, "monotonic", lambda: ticker[0])
+        drop = coord._apply_lifetime_guard(sn, 2000, None)
+        assert drop == pytest.approx(15.0)
+        ticker.popleft()
+        confirmed = coord._apply_lifetime_guard(sn, 2000, None)
+        assert confirmed == pytest.approx(2.0)
+
+    coord.summary.invalidate.assert_called_once()
+
+
+def test_determine_polling_state_handles_options(hass):
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    coord.data = {"A": {"charging": False}}
+    coord._fast_until = coord_mod.time.monotonic() + 5
+    coord._streaming = True
+    coord.update_interval = timedelta(seconds=90)
+    coord.config_entry = SimpleNamespace(
+        options={
+        coord_mod.OPT_FAST_POLL_INTERVAL: "not-a-number",
+        coord_mod.OPT_SLOW_POLL_INTERVAL: "75",
+        coord_mod.OPT_FAST_WHILE_STREAMING: False,
+        }
+    )
+
+    state = coord._determine_polling_state({"A": {"charging": True}})
+    assert state["want_fast"] is True
+    assert state["fast"] == coord_mod.DEFAULT_FAST_POLL_INTERVAL
+    assert state["slow"] == 75
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_charge_modes_uses_cache_and_handles_errors(monkeypatch, coordinator_factory):
+    coord = coordinator_factory(serials=["EV1", "EV2"])
+    coord._charge_mode_cache = {"EV1": ("IMMEDIATE", coord_mod.time.monotonic())}
+
+    async def fake_get(sn: str):
+        if sn == "EV2":
+            return "SMART"
+        raise RuntimeError("boom")
+
+    coord._get_charge_mode = AsyncMock(side_effect=fake_get)
+    result = await coord._async_resolve_charge_modes(["EV1", "EV2", "EV3"])
+    assert result["EV1"] == "IMMEDIATE"
+    assert result["EV2"] == "SMART"
+    assert "EV3" not in result
+
+
+def test_has_embedded_charge_mode_detects_nested():
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    payload = {
+        "sch_d": {"info": [{"status": "enabled"}]},
+    }
+    assert coord._has_embedded_charge_mode(payload) is True
+    assert coord._has_embedded_charge_mode({"foo": "bar"}) is False
+
+
+@pytest.mark.asyncio
+async def test_attempt_auto_refresh_updates_tokens(monkeypatch, coordinator_factory):
+    coord = coordinator_factory()
+    coord._email = "user@example.com"
+    coord._remember_password = True
+    coord._stored_password = "pw"
+    tokens = coord_mod.AuthTokens("cookie", "sess", "token", 123)
+    monkeypatch.setattr(
+        coord_mod, "async_authenticate", AsyncMock(return_value=(tokens, None))
+    )
+    coord.client.update_credentials = MagicMock()
+    coord._persist_tokens = MagicMock()
+
+    assert await coord._attempt_auto_refresh() is True
+    coord.client.update_credentials.assert_called_once()
+    coord._persist_tokens.assert_called_once_with(tokens)
+
+
+@pytest.mark.asyncio
+async def test_handle_client_unauthorized_paths(
+    coordinator_factory, mock_issue_registry
+):
+    coord = coordinator_factory()
+    coord._attempt_auto_refresh = AsyncMock(return_value=True)
+    assert await coord._handle_client_unauthorized() is True
+
+    coord._attempt_auto_refresh = AsyncMock(return_value=False)
+    coord._unauth_errors = 1
+    with pytest.raises(coord_mod.ConfigEntryAuthFailed):
+        await coord._handle_client_unauthorized()
+    assert any(issue[1] == "reauth_required" for issue in mock_issue_registry.created)
+
+
+@pytest.mark.asyncio
+async def test_async_start_charging_handles_not_ready(coordinator_factory, monkeypatch):
+    coord = coordinator_factory()
+    sn = next(iter(coord.serials))
+    coord.data[sn]["plugged"] = True
+    coord.require_plugged = MagicMock()
+    coord.pick_start_amps = MagicMock(return_value=32)
+    coord.client.start_charging = AsyncMock(return_value={"status": "not_ready"})
+    coord.async_request_refresh = AsyncMock()
+
+    result = await coord.async_start_charging(sn, hold_seconds=10)
+    assert result["status"] == "not_ready"
+    coord.set_desired_charging(sn, False)
+
+
+@pytest.mark.asyncio
+async def test_async_stop_charging_respects_allow_flag(coordinator_factory):
+    coord = coordinator_factory()
+    sn = next(iter(coord.serials))
+    coord.require_plugged = MagicMock()
+    coord.client.stop_charging = AsyncMock(return_value={"ok": True})
+    coord.async_request_refresh = AsyncMock()
+
+    await coord.async_stop_charging(sn, allow_unplugged=False)
+    coord.require_plugged.assert_called_once_with(sn)
+
+
+def test_schedule_amp_restart_replaces_existing_task(coordinator_factory, hass):
+    coord = coordinator_factory()
+    sn = next(iter(coord.serials))
+    stored = {}
+
+    class DummyTask:
+        def __init__(self):
+            self._done = False
+            self.callbacks = []
+
+        def cancel(self):
+            self._done = True
+
+        def done(self):
+            return self._done
+
+        def add_done_callback(self, cb):
+            self.callbacks.append(cb)
+
+    def fake_task(coro, *, name=None):
+        coro.close()
+        task = DummyTask()
+        stored[name] = task
+        return task
+
+    hass.async_create_task = fake_task
+    coord.schedule_amp_restart(sn, delay=1)
+    coord.schedule_amp_restart(sn, delay=2)
+    assert len(coord._amp_restart_tasks) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_restart_after_amp_change_runs_sequence(monkeypatch):
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    coord.async_stop_charging = AsyncMock()
+    coord.async_start_charging = AsyncMock()
+    monkeypatch.setattr(coord_mod.asyncio, "sleep", AsyncMock())
+
+    await coord._async_restart_after_amp_change("EV1", "invalid")
+    coord.async_stop_charging.assert_awaited()
+    coord.async_start_charging.assert_awaited()
+
+
+def test_persist_tokens_updates_entry(hass, config_entry):
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    coord.config_entry = config_entry
+    coord.hass = hass
+    hass.config_entries.async_update_entry = MagicMock()
+    tokens = coord_mod.AuthTokens("cookie", "sess", "token", 111)
+
+    coord._persist_tokens(tokens)
+
+    hass.config_entries.async_update_entry.assert_called_once()
+
+
+def test_kick_fast_handles_invalid_seconds(coordinator_factory):
+    coord = coordinator_factory()
+    coord.kick_fast("invalid")
+    assert coord._fast_until is not None
+
+
+def test_record_actual_charging_triggers_fast(coordinator_factory):
+    coord = coordinator_factory()
+    coord.kick_fast = MagicMock()
+    coord._record_actual_charging(SERIAL_ONE, True)
+    coord._record_actual_charging(SERIAL_ONE, False)
+    coord.kick_fast.assert_called_with(FAST_TOGGLE_POLL_HOLD_S)
+
+
+def test_set_charging_expectation_handles_zero(coordinator_factory):
+    coord = coordinator_factory()
+    coord.set_charging_expectation(SERIAL_ONE, True, hold_for=0)
+    assert SERIAL_ONE not in coord._pending_charging
+    coord.set_charging_expectation(SERIAL_ONE, True, hold_for=10)
+    assert SERIAL_ONE in coord._pending_charging
+
+
+def test_clear_and_schedule_backoff_timer(monkeypatch, coordinator_factory):
+    coord = coordinator_factory()
+    cancelled = {"count": 0}
+
+    def fake_cancel():
+        cancelled["count"] += 1
+
+    coord._backoff_cancel = fake_cancel
+    coord._clear_backoff_timer()
+    assert cancelled["count"] == 1
+
+    created = {}
+
+    coord.async_request_refresh = AsyncMock()
+
+    def fake_async_call_later(_hass, delay, cb):
+        created["callback"] = cb
+        return lambda: created.setdefault("cancelled", True)
+
+    monkeypatch.setattr(coord_mod, "async_call_later", fake_async_call_later)
+
+    called = {}
+
+    def fake_async_create_task(coro, *, name=None):
+        called["coro"] = coro
+        called["name"] = name
+        return None
+
+    monkeypatch.setattr(coord.hass, "async_create_task", fake_async_create_task)
+
+    coord._schedule_backoff_timer(0)
+    coro = called["coro"]
+    coro.close()
+    assert "coro" in called
+
+    coord._schedule_backoff_timer(5)
+    assert "callback" in created
+
+
+def test_require_plugged_raises(monkeypatch):
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    coord.data = {"EV1": {"name": "Garage", "plugged": False}}
+    with pytest.raises(ServiceValidationError):
+        coord.require_plugged("EV1")
+
+
+def test_ensure_serial_tracked_discovers(monkeypatch):
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    coord.serials = set()
+    coord._serial_order = []
+    assert coord._ensure_serial_tracked(" 12345 ") is True
+    assert "12345" in coord.serials
+    assert coord._ensure_serial_tracked("") is False

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -1,0 +1,498 @@
+"""Additional coverage for Enphase EV sensor helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
+
+pytest.importorskip("homeassistant")
+
+
+def _mk_coord(sn: str, payload: dict[str, Any]) -> Any:
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    coord.hass = SimpleNamespace()
+    coord.hass.config = SimpleNamespace(
+        units=SimpleNamespace(length_unit="mi"),
+    )
+    coord.data = {sn: payload}
+    coord.serials = {sn}
+    coord.last_set_amps = {}
+    coord.site_id = "site-test"
+    coord._serial_order = [sn]
+    coord.iter_serials = lambda: list(coord.serials)
+    coord.async_add_listener = lambda cb: cb  # type: ignore[assignment]
+    coord.last_success_utc = None
+    coord.last_failure_utc = None
+    coord.last_failure_status = None
+    coord.last_failure_description = None
+    coord.last_failure_source = None
+    coord.last_failure_response = None
+    coord.backoff_ends_utc = None
+    coord.latency_ms = None
+    return coord
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_entities(
+    hass, config_entry, coordinator_factory, monkeypatch
+):
+    from custom_components.enphase_ev.const import DOMAIN
+    from custom_components.enphase_ev.sensor import async_setup_entry
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord.data[RANDOM_SERIAL].update(
+        {
+            "connector_status": "AVAILABLE",
+            "charge_mode": "IMMEDIATE",
+            "plugged": True,
+            "charging_level": 32,
+        }
+    )
+    callbacks: dict[str, Any] = {}
+
+    def fake_add_listener(cb):
+        callbacks["cb"] = cb
+        return lambda: None
+
+    coord.async_add_listener = fake_add_listener  # type: ignore[assignment]
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+
+    added = []
+
+    def _async_add_entities(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _async_add_entities)
+    assert any(ent.unique_id.endswith("_energy_today") for ent in added)
+
+    # Simulate discovery of a new charger via the registered callback
+    coord.serials.add("NEW123")
+    coord.data["NEW123"] = {"sn": "NEW123", "name": "Second"}
+    callbacks["cb"]()
+    assert any(ent.unique_id.endswith("_NEW123_energy_today") for ent in added)
+
+
+def test_energy_today_restore_data_handles_invalid_payload():
+    from custom_components.enphase_ev.sensor import _EnergyTodayRestoreData
+
+    parsed = _EnergyTodayRestoreData.from_dict(
+        {
+            "baseline_kwh": "bad",
+            "baseline_day": 20251030,
+            "last_total_kwh": object(),
+            "last_reset_at": None,
+            "stale_session_kwh": "oops",
+            "stale_session_day": "",
+            "last_session_kwh": "invalid",
+        }
+    )
+    assert parsed.baseline_kwh is None
+    assert parsed.baseline_day == "20251030"
+    assert parsed.last_total_kwh is None
+    assert parsed.stale_session_day == ""
+    assert parsed.last_session_kwh is None
+
+
+@pytest.mark.asyncio
+async def test_energy_today_async_added_restores_state(monkeypatch):
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.enphase_ev.sensor import (
+        EnphaseEnergyTodaySensor,
+        _EnergyTodayRestoreData,
+    )
+
+    sn = RANDOM_SERIAL
+    coord = _mk_coord(sn, {"sn": sn, "name": "Garage", "lifetime_kwh": 12.0})
+    sensor = EnphaseEnergyTodaySensor(coord, sn)
+    base_time = datetime(2025, 10, 30, 8, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: base_time)
+    monkeypatch.setattr(dt_util, "utcnow", lambda: base_time)
+    async def _noop(self):
+        return None
+
+    monkeypatch.setattr(CoordinatorEntity, "async_added_to_hass", _noop)
+
+    fake_state = SimpleNamespace(
+        state="1.23",
+        attributes={
+            "baseline_kwh": "5.5",
+            "baseline_day": base_time.strftime("%Y-%m-%d"),
+            "last_total_kwh": "8.0",
+            "last_reset_at": "state-reset",
+        },
+    )
+
+    async def _fake_last_state(self):
+        return fake_state
+
+    async def _fake_last_extra(self):
+        return _EnergyTodayRestoreData(
+            baseline_kwh=4.0,
+            baseline_day=base_time.strftime("%Y-%m-%d"),
+            last_total_kwh=None,
+            last_reset_at=None,
+            stale_session_kwh=None,
+            stale_session_day="2025-10-29",
+            last_session_kwh=0.25,
+        )
+
+    monkeypatch.setattr(
+        EnphaseEnergyTodaySensor, "async_get_last_state", _fake_last_state
+    )
+    monkeypatch.setattr(
+        EnphaseEnergyTodaySensor, "async_get_last_extra_data", _fake_last_extra
+    )
+
+    await sensor.async_added_to_hass()
+    assert sensor._baseline_kwh == pytest.approx(4.0)
+    assert sensor._last_total == pytest.approx(8.0)
+    assert sensor._last_session_kwh == pytest.approx(0.25)
+
+
+def test_energy_today_native_value_resets_on_session_end():
+    from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
+
+    sn = RANDOM_SERIAL
+    payload = {
+        "sn": sn,
+        "name": "EV",
+        "session_kwh": 1.5,
+        "session_end": 123456,
+        "charging": False,
+    }
+    coord = _mk_coord(sn, payload)
+    sensor = EnphaseEnergyTodaySensor(coord, sn)
+    sensor._last_total = None
+    assert sensor.native_value == 0.0
+    assert sensor._last_value == 0.0
+
+
+def test_energy_today_status_handles_stale_day(monkeypatch):
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
+
+    sn = RANDOM_SERIAL
+    day = "2025-10-30"
+    payload = {"sn": sn, "name": "EV"}
+    coord = _mk_coord(sn, payload)
+    sensor = EnphaseEnergyTodaySensor(coord, sn)
+    sensor._baseline_day = day
+    sensor._last_value = 0.6
+    sensor._stale_session_kwh = 0.5
+    sensor._stale_session_day = day
+    sensor._rollover_reference_kwh = None
+    sensor._last_total = None
+    base_time = datetime(2025, 10, 30, 10, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "utcnow", lambda: base_time)
+    val = sensor._value_from_status({"session_energy_wh": 500, "charging": False})
+    assert val == 0.0
+
+
+def test_energy_today_lifetime_detects_reset(monkeypatch):
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
+
+    sn = RANDOM_SERIAL
+    coord = _mk_coord(sn, {"sn": sn, "name": "EV", "lifetime_kwh": 10.0})
+    sensor = EnphaseEnergyTodaySensor(coord, sn)
+    sensor._baseline_kwh = 8.0
+    sensor._baseline_day = "2025-10-30"
+    sensor._last_value = 2.0
+    sensor._last_total = 10.0
+    base_time = datetime(2025, 10, 30, 11, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: base_time)
+    monkeypatch.setattr(dt_util, "utcnow", lambda: base_time)
+    val = sensor._value_from_lifetime({"lifetime_kwh": 3.0})
+    assert val == 0.0
+    assert sensor._baseline_kwh == pytest.approx(3.0)
+
+
+def test_energy_today_sessions_reset_on_day_change(monkeypatch):
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
+
+    sn = RANDOM_SERIAL
+    payload = {
+        "sn": sn,
+        "name": "EV",
+        "energy_today_sessions": [{"energy_kwh": 1}],
+        "energy_today_sessions_kwh": 1.0,
+        "session_end": "2025-10-29T23:59:00Z",
+        "charging": False,
+    }
+    coord = _mk_coord(sn, payload)
+    sensor = EnphaseEnergyTodaySensor(coord, sn)
+    sensor._baseline_day = "2025-10-30"
+    sensor._rollover_reference_kwh = 10.0
+    sensor._last_total = None
+    base_time = datetime(2025, 10, 30, 1, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: base_time)
+    monkeypatch.setattr(dt_util, "utcnow", lambda: base_time)
+    assert sensor._value_from_sessions(payload) == 0.0
+
+
+def test_session_metadata_attributes_formats_fields(monkeypatch):
+    from homeassistant.const import UnitOfLength
+
+    from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
+
+    hass = SimpleNamespace(config=SimpleNamespace(units=SimpleNamespace(length_unit=UnitOfLength.KILOMETERS)))
+    attrs = EnphaseEnergyTodaySensor._session_metadata_attributes(
+        {
+            "session_plug_in_at": "2025-10-30T06:00:00Z[UTC]",
+            "session_plug_out_at": 1_700_000_000,
+            "session_kwh": "1.5",
+            "session_energy_wh": "400",
+            "session_cost": "3.4567",
+            "session_charge_level": "88",
+            "session_miles": "12.5",
+        },
+        hass=hass,
+    )
+    assert attrs["plugged_in_at"] is not None
+    assert attrs["energy_consumed_wh"] is not None
+    assert attrs["session_charge_level"] == 88
+    assert attrs["range_added"] == pytest.approx(20.117)
+
+
+def test_resolve_session_local_day_returns_first_available():
+    from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
+
+    sn = RANDOM_SERIAL
+    coord = _mk_coord(sn, {"sn": sn, "name": "EV"})
+    sensor = EnphaseEnergyTodaySensor(coord, sn)
+    day = sensor._resolve_session_local_day(
+        {"session_plug_out_at": "2025-10-30T10:00:00Z", "session_end": 1_700_000_000}
+    )
+    assert day is not None
+
+
+def test_connector_status_icon_variants():
+    from custom_components.enphase_ev.sensor import EnphaseConnectorStatusSensor
+
+    sn = RANDOM_SERIAL
+    payload = {"sn": sn, "name": "EV", "connector_status": "UNPLUGGED"}
+    sensor = EnphaseConnectorStatusSensor(_mk_coord(sn, payload), sn)
+    assert sensor.icon == "mdi:power-plug-off"
+
+
+@pytest.mark.asyncio
+async def test_power_sensor_restores_state(monkeypatch):
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    from custom_components.enphase_ev.sensor import EnphasePowerSensor
+
+    sn = RANDOM_SERIAL
+    payload = {"sn": sn, "name": "EV", "lifetime_kwh": 5.0, "last_reported_at": "2025-10-30T09:55:00Z"}
+    coord = _mk_coord(sn, payload)
+    sensor = EnphasePowerSensor(coord, sn)
+    async def _noop(self):
+        return None
+
+    monkeypatch.setattr(CoordinatorEntity, "async_added_to_hass", _noop)
+
+    fake_state = SimpleNamespace(
+        state="bad",
+        attributes={
+            "last_lifetime_kwh": "10.5",
+            "last_energy_ts": "1",
+            "last_sample_ts": "2",
+            "last_power_w": "3000",
+            "last_window_seconds": "5",
+            "method": "legacy",
+            "last_reset_at": "123",
+            "baseline_kwh": "8",
+            "last_energy_today_kwh": "1.5",
+            "last_ts": "3",
+        },
+    )
+
+    async def _fake_last_state(self):
+        return fake_state
+
+    monkeypatch.setattr(EnphasePowerSensor, "async_get_last_state", _fake_last_state)
+    await sensor.async_added_to_hass()
+    assert sensor._last_power_w == 3000
+
+
+def test_power_sensor_parse_timestamp_variants():
+    from custom_components.enphase_ev.sensor import EnphasePowerSensor
+
+    assert EnphasePowerSensor._parse_timestamp(1_700_000_000_000) is not None
+    assert EnphasePowerSensor._parse_timestamp("2025-10-30T10:00:00Z[UTC]") is not None
+    assert EnphasePowerSensor._parse_timestamp("") is None
+
+
+def test_power_sensor_resolve_max_throughput_prefers_session_level():
+    from custom_components.enphase_ev.sensor import EnphasePowerSensor
+
+    data = {"session_charge_level": "40", "operating_v": 230}
+    sensor = EnphasePowerSensor(_mk_coord(RANDOM_SERIAL, {"sn": RANDOM_SERIAL, "name": "EV"}), RANDOM_SERIAL)
+    bounded, source, amps, voltage, unbounded = sensor._resolve_max_throughput(data)
+    assert source == "session_charge_level"
+    assert amps == pytest.approx(40.0)
+    assert bounded <= sensor._STATIC_MAX_WATTS
+
+
+def test_power_sensor_native_value_handles_drop(monkeypatch):
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.enphase_ev.sensor import EnphasePowerSensor
+
+    sn = RANDOM_SERIAL
+    coord = _mk_coord(sn, {"sn": sn, "name": "EV", "lifetime_kwh": 10.0, "last_reported_at": "2025-10-30T10:00:00Z"})
+    sensor = EnphasePowerSensor(coord, sn)
+    assert sensor.native_value == 0
+
+    coord.data[sn]["lifetime_kwh"] = 9.0
+    coord.data[sn]["last_reported_at"] = "2025-10-30T10:05:00Z"
+    assert sensor.native_value == 0
+
+    coord.data[sn]["lifetime_kwh"] = 9.5
+    coord.data[sn]["last_reported_at"] = "2025-10-30T10:10:00Z"
+    monkeypatch.setattr(dt_util, "now", lambda: datetime(2025, 10, 30, 10, 10, tzinfo=timezone.utc))
+    assert sensor.native_value > 0
+
+
+def test_session_duration_uses_fixed_end(monkeypatch):
+    from custom_components.enphase_ev.sensor import EnphaseSessionDurationSensor
+
+    sn = RANDOM_SERIAL
+    start = int(datetime.now(timezone.utc).timestamp()) - 600
+    payload = {"sn": sn, "name": "EV", "session_start": start, "session_end": start + 300, "charging": False}
+    coord = _mk_coord(sn, payload)
+    sensor = EnphaseSessionDurationSensor(coord, sn)
+    assert sensor.native_value == 5
+
+
+def test_charge_mode_sensor_prefers_pref_field():
+    from custom_components.enphase_ev.sensor import EnphaseChargeModeSensor
+
+    sn = RANDOM_SERIAL
+    payload = {"sn": sn, "name": "EV", "charge_mode_pref": "green_charging"}
+    sensor = EnphaseChargeModeSensor(_mk_coord(sn, payload), sn)
+    assert sensor.native_value == "green_charging"
+    assert sensor.icon == "mdi:leaf"
+
+
+@pytest.mark.asyncio
+async def test_lifetime_energy_restore(monkeypatch):
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    from custom_components.enphase_ev.sensor import EnphaseLifetimeEnergySensor
+
+    sn = RANDOM_SERIAL
+    coord = _mk_coord(sn, {"sn": sn, "name": "EV"})
+    sensor = EnphaseLifetimeEnergySensor(coord, sn)
+    async def _noop(self):
+        return None
+
+    monkeypatch.setattr(CoordinatorEntity, "async_added_to_hass", _noop)
+
+    class _SensorData:
+        native_value = "11.0"
+
+    async def _fake_sensor_data(self):
+        return _SensorData()
+
+    async def _fake_last_state(self):
+        return SimpleNamespace(attributes={"last_reset_value": "5.0", "last_reset_at": "ts"})
+
+    monkeypatch.setattr(
+        EnphaseLifetimeEnergySensor, "async_get_last_sensor_data", _fake_sensor_data
+    )
+    monkeypatch.setattr(
+        EnphaseLifetimeEnergySensor, "async_get_last_state", _fake_last_state
+    )
+    await sensor.async_added_to_hass()
+    assert sensor.native_value == pytest.approx(11.0)
+
+
+def test_lifetime_energy_native_value_handles_drop(monkeypatch):
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.enphase_ev.sensor import EnphaseLifetimeEnergySensor
+
+    sn = RANDOM_SERIAL
+    coord = _mk_coord(sn, {"sn": sn, "name": "EV", "lifetime_kwh": 50.0})
+    sensor = EnphaseLifetimeEnergySensor(coord, sn)
+    sensor._last_value = 40.0
+    sensor._boot_filter = False
+    coord.data[sn]["lifetime_kwh"] = 10.0
+    base_time = datetime(2025, 10, 30, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "utcnow", lambda: base_time)
+    assert sensor.native_value == 10.0
+    assert sensor._last_reset_value == 10.0
+
+
+def test_status_sensor_passthrough():
+    from custom_components.enphase_ev.sensor import EnphaseStatusSensor
+
+    sn = RANDOM_SERIAL
+    payload = {"sn": sn, "name": "EV", "status": "available"}
+    sensor = EnphaseStatusSensor(_mk_coord(sn, payload), sn)
+    assert sensor.native_value == "available"
+
+
+def test_timestamp_from_iso_sensor_parses_values():
+    from custom_components.enphase_ev.sensor import _TimestampFromIsoSensor
+
+    sn = RANDOM_SERIAL
+    payload = {"sn": sn, "name": "EV", "iso": "2025-10-30T10:00:00Z[UTC]"}
+    sensor = _TimestampFromIsoSensor(_mk_coord(sn, payload), sn, "iso", "ISO", "uniq")
+    assert sensor.native_value is not None
+
+
+def test_timestamp_from_epoch_sensor_parses_values():
+    from custom_components.enphase_ev.sensor import _TimestampFromEpochSensor
+
+    sn = RANDOM_SERIAL
+    payload = {"sn": sn, "name": "EV", "epoch": 1_700_000_000}
+    sensor = _TimestampFromEpochSensor(_mk_coord(sn, payload), sn, "epoch", "Epoch", "uniq2")
+    assert sensor.native_value is not None
+
+
+def test_site_base_entity_helpers(monkeypatch):
+    from homeassistant.util import dt as dt_util
+
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from custom_components.enphase_ev.sensor import (
+        EnphaseSiteBackoffEndsSensor,
+        EnphaseSiteLastErrorCodeSensor,
+        EnphaseSiteLastUpdateSensor,
+    )
+
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+    coord.site_id = "site"
+    coord.last_success_utc = datetime(2025, 10, 30, 8, 0, 0, tzinfo=timezone.utc)
+    coord.last_failure_utc = datetime(2025, 10, 30, 9, 0, 0, tzinfo=timezone.utc)
+    coord.last_failure_status = None
+    coord.last_failure_description = "dns lookup failed"
+    coord.last_failure_source = "network"
+    coord.last_failure_response = "resp"
+    coord.backoff_ends_utc = datetime(2025, 10, 30, 11, 0, 0, tzinfo=timezone.utc)
+    coord.latency_ms = 120
+    coord.async_add_listener = lambda cb: None
+
+    err_sensor = EnphaseSiteLastErrorCodeSensor(coord)
+    assert err_sensor.available is True
+    assert err_sensor.native_value == "dns_error"
+
+    update_sensor = EnphaseSiteLastUpdateSensor(coord)
+    assert update_sensor.device_info["name"].startswith("Enphase Site")
+
+    backoff_sensor = EnphaseSiteBackoffEndsSensor(coord)
+    monkeypatch.setattr(dt_util, "utcnow", lambda: datetime(2025, 10, 30, 10, 30, 0, tzinfo=timezone.utc))
+    assert backoff_sensor._backoff_remaining_seconds() >= 1


### PR DESCRIPTION
## Summary
- add targeted coordinator regression suite covering backoff, auth, and session history flows
- add sensor coverage exercises for Energy Today, power, lifetime, and diagnostics entities to close reported gaps

## Testing
- ruff check .
- pytest tests/components/enphase_ev -q
- python3 -m pre_commit run --all-files
