### PR TITLE
Fix site-only setup and ensure site energy sensors appear

### DIFF
--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -176,8 +176,10 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 user_input.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
             )
             site_only_selected = bool(user_input.get(CONF_SITE_ONLY, False))
-            selected = self._normalize_serials(serials)
-            if selected or (site_only_selected and site_only_available):
+            selected = [] if site_only_selected else self._normalize_serials(serials)
+            if (selected and not site_only_selected) or (
+                site_only_selected and site_only_available
+            ):
                 self._site_only = site_only_selected
                 return await self._finalize_login_entry(
                     selected, scan_interval, site_only_selected
@@ -207,7 +209,9 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             schema = vol.Schema(
                 {
                     vol.Optional(CONF_SITE_ONLY, default=site_only_selected): bool,
-                    vol.Required(CONF_SERIALS): selector({"text": {"multiline": True}}),
+                    vol.Optional(CONF_SERIALS, default=""): selector(
+                        {"text": {"multiline": True}}
+                    ),
                     vol.Optional(CONF_SCAN_INTERVAL, default=default_scan): int,
                 }
             )

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -2434,6 +2434,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     def iter_serials(self) -> list[str]:
         """Return charger serials in a stable order for entity setup."""
+        if getattr(self, "site_only", False):
+            return []
         ordered: list[str] = []
         serial_order = getattr(self, "_serial_order", None)
         known_serials = getattr(self, "serials", None)

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -35,22 +35,24 @@ async def async_setup_entry(
     coord: EnphaseCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
 
     # Site-level diagnostic sensors
-    site_entities = [
+    site_entities: list[SensorEntity] = [
         EnphaseSiteLastUpdateSensor(coord),
         EnphaseCloudLatencySensor(coord),
         EnphaseSiteLastErrorCodeSensor(coord),
         EnphaseSiteBackoffEndsSensor(coord),
     ]
-    async_add_entities(site_entities, update_before_add=False)
-
-    site_energy_specs = {
+    site_energy_specs: dict[str, tuple[str, str]] = {
         "solar_production": ("site_solar_production", "Site Solar Production"),
         "grid_import": ("site_grid_import", "Site Grid Import"),
         "grid_export": ("site_grid_export", "Site Grid Export"),
         "battery_charge": ("site_battery_charge", "Site Battery Charge"),
         "battery_discharge": ("site_battery_discharge", "Site Battery Discharge"),
     }
-    known_site_flows: set[str] = set()
+    site_entities.extend(
+        EnphaseSiteEnergySensor(coord, flow_key, translation_key, name)
+        for flow_key, (translation_key, name) in site_energy_specs.items()
+    )
+    async_add_entities(site_entities, update_before_add=False)
     known_serials: set[str] = set()
 
     @callback
@@ -76,31 +78,9 @@ async def async_setup_entry(
             async_add_entities(per_serial_entities, update_before_add=False)
             known_serials.update(serials)
 
-    @callback
-    def _async_sync_site_energy() -> None:
-        flows = getattr(coord, "site_energy", {}) or {}
-        new_entities = []
-        for flow_key, (translation_key, name) in site_energy_specs.items():
-            if flow_key in known_site_flows:
-                continue
-            flow_data = flows.get(flow_key)
-            if flow_data is None:
-                continue
-            new_entities.append(
-                EnphaseSiteEnergySensor(coord, flow_key, translation_key, name)
-            )
-            known_site_flows.add(flow_key)
-        if new_entities:
-            async_add_entities(new_entities, update_before_add=False)
-
-    @callback
-    def _async_sync_all() -> None:
-        _async_sync_chargers()
-        _async_sync_site_energy()
-
-    unsubscribe = coord.async_add_listener(_async_sync_all)
+    unsubscribe = coord.async_add_listener(_async_sync_chargers)
     entry.async_on_unload(unsubscribe)
-    _async_sync_all()
+    _async_sync_chargers()
 
 
 class _BaseEVSensor(EnphaseBaseEntity, SensorEntity):

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -707,6 +707,14 @@ def test_iter_serials_falls_back_to_sorted(coordinator_factory):
     assert ordered[:2] == ["A", "B"]
 
 
+def test_iter_serials_empty_when_site_only(coordinator_factory):
+    coord = coordinator_factory()
+    coord.serials = {"A"}
+    coord._serial_order = ["A"]
+    coord.site_only = True
+    assert coord.iter_serials() == []
+
+
 def test_coerce_amp_and_amp_limits(coordinator_factory):
     coord = coordinator_factory()
     assert coord._coerce_amp("   ") is None


### PR DESCRIPTION
## Summary
- Fix site-only setup so the charger field is not required and entering a placeholder serial no longer creates charger entities.
- Always create the site lifetime energy sensors (disabled by default) so they appear even when the first lifetime-energy fetch fails (e.g. 403).

## Testing
- `ruff check .`
- `python3 -m pre_commit run --all-files`
- `pytest tests/components/enphase_ev -q`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
