### PR TITLE
Expose missing API data and regroup sensor attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,16 @@ All notable changes to this project will be documented in this file.
 ### ✨ New features
 - Added site-level BatteryConfig profile controls.
 - Added site-level Battery Settings controls on the Site device (battery mode, charge-from-grid toggles, schedule start/end times, and battery shutdown level).
+- Exposed additional EV charger cloud metadata from the status/summary APIs across existing diagnostic entities (charge mode, last reported, storm alert, battery mode, and system profile status), including schedule context, firmware/network diagnostics, storm alert metadata, and battery site/profile capability flags.
 
 ### 🐛 Bug fixes
 - Hide battery-specific entities when a site does not report battery support.
+- Preserve modern nested status payload fields (`session_d`, schedule details, and smart EV metadata) when normalizing status responses.
 
 ### 🔧 Improvements
 - Improved Battery Settings write handling with optimistic updates, disclaimer auto-stamping when enabling charge-from-grid, and dedicated write lock/debounce safeguards.
+- Moved safe-limit diagnostics to the Set Amps sensor (from Connector Status) and expanded Last Session attributes with session authentication metadata.
+- Added EVSE lifetime energy flow parsing and exposed EVSE charging kWh as a site-energy sensor attribute.
 
 ### 🔄 Other changes
 - Fixed full-suite `pytest tests/components/enphase_ev -q` recursion failures by resetting pytest-socket state during test setup.

--- a/custom_components/enphase_ev/energy.py
+++ b/custom_components/enphase_ev/energy.py
@@ -442,6 +442,12 @@ class EnergyManager:
         )
         _store("consumption", cons_total, ["consumption"], cons_count)
 
+        # EVSE lifetime charging energy when the backend provides a dedicated flow.
+        evse_total, evse_count = self._sum_energy_buckets(
+            payload.get("evse"), interval_hours
+        )
+        _store("evse_charging", evse_total, ["evse"], evse_count)
+
         # Grid import (consumption from grid)
         imp_total, imp_count, imp_fields = self._diff_energy_fields(
             payload, "consumption", "solar_home", interval_hours

--- a/custom_components/enphase_ev/entity.py
+++ b/custom_components/enphase_ev/entity.py
@@ -4,6 +4,7 @@ import logging
 from typing import Any
 
 from homeassistant.core import callback
+from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -105,8 +106,18 @@ class EnphaseBaseEntity(CoordinatorEntity[EnphaseCoordinator]):
         # Optional enrichment when available
         if model_display:
             info_kwargs["model"] = model_display
+        if d.get("model_id"):
+            info_kwargs["model_id"] = str(d.get("model_id"))
         if d.get("hw_version"):
             info_kwargs["hw_version"] = str(d.get("hw_version"))
         if d.get("sw_version"):
             info_kwargs["sw_version"] = str(d.get("sw_version"))
+        mac_address = d.get("mac_address")
+        if mac_address is not None:
+            try:
+                mac_clean = str(mac_address).strip().lower().replace("-", ":")
+            except Exception:  # noqa: BLE001
+                mac_clean = None
+            if mac_clean:
+                info_kwargs["connections"] = {(CONNECTION_NETWORK_MAC, mac_clean)}
         return DeviceInfo(**info_kwargs)

--- a/tests/components/enphase_ev/test_coordinator_battery_settings.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_settings.py
@@ -26,6 +26,14 @@ def test_parse_battery_settings_payload_maps_mode_and_controls(
                 "veryLowSoc": 15,
                 "veryLowSocMin": 10,
                 "veryLowSocMax": 25,
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 20,
+                "stormGuardState": "enabled",
+                "devices": {
+                    "iqEvse": {
+                        "useBatteryFrSelfConsumption": True,
+                    }
+                },
             }
         }
     )
@@ -41,6 +49,10 @@ def test_parse_battery_settings_payload_maps_mode_and_controls(
     assert coord.battery_shutdown_level_min == 10
     assert coord.battery_shutdown_level_max == 25
     assert coord.battery_shutdown_level_available is True
+    assert coord.battery_profile == "self-consumption"
+    assert coord.battery_effective_backup_percentage == 20
+    assert coord.storm_guard_state == "enabled"
+    assert coord.battery_use_battery_for_self_consumption is True
 
 
 def test_parse_battery_settings_unknown_grid_mode_uses_none_permissions(

--- a/tests/components/enphase_ev/test_device_info.py
+++ b/tests/components/enphase_ev/test_device_info.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 def test_device_info_uses_display_name_and_model():
     from custom_components.enphase_ev.entity import EnphaseBaseEntity
+    from homeassistant.helpers.device_registry import CONNECTION_NETWORK_MAC
 
     entity = object.__new__(EnphaseBaseEntity)
     entity._coord = SimpleNamespace(
@@ -10,6 +11,8 @@ def test_device_info_uses_display_name_and_model():
             "555555555555": {
                 "display_name": "Garage Charger",
                 "model_name": "IQ-EVSE-EU-3032",
+                "model_id": "IQ-EVSE-EU-3032-01",
+                "mac_address": "00-11-22-33-44-55",
                 "hw_version": "2.0",
                 "sw_version": "3.1",
             }
@@ -22,7 +25,9 @@ def test_device_info_uses_display_name_and_model():
 
     assert info["name"] == "Garage Charger"
     assert info["model"] == "Garage Charger (IQ-EVSE-EU-3032)"
+    assert info["model_id"] == "IQ-EVSE-EU-3032-01"
     assert info["serial_number"] == "555555555555"
+    assert info["connections"] == {(CONNECTION_NETWORK_MAC, "00:11:22:33:44:55")}
 
 
 def test_device_info_falls_back_to_model_name():
@@ -61,6 +66,29 @@ def test_device_info_defaults_when_metadata_missing():
 
     assert info["name"] == "Enphase EV Charger"
     assert info.get("model") is None
+
+
+def test_device_info_ignores_bad_mac_values():
+    from custom_components.enphase_ev.entity import EnphaseBaseEntity
+
+    class BadMac:
+        def __str__(self) -> str:
+            raise ValueError("boom")
+
+    entity = object.__new__(EnphaseBaseEntity)
+    entity._coord = SimpleNamespace(
+        data={
+            "321": {
+                "display_name": "Garage Charger",
+                "mac_address": BadMac(),
+            }
+        },
+        site_id="1001",
+    )
+    entity._sn = "321"
+
+    info = entity.device_info
+    assert "connections" not in info
 
 
 def test_device_info_uses_display_name_when_model_missing():


### PR DESCRIPTION
## Summary
- Preserve modern nested EV status payload fields during normalization so session/schedule/smart EV metadata is not dropped.
- Expose additional status/summary/BatteryConfig/storm fields through coordinator mappings, regroup diagnostics onto logical existing entities, and move safe-limit diagnostics to Set Amps.
- Add EVSE lifetime flow handling for site energy metadata and expand device metadata (including `model_id`/MAC connection mapping).
- Update changelog under Unreleased and add comprehensive regression coverage for all changed behavior.
- Coverage: changed modules (`custom_components/enphase_ev/api.py`, `custom_components/enphase_ev/coordinator.py`, `custom_components/enphase_ev/sensor.py`, `custom_components/enphase_ev/entity.py`, `custom_components/enphase_ev/energy.py`) verified at **100%**.

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report --include='custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/entity.py,custom_components/enphase_ev/energy.py' --show-missing --fail-under=100"`
