### PR TITLE
Prepare v1.5.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,36 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
-- None
+- Added Site Consumption lifetime energy sensor for total site usage alongside the existing site energy sensors (disabled by default).
+- Validate manually entered site IDs during setup, blocking non-numeric values with a friendly error.
 
 ### 🐛 Bug fixes
-- Fixed site lifetime energy kWh conversion by treating lifetime buckets as Wh values (no interval scaling), preventing over/under-counted totals.
-- Fixed site-only setup by making charger serials optional, skipping charger entity creation when enabled, and always registering site energy entities.
+- None
 
 ### 🔧 Improvements
 - None
 
 ### 🔄 Other changes
 - None
+
+## v1.5.2 – 2025-12-21
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Fixed site lifetime energy kWh conversion by treating lifetime buckets as Wh values (no interval scaling), preventing over/under-counted totals.
+- Corrected site lifetime energy flow mappings for grid import/export and consumption to align with the Enlighten payload fields.
+- Fixed site-only setup by making charger serials optional, skipping charger entity creation when enabled, and always registering site energy entities.
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- Expanded config flow and site energy regression coverage and added translations for the new site ID validation error.
 
 ## v1.5.1 – 2025-12-12
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ If the login form reports that multi-factor authentication is required, complete
 | --- | --- |
 | Site sensors | Last Successful Update timestamp, Cloud Latency in milliseconds, Cloud Error Code (with descriptive context), and a Cloud Backoff Ends timestamp so you can see exactly when active retry windows clear. |
 | Site binary sensor | Cloud Reachable indicator (on/off) with attributes for the last success, last failure (status, description, response), and any active backoff window. |
-| Site lifetime energy sensors | Disabled by default; expose lifetime Grid Import/Export, Solar Production, Battery Charge, and Battery Discharge totals for the Energy Dashboard. |
+| Site lifetime energy sensors | Disabled by default; expose lifetime Grid Import/Export, Solar Production, Site Consumption, Battery Charge, and Battery Discharge totals (Energy Dashboard uses the Grid/Solar/Battery sensors). |
 | Switch | Per-charger charging control (on/off) that honors the configured charge mode and stays in sync even if a session is already active. |
 | Button | Start Charging and Stop Charging actions for each charger that enforce the active Manual/Scheduled/Green preference before calling the cloud API. |
 | Select | Charge Mode selector (Manual, Scheduled, Green) backed by the cloud scheduler. |
@@ -161,6 +161,7 @@ docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "p
   - Return to Grid → `Site Grid Export`
   - Solar Production → `Site Solar Production`
   - Battery Charge / Discharge → `Site Battery Charge` and `Site Battery Discharge`
+- `Site Consumption` is available for total usage tracking and custom dashboards, but it is not required by the Energy Dashboard.
 - These sensors live on the Site device with `device_class: energy`, `state_class: total_increasing`, and kWh units, and they track lifetime totals with reset guards.
 - The charger `Lifetime Energy` sensor remains available for per-charger consumption tracking if you prefer.
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.5.1"
+  "version": "1.5.2"
 }


### PR DESCRIPTION
## Summary
- Prepare v1.5.2 release notes, including site ID validation, site-only setup fixes, and corrected site energy mappings.
- Bump the manifest to 1.5.2 and document the Site Consumption energy sensor in the README.

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q" (skipped per request)
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest" (skipped per request)
