### PR TITLE
Fix scheduler sync payloads and enablement

### DIFF
--- a/custom_components/enphase_ev/schedule.py
+++ b/custom_components/enphase_ev/schedule.py
@@ -43,6 +43,23 @@ CONF_DAY_ORDER = [
 ]
 CONF_TO_ENPHASE = {day: idx + 1 for idx, day in enumerate(CONF_DAY_ORDER)}
 END_OF_DAY = time(23, 59, 59)
+SLOT_PATCH_FIELDS = (
+    "id",
+    "startTime",
+    "endTime",
+    "chargingLevel",
+    "chargingLevelAmp",
+    "scheduleType",
+    "days",
+    "remindTime",
+    "remindFlag",
+    "enabled",
+    "recurringKind",
+    "chargeLevelType",
+    "sourceType",
+    "reminderTimeUtc",
+    "serializedDays",
+)
 
 
 @dataclass(slots=True)
@@ -325,3 +342,80 @@ def helper_to_slot(
         slot["sourceType"] = "SYSTEM"
 
     return slot
+
+
+def _coerce_bool(value: Any) -> Any:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "yes", "1", "on"}:
+            return True
+        if lowered in {"false", "no", "0", "off"}:
+            return False
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return value
+
+
+def _coerce_int(value: Any) -> Any:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return value
+    return value
+
+
+def normalize_slot_payload(slot: dict[str, Any]) -> dict[str, Any]:
+    sanitized: dict[str, Any] = {
+        key: slot.get(key) for key in SLOT_PATCH_FIELDS if key in slot
+    }
+    slot_id = sanitized.get("id")
+    if slot_id is not None:
+        sanitized["id"] = str(slot_id)
+
+    schedule_type = sanitized.get("scheduleType")
+    if schedule_type is None:
+        schedule_type = "CUSTOM"
+    sanitized["scheduleType"] = str(schedule_type)
+
+    if "enabled" in sanitized:
+        sanitized["enabled"] = _coerce_bool(sanitized["enabled"])
+    if "remindFlag" in sanitized:
+        sanitized["remindFlag"] = _coerce_bool(sanitized["remindFlag"])
+
+    days = sanitized.get("days")
+    if isinstance(days, list):
+        normalized_days = []
+        for day in days:
+            try:
+                day_int = int(day)
+            except (TypeError, ValueError):
+                continue
+            if 1 <= day_int <= 7 and day_int not in normalized_days:
+                normalized_days.append(day_int)
+        sanitized["days"] = normalized_days
+    elif schedule_type == "OFF_PEAK":
+        sanitized["days"] = list(range(1, 8))
+
+    for key in ("startTime", "endTime", "reminderTimeUtc"):
+        value = sanitized.get(key)
+        if isinstance(value, time):
+            sanitized[key] = value.strftime("%H:%M")
+
+    if "remindTime" in sanitized:
+        sanitized["remindTime"] = _coerce_int(sanitized["remindTime"])
+    if "chargingLevel" in sanitized:
+        sanitized["chargingLevel"] = _coerce_int(sanitized["chargingLevel"])
+    if "chargingLevelAmp" in sanitized:
+        sanitized["chargingLevelAmp"] = _coerce_int(sanitized["chargingLevelAmp"])
+
+    return sanitized

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -369,6 +369,11 @@ Notes:
 - `scheduleType=OFF_PEAK` typically has null `startTime`/`endTime`.
 - `days` uses 1=Monday through 7=Sunday.
 - `remindFlag` toggles reminders and `remindTime` is minutes before `startTime`.
