### PR TITLE
Align service translations with HA strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ All notable changes to this project will be documented in this file.
 ### 🔧 Improvements
 - Removed the `last_success_utc` attribute from cloud diagnostic sensors to keep metadata focused.
 - Split energy aggregation/guard logic into a dedicated module to simplify coordinator responsibilities.
+- Synced `strings.json` with locale translations for services, issues, device automation, and system health metadata.
+- Removed the stale device automation action translation and rely on entity translations for site-level names.
+- Added service section translations for advanced options and filled site ID service field labels.
 
 ### 🔄 Other changes
 - Documented the `dlbActive` connector field in the cloud status API spec.

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -109,10 +109,6 @@ class SiteCloudReachableBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self._attr_unique_id = f"{DOMAIN}_site_{coord.site_id}_cloud_reachable"
 
     @property
-    def name(self):
-        return "Cloud Reachable"
-
-    @property
     def available(self) -> bool:
         if self._coord.last_success_utc is not None:
             return True

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -1422,11 +1422,10 @@ class _TimestampFromEpochSensor(EnphaseBaseEntity, SensorEntity):
 class _SiteBaseEntity(CoordinatorEntity, SensorEntity):
     _attr_has_entity_name = True
 
-    def __init__(self, coord: EnphaseCoordinator, key: str, name: str):
+    def __init__(self, coord: EnphaseCoordinator, key: str, _name: str):
         super().__init__(coord)
         self._coord = coord
         self._key = key
-        self._attr_name = name
         self._attr_unique_id = f"{DOMAIN}_site_{coord.site_id}_{key}"
 
     @property

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -377,5 +377,154 @@
       "start_charging": { "name": "Start Charging" },
       "stop_charging": { "name": "Stop Charging" }
     }
