### PR TITLE
Improve live stream polling lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "p
 
 ### Options
 
-- Polling intervals: Configure slow (idle) and fast (charging) intervals. The integration auto‑switches and also uses a short fast window after Start/Stop to reflect changes faster.
+- Polling intervals: Configure slow (idle) and fast (charging) intervals. The integration auto‑switches and also uses a short fast window plus a brief live‑stream burst after Start/Stop to reflect changes faster.
 - API timeout: Default 15s (Options → API timeout).
 - Nominal voltage: Default 240 V; used to estimate power from amps when the API omits power.
 - Fast while streaming: On by default; prefers faster polling while an explicit cloud live stream is active.

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -368,10 +368,7 @@ def _register_services(hass: HomeAssistant) -> None:
         if not site_ids:
             coords = coords[:1]
         for coord in coords:
-            await coord.client.start_live_stream()
-            coord._streaming = (
-                True  # noqa: SLF001 - internal flag for coordinator behaviour
-            )
+            await coord.async_start_streaming(manual=True)
             await coord.async_request_refresh()
 
     async def _svc_stop_stream(call):
@@ -382,10 +379,7 @@ def _register_services(hass: HomeAssistant) -> None:
         if not site_ids:
             coords = coords[:1]
         for coord in coords:
-            await coord.client.stop_live_stream()
-            coord._streaming = (
-                False  # noqa: SLF001 - internal flag for coordinator behaviour
-            )
+            await coord.async_stop_streaming(manual=True)
             await coord.async_request_refresh()
 
     hass.services.async_register(DOMAIN, "start_live_stream", _svc_start_stream)

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -110,7 +110,7 @@ GET /service/evse_controller/<site_id>/ev_chargers/start_live_stream
 ```
 Initiates a short burst of rapid status updates.
 ```json
-{ "status": "accepted", "topics": ["evse/<sn>/status"], "duration_s": 60 }
+{ "status": "accepted", "topics": ["evse/<sn>/status"], "duration_s": 900 }
 ```
 
 ### 2.4 Stop Live Stream
@@ -453,7 +453,7 @@ Additional metrics documented in the official `/api/v4/.../telemetry` endpoint a
 - HTTP 401 — credentials expired; request reauth.
 - HTTP 400/404/409/422 during control operations — charger not ready/not plugged; treated as no-ops.
 - Rate limiting presents as HTTP 429; the integration backs off and logs the event.
-- Recommended polling interval: 30 s (configurable). Live stream can be used for short bursts (60 s)
+- Recommended polling interval: 30 s (configurable). Live stream can be used for short bursts (15 min)
 
 ### 7.1 Cloud status codes (from the official v4 control API)
 Enphase’s public “EV Charger Control” reference (https://developer-v4.enphase.com/docs.html) documents the same backend actions behind a `/api/v4/systems/{system_id}/ev_charger/{serial_no}/…` surface. Although we do not call that REST layer directly, the status codes it lists match the JSON payloads we have seen bubble out of the Enlighten UI endpoints. The most relevant responses are:

--- a/tests/components/enphase_ev/test_buttons_and_fast.py
+++ b/tests/components/enphase_ev/test_buttons_and_fast.py
@@ -69,6 +69,7 @@ async def test_start_stop_buttons_press(hass, monkeypatch):
         def __init__(self):
             self.start_calls = []
             self.stop_calls = []
+            self.stream_start_calls = 0
 
         async def start_charging(
             self,
@@ -85,6 +86,10 @@ async def test_start_stop_buttons_press(hass, monkeypatch):
         async def stop_charging(self, s):
             self.stop_calls.append(s)
             return {"status": "ok"}
+
+        async def start_live_stream(self):
+            self.stream_start_calls += 1
+            return {"status": "accepted", "duration_s": 900}
 
     coord.client = StubClient()
 

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -603,6 +603,9 @@ async def test_async_start_stop_trigger_paths(hass, monkeypatch):
     coord.client = SimpleNamespace(
         start_charging=AsyncMock(return_value={"status": "ok"}),
         stop_charging=AsyncMock(return_value=None),
+        start_live_stream=AsyncMock(
+            return_value={"status": "accepted", "duration_s": 900}
+        ),
         trigger_message=AsyncMock(side_effect=_trigger_message),
     )
 
@@ -646,6 +649,9 @@ async def test_async_start_charging_manual_mode_sends_requested_amps(hass, monke
         start_charging=AsyncMock(return_value={"status": "ok"}),
         stop_charging=AsyncMock(return_value=None),
         set_charge_mode=AsyncMock(return_value={"status": "ok"}),
+        start_live_stream=AsyncMock(
+            return_value={"status": "accepted", "duration_s": 900}
+        ),
     )
     coord.async_request_refresh = AsyncMock()
 
@@ -675,6 +681,9 @@ async def test_async_start_and_stop_preserve_scheduled_mode(hass, monkeypatch):
         start_charging=AsyncMock(return_value={"status": "ok"}),
         stop_charging=AsyncMock(return_value={"status": "ok"}),
         set_charge_mode=AsyncMock(return_value={"status": "ok"}),
+        start_live_stream=AsyncMock(
+            return_value={"status": "accepted", "duration_s": 900}
+        ),
     )
     coord.async_request_refresh = AsyncMock()
 
@@ -711,6 +720,9 @@ async def test_async_start_charging_green_mode_omits_amp_payload(hass, monkeypat
         start_charging=AsyncMock(return_value={"status": "ok"}),
         stop_charging=AsyncMock(return_value=None),
         set_charge_mode=AsyncMock(return_value={"status": "ok"}),
+        start_live_stream=AsyncMock(
+            return_value={"status": "accepted", "duration_s": 900}
+        ),
     )
     coord.async_request_refresh = AsyncMock()
 
@@ -1922,6 +1934,7 @@ async def test_streaming_prefers_fast(hass, monkeypatch):
     }
     coord.client = StubClient(payload_idle)
     coord._streaming = True
+    coord._streaming_until = time.monotonic() + 60
     await coord._async_update_data()
     assert int(coord.update_interval.total_seconds()) == 6
 

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -51,6 +51,9 @@ def coordinator_factory(hass, config_entry, monkeypatch):
         coord.client = SimpleNamespace(
             start_charging=AsyncMock(return_value={"status": "ok"}),
             stop_charging=AsyncMock(return_value=None),
+            start_live_stream=AsyncMock(
+                return_value={"status": "accepted", "duration_s": 900}
+            ),
         )
         coord.async_request_refresh = AsyncMock()
         coord.kick_fast = MagicMock()


### PR DESCRIPTION
## Summary
- track live stream lifecycles with auto-expiry and auto-stop when charging state changes
- start streaming automatically on start/stop actions and route services through coordinator helpers
- update tests and docs to cover the streaming flow and duration

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m coverage run -m pytest tests/components/enphase_ev -q && python -m coverage report --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/__init__.py --fail-under=100"