### PR TITLE
Fix scheduler switch toggles

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -1296,6 +1296,36 @@ class EnphaseEVClient:
         }
         return await self._json("PATCH", url, json=payload, headers=headers)
 
+    async def patch_schedule_states(self, sn: str, *, slot_states: dict[str, bool]) -> dict:
+        """Patch schedule slot enabled states for the charger.
+
+        PATCH /service/evse_scheduler/api/v1/iqevc/charging-mode/SCHEDULED_CHARGING/<site>/<sn>/schedules
+        """
+        url = (
+            f"{BASE_URL}/service/evse_scheduler/api/v1/iqevc/charging-mode/"
+            f"SCHEDULED_CHARGING/{self._site}/{sn}/schedules"
+        )
+        headers = dict(self._h)
+        headers.update(self._control_headers())
+        payload = {
+            str(slot_id): "ENABLED" if enabled else "DISABLED"
+            for slot_id, enabled in slot_states.items()
+        }
+        return await self._json("PATCH", url, json=payload, headers=headers)
+
+    async def patch_schedule(self, sn: str, slot_id: str, slot: dict) -> dict:
+        """Patch a single schedule slot for the charger.
+
+        PATCH /service/evse_scheduler/api/v1/iqevc/charging-mode/SCHEDULED_CHARGING/<site>/<sn>/schedule/<slot_id>
+        """
+        url = (
+            f"{BASE_URL}/service/evse_scheduler/api/v1/iqevc/charging-mode/"
+            f"SCHEDULED_CHARGING/{self._site}/{sn}/schedule/{slot_id}"
+        )
+        headers = dict(self._h)
+        headers.update(self._control_headers())
+        return await self._json("PATCH", url, json=slot, headers=headers)
+
     async def lifetime_energy(self) -> dict | None:
         """Return lifetime energy buckets for the configured site.
 

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -319,6 +319,44 @@ async def test_patch_schedules_builds_payload() -> None:
 
 
 @pytest.mark.asyncio
+async def test_patch_schedule_states_builds_payload() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value={"ok": True})
+
+    data = await client.patch_schedule_states(
+        "SN123",
+        slot_states={"slot-1": True, "slot-2": False},
+    )
+
+    assert data == {"ok": True}
+
+    method, url = client._json.call_args.args[:2]
+    payload = client._json.call_args.kwargs["json"]
+    assert method == "PATCH"
+    assert url.endswith("/charging-mode/SCHEDULED_CHARGING/SITE/SN123/schedules")
+    assert payload == {"slot-1": "ENABLED", "slot-2": "DISABLED"}
+
+
+@pytest.mark.asyncio
+async def test_patch_schedule_builds_payload() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value={"ok": True})
+    slot = {"id": "slot-1", "startTime": "11:00"}
+
+    data = await client.patch_schedule("SN123", "slot-1", slot)
+
+    assert data == {"ok": True}
+
+    method, url = client._json.call_args.args[:2]
+    payload = client._json.call_args.kwargs["json"]
+    assert method == "PATCH"
+    assert url.endswith(
+        "/charging-mode/SCHEDULED_CHARGING/SITE/SN123/schedule/slot-1"
+    )
+    assert payload == slot
+
+
+@pytest.mark.asyncio
 async def test_status_falls_back_to_alt_endpoint() -> None:
     client = _make_client()
     client._json = AsyncMock(


### PR DESCRIPTION
## Summary
- Switch scheduler toggle PATCH to the slot state mapping payload and normalize response caching/refreshing.
- Add per-slot schedule PATCH support for updates and cache synchronization.
- Coverage: 100% for custom_components/enphase_ev/api.py and custom_components/enphase_ev/schedule_sync.py (coverage run -m pytest tests/components/enphase_ev -q && coverage report --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/schedule_sync.py --show-missing --fail-under=100).

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "coverage run -m pytest tests/components/enphase_ev -q && coverage report --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/schedule_sync.py --show-missing --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"