+- Observed: `recurringKind` and `chargeLevelType` may be `null` even for `CUSTOM` slots.
+- Observed: `chargingLevel`/`chargingLevelAmp` can be populated for `OFF_PEAK` schedules even when `startTime`/`endTime` are null.
+- Observed: `remindTime` may be present even when `remindFlag` is `false`.
+- Observed: `reminderTimeUtc` is `HH:MM` when `remindFlag=true`, otherwise null.
+- Observed: editing a schedule time in Enlighten auto-enables the slot and populates `reminderTimeUtc`.
 
 ### 4.4 Update Schedules
 ```
@@ -382,6 +387,10 @@ Body: {
 Notes:
 - Send the full list of slots; omitted slots may be deleted server-side.
 - Preserve unchanged fields like `sourceType`, `recurringKind`, `chargeLevelType`.
+- Observed: frontend PATCH requests may include `chargingLevel=100` and `chargingLevelAmp=null` for `CUSTOM` schedules; subsequent GETs may normalize back to `32/32`.
+- Observed: frontend PATCH requests include a top-level `"error": {}` field; the API accepts PATCH payloads without it.
+- Integration behavior: PATCH payloads are normalized to known slot fields only, ids are coerced to strings, booleans/ints are coerced, and `OFF_PEAK` days default to `[1..7]` if missing.
+- Integration behavior: when a schedule helper change updates time blocks, the integration auto-enables the slot to mirror Enlighten's edit behavior.
 
 ---
 

--- a/tests/components/enphase_ev/test_schedule.py
+++ b/tests/components/enphase_ev/test_schedule.py
@@ -366,3 +366,69 @@ def test_schedule_helpers_internal_helpers() -> None:
 
 def test_normalize_time_fallback_parses_non_iso() -> None:
     assert schedule_mod._normalize_time("8:0") == time(8, 0)
+
+
+def test_normalize_slot_payload_filters_fields_and_defaults() -> None:
+    slot = {
+        "id": 123,
+        "scheduleType": None,
+        "enabled": "false",
+        "days": ["1", 9, "bad", 2],
+        "unknown": "ignored",
+    }
+    normalized = schedule_mod.normalize_slot_payload(slot)
+
+    assert normalized["id"] == "123"
+    assert normalized["scheduleType"] == "CUSTOM"
+    assert normalized["enabled"] is False
+    assert normalized["days"] == [1, 2]
+    assert "unknown" not in normalized
+
+
+def test_normalize_slot_payload_off_peak_defaults_days() -> None:
+    slot = {"id": "slot-2", "scheduleType": "OFF_PEAK"}
+    normalized = schedule_mod.normalize_slot_payload(slot)
+
+    assert normalized["days"] == [1, 2, 3, 4, 5, 6, 7]
+
+
+def test_normalize_slot_payload_formats_times() -> None:
+    slot = {
+        "id": "slot-3",
+        "scheduleType": "CUSTOM",
+        "startTime": time(8, 0),
+        "endTime": time(9, 0),
+    }
+    normalized = schedule_mod.normalize_slot_payload(slot)
+
+    assert normalized["startTime"] == "08:00"
+    assert normalized["endTime"] == "09:00"
+
+
+def test_coerce_bool_variants() -> None:
+    assert schedule_mod._coerce_bool(True) is True
+    assert schedule_mod._coerce_bool("true") is True
+    assert schedule_mod._coerce_bool("false") is False
+    assert schedule_mod._coerce_bool("maybe") == "maybe"
+    assert schedule_mod._coerce_bool(0) is False
+
+    class Dummy:
+        pass
+
+    dummy = Dummy()
+    assert schedule_mod._coerce_bool(dummy) is dummy
+
+
+def test_coerce_int_variants() -> None:
+    assert schedule_mod._coerce_int(None) is None
+    assert schedule_mod._coerce_int(True) is True
+    assert schedule_mod._coerce_int(5) == 5
+    assert schedule_mod._coerce_int(5.4) == 5
+    assert schedule_mod._coerce_int("7") == 7
+    assert schedule_mod._coerce_int("bad") == "bad"
+
+    class Dummy:
+        pass
+
+    dummy = Dummy()
+    assert schedule_mod._coerce_int(dummy) is dummy

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -1,3 +1,7 @@
+import json
+from types import SimpleNamespace
+
+import aiohttp
 import pytest
 
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL, RANDOM_SITE_ID
@@ -51,6 +55,139 @@ async def test_charge_mode_select(hass, monkeypatch):
     await sel.async_select_option("Manual")
     # cache should update immediately
     assert coord._charge_mode_cache[RANDOM_SERIAL][0] == "MANUAL_CHARGING"
+
+
+@pytest.mark.asyncio
+async def test_charge_mode_select_scheduled_requires_enabled_schedule(
+    hass, monkeypatch
+) -> None:
+    from homeassistant.exceptions import HomeAssistantError
+
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from custom_components.enphase_ev.select import ChargeModeSelect
+
+    cfg = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 30,
+    }
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    coord = EnphaseCoordinator(hass, cfg)
+    coord.data = {RANDOM_SERIAL: {"charge_mode": "MANUAL_CHARGING"}}
+
+    error_message = json.dumps(
+        {
+            "error": {
+                "displayMessage": "No Schedules enabled for Scheduled Charging",
+                "errorMessageCode": "iqevc_sch_10031",
+            }
+        }
+    )
+
+    class StubClient:
+        async def set_charge_mode(self, sn: str, mode: str):
+            raise aiohttp.ClientResponseError(
+                request_info=SimpleNamespace(real_url="https://example.test"),
+                history=(),
+                status=400,
+                message=error_message,
+            )
+
+    coord.client = StubClient()
+
+    async def _noop():
+        return None
+
+    coord.async_request_refresh = _noop  # type: ignore[attr-defined]
+
+    sel = ChargeModeSelect(coord, RANDOM_SERIAL)
+
+    with pytest.raises(
+        HomeAssistantError, match="Enable at least one schedule before selecting"
+    ):
+        await sel.async_select_option("Scheduled")
+
+
+@pytest.mark.asyncio
+async def test_charge_mode_select_reraises_unknown_scheduler_error(
+    hass, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from custom_components.enphase_ev.select import ChargeModeSelect
+
+    cfg = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 30,
+    }
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    coord = EnphaseCoordinator(hass, cfg)
+    coord.data = {RANDOM_SERIAL: {"charge_mode": "MANUAL_CHARGING"}}
+
+    error_message = json.dumps(
+        {
+            "error": {
+                "displayMessage": "Invalid Input",
+                "errorMessageCode": "some_other_code",
+            }
+        }
+    )
+
+    class StubClient:
+        async def set_charge_mode(self, sn: str, mode: str):
+            raise aiohttp.ClientResponseError(
+                request_info=SimpleNamespace(real_url="https://example.test"),
+                history=(),
+                status=400,
+                message=error_message,
+            )
+
+    coord.client = StubClient()
+
+    async def _noop():
+        return None
+
+    coord.async_request_refresh = _noop  # type: ignore[attr-defined]
+
+    sel = ChargeModeSelect(coord, RANDOM_SERIAL)
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await sel.async_select_option("Scheduled")
+
+
+def test_parse_scheduler_error_handles_invalid_payloads() -> None:
+    from custom_components.enphase_ev.select import _parse_scheduler_error
+
+    assert _parse_scheduler_error("") == (None, None)
+    assert _parse_scheduler_error("not-json") == (None, None)
+    assert _parse_scheduler_error(json.dumps(["bad"])) == (None, None)
+    assert _parse_scheduler_error(json.dumps({"error": "bad"})) == (None, None)
 
 
 def test_charge_mode_select_current_option_paths(coordinator_factory):


### PR DESCRIPTION
## Summary
- Normalize scheduler slot payloads and avoid no-op patches; auto-enable schedule edits to mirror Enlighten behavior.
- Improve scheduled-charge error handling and add coverage for slot normalization/auto-enable cases.
- Document observed scheduler payload fields and frontend PATCH quirks.

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"