### PR TITLE
Validate Site ID input during setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,9 +7,10 @@
 - Documentation and project metadata (README, CHANGELOG, quality scale) are in the repository root.
 
 ## Build, Test, and Development Commands
-- `ruff check .` — static analysis and import sorting; keep it clean before touching code.
-- `python3 -m pre_commit run --all-files` — run the full lint/format pipeline exactly as CI.
-- `pytest tests/components/enphase_ev -q` — quick local regression against the focused suite.
+- Use the dockerized `ha-dev` environment for **all** linting and tests (ruff, pre-commit, pytest); do not run these locally.
+- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."` — static analysis and import sorting; keep it clean before touching code.
+- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"` — run the full lint/format pipeline exactly as CI.
+- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"` — quick regression against the focused suite.
 - `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"` — authoritative test run inside the pinned dev container (must pass before PR).
 - `python3 -m black custom_components/enphase_ev` — apply formatting when Black reports diffs.
 - Before pushing any branch, confirm `strings.json` changes are mirrored in every locale under `custom_components/enphase_ev/translations/` so runtime translations stay in sync.
@@ -48,6 +49,17 @@
 - Before requesting review, confirm all local quality gates: `ruff check .`, `python3 -m pre_commit run --all-files`, local `pytest`, and the Dockerized `pytest`.
 - Never push a branch until `python3 -m pre_commit run --all-files` completes without changes; rerun and commit any formatting/lint fixes first.
 - Highlight coverage numbers in the PR description when touching new code to reinforce the 100 % coverage standard.
+
+## GitHub Push Workflow (gh)
+- If `git push` hangs, push the branch via the GitHub API using `gh`:
+  - Create blobs from local files, build a tree off `main`, and create a commit.
+  - Create or update `refs/heads/<branch>` to point at the new commit.
+  - Example script pattern (run from repo root):
+    - Use `gh api repos/<owner>/<repo>/git/ref/heads/main` to get base SHA.
+    - Use `gh api repos/<owner>/<repo>/git/blobs` for each file.
+    - Use `gh api repos/<owner>/<repo>/git/trees` to assemble a tree.
+    - Use `gh api repos/<owner>/<repo>/git/commits` to create the commit.
+    - Use `gh api repos/<owner>/<repo>/git/refs` to create/update the branch ref.
 
 ## Best Practice Checks
 - Verified sensor rationalisation against Home Assistant developer best practices using Context7 (`/home-assistant/developers.home-assistant`, integration quality scale guidance on dynamic devices and attribute usage).

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -131,13 +131,18 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            site_id = user_input.get(CONF_SITE_ID)
+            site_id_raw = user_input.get(CONF_SITE_ID)
+            site_id = str(site_id_raw).strip() if site_id_raw is not None else ""
             if site_id:
