### PR TITLE
Prepare 1.8.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v1.8.2 – 2026-01-31
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
 - Prefer session history payload for last session metadata when idle so cost/duration/id fields populate correctly.
 
 ### 🔧 Improvements

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.8.1"
+  "version": "1.8.2"
 }


### PR DESCRIPTION
## Summary
- Bump manifest version to 1.8.2.
- Publish the 1.8.2 changelog entry and reset Unreleased.

## Testing
- Not run (release prep only).