### PR TITLE
Prefill site selection in config flow

### DIFF
--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -304,9 +304,14 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         ]
 
         if options:
+            default_site_id = None
+            if self._selected_site_id and self._selected_site_id in self._sites:
+                default_site_id = self._selected_site_id
+            else:
+                default_site_id = options[0]["value"]
             schema = vol.Schema(
                 {
-                    vol.Required(CONF_SITE_ID): selector(
+                    vol.Required(CONF_SITE_ID, default=default_site_id): selector(
                         {"select": {"options": options, "multiple": False}}
                     )
                 }


### PR DESCRIPTION
## Summary
- Preselect the site dropdown after authentication (prior selection wins, otherwise first site).
- Add config-flow tests to assert defaulted selection behavior.
- Coverage: custom_components.enphase_ev.config_flow 100% (368/368).

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -p pytest_cov tests/components/enphase_ev -q --cov=custom_components.enphase_ev.config_flow --cov-report=term-missing --cov-fail-under=100"