-                self._selected_site_id = str(site_id)
-                if self._selected_site_id not in self._sites:
-                    self._sites[self._selected_site_id] = None
-                return await self.async_step_devices()
-            errors["base"] = "site_required"
+                if not site_id.isdigit():
+                    errors["base"] = "site_invalid"
+                else:
+                    self._selected_site_id = site_id
+                    if self._selected_site_id not in self._sites:
+                        self._sites[self._selected_site_id] = None
+                    return await self.async_step_devices()
+            else:
+                errors["base"] = "site_required"
 
         options = [
             {

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -43,6 +43,7 @@ async def async_setup_entry(
     ]
     site_energy_specs: dict[str, tuple[str, str]] = {
         "solar_production": ("site_solar_production", "Site Solar Production"),
+        "consumption": ("site_consumption", "Site Consumption"),
         "grid_import": ("site_grid_import", "Site Grid Import"),
         "grid_export": ("site_grid_export", "Site Grid Export"),
         "battery_charge": ("site_battery_charge", "Site Battery Charge"),

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -43,6 +43,7 @@
       "service_unavailable": "Enphase temporarily unavailable. Try again later.",
       "mfa_required": "Account requires multi-factor authentication. Complete MFA in the browser and try again.",
       "site_required": "Select a site to continue.",
+      "site_invalid": "Site ID must be numeric.",
       "serials_required": "Select or enter at least one charger.",
       "serials_or_site_only_required": "Enter at least one charger or enable site-only mode.",
       "unknown": "Unexpected error"
@@ -91,6 +92,7 @@
   "entity": {
     "sensor": {
       "site_solar_production": { "name": "Site Solar Production" },
+      "site_consumption": { "name": "Site Consumption" },
       "site_grid_import": { "name": "Site Grid Import" },
       "site_grid_export": { "name": "Site Grid Export" },
       "site_battery_charge": { "name": "Site Battery Charge" },

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -43,6 +43,7 @@
       "service_unavailable": "Enphase ist vorübergehend nicht verfügbar. Versuchen Sie es später erneut.",
       "mfa_required": "Für dieses Konto ist eine Multi-Faktor-Authentifizierung erforderlich. Schließen Sie MFA im Browser ab und versuchen Sie es erneut.",
       "site_required": "Wählen Sie einen Standort, um fortzufahren.",
+      "site_invalid": "Die Standort-ID muss numerisch sein.",
       "serials_required": "Wählen oder geben Sie mindestens ein Ladegerät an.",
       "serials_or_site_only_required": "Geben Sie mindestens ein Ladegerät an oder aktivieren Sie den Nur-Standort-Modus.",
       "unknown": "Unerwarteter Fehler"
@@ -131,6 +132,7 @@
       "schedule_end": { "name": "Zeitplan-Ende" },
       "lifetime_energy": { "name": "Gesamtenergie" },
       "site_solar_production": { "name": "Standort Solarproduktion" },
+      "site_consumption": { "name": "Standortverbrauch" },
       "site_grid_import": { "name": "Standort Netzbezug" },
       "site_grid_export": { "name": "Standort Netzeinspeisung" },
       "site_battery_charge": { "name": "Standort Batterieladung" },

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -43,6 +43,7 @@
       "service_unavailable": "Enphase temporarily unavailable. Try again later.",
       "mfa_required": "Account requires multi-factor authentication. Complete MFA in the browser and try again.",
       "site_required": "Select a site to continue.",
+      "site_invalid": "Site ID must be numeric.",
       "serials_required": "Select or enter at least one charger.",
       "serials_or_site_only_required": "Enter at least one charger or enable site-only mode.",
       "unknown": "Unexpected error"
@@ -133,6 +134,7 @@
       "schedule_end": { "name": "Schedule End" },
       "lifetime_energy": { "name": "Lifetime Energy" },
       "site_solar_production": { "name": "Site Solar Production" },
+      "site_consumption": { "name": "Site Consumption" },
       "site_grid_import": { "name": "Site Grid Import" },
       "site_grid_export": { "name": "Site Grid Export" },
       "site_battery_charge": { "name": "Site Battery Charge" },

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -43,6 +43,7 @@
       "service_unavailable": "Enphase no está disponible temporalmente. Inténtelo de nuevo más tarde.",
       "mfa_required": "La cuenta requiere autenticación multifactor. Complete el MFA en el navegador e inténtelo de nuevo.",
       "site_required": "Seleccione un sitio para continuar.",
+      "site_invalid": "El ID del sitio debe ser numérico.",
       "serials_required": "Seleccione o introduzca al menos un cargador.",
       "serials_or_site_only_required": "Introduzca al menos un cargador o active el modo solo sitio.",
       "unknown": "Error inesperado"
@@ -131,6 +132,7 @@
       "schedule_end": { "name": "Fin de programación" },
       "lifetime_energy": { "name": "Energía acumulada" },
       "site_solar_production": { "name": "Producción solar del sitio" },
+      "site_consumption": { "name": "Consumo del sitio" },
       "site_grid_import": { "name": "Importación de red del sitio" },
       "site_grid_export": { "name": "Exportación a la red del sitio" },
       "site_battery_charge": { "name": "Carga de batería del sitio" },

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -43,6 +43,7 @@
       "service_unavailable": "Enphase temporairement indisponible. Réessayez plus tard.",
       "mfa_required": "Le compte nécessite une authentification multi-facteurs. Complétez le MFA dans le navigateur et réessayez.",
       "site_required": "Sélectionnez un site pour continuer.",
+      "site_invalid": "L'identifiant du site doit être numérique.",
       "serials_required": "Sélectionnez ou saisissez au moins un chargeur.",
       "serials_or_site_only_required": "Saisissez au moins un chargeur ou activez le mode site uniquement.",
       "unknown": "Erreur inattendue"
@@ -126,6 +127,7 @@
       "schedule_end": { "name": "Fin planifiée" },
       "lifetime_energy": { "name": "Énergie totale" },
       "site_solar_production": { "name": "Production solaire du site" },
+      "site_consumption": { "name": "Consommation du site" },
       "site_grid_import": { "name": "Import réseau du site" },
       "site_grid_export": { "name": "Export réseau du site" },
       "site_battery_charge": { "name": "Charge batterie du site" },

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -43,6 +43,7 @@
       "service_unavailable": "Enphase temporariamente indisponível. Tente novamente mais tarde.",
       "mfa_required": "A conta exige autenticação multifator. Conclua o MFA no navegador e tente novamente.",
       "site_required": "Selecione um site para continuar.",
+      "site_invalid": "O ID do site deve ser numérico.",
       "serials_required": "Selecione ou informe ao menos um carregador.",
       "serials_or_site_only_required": "Informe ao menos um carregador ou ative o modo somente site.",
       "unknown": "Erro inesperado"
@@ -131,6 +132,7 @@
       "schedule_end": { "name": "Fim da programação" },
       "lifetime_energy": { "name": "Energia acumulada" },
       "site_solar_production": { "name": "Produção solar do site" },
+      "site_consumption": { "name": "Consumo do site" },
       "site_grid_import": { "name": "Importação da rede do site" },
       "site_grid_export": { "name": "Exportação para a rede do site" },
       "site_battery_charge": { "name": "Carga da bateria do site" },

--- a/tests/components/enphase_ev/test_config_flow_coverage.py
+++ b/tests/components/enphase_ev/test_config_flow_coverage.py
@@ -94,7 +94,7 @@ async def test_user_step_handles_auth_errors(hass, exc, expected) -> None:
 
 @pytest.mark.asyncio
 async def test_user_step_single_site_shortcuts_to_devices(hass) -> None:
-    site = SiteInfo(site_id="site-123", name="Garage Site")
+    site = SiteInfo(site_id="12345", name="Garage Site")
     chargers = [ChargerInfo(serial="EV123", name="Driveway")]
 
     with (
@@ -122,7 +122,7 @@ async def test_user_step_single_site_shortcuts_to_devices(hass) -> None:
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "devices"
     flow = hass.config_entries.flow._progress[result["flow_id"]]
-    assert flow._selected_site_id == "site-123"
+    assert flow._selected_site_id == "12345"
     assert flow._chargers_loaded is True
     assert flow._chargers == [("EV123", "Driveway")]
     hass.config_entries.flow.async_abort(result["flow_id"])
@@ -131,27 +131,39 @@ async def test_user_step_single_site_shortcuts_to_devices(hass) -> None:
 @pytest.mark.asyncio
 async def test_site_step_requires_selection(hass) -> None:
     flow = _make_flow(hass)
-    flow._sites = {"site-1": "Existing"}
+    flow._sites = {"1001": "Existing"}
     result = await flow.async_step_site({})
     assert result["type"] is FlowResultType.FORM
     assert result["errors"] == {"base": "site_required"}
 
 
 @pytest.mark.asyncio
+async def test_site_step_rejects_non_numeric_site_id(hass) -> None:
+    flow = _make_flow(hass)
+    flow._sites = {}
+    result = await flow.async_step_site({CONF_SITE_ID: "12A45"})
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {"base": "site_invalid"}
+    assert flow._selected_site_id is None
+    assert flow._sites == {}
+
+
+@pytest.mark.asyncio
 async def test_site_step_handles_unknown_site_id(hass) -> None:
     flow = _make_flow(hass)
-    flow._sites = {"site-1": "Existing"}
+    flow._sites = {"1001": "Existing"}
     flow._selected_site_id = None
     with patch.object(
         flow,
         "async_step_devices",
         AsyncMock(return_value={"type": FlowResultType.FORM, "step_id": "devices"}),
     ) as mock_devices:
-        result = await flow.async_step_site({CONF_SITE_ID: "new-site"})
+        result = await flow.async_step_site({CONF_SITE_ID: "98765"})
 
     assert result["type"] is FlowResultType.FORM
     mock_devices.assert_awaited_once()
-    assert "new-site" in flow._sites
+    assert "98765" in flow._sites
 
 
 @pytest.mark.asyncio
@@ -179,8 +191,8 @@ async def test_devices_step_requires_serial_selection(hass) -> None:
 async def test_devices_step_requires_site_only_opt_in(hass) -> None:
     flow = _make_flow(hass)
     flow._auth_tokens = TOKENS
-    flow._selected_site_id = "site-123"
-    flow._sites = {"site-123": "Garage"}
+    flow._selected_site_id = "12345"
+    flow._sites = {"12345": "Garage"}
     with patch(
         "custom_components.enphase_ev.config_flow.async_fetch_chargers",
         AsyncMock(return_value=[]),
@@ -195,8 +207,8 @@ async def test_devices_step_requires_site_only_opt_in(hass) -> None:
 async def test_devices_step_site_only_schema_allows_empty_serials(hass) -> None:
     flow = _make_flow(hass)
     flow._auth_tokens = TOKENS
-    flow._selected_site_id = "site-123"
-    flow._sites = {"site-123": "Garage"}
+    flow._selected_site_id = "12345"
+    flow._sites = {"12345": "Garage"}
     with patch(
         "custom_components.enphase_ev.config_flow.async_fetch_chargers",
         AsyncMock(return_value=[]),
@@ -213,7 +225,7 @@ async def test_devices_step_site_only_schema_allows_empty_serials(hass) -> None:
 
 @pytest.mark.asyncio
 async def test_devices_step_allows_site_only_entry(hass) -> None:
-    site = SiteInfo(site_id="site-123", name="Garage Site")
+    site = SiteInfo(site_id="12345", name="Garage Site")
 
     with (
         patch(
@@ -260,7 +272,7 @@ async def test_finalize_login_entry_reconfigure_awaits_helper(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_SITE_ID: "site-123",
+            CONF_SITE_ID: "12345",
             CONF_EMAIL: "user@example.com",
             CONF_REMEMBER_PASSWORD: False,
         },
@@ -270,8 +282,8 @@ async def test_finalize_login_entry_reconfigure_awaits_helper(hass) -> None:
     flow = _make_flow(hass)
     flow._reconfigure_entry = entry
     flow._auth_tokens = TOKENS
-    flow._sites = {"site-123": "Garage"}
-    flow._selected_site_id = "site-123"
+    flow._sites = {"12345": "Garage"}
+    flow._selected_site_id = "12345"
     flow._remember_password = False
     flow._email = "user@example.com"
     flow.async_update_reload_and_abort = AsyncMock(
@@ -288,9 +300,9 @@ async def test_finalize_login_entry_reconfigure_awaits_helper(hass) -> None:
 async def test_finalize_login_entry_reconfigure_updates_entry(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="site-123",
+        unique_id="12345",
         data={
-            CONF_SITE_ID: "site-123",
+            CONF_SITE_ID: "12345",
             CONF_EMAIL: "user@example.com",
             CONF_REMEMBER_PASSWORD: True,
             CONF_PASSWORD: "old-secret",
@@ -301,8 +313,8 @@ async def test_finalize_login_entry_reconfigure_updates_entry(hass) -> None:
     flow = _make_flow(hass)
     flow._reconfigure_entry = entry
     flow._auth_tokens = TOKENS
-    flow._sites = {"site-123": "Garage"}
-    flow._selected_site_id = "site-123"
+    flow._sites = {"12345": "Garage"}
+    flow._selected_site_id = "12345"
     flow._remember_password = True
     flow._password = "new-secret"
     flow._email = "user@example.com"
@@ -322,9 +334,9 @@ async def test_finalize_login_entry_reconfigure_updates_entry(hass) -> None:
 async def test_finalize_login_entry_sync_update_removes_none(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
-        unique_id="site-123",
+        unique_id="12345",
         data={
-            CONF_SITE_ID: "site-123",
+            CONF_SITE_ID: "12345",
             CONF_EMAIL: "user@example.com",
             CONF_REMEMBER_PASSWORD: True,
             CONF_PASSWORD: "legacy",
@@ -341,8 +353,8 @@ async def test_finalize_login_entry_sync_update_removes_none(hass) -> None:
         access_token=None,
         token_expires_at=None,
     )
-    flow._sites = {"site-123": "Garage"}
-    flow._selected_site_id = "site-123"
+    flow._sites = {"12345": "Garage"}
+    flow._selected_site_id = "12345"
     flow._remember_password = False
     flow._password = None
     flow._email = "user@example.com"
@@ -379,7 +391,7 @@ async def test_ensure_chargers_handles_missing_state(hass) -> None:
 async def test_ensure_chargers_fetches_from_api(hass) -> None:
     flow = _make_flow(hass)
     flow._auth_tokens = TOKENS
-    flow._selected_site_id = "site-123"
+    flow._selected_site_id = "12345"
     chargers = [ChargerInfo(serial="EV1", name=None)]
 
     with (
@@ -440,11 +452,11 @@ def test_get_reconfigure_entry_falls_back_to_context(hass) -> None:
 async def test_abort_if_unique_id_mismatch_fallback(hass) -> None:
     flow = _make_flow(hass)
     entry = MockConfigEntry(
-        domain=DOMAIN, data={CONF_SITE_ID: "site-1"}, unique_id="site-1"
+        domain=DOMAIN, data={CONF_SITE_ID: "1001"}, unique_id="1001"
     )
     flow._reconfigure_entry = entry
     flow._get_reconfigure_entry = MagicMock(return_value=entry)
-    await flow.async_set_unique_id("site-2")
+    await flow.async_set_unique_id("1002")
 
     with patch(
         "homeassistant.config_entries.ConfigFlow._abort_if_unique_id_mismatch",
@@ -545,7 +557,7 @@ async def test_options_flow_forget_password(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_SITE_ID: "site-123",
+            CONF_SITE_ID: "12345",
             CONF_EMAIL: "user@example.com",
             CONF_PASSWORD: "secret",
             CONF_REMEMBER_PASSWORD: True,
@@ -634,7 +646,7 @@ async def test_options_flow_show_form_uses_existing_options(hass) -> None:
 async def test_options_flow_updates_site_only_in_data(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
-        data={CONF_SITE_ID: "site-123", CONF_SITE_ONLY: False},
+        data={CONF_SITE_ID: "12345", CONF_SITE_ONLY: False},
         options={},
     )
     entry.add_to_hass(hass)

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -80,7 +80,7 @@ async def test_coordinator_init_normalizes_serials_and_options(hass, monkeypatch
             raise ValueError("boom")
 
     config = {
-        CONF_SITE_ID: "site-123",
+        CONF_SITE_ID: "12345",
         CONF_SERIALS: [None, " EV01 ", "", "EV02", "EV01", BadSerial()],
         CONF_EAUTH: "token",
         CONF_COOKIE: "cookie",
@@ -129,7 +129,7 @@ def test_coordinator_init_handles_single_serial(monkeypatch, hass):
     from custom_components.enphase_ev.coordinator import EnphaseCoordinator
 
     config = {
-        CONF_SITE_ID: "site-789",
+        CONF_SITE_ID: "78901",
         CONF_SERIALS: " EV42 ",
         CONF_EAUTH: None,
         CONF_COOKIE: None,

--- a/tests/components/enphase_ev/test_device_info.py
+++ b/tests/components/enphase_ev/test_device_info.py
@@ -53,7 +53,7 @@ def test_device_info_defaults_when_metadata_missing():
     entity = object.__new__(EnphaseBaseEntity)
     entity._coord = SimpleNamespace(
         data={"321": {}},
-        site_id="site-1",
+        site_id="1001",
     )
     entity._sn = "321"
 
@@ -73,7 +73,7 @@ def test_device_info_uses_display_name_when_model_missing():
                 "display_name": "Driveway Charger",
             }
         },
-        site_id="site-2",
+        site_id="1002",
     )
     entity._sn = "999"
 

--- a/tests/components/enphase_ev/test_reconfigure_flow.py
+++ b/tests/components/enphase_ev/test_reconfigure_flow.py
@@ -95,7 +95,7 @@ async def test_reconfigure_skips_site_selection(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_SITE_ID: "site-123",
+            CONF_SITE_ID: "12345",
             CONF_SITE_NAME: "Garage Site",
             CONF_EMAIL: "user@example.com",
             CONF_REMEMBER_PASSWORD: True,
@@ -118,8 +118,8 @@ async def test_reconfigure_skips_site_selection(hass) -> None:
         token_expires_at=1_700_000_000,
     )
     sites = [
-        SiteInfo(site_id="site-123", name="Garage Site"),
-        SiteInfo(site_id="site-456", name="Backup Site"),
+        SiteInfo(site_id="12345", name="Garage Site"),
+        SiteInfo(site_id="67890", name="Backup Site"),
     ]
     chargers = [ChargerInfo(serial="EV123", name="Driveway Charger")]
 
@@ -154,7 +154,7 @@ async def test_reconfigure_wrong_account_abort_has_placeholders(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_SITE_ID: "site-123",
+            CONF_SITE_ID: "12345",
             CONF_SITE_NAME: "Garage Site",
             CONF_EMAIL: "user@example.com",
             CONF_REMEMBER_PASSWORD: True,
@@ -176,8 +176,8 @@ async def test_reconfigure_wrong_account_abort_has_placeholders(hass) -> None:
         token_expires_at=1_700_000_000,
     )
     sites = [
-        SiteInfo(site_id="site-123", name="Garage Site"),
-        SiteInfo(site_id="site-456", name="Backup Site"),
+        SiteInfo(site_id="12345", name="Garage Site"),
+        SiteInfo(site_id="67890", name="Backup Site"),
     ]
     chargers = [ChargerInfo(serial="EV999", name="Workshop Charger")]
 
@@ -207,7 +207,7 @@ async def test_reconfigure_wrong_account_abort_has_placeholders(hass) -> None:
         assert result["step_id"] == "devices"
 
         # Simulate selecting a different site before finalizing
-        flow._selected_site_id = "site-456"
+        flow._selected_site_id = "67890"
 
         result = await flow.async_step_devices(
             {CONF_SERIALS: ["EV999"], CONF_SCAN_INTERVAL: 60}
@@ -217,8 +217,8 @@ async def test_reconfigure_wrong_account_abort_has_placeholders(hass) -> None:
     assert result["reason"] == "wrong_account"
     placeholders = result.get("description_placeholders")
     assert placeholders == {
-        "configured_label": "Garage Site (site-123)",
-        "requested_label": "Backup Site (site-456)",
+        "configured_label": "Garage Site (12345)",
+        "requested_label": "Backup Site (67890)",
     }
 
 
@@ -227,7 +227,7 @@ async def test_reauth_skips_site_selection(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_SITE_ID: "site-123",
+            CONF_SITE_ID: "12345",
             CONF_SITE_NAME: "Garage Site",
             CONF_EMAIL: "user@example.com",
             CONF_REMEMBER_PASSWORD: True,
@@ -250,8 +250,8 @@ async def test_reauth_skips_site_selection(hass) -> None:
         token_expires_at=1_700_000_000,
     )
     sites = [
-        SiteInfo(site_id="site-123", name="Garage Site"),
-        SiteInfo(site_id="site-456", name="Backup Site"),
+        SiteInfo(site_id="12345", name="Garage Site"),
+        SiteInfo(site_id="67890", name="Backup Site"),
     ]
     chargers = [ChargerInfo(serial="EV123", name="Driveway Charger")]
 

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -24,7 +24,7 @@ def _mk_coord(sn: str, payload: dict[str, Any]) -> Any:
     coord.data = {sn: payload}
     coord.serials = {sn}
     coord.last_set_amps = {}
-    coord.site_id = "site-test"
+    coord.site_id = "123456"
     coord._serial_order = [sn]
     coord.iter_serials = lambda: list(coord.serials)
 
@@ -136,6 +136,8 @@ async def test_async_setup_entry_adds_site_energy_entities(
     for cb in callbacks:
         cb()
     assert created, "Expected site energy sensor to be created"
+    assert any(ent._flow_key == "consumption" for ent in created)
+    assert any(ent.translation_key == "site_consumption" for ent in created)
 
 
 def test_session_metadata_attributes_handle_blanks():

--- a/tests/components/enphase_ev/test_sensor_coverage_last_session.py
+++ b/tests/components/enphase_ev/test_sensor_coverage_last_session.py
@@ -245,7 +245,7 @@ def test_site_backoff_remaining_seconds(monkeypatch):
         last_failure_description=None,
         last_failure_response=None,
         last_failure_source=None,
-        site_id="site",
+        site_id="12345",
     )
     sensor = EnphaseSiteBackoffEndsSensor(coord)
     monkeypatch.setattr(sensor, "_coord", coord)

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -17,11 +17,10 @@ def test_site_energy_aggregation_with_fallbacks(coordinator_factory) -> None:
     coord = coordinator_factory()
     payload = {
         "production": [1000, None, 2000, -5],
-        "import": [],
-        "grid_home": [200, 100],
+        "consumption": [1500, 500],
+        "solar_home": [400, 100],
+        "solar_grid": [600, None],
         "grid_battery": [50],
-        "export": [],
-        "solar_grid": [600],
         "battery_grid": [100],
         "charge": None,
         "solar_battery": [100],
@@ -36,14 +35,17 @@ def test_site_energy_aggregation_with_fallbacks(coordinator_factory) -> None:
     assert flows is not None
     assert set(flows) == {
         "solar_production",
+        "consumption",
         "grid_import",
         "grid_export",
         "battery_charge",
         "battery_discharge",
     }
     assert flows["solar_production"].value_kwh == pytest.approx(3.0)
-    assert flows["grid_import"].fields_used == ["grid_home", "grid_battery"]
-    assert flows["grid_export"].fields_used == ["solar_grid", "battery_grid"]
+    assert flows["consumption"].value_kwh == pytest.approx(2.0)
+    assert flows["grid_import"].fields_used == ["consumption", "solar_home"]
+    assert flows["grid_import"].value_kwh == pytest.approx(1.5)
+    assert flows["grid_export"].fields_used == ["solar_grid"]
     assert flows["battery_charge"].bucket_count == 1
     assert flows["battery_charge"].value_kwh == pytest.approx(0.15)
     assert flows["battery_discharge"].value_kwh == pytest.approx(0.25)
@@ -438,8 +440,8 @@ def test_site_energy_import_diff_with_battery_home(coordinator_factory) -> None:
     }
     flows, _meta = coord._aggregate_site_energy(payload)  # noqa: SLF001
     assert flows is not None
-    # Base diff: (1500-600)=900 Wh; subtract battery_home 700 Wh => 200 Wh
-    assert flows["grid_import"].value_kwh == pytest.approx(0.2)
+    # Base diff: (1500-600)=900 Wh
+    assert flows["grid_import"].value_kwh == pytest.approx(0.9)
     assert flows["grid_import"].fields_used == ["consumption", "solar_home"]
 
 
@@ -452,7 +454,7 @@ def test_site_energy_import_diff_skips_when_battery_overlaps(coordinator_factory
         "interval_minutes": 60,
     }
     flows, _meta = coord._aggregate_site_energy(payload)  # noqa: SLF001
-    assert "grid_import" not in flows
+    assert flows["grid_import"].value_kwh == pytest.approx(0.3)
 
 
 def test_site_energy_honors_interval_minutes(coordinator_factory) -> None:
@@ -656,8 +658,9 @@ async def test_site_energy_direct_arrays(monkeypatch, coordinator_factory):
     coord = coordinator_factory()
     coord.client.lifetime_energy = AsyncMock(
         return_value={
-            "import": [100],
-            "export": [50],
+            "consumption": [200],
+            "solar_home": [50],
+            "solar_grid": [75],
             "charge": [25],
             "discharge": [10],
             "start_date": "2024-01-01",
@@ -667,6 +670,7 @@ async def test_site_energy_direct_arrays(monkeypatch, coordinator_factory):
     )
     await coord._async_refresh_site_energy()  # noqa: SLF001
     assert set(coord.site_energy) == {
+        "consumption",
         "grid_import",
         "grid_export",
         "battery_charge",


### PR DESCRIPTION
## Summary
- fix site lifetime energy mappings (production/consumption/solar_home/solar_grid)
- add Site Consumption sensor and translations
- update site energy tests and coverage for new mappings

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
