### PR TITLE
Release v1.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v1.4.5 – 2025-11-24
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Start Charging button, switch, and service calls now honor the charger’s configured charge mode (Manual, Scheduled, or Green) so scheduler-driven or solar-only sessions are no longer forced into Manual mode when kicked off from Home Assistant.
+
+### 🔧 Improvements
+- The Enlighten start-charging API discovery now caches independent “include charging level” and “scheduler-driven” request variants, preventing repeated retries and making charge mode transitions faster and more reliable.
+
+### 🔄 Other changes
+- Expanded API, coordinator, button, and switch tests to capture the new charge-mode-aware behaviour and to keep coverage at 100%.
+
 ## v1.4.4 – 2025-11-17
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.4.4"
+  "version": "1.4.5"
 }


### PR DESCRIPTION
## Summary
- bump manifest to v1.4.5 and document the release in the changelog
- highlight the new charge-mode-aware start/stop behaviour in the README

## Testing
- ruff check .
- python3 -m pre_commit run --all-files
- pytest tests/components/enphase_ev -q