### PR TITLE
Fix power reporting when charger suspended

### DIFF
--- a/tests/components/enphase_ev/test_power_restore.py
+++ b/tests/components/enphase_ev/test_power_restore.py
@@ -20,7 +20,15 @@ async def test_power_restore_continues_from_last_sample(monkeypatch):
 
     # Build coordinator stub and initial data
     coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
-    coord.data = {sn: {"sn": sn, "name": "Garage EV", "lifetime_kwh": 10.5, "operating_v": 230}}
+    coord.data = {
+        sn: {
+            "sn": sn,
+            "name": "Garage EV",
+            "lifetime_kwh": 10.5,
+            "operating_v": 230,
+            "charging": True,
+        }
+    }
     coord.serials = {sn}
     coord.site_id = "1234567"
     coord.last_update_success = True

--- a/tests/components/enphase_ev/test_power_sensor_dynamic_max.py
+++ b/tests/components/enphase_ev/test_power_sensor_dynamic_max.py
@@ -8,7 +8,7 @@ def _build_sensor(sn: str = "555555555555"):
     from custom_components.enphase_ev.sensor import EnphasePowerSensor
 
     coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
-    coord.data = {sn: {"sn": sn, "name": "Garage EV"}}
+    coord.data = {sn: {"sn": sn, "name": "Garage EV", "charging": True}}
     coord.serials = {sn}
     coord.site_id = "1234567"
     coord.last_update_success = True

--- a/tests/components/enphase_ev/test_voltage_and_daily_energy.py
+++ b/tests/components/enphase_ev/test_voltage_and_daily_energy.py
@@ -12,7 +12,13 @@ def test_power_derived_from_lifetime_delta(monkeypatch):
     sn = RANDOM_SERIAL_ALT
     coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
     coord.data = {
-        sn: {"sn": sn, "name": "Garage EV", "lifetime_kwh": 10.0, "operating_v": 230}
+        sn: {
+            "sn": sn,
+            "name": "Garage EV",
+            "lifetime_kwh": 10.0,
+            "operating_v": 230,
+            "charging": True,
+        }
     }
     coord.serials = {sn}
 


### PR DESCRIPTION
## Summary
- Gate power sensor output on actual charging and expose an actual_charging attribute.
- Add coverage for suspended connector/EVSE cases and align power tests with the stricter charging gate.
- Coverage: `custom_components/enphase_ev/sensor.py` 100% (0 misses).

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "PYTEST_DISABLE_PLUGIN_AUTOLOAD=0 pytest -p pytest_cov tests/components/enphase_ev -q --cov=custom_components.enphase_ev.sensor --cov-report=term-missing --cov-fail-under=100"
