### PR TITLE
Await system health reachability

### DIFF
--- a/custom_components/enphase_ev/system_health.py
+++ b/custom_components/enphase_ev/system_health.py
@@ -57,6 +57,7 @@ async def system_health_info(hass: HomeAssistant):
         site_infos.append(metrics)
 
     primary = site_infos[0] if site_infos else {}
+    can_reach_server = await system_health.async_check_can_reach_url(hass, BASE_URL)
     return {
         "site_count": len(site_infos),
         "site_id": primary.get("site_id"),
@@ -65,7 +66,7 @@ async def system_health_info(hass: HomeAssistant):
         "site_names": [
             info.get("site_name") for info in site_infos if info.get("site_name")
         ],
-        "can_reach_server": system_health.async_check_can_reach_url(hass, BASE_URL),
+        "can_reach_server": can_reach_server,
         "last_success": primary.get("last_success"),
         "latency_ms": primary.get("latency_ms"),
         "last_error": primary.get("last_error"),

--- a/tests/components/enphase_ev/test_system_health.py
+++ b/tests/components/enphase_ev/test_system_health.py
@@ -58,10 +58,13 @@ async def test_system_health_info_reports_state(hass, config_entry, monkeypatch)
 
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
 
+    async def can_reach_server(hass, url):
+        return url == BASE_URL
+
     monkeypatch.setattr(
         system_health.system_health,
         "async_check_can_reach_url",
-        lambda hass, url: url == BASE_URL,
+        can_reach_server,
     )
 
     info = await system_health.system_health_info(hass)
@@ -146,10 +149,13 @@ async def test_system_health_info_multiple_entries(
     second_entry.add_to_hass(hass)
     hass.data[DOMAIN][second_entry.entry_id] = {"coordinator": coord2}
 
+    async def can_reach_server(hass, url):
+        return url == BASE_URL
+
     monkeypatch.setattr(
         system_health.system_health,
         "async_check_can_reach_url",
-        lambda hass, url: url == BASE_URL,
+        can_reach_server,
     )
 
     info = await system_health.system_health_info(hass)
@@ -176,10 +182,13 @@ async def test_system_health_fallback_metrics(hass, config_entry, monkeypatch) -
 
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
 
+    async def can_reach_server(hass_, url):
+        return True
+
     monkeypatch.setattr(
         system_health.system_health,
         "async_check_can_reach_url",
-        lambda hass_, url: True,
+        can_reach_server,
     )
 
     info = await system_health.system_health_info(hass)
@@ -215,10 +224,13 @@ async def test_system_health_missing_site_id_fills_from_entry(
 
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
 
+    async def can_reach_server(hass_, url):
+        return True
+
     monkeypatch.setattr(
         system_health.system_health,
         "async_check_can_reach_url",
-        lambda hass_, url: True,
+        can_reach_server,
     )
 
     info = await system_health.system_health_info(hass)
@@ -246,10 +258,13 @@ async def test_system_health_uses_session_manager_ttl(
 
     hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
 
+    async def can_reach_server(hass_, url):
+        return True
+
     monkeypatch.setattr(
         system_health.system_health,
         "async_check_can_reach_url",
-        lambda hass_, url: True,
+        can_reach_server,
     )
 
     info = await system_health.system_health_info(hass)


### PR DESCRIPTION
## Summary

- Await the system health reachability check so health info never returns a coroutine.
- Update system health tests to patch async reachability checks.
- Coverage: custom_components/enphase_ev/system_health.py 100% (32/32, 0 missing).

## Type of change

- [x] Bugfix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Tick all commands you ran locally (remove lines that do not apply):

- [x] `ruff check .`
- [ ] `black custom_components/enphase_ev`
- [ ] `pytest -q tests_enphase_ev`
- [ ] `python scripts/validate_quality_scale.py`
- [ ] `python -m script.hassfest`
- [x] `pre-commit run --all-files`
- [x] Other (describe below)

Other:
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/.coverage python3 -m coverage report --include=custom_components/enphase_ev/system_health.py --fail-under=100 --show-missing"`

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Additional context

- None.