+  },
+  "device": {
+    "enphase_site": {
+      "name": "Enphase Site {site_id}"
+    }
+  },
+  "device_automation": {
+    "action_type": {
+      "start_charging": "Start charging",
+      "stop_charging": "Stop charging"
+    },
+    "trigger_type": {
+      "charging_started": "Charging started",
+      "charging_stopped": "Charging stopped",
+      "plugged_in": "Plugged in",
+      "unplugged": "Unplugged"
+    }
+  },
+  "issues": {
+    "reauth_required": {
+      "title": "Enphase EV needs reauthentication",
+      "description": "Site {site_id} requires updated session headers. Please reauthenticate."
+    },
+    "rate_limited": {
+      "title": "Enphase EV is rate limited",
+      "description": "The cloud API returned rate limiting. Polling will slow temporarily."
+    },
+    "cloud_unreachable": {
+      "title": "Enphase EV cloud unreachable",
+      "description": "Home Assistant cannot reach the Enphase cloud for site {site_id}. Polling slows automatically; verify the service status and your network."
+    },
+    "cloud_dns_resolution": {
+      "title": "Enphase EV DNS resolution failure",
+      "description": "Home Assistant could not resolve enlighten.enphaseenergy.com for site {site_id}. Check your DNS resolver or internet connection."
+    },
+    "cloud_service_unavailable": {
+      "title": "Enphase EV cloud errors",
+      "description": "The Enphase cloud for site {site_id} is responding with errors. Polling is backing off automatically; check the service status or usage limits."
+    }
+  },
+  "system_health": {
+    "info": {
+      "site_id": "Site ID",
+      "can_reach_server": "Reach Enphase cloud",
+      "last_success": "Last successful update",
+      "latency_ms": "Cloud latency (ms)",
+      "last_error": "Last error",
+      "backoff_active": "Backoff active",
+      "network_errors": "Consecutive network errors",
+      "http_errors": "Consecutive HTTP errors"
+    }
+  },
+  "services": {
+    "start_charging": {
+      "name": "Start Charging",
+      "description": "Start charging on the selected Enphase EV charger.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "charging_level": {
+          "name": "Charging level (A)",
+          "description": "Optional current setpoint in amps (6-40)."
+        },
+        "connector_id": {
+          "name": "Connector ID",
+          "description": "Optional connector index (usually 1)."
+        }
+      }
+    },
+    "stop_charging": {
+      "name": "Stop Charging",
+      "description": "Stop charging on the selected Enphase EV charger."
+    },
+    "trigger_message": {
+      "name": "Trigger OCPP Message",
+      "description": "Request the charger to send an OCPP message and return the cloud response.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "requested_message": {
+          "name": "Requested message",
+          "description": "OCPP message name (e.g., MeterValues); service response shows charger output."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        }
+      }
+    },
+    "clear_reauth_issue": {
+      "name": "Clear Reauth Issue",
+      "description": "Select an Enphase site device to clear its reauthentication repair issue.",
+      "fields": {
+        "device_id": {
+          "name": "Chargers",
+          "description": "Select Enphase chargers whose reauthentication repair issue should be cleared."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        }
+      }
+    },
+    "start_live_stream": {
+      "name": "Start Live Stream",
+      "description": "Request faster cloud status updates for a short period.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        }
+      }
+    },
+    "stop_live_stream": {
+      "name": "Stop Live Stream",
+      "description": "Stop the cloud live stream request.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        }
+      }
+    },
+    "sync_schedules": {
+      "name": "Sync Schedules",
+      "description": "Refresh Enphase schedules and update schedule helpers.",
+      "fields": {
+        "device_id": {
+          "name": "Chargers",
+          "description": "Optional charger selection for a targeted sync."
+        }
+      }
+    }
   }
 }

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -354,8 +354,7 @@
   "device_automation": {
     "action_type": {
       "start_charging": "Laden starten",
-      "stop_charging": "Laden stoppen",
-      "set_charging_amps": "Ladestrom festlegen"
+      "stop_charging": "Laden stoppen"
     },
     "trigger_type": {
       "charging_started": "Laden gestartet",
@@ -436,6 +435,11 @@
     "start_charging": {
       "name": "Laden starten",
       "description": "Startet den Ladevorgang am ausgewählten Enphase EV-Ladegerät.",
+      "sections": {
+        "advanced": {
+          "name": "Erweiterte Optionen"
+        }
+      },
       "fields": {
         "charging_level": {
           "name": "Ladestrom (A)",
@@ -454,10 +458,19 @@
     "trigger_message": {
       "name": "OCPP-Nachricht auslösen",
       "description": "Fordert das Ladegerät auf, eine OCPP-Nachricht zu senden, und gibt die Cloud-Antwort zurück.",
+      "sections": {
+        "advanced": {
+          "name": "Erweiterte Optionen"
+        }
+      },
       "fields": {
         "requested_message": {
           "name": "Angeforderte Nachricht",
           "description": "OCPP-Nachrichtenname (z. B. MeterValues); die Serviceantwort zeigt die Ausgabe des Ladegeräts."
+        },
+        "site_id": {
+          "name": "Standort-ID",
+          "description": "Optionaler Standortbezeichner; wird automatisch erkannt, wenn ein Standortgerät ausgewählt ist."
         }
       }
     },
@@ -477,11 +490,33 @@
     },
     "start_live_stream": {
       "name": "Livestream starten",
-      "description": "Fordert für kurze Zeit schnellere Cloud-Statusaktualisierungen an."
+      "description": "Fordert für kurze Zeit schnellere Cloud-Statusaktualisierungen an.",
+      "sections": {
+        "advanced": {
+          "name": "Erweiterte Optionen"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Standort-ID",
+          "description": "Optionaler Standortbezeichner; wird automatisch erkannt, wenn ein Standortgerät ausgewählt ist."
+        }
+      }
     },
     "stop_live_stream": {
       "name": "Livestream stoppen",
-      "description": "Beendet die Cloud-Livestream-Anforderung."
+      "description": "Beendet die Cloud-Livestream-Anforderung.",
+      "sections": {
+        "advanced": {
+          "name": "Erweiterte Optionen"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Standort-ID",
+          "description": "Optionaler Standortbezeichner; wird automatisch erkannt, wenn ein Standortgerät ausgewählt ist."
+        }
+      }
     },
     "sync_schedules": {
       "name": "Zeitpläne synchronisieren",

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -358,8 +358,7 @@
   "device_automation": {
     "action_type": {
       "start_charging": "Start charging",
-      "stop_charging": "Stop charging",
-      "set_charging_amps": "Set charging amps"
+      "stop_charging": "Stop charging"
     },
     "trigger_type": {
       "charging_started": "Charging started",
@@ -443,10 +442,15 @@
     "start_charging": {
       "name": "Start Charging",
       "description": "Start charging on the selected Enphase EV charger.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
       "fields": {
       "charging_level": {
         "name": "Charging level (A)",
-        "description": "Optional current setpoint in amps (6–40)."
+        "description": "Optional current setpoint in amps (6-40)."
         },
         "connector_id": {
           "name": "Connector ID",
@@ -461,10 +465,19 @@
     "trigger_message": {
       "name": "Trigger OCPP Message",
       "description": "Request the charger to send an OCPP message and return the cloud response.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
       "fields": {
         "requested_message": {
           "name": "Requested message",
           "description": "OCPP message name (e.g., MeterValues); service response shows charger output."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
         }
       }
     },
@@ -484,11 +497,33 @@
     },
     "start_live_stream": {
       "name": "Start Live Stream",
-      "description": "Request faster cloud status updates for a short period."
+      "description": "Request faster cloud status updates for a short period.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        }
+      }
     },
     "stop_live_stream": {
       "name": "Stop Live Stream",
-      "description": "Stop the cloud live stream request."
+      "description": "Stop the cloud live stream request.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        }
+      }
     },
     "sync_schedules": {
       "name": "Sync Schedules",

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -358,8 +358,7 @@
   "device_automation": {
     "action_type": {
       "start_charging": "Iniciar carga",
-      "stop_charging": "Detener carga",
-      "set_charging_amps": "Establecer amperios de carga"
+      "stop_charging": "Detener carga"
     },
     "trigger_type": {
       "charging_started": "Carga iniciada",
@@ -440,6 +439,11 @@
     "start_charging": {
       "name": "Iniciar carga",
       "description": "Inicia la carga en el cargador Enphase EV seleccionado.",
+      "sections": {
+        "advanced": {
+          "name": "Opciones avanzadas"
+        }
+      },
       "fields": {
         "charging_level": {
           "name": "Nivel de carga (A)",
@@ -458,10 +462,19 @@
     "trigger_message": {
       "name": "Lanzar mensaje OCPP",
       "description": "Solicita que el cargador envíe un mensaje OCPP y devuelve la respuesta de la nube.",
+      "sections": {
+        "advanced": {
+          "name": "Opciones avanzadas"
+        }
+      },
       "fields": {
         "requested_message": {
           "name": "Mensaje solicitado",
           "description": "Nombre del mensaje OCPP (por ejemplo, MeterValues); la respuesta del servicio muestra la salida del cargador."
+        },
+        "site_id": {
+          "name": "ID del sitio",
+          "description": "Identificador de sitio opcional; se detecta automáticamente cuando se selecciona un dispositivo de sitio."
         }
       }
     },
@@ -481,11 +494,33 @@
     },
     "start_live_stream": {
       "name": "Iniciar transmisión en vivo",
-      "description": "Solicita actualizaciones de estado en la nube más rápidas durante un periodo corto."
+      "description": "Solicita actualizaciones de estado en la nube más rápidas durante un periodo corto.",
+      "sections": {
+        "advanced": {
+          "name": "Opciones avanzadas"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "ID del sitio",
+          "description": "Identificador de sitio opcional; se detecta automáticamente cuando se selecciona un dispositivo de sitio."
+        }
+      }
     },
     "stop_live_stream": {
       "name": "Detener transmisión en vivo",
-      "description": "Detiene la solicitud de transmisión en vivo de la nube."
+      "description": "Detiene la solicitud de transmisión en vivo de la nube.",
+      "sections": {
+        "advanced": {
+          "name": "Opciones avanzadas"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "ID del sitio",
+          "description": "Identificador de sitio opcional; se detecta automáticamente cuando se selecciona un dispositivo de sitio."
+        }
+      }
     },
     "sync_schedules": {
       "name": "Sincronizar horarios",

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -356,8 +356,7 @@
   "device_automation": {
     "action_type": {
       "start_charging": "Démarrer la charge",
-      "stop_charging": "Arrêter la charge",
-      "set_charging_amps": "Définir les ampères de charge"
+      "stop_charging": "Arrêter la charge"
     },
     "trigger_type": {
       "charging_started": "Charge démarrée",
@@ -441,6 +440,11 @@
     "start_charging": {
       "name": "Démarrer la charge",
       "description": "Démarrer la charge sur le chargeur VE Enphase sélectionné.",
+      "sections": {
+        "advanced": {
+          "name": "Options avancées"
+        }
+      },
       "fields": {
       "charging_level": {
         "name": "Niveau de charge (A)",
@@ -459,10 +463,19 @@
     "trigger_message": {
       "name": "Déclencher un message OCPP",
       "description": "Demander au chargeur d'envoyer un message OCPP et retourner la réponse du cloud.",
+      "sections": {
+        "advanced": {
+          "name": "Options avancées"
+        }
+      },
       "fields": {
         "requested_message": {
           "name": "Message demandé",
           "description": "Nom du message OCPP (ex : MeterValues) ; la réponse du service affiche la sortie du chargeur."
+        },
+        "site_id": {
+          "name": "ID du site",
+          "description": "Identifiant de site optionnel ; détecté automatiquement lorsqu'un périphérique de site est sélectionné."
         }
       }
     },
@@ -482,11 +495,33 @@
     },
     "start_live_stream": {
       "name": "Démarrer le flux en direct",
-      "description": "Demander des mises à jour de statut cloud plus rapides pour une courte période."
+      "description": "Demander des mises à jour de statut cloud plus rapides pour une courte période.",
+      "sections": {
+        "advanced": {
+          "name": "Options avancées"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "ID du site",
+          "description": "Identifiant de site optionnel ; détecté automatiquement lorsqu'un périphérique de site est sélectionné."
+        }
+      }
     },
     "stop_live_stream": {
       "name": "Arrêter le flux en direct",
-      "description": "Arrêter la demande de flux en direct cloud."
+      "description": "Arrêter la demande de flux en direct cloud.",
+      "sections": {
+        "advanced": {
+          "name": "Options avancées"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "ID du site",
+          "description": "Identifiant de site optionnel ; détecté automatiquement lorsqu'un périphérique de site est sélectionné."
+        }
+      }
     },
     "sync_schedules": {
       "name": "Synchroniser les horaires",

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -356,8 +356,7 @@
   "device_automation": {
     "action_type": {
       "start_charging": "Iniciar carga",
-      "stop_charging": "Parar carga",
-      "set_charging_amps": "Definir corrente de carga"
+      "stop_charging": "Parar carga"
     },
     "trigger_type": {
       "charging_started": "Carga iniciada",
@@ -438,6 +437,11 @@
     "start_charging": {
       "name": "Iniciar carga",
       "description": "Inicia a carga no carregador Enphase EV selecionado.",
+      "sections": {
+        "advanced": {
+          "name": "Opções avançadas"
+        }
+      },
       "fields": {
         "charging_level": {
           "name": "Nível de carga (A)",
@@ -456,10 +460,19 @@
     "trigger_message": {
       "name": "Disparar mensagem OCPP",
       "description": "Solicita que o carregador envie uma mensagem OCPP e retorna a resposta da nuvem.",
+      "sections": {
+        "advanced": {
+          "name": "Opções avançadas"
+        }
+      },
       "fields": {
         "requested_message": {
           "name": "Mensagem solicitada",
           "description": "Nome da mensagem OCPP (ex.: MeterValues); a resposta do serviço mostra a saída do carregador."
+        },
+        "site_id": {
+          "name": "ID do site",
+          "description": "Identificador de site opcional; detectado automaticamente quando um dispositivo de site é selecionado."
         }
       }
     },
@@ -479,11 +492,33 @@
     },
     "start_live_stream": {
       "name": "Iniciar transmissão ao vivo",
-      "description": "Solicita atualizações de status na nuvem mais rápidas por um curto período."
+      "description": "Solicita atualizações de status na nuvem mais rápidas por um curto período.",
+      "sections": {
+        "advanced": {
+          "name": "Opções avançadas"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "ID do site",
+          "description": "Identificador de site opcional; detectado automaticamente quando um dispositivo de site é selecionado."
+        }
+      }
     },
     "stop_live_stream": {
       "name": "Parar transmissão ao vivo",
-      "description": "Encerra a solicitação de transmissão ao vivo da nuvem."
+      "description": "Encerra a solicitação de transmissão ao vivo da nuvem.",
+      "sections": {
+        "advanced": {
+          "name": "Opções avançadas"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "ID do site",
+          "description": "Identificador de site opcional; detectado automaticamente quando um dispositivo de site é selecionado."
+        }
+      }
     },
     "sync_schedules": {
       "name": "Sincronizar horários",

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -140,7 +140,7 @@ def test_site_cloud_reachable_binary_sensor_metadata(
     monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
 
     sensor = SiteCloudReachableBinarySensor(coord)
-    assert sensor.name == "Cloud Reachable"
+    assert sensor.translation_key == "cloud_reachable"
 
     coord.last_success_utc = None
     coord.last_update_success = False


### PR DESCRIPTION
## Summary
- Sync `strings.json` with service, issue, device automation, and system health translations; add advanced section labels and site ID fields for service UI.
- Remove the stale device automation action translation and rely on translation keys for site entities.
- Update the cloud reachable sensor expectation and document translation improvements in the changelog.

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -p pytest_cov tests/components/enphase_ev -q --cov=custom_components.enphase_ev/binary_sensor --cov=custom_components.enphase_ev/sensor --cov-report=term-missing --cov-fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
