### PR TITLE
Prepare release 1.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,22 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
-## v1.8.0 – 2026-01-29
+## Unreleased
 
 ### 🚧 Breaking changes
 - None
 
 ### ✨ New features
-- Added the green charging “Use Battery for EV Charging” toggle so green-mode sessions can force battery supplementation when supported by the site summary.
-- Introduced the charger authentication diagnostic sensor plus the “Auth via App” toggle so Home Assistant surfaces Enphase app/RFID requirements and lets users toggle app auth without leaving HA; start charging now logs a warning (instead of blocking) when authentication is required so the request completes once Enphase auth finishes.
+- None
 
 ### 🐛 Bug fixes
 - None
 
 ### 🔧 Improvements
-- Handle degraded Enlighten subservices gracefully, marking scheduler/session-history/site-energy/auth-settings availability and treating 550 session-history responses as degraded instead of erroring so sensors fall back to cache when the backend is partially offline.
+- None
 
-## Unreleased
+### 🔄 Other changes
+- None
+
+## v1.8.1 – 2026-01-30
 
 ### 🚧 Breaking changes
 - None
@@ -37,6 +39,21 @@ All notable changes to this project will be documented in this file.
 
 ### 🔄 Other changes
 - None
+
+## v1.8.0 – 2026-01-29
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Added the green charging “Use Battery for EV Charging” toggle so green-mode sessions can force battery supplementation when supported by the site summary.
+- Introduced the charger authentication diagnostic sensor plus the “Auth via App” toggle so Home Assistant surfaces Enphase app/RFID requirements and lets users toggle app auth without leaving HA; start charging now logs a warning (instead of blocking) when authentication is required so the request completes once Enphase auth finishes.
+
+### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- Handle degraded Enlighten subservices gracefully, marking scheduler/session-history/site-energy/auth-settings availability and treating 550 session-history responses as degraded instead of erroring so sensors fall back to cache when the backend is partially offline.
 
 ## v1.7.2 – 2026-01-25
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.8.0"
+  "version": "1.8.1"
 }


### PR DESCRIPTION
## Summary
- Prepare v1.8.1 release notes and reset the Unreleased section.
- Bump the integration manifest version to 1.8.1.

## Testing
- Not run (not requested).