### PR TITLE
Prepare release 1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,24 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v1.7.2 – 2026-01-25
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Treat 204/205 API responses as empty JSON payloads to avoid parsing errors.
+- Await the system health reachability check so connectivity status reports correctly.
+
+### 🔧 Improvements
+- Add system health labels for site summary and cache metrics across translations.
+
+### 🔄 Other changes
+- Fix the HACS integration name typo.
+
 ## v1.7.1 – 2026-01-02
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.7.1"
+  "version": "1.7.2"
 }


### PR DESCRIPTION
## Summary
- Prepare release notes for v1.7.2 and bump the manifest version to 1.7.2.

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"