### PR TITLE
Fix schedule off-peak toggles and time sanitization

### DIFF
--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -25,9 +25,14 @@ async def async_setup_entry(
     known_serials: set[str] = set()
     known_slots: set[tuple[str, str]] = set()
 
-    def _slot_is_toggleable(slot: dict[str, Any]) -> bool:
+    def _slot_is_toggleable(sn: str, slot: dict[str, Any]) -> bool:
         schedule_type = str(slot.get("scheduleType") or "")
         if schedule_type == "OFF_PEAK":
+            if schedule_sync is not None and hasattr(
+                schedule_sync, "is_off_peak_eligible"
+            ):
+                if not schedule_sync.is_off_peak_eligible(sn):
+                    return False
             return True
         if slot.get("startTime") is None or slot.get("endTime") is None:
             return False
@@ -51,7 +56,7 @@ async def async_setup_entry(
             key = (sn, slot_id)
             if key in known_slots:
                 continue
-            if not _slot_is_toggleable(slot):
+            if not _slot_is_toggleable(sn, slot):
                 continue
             entities.append(ScheduleSlotSwitch(coord, schedule_sync, sn, slot_id))
             known_slots.add(key)


### PR DESCRIPTION
## Summary
- Sanitize schedule times to avoid HA schedule storage errors and preserve end-of-day semantics.
- Gate off-peak schedule toggles by eligibility and normalize OFF_PEAK payload fields.
- Add tests for time sanitization, off-peak eligibility, and payload normalization.

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -p pytest_cov tests/components/enphase_ev -q --cov=custom_components.enphase_ev.schedule --cov=custom_components.enphase_ev.schedule_sync --cov=custom_components.enphase_ev.switch --cov-report=term-missing --cov-fail-under=100"