### PR TITLE
Add system health labels and fix HACS name

### DIFF
--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -706,7 +706,16 @@
       "last_error": "Last error",
       "backoff_active": "Backoff active",
       "network_errors": "Consecutive network errors",
-      "http_errors": "Consecutive HTTP errors"
+      "http_errors": "Consecutive HTTP errors",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -706,7 +706,16 @@
       "last_error": "Последна грешка",
       "backoff_active": "Backoff активен",
       "network_errors": "Последователни мрежови грешки",
-      "http_errors": "Последователни HTTP грешки"
+      "http_errors": "Последователни HTTP грешки",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -706,7 +706,16 @@
       "last_error": "Poslední chyba",
       "backoff_active": "Backoff aktivní",
       "network_errors": "Po sobě jdoucí síťové chyby",
-      "http_errors": "Po sobě jdoucí chyby HTTP"
+      "http_errors": "Po sobě jdoucí chyby HTTP",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -706,7 +706,16 @@
       "last_error": "Seneste fejl",
       "backoff_active": "Backoff aktiv",
       "network_errors": "Efterfølgende netværksfejl",
-      "http_errors": "Efterfølgende HTTP-fejl"
+      "http_errors": "Efterfølgende HTTP-fejl",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -706,7 +706,16 @@
       "last_error": "Letzter Fehler",
       "backoff_active": "Backoff aktiv",
       "network_errors": "Aufeinanderfolgende Netzwerkfehler",
-      "http_errors": "Aufeinanderfolgende HTTP-Fehler"
+      "http_errors": "Aufeinanderfolgende HTTP-Fehler",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -706,7 +706,16 @@
       "last_error": "Τελευταίο σφάλμα",
       "backoff_active": "Backoff ενεργό",
       "network_errors": "Διαδοχικά σφάλματα δικτύου",
-      "http_errors": "Διαδοχικά σφάλματα HTTP"
+      "http_errors": "Διαδοχικά σφάλματα HTTP",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -706,7 +706,16 @@
       "last_error": "Last error",
       "backoff_active": "Backoff active",
       "network_errors": "Consecutive network errors",
-      "http_errors": "Consecutive HTTP errors"
+      "http_errors": "Consecutive HTTP errors",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -706,7 +706,16 @@
       "last_error": "Last error",
       "backoff_active": "Backoff active",
       "network_errors": "Consecutive network errors",
-      "http_errors": "Consecutive HTTP errors"
+      "http_errors": "Consecutive HTTP errors",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -706,7 +706,16 @@
       "last_error": "Last error",
       "backoff_active": "Backoff active",
       "network_errors": "Consecutive network errors",
-      "http_errors": "Consecutive HTTP errors"
+      "http_errors": "Consecutive HTTP errors",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -706,7 +706,16 @@
       "last_error": "Last error",
       "backoff_active": "Backoff active",
       "network_errors": "Consecutive network errors",
-      "http_errors": "Consecutive HTTP errors"
+      "http_errors": "Consecutive HTTP errors",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -706,7 +706,16 @@
       "last_error": "Last error",
       "backoff_active": "Backoff active",
       "network_errors": "Consecutive network errors",
-      "http_errors": "Consecutive HTTP errors"
+      "http_errors": "Consecutive HTTP errors",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -706,7 +706,16 @@
       "last_error": "Last error",
       "backoff_active": "Backoff active",
       "network_errors": "Consecutive network errors",
-      "http_errors": "Consecutive HTTP errors"
+      "http_errors": "Consecutive HTTP errors",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -706,7 +706,16 @@
       "last_error": "Último error",
       "backoff_active": "Tiempo de espera activo",
       "network_errors": "Errores de red consecutivos",
-      "http_errors": "Errores HTTP consecutivos"
+      "http_errors": "Errores HTTP consecutivos",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -706,7 +706,16 @@
       "last_error": "Viimane viga",
       "backoff_active": "Backoff aktiivne",
       "network_errors": "Järjestikused võrguvead",
-      "http_errors": "Järjestikused HTTP vead"
+      "http_errors": "Järjestikused HTTP vead",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -706,7 +706,16 @@
       "last_error": "Last error",
       "backoff_active": "Backoff active",
       "network_errors": "Consecutive network errors",
-      "http_errors": "Consecutive HTTP errors"
+      "http_errors": "Consecutive HTTP errors",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -706,7 +706,16 @@
       "last_error": "Dernière erreur",
       "backoff_active": "Backoff actif",
       "network_errors": "Erreurs réseau consécutives",
-      "http_errors": "Erreurs HTTP consécutives"
+      "http_errors": "Erreurs HTTP consécutives",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -706,7 +706,16 @@
       "last_error": "Utolsó hiba",
       "backoff_active": "Backoff aktív",
       "network_errors": "Egymást követő hálózati hibák",
-      "http_errors": "Egymást követő HTTP-hibák"
+      "http_errors": "Egymást követő HTTP-hibák",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -706,7 +706,16 @@
       "last_error": "Ultimo errore",
       "backoff_active": "Backoff attivo",
       "network_errors": "Errori di rete consecutivi",
-      "http_errors": "Errori HTTP consecutivi"
+      "http_errors": "Errori HTTP consecutivi",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -706,7 +706,16 @@
       "last_error": "Paskutinė klaida",
       "backoff_active": "Backoff aktyvus",
       "network_errors": "Nuoseklios tinklo klaidos",
-      "http_errors": "Nuoseklios HTTP klaidos"
+      "http_errors": "Nuoseklios HTTP klaidos",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -706,7 +706,16 @@
       "last_error": "Pēdējā kļūda",
       "backoff_active": "Backoff aktīvs",
       "network_errors": "Secīgas tīkla kļūdas",
-      "http_errors": "Secīgas HTTP kļūdas"
+      "http_errors": "Secīgas HTTP kļūdas",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -706,7 +706,16 @@
       "last_error": "Siste feil",
       "backoff_active": "Backoff aktiv",
       "network_errors": "Påfølgende nettverksfeil",
-      "http_errors": "Påfølgende HTTP-feil"
+      "http_errors": "Påfølgende HTTP-feil",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -706,7 +706,16 @@
       "last_error": "Laatste fout",
       "backoff_active": "Backoff actief",
       "network_errors": "Opeenvolgende netwerkfouten",
-      "http_errors": "Opeenvolgende HTTP-fouten"
+      "http_errors": "Opeenvolgende HTTP-fouten",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -706,7 +706,16 @@
       "last_error": "Ostatni błąd",
       "backoff_active": "Backoff aktywny",
       "network_errors": "Kolejne błędy sieci",
-      "http_errors": "Kolejne błędy HTTP"
+      "http_errors": "Kolejne błędy HTTP",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -706,7 +706,16 @@
       "last_error": "Último erro",
       "backoff_active": "Tempo de espera ativo",
       "network_errors": "Erros de rede consecutivos",
-      "http_errors": "Erros HTTP consecutivos"
+      "http_errors": "Erros HTTP consecutivos",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -706,7 +706,16 @@
       "last_error": "Ultima eroare",
       "backoff_active": "Backoff activ",
       "network_errors": "Erori de rețea consecutive",
-      "http_errors": "Erori HTTP consecutive"
+      "http_errors": "Erori HTTP consecutive",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -706,7 +706,16 @@
       "last_error": "Senaste fel",
       "backoff_active": "Backoff aktiv",
       "network_errors": "På varandra följande nätverksfel",
-      "http_errors": "På varandra följande HTTP-fel"
+      "http_errors": "På varandra följande HTTP-fel",
+      "site_count": "Site count",
+      "site_name": "Site name",
+      "site_ids": "Site IDs",
+      "site_names": "Site names",
+      "last_failure_status": "Last failure status",
+      "last_failure_description": "Last failure description",
+      "phase_timings": "Phase timings",
+      "session_cache_ttl_s": "Session cache TTL (s)",
+      "sites": "Sites"
     }
   },
   "services": {

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,5 @@
 {
-    "name": "Enphase EV Chager 2 (Cloud)",
+    "name": "Enphase EV Charger 2 (Cloud)",
     "homeassistant": "2024.5.3",
     "render_readme": true,
     "content_in_root": false


### PR DESCRIPTION
## Summary
- Add missing system health translation labels across strings/locales.
- Fix the HACS integration name typo.

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"