### PR TITLE
Align session history and hourly status workflow

### DIFF
--- a/.github/workflows/service-status.yml
+++ b/.github/workflows/service-status.yml
@@ -2,7 +2,7 @@ name: Service status
 
 on:
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "0 * * * *"
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - Trigger a fast refresh and immediate state write when charging start fails (e.g., unplugged/not_ready) so HomeKit switches revert quickly.
 - Swap site discovery to the Enlighten search API for both the integration and service-status report, with deduped site titles in the picker and updated API documentation.
 - Drop the legacy single-charger status endpoint from the integration, service-status checks, and documentation.
+- Align session history requests with the Enlighten web API (filter criteria call, username/requestid headers, updated payload shape, and timezone support).
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1848,7 +1848,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
             self._tokens = tokens
             self.client.update_credentials(
-                eauth=tokens.access_token, cookie=tokens.cookie
+                eauth=tokens.access_token,
+                cookie=tokens.cookie,
             )
             self._persist_tokens(tokens)
             return True

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -300,23 +300,51 @@ Notes:
 - Observed: read responses use `status=1`; update responses use `status=2`, with `value` reflecting the prior state and `reqValue` the desired state.
 - Observed: `sessionAuthentication` can return `null` when disabled or unset.
 
-### 2.6 Session History
+### 2.6 Session History (Filter Criteria)
+```
+GET /service/enho_historical_events_ms/<site_id>/filter_criteria?source=evse&requestId=<uuid>&username=<user_id>
+Headers:
+  Accept: application/json, text/javascript, */*; q=0.01
+  Authorization: Bearer <jwt>
+  Cookie: ...; XSRF-TOKEN=<token>; ...
+  e-auth-token: <session_id>
+  requestid: <uuid>
+  username: <user_id>
+  X-Requested-With: XMLHttpRequest
+```
+Returns the chargers available for session history lookups (IDs + display names).
+Notes:
+- `Authorization` uses the Auth MS JWT (from `/tokens` or the `enlighten_manager_token_production` cookie).
+- `e-auth-token` should match the JWT `session_id` claim; `username` should match the JWT `user_id` claim.
+- `requestid` is a UUID generated per request.
+
+### 2.7 Session History
 ```
 POST /service/enho_historical_events_ms/<site_id>/sessions/<sn>/history
 Body: {
-  "startDate": "16-10-2025",
-  "endDate": "16-10-2025",
-  "offset": 0,
-  "limit": 20
+  "source": "evse",
+  "params": {
+    "offset": 0,
+    "limit": 20,
+    "startDate": "16-10-2025",
+    "endDate": "16-10-2025",
+    "timezone": "Australia/Melbourne"
+  }
 }
 Headers:
   Accept: application/json, text/javascript, */*; q=0.01
   Authorization: Bearer <jwt>
   Cookie: ...; XSRF-TOKEN=<token>; ...
-  e-auth-token: <token>
+  e-auth-token: <session_id>
+  requestid: <uuid>
+  username: <user_id>
   X-Requested-With: XMLHttpRequest
 ```
 Returns a list of recent charging sessions for the requested charger. `startDate`/`endDate` are `DD-MM-YYYY` in the site's local timezone. The response indicates whether more pages are available via `hasMore`.
+Notes:
+- `Authorization` uses the Auth MS JWT (from `/tokens` or the `enlighten_manager_token_production` cookie).
+- `e-auth-token` should match the JWT `session_id` claim; `username` should match the JWT `user_id` claim.
+- `requestid` is a UUID generated per request.
 
 Example response:
 ```json

--- a/tests/components/enphase_ev/test_api_helpers.py
+++ b/tests/components/enphase_ev/test_api_helpers.py
@@ -106,6 +106,55 @@ def test_decode_jwt_exp_failure() -> None:
     assert api._decode_jwt_exp("not-a-token") is None
 
 
+def test_jwt_user_id_from_payload() -> None:
+    """Extract user_id from a top-level JWT payload."""
+    token = _make_token({"user_id": 1234})
+    assert api._jwt_user_id(token) == "1234"
+
+
+def test_jwt_user_id_from_nested_data() -> None:
+    """Extract user_id from nested JWT data."""
+    token = _make_token({"data": {"user_id": 5678}})
+    assert api._jwt_user_id(token) == "5678"
+
+
+def test_jwt_user_id_missing() -> None:
+    """Missing or invalid tokens return None."""
+    assert api._jwt_user_id(None) is None
+    assert api._jwt_user_id("not-a-token") is None
+
+
+def test_jwt_user_id_invalid_payload() -> None:
+    """Invalid JWT payloads should return None."""
+    bad_payload = base64.urlsafe_b64encode(b"not-json").decode().rstrip("=")
+    token = f"header.{bad_payload}.sig"
+    assert api._jwt_user_id(token) is None
+
+
+def test_jwt_session_id_from_payload() -> None:
+    """Extract session_id from a top-level JWT payload."""
+    token = _make_token({"session_id": "sess-1"})
+    assert api._jwt_session_id(token) == "sess-1"
+
+
+def test_jwt_session_id_from_nested_data() -> None:
+    """Extract session_id from nested JWT data."""
+    token = _make_token({"data": {"session_id": "sess-2"}})
+    assert api._jwt_session_id(token) == "sess-2"
+
+
+def test_jwt_session_id_missing() -> None:
+    """Missing or invalid tokens return None."""
+    assert api._jwt_session_id(None) is None
+    assert api._jwt_session_id("not-a-token") is None
+
+
+def test_jwt_session_id_missing_in_payload() -> None:
+    """JWT payloads without session_id return None."""
+    token = _make_token({"data": "no-session"})
+    assert api._jwt_session_id(token) is None
+
+
 def test_extract_xsrf_token() -> None:
     """XSRF token is located case-insensitively."""
     cookies = {"session": "abc", "XSRF-TOKEN": "xsrf-value"}

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2263,7 +2263,9 @@ async def test_session_history_cross_midnight_split(hass, monkeypatch):
     client = coord.client
     calls: list[dict] = []
 
-    async def fake_session_history(self, sn, *, start_date, end_date, offset, limit):
+    async def fake_session_history(
+        self, sn, *, start_date, end_date, offset, limit, **_kwargs
+    ):
         calls.append(
             {
                 "sn": sn,
@@ -2301,6 +2303,15 @@ async def test_session_history_cross_midnight_split(hass, monkeypatch):
         client,
         "session_history",
         fake_session_history.__get__(client, client.__class__),
+        raising=False,
+    )
+    async def fake_filter_criteria(self, **_kwargs):
+        return {"data": [{"id": RANDOM_SERIAL}]}
+
+    monkeypatch.setattr(
+        client,
+        "session_history_filter_criteria",
+        fake_filter_criteria.__get__(client, client.__class__),
         raising=False,
     )
 


### PR DESCRIPTION
## Summary
- align session history API calls with the Enlighten web flow (filter criteria preflight, headers, payload shape, timezone) and update service-status checks/docs/tests
- run service-status workflow hourly instead of every 15 minutes

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "coverage run -m pytest tests/components/enphase_ev -q && coverage report --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/session_history.py,custom_components/enphase_ev/coordinator.py --fail-under=100"