### PR TITLE
Release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v1.5.1 – 2025-12-12
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Corrected site lifetime energy bucket scaling by applying the reported interval minutes, fixing over/under-counted totals in the Energy Dashboard.
+
+### 🔧 Improvements
+- Site energy diagnostics now record the payload interval and source unit (W vs Wh) to aid troubleshooting.
+
+### 🔄 Other changes
+- Expanded site energy regression coverage to lock in interval handling.
+
 ## v1.5.0 – 2025-12-12
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.5.0"
+  "version": "1.5.1"
 }


### PR DESCRIPTION
## Summary
- Fix site lifetime energy interval calculations for Energy Dashboard.
- Bump integration manifest version to 1.5.1.
- Update changelog for v1.5.1.

## Testing
- Not run locally in this release-only PR.