### PR TITLE
Handle no-content responses in json helper

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -804,6 +804,8 @@ class EnphaseEVClient:
                             if reauth_ok:
                                 continue
                         raise Unauthorized()
+                    if r.status in (204, 205):
+                        return {}
                     if r.status >= 400:
                         try:
                             body_text = await r.text()

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -192,6 +192,14 @@ async def test_json_reauth_failure_falls_back() -> None:
 
 
 @pytest.mark.asyncio
+async def test_json_returns_empty_on_no_content() -> None:
+    session = _FakeSession([_FakeResponse(status=204, json_body=None)])
+    client = api.EnphaseEVClient(session, "SITE", None, None)
+    payload = await client._json("POST", "https://example.test")
+    assert payload == {}
+
+
+@pytest.mark.asyncio
 async def test_json_truncates_long_error_messages() -> None:
     long_body = "x" * 600
     session = _FakeSession(


### PR DESCRIPTION
## Summary
- Return {} for 204/205 responses in EnphaseEVClient._json to avoid JSON parse errors.
- Add regression coverage for no-content responses.

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -p pytest_cov tests/components/enphase_ev -q --cov=custom_components.enphase_ev.api --cov-report=term-missing --cov-fail-under=100"