### PR TITLE
Add Backup History calendar entity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ All notable changes to this project will be documented in this file.
 - Added a shared `Microinverters` device with one lifetime-energy sensor per inverter (MWh), including inverter metadata attributes and device-level model/status summaries.
 - Added inverter endpoint integration (`inverters.json`, `inverter_status_x`, `inverter_data_x`) with ID-to-serial mapping, site-local date handling, and dynamic add/remove entity lifecycle updates.
 - Added battery status endpoint integration (`/pv/settings/<site_id>/battery_status.json`) with per-battery charge sensors, aggregate battery charge/status sensors, dynamic add/remove lifecycle handling, and diagnostics payload capture under the shared `Battery` type device.
+- Added a site-level `Backup History` calendar entity on the `Battery` type device, backed by `/app-api/<site_id>/battery_backup_history.json` with normalized outage intervals, coordinator caching, and diagnostics payload capture.
 
 ### 🔧 Improvements
 - Improved Battery Settings write handling with optimistic updates, disclaimer auto-stamping when enabling charge-from-grid, and dedicated write lock/debounce safeguards.

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -33,6 +33,7 @@ PLATFORMS: list[str] = [
     "number",
     "switch",
     "time",
+    "calendar",
 ]
 
 

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2000,6 +2000,18 @@ class EnphaseEVClient:
             return data
         return {}
 
+    async def battery_backup_history(self) -> dict:
+        """Return battery backup outage history for the site.
+
+        GET /app-api/<site_id>/battery_backup_history.json
+        """
+
+        url = f"{BASE_URL}/app-api/{self._site}/battery_backup_history.json"
+        data = await self._json("GET", url)
+        if isinstance(data, dict):
+            return data
+        return {}
+
     async def battery_status(self) -> dict:
         """Return battery status payload used by the Enlighten battery card.
 

--- a/custom_components/enphase_ev/calendar.py
+++ b/custom_components/enphase_ev/calendar.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from homeassistant.components.calendar import CalendarEntity, CalendarEvent
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+from .coordinator import EnphaseCoordinator
+
+PARALLEL_UPDATES = 0
+
+
+def _site_has_battery(coord: EnphaseCoordinator, *, strict: bool = False) -> bool:
+    has_encharge = getattr(coord, "battery_has_encharge", None)
+    if has_encharge is None:
+        has_encharge = getattr(coord, "_battery_has_encharge", None)
+    if strict:
+        return has_encharge is True
+    return has_encharge is not False
+
+
+def _type_available(coord: EnphaseCoordinator, type_key: str) -> bool:
+    has_type_for_entities = getattr(coord, "has_type_for_entities", None)
+    if callable(has_type_for_entities):
+        return bool(has_type_for_entities(type_key))
+    has_type = getattr(coord, "has_type", None)
+    return bool(has_type(type_key)) if callable(has_type) else True
+
+
+async def async_setup_entry(
+    hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback
+) -> None:
+    coord: EnphaseCoordinator = hass.data[DOMAIN][entry.entry_id]["coordinator"]
+    site_entity_added = False
+
+    @callback
+    def _async_sync_site_entities() -> None:
+        nonlocal site_entity_added
+        if site_entity_added:
+            return
+        if not _site_has_battery(coord, strict=True) or not _type_available(
+            coord, "encharge"
+        ):
+            return
+        async_add_entities([BackupHistoryCalendarEntity(coord)], update_before_add=False)
+        site_entity_added = True
+
+    unsubscribe = coord.async_add_listener(_async_sync_site_entities)
+    entry.async_on_unload(unsubscribe)
+    _async_sync_site_entities()
+
+
+class BackupHistoryCalendarEntity(CoordinatorEntity, CalendarEntity):
+    _attr_has_entity_name = True
+    _attr_translation_key = "backup_history"
+
+    def __init__(self, coord: EnphaseCoordinator) -> None:
+        super().__init__(coord)
+        self._coord = coord
+        self._attr_unique_id = f"{DOMAIN}_site_{coord.site_id}_backup_history"
+
+    @property
+    def available(self) -> bool:
+        if not super().available:
+            return False
+        if not _type_available(self._coord, "encharge"):
+            return False
+        return _site_has_battery(self._coord)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        type_device_info = getattr(self._coord, "type_device_info", None)
+        info = type_device_info("encharge") if callable(type_device_info) else None
+        if info is not None:
+            return info
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"type:{self._coord.site_id}:encharge")},
+            manufacturer="Enphase",
+        )
+
+    def _iter_history_events(self) -> list[tuple[datetime, datetime]]:
+        events: list[tuple[datetime, datetime]] = []
+        for item in self._coord.battery_backup_history_events:
+            if not isinstance(item, dict):
+                continue
+            start = item.get("start")
+            end = item.get("end")
+            if not isinstance(start, datetime) or not isinstance(end, datetime):
+                continue
+            if start.tzinfo is None or end.tzinfo is None:
+                continue
+            if end <= start:
+                continue
+            events.append((start, end))
+        return events
+
+    def _to_calendar_event(self, start: datetime, end: datetime) -> CalendarEvent:
+        summary: str | None = None
+        try:
+            name = self.name
+        except Exception:  # noqa: BLE001 - platform may not be attached in tests
+            name = None
+        if isinstance(name, str) and name.strip():
+            summary = name.strip()
+        else:
+            entity_id = getattr(self, "entity_id", None)
+            if isinstance(entity_id, str) and entity_id.strip():
+                summary = entity_id.strip()
+        return CalendarEvent(
+            summary=summary or self._attr_unique_id,
+            start=start,
+            end=end,
+        )
+
+    @property
+    def event(self) -> CalendarEvent | None:
+        now = dt_util.now()
+        next_upcoming: tuple[datetime, datetime] | None = None
+        for start, end in self._iter_history_events():
+            if start <= now < end:
+                return self._to_calendar_event(start, end)
+            if start > now:
+                next_upcoming = (start, end)
+                break
+        if next_upcoming is None:
+            return None
+        return self._to_calendar_event(next_upcoming[0], next_upcoming[1])
+
+    async def async_get_events(
+        self,
+        hass: HomeAssistant,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[CalendarEvent]:
+        _ = hass
+        if start_date.tzinfo is None:
+            start_date = start_date.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+        if end_date.tzinfo is None:
+            end_date = end_date.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+        out: list[CalendarEvent] = []
+        for event_start, event_end in self._iter_history_events():
+            if event_end <= start_date or event_start >= end_date:
+                continue
+            out.append(self._to_calendar_event(event_start, event_end))
+        return out

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -123,6 +123,8 @@ STORM_GUARD_CACHE_TTL = 300.0
 STORM_ALERT_CACHE_TTL = 60.0
 BATTERY_SITE_SETTINGS_CACHE_TTL = 300.0
 BATTERY_SETTINGS_CACHE_TTL = 300.0
+BATTERY_BACKUP_HISTORY_CACHE_TTL = 300.0
+BATTERY_BACKUP_HISTORY_FAILURE_CACHE_TTL = 60.0
 DEVICES_INVENTORY_CACHE_TTL = 300.0
 SAVINGS_OPERATION_MODE_SUBTYPE = "prioritize-energy"
 BATTERY_PROFILE_PENDING_TIMEOUT_S = 900.0
@@ -444,6 +446,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._battery_profile_payload: dict[str, object] | None = None
         self._battery_settings_payload: dict[str, object] | None = None
         self._battery_status_payload: dict[str, object] | None = None
+        self._battery_backup_history_payload: dict[str, object] | None = None
+        self._battery_backup_history_events: list[dict[str, object]] = []
+        self._battery_backup_history_cache_until: float | None = None
         self._battery_storage_data: dict[str, dict[str, object]] = {}
         self._battery_storage_order: list[str] = []
         self._battery_aggregate_charge_pct: float | None = None
@@ -1569,6 +1574,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             "battery_status_details": dict(
                 getattr(self, "_battery_aggregate_status_details", {}) or {}
             ),
+            "battery_backup_history_count": len(
+                getattr(self, "_battery_backup_history_events", []) or []
+            ),
             "battery_write_in_progress": bool(
                 getattr(self, "_battery_profile_write_lock", None)
                 and self._battery_profile_write_lock.locked()
@@ -1738,6 +1746,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 pass
             try:
                 await self._async_refresh_battery_status()
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await self._async_refresh_battery_backup_history()
             except Exception:  # noqa: BLE001
                 pass
             try:
@@ -2043,6 +2055,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             pass
         phase_timings["battery_status_s"] = round(
             time.monotonic() - battery_status_start, 3
+        )
+        battery_backup_history_start = time.monotonic()
+        try:
+            await self._async_refresh_battery_backup_history()
+        except Exception:  # noqa: BLE001
+            pass
+        phase_timings["battery_backup_history_s"] = round(
+            time.monotonic() - battery_backup_history_start, 3
         )
         battery_settings_start = time.monotonic()
         try:
@@ -3971,6 +3991,17 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return dict(payload)
 
     @property
+    def battery_backup_history_events(self) -> list[dict[str, object]]:
+        events = getattr(self, "_battery_backup_history_events", None)
+        if not isinstance(events, list):
+            return []
+        out: list[dict[str, object]] = []
+        for item in events:
+            if isinstance(item, dict):
+                out.append(dict(item))
+        return out
+
+    @property
     def battery_status_summary(self) -> dict[str, object]:
         details = dict(getattr(self, "_battery_aggregate_status_details", {}) or {})
         details["aggregate_charge_pct"] = self.battery_aggregate_charge_pct
@@ -5471,6 +5502,120 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         else:
             self._battery_status_payload = {"value": redacted_payload}
         self._parse_battery_status_payload(payload)
+
+    def _backup_history_tzinfo(self) -> _tz | ZoneInfo:
+        tz_name = getattr(self, "_battery_timezone", None)
+        if isinstance(tz_name, str) and tz_name.strip():
+            try:
+                return ZoneInfo(tz_name.strip())
+            except Exception:  # noqa: BLE001
+                pass
+        default_tz = getattr(dt_util, "DEFAULT_TIME_ZONE", None)
+        if default_tz is not None:
+            return default_tz
+        return _tz.utc
+
+    def _parse_battery_backup_history_payload(
+        self,
+        payload: object,
+    ) -> list[dict[str, object]] | None:
+        if not isinstance(payload, dict):
+            return None
+        histories = payload.get("histories")
+        if not isinstance(histories, list):
+            return None
+        total_records = self._coerce_int(payload.get("total_records"), default=-1)
+        total_backup = self._coerce_int(payload.get("total_backup"), default=-1)
+        events: list[dict[str, object]] = []
+        for item in histories:
+            if not isinstance(item, dict):
+                continue
+            try:
+                duration = int(item.get("duration"))
+            except (TypeError, ValueError):
+                continue
+            if duration <= 0:
+                continue
+            start_raw = item.get("start_time")
+            if start_raw is None:
+                continue
+            try:
+                start_text = str(start_raw).strip()
+            except Exception:  # noqa: BLE001
+                continue
+            if not start_text:
+                continue
+            start = dt_util.parse_datetime(start_text)
+            if start is None:
+                continue
+            if start.tzinfo is None:
+                start = start.replace(tzinfo=self._backup_history_tzinfo())
+            end = start + timedelta(seconds=duration)
+            events.append(
+                {
+                    "start": start,
+                    "end": end,
+                    "duration_seconds": duration,
+                }
+            )
+        events.sort(key=lambda item: item["start"])
+        if total_records >= 0 and total_records != len(events):
+            _LOGGER.debug(
+                "Battery backup history total_records mismatch for site %s (payload=%s parsed=%s)",
+                self.site_id,
+                total_records,
+                len(events),
+            )
+        if total_backup >= 0:
+            parsed_total_backup = sum(int(item["duration_seconds"]) for item in events)
+            if total_backup != parsed_total_backup:
+                _LOGGER.debug(
+                    "Battery backup history total_backup mismatch for site %s (payload=%s parsed=%s)",
+                    self.site_id,
+                    total_backup,
+                    parsed_total_backup,
+                )
+        return events
+
+    async def _async_refresh_battery_backup_history(
+        self, *, force: bool = False
+    ) -> None:
+        now = time.monotonic()
+        if not force and self._battery_backup_history_cache_until:
+            if now < self._battery_backup_history_cache_until:
+                return
+        fetcher = getattr(self.client, "battery_backup_history", None)
+        if not callable(fetcher):
+            return
+        try:
+            payload = await fetcher()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Battery backup history fetch failed for site %s: %s", self.site_id, err
+            )
+            self._battery_backup_history_cache_until = (
+                now + BATTERY_BACKUP_HISTORY_FAILURE_CACHE_TTL
+            )
+            return
+        parsed = self._parse_battery_backup_history_payload(payload)
+        if parsed is None:
+            _LOGGER.debug(
+                "Battery backup history payload was invalid for site %s",
+                self.site_id,
+            )
+            self._battery_backup_history_cache_until = (
+                now + BATTERY_BACKUP_HISTORY_FAILURE_CACHE_TTL
+            )
+            return
+        redacted_payload = self._redact_battery_payload(payload)
+        if isinstance(redacted_payload, dict):
+            self._battery_backup_history_payload = redacted_payload
+        else:
+            self._battery_backup_history_payload = {"value": redacted_payload}
+        self._battery_backup_history_events = parsed
+        self._battery_backup_history_cache_until = (
+            now + BATTERY_BACKUP_HISTORY_CACHE_TTL
+        )
 
     async def _async_refresh_battery_settings(self, *, force: bool = False) -> None:
         now = time.monotonic()

--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -114,6 +114,9 @@ async def async_get_config_entry_diagnostics(hass, entry):
                 "profile_payload": getattr(coord, "_battery_profile_payload", None),
                 "settings_payload": getattr(coord, "_battery_settings_payload", None),
                 "status_payload": getattr(coord, "_battery_status_payload", None),
+                "backup_history_payload": getattr(
+                    coord, "_battery_backup_history_payload", None
+                ),
                 "devices_inventory_payload": getattr(
                     coord, "_devices_inventory_payload", None
                 ),

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -805,6 +805,11 @@
         "name": "Charge From Grid End Time"
       }
     },
+    "calendar": {
+      "backup_history": {
+        "name": "Backup History"
+      }
+    },
     "select": {
       "system_profile": {
         "name": "System Profile"

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Краен час за зареждане от мрежата"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "История на резервното захранване"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Čas ukončení nabíjení ze sítě"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Historie záložního napájení"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Sluttid for opladning fra elnet"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Historik for backupdrift"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Endzeit für Laden aus dem Netz"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Verlauf der Ersatzstromversorgung"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Ώρα λήξης φόρτισης από το δίκτυο"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Ιστορικό εφεδρικής τροφοδοσίας"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Charge From Grid End Time"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Backup History"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Charge From Grid End Time"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Backup History"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Charge From Grid End Time"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Backup History"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Charge From Grid End Time"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Backup History"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Charge From Grid End Time"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Backup History"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Charge From Grid End Time"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Backup History"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Hora de fin de carga desde la red"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Historial de respaldo"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Võrgust laadimise lõpuaeg"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Varutoite ajalugu"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Sähköverkkolatauksen lopetusaika"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Varmennushistoria"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Heure de fin de recharge depuis le réseau"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Historique de secours"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Hálózatról töltés befejezési ideje"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Tartalékellátás előzményei"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Ora di fine carica da rete"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Cronologia backup"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Įkrovimo iš tinklo pabaigos laikas"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Atsarginio maitinimo istorija"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Uzlādes no tīkla beigu laiks"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Rezerves barošanas vēsture"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Sluttid for lading fra strømnettet"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Historikk for reservekraft"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Eindtijd laden vanaf net"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Back-upgeschiedenis"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Godzina zakończenia ładowania z sieci"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Historia zasilania rezerwowego"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Hora de término da carga da rede"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Histórico de backup"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Ora de sfârșit a încărcării din rețea"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Istoric alimentare de rezervă"
+      }
     }
   },
   "device": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -793,6 +793,11 @@
       "charge_from_grid_end_time": {
         "name": "Sluttid för laddning från nätet"
       }
+    },
+    "calendar": {
+      "backup_history": {
+        "name": "Historik för reservkraft"
+      }
     }
   },
   "device": {

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -260,6 +260,29 @@ async def test_devices_inventory_returns_empty_when_payload_not_dict() -> None:
 
 
 @pytest.mark.asyncio
+async def test_battery_backup_history_uses_endpoint() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value={"histories": []})
+
+    result = await client.battery_backup_history()
+
+    assert result == {"histories": []}
+    client._json.assert_awaited_once_with(
+        "GET", f"{api.BASE_URL}/app-api/SITE/battery_backup_history.json"
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_backup_history_returns_empty_when_payload_not_dict() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value=["bad"])
+
+    result = await client.battery_backup_history()
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
 async def test_battery_status_uses_battery_status_json_endpoint() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"current_charge": "48%"})

--- a/tests/components/enphase_ev/test_api_urls.py
+++ b/tests/components/enphase_ev/test_api_urls.py
@@ -21,6 +21,7 @@ async def test_api_builds_urls_correctly():
     c = StubClient(site_id=RANDOM_SITE_ID)
     await c.status()
     await c.battery_status()
+    await c.battery_backup_history()
     await c.inverters_inventory()
     await c.inverter_status()
     await c.inverter_production(start_date="2022-01-01", end_date="2026-01-01")
@@ -38,11 +39,13 @@ async def test_api_builds_urls_correctly():
     assert methods_urls[1][0] == "GET"
     assert f"/pv/settings/{RANDOM_SITE_ID}/battery_status.json" in methods_urls[1][1]
     assert methods_urls[2][0] == "GET"
-    assert f"/app-api/{RANDOM_SITE_ID}/inverters.json" in methods_urls[2][1]
+    assert f"/app-api/{RANDOM_SITE_ID}/battery_backup_history.json" in methods_urls[2][1]
     assert methods_urls[3][0] == "GET"
-    assert f"/systems/{RANDOM_SITE_ID}/inverter_status_x.json" in methods_urls[3][1]
+    assert f"/app-api/{RANDOM_SITE_ID}/inverters.json" in methods_urls[3][1]
     assert methods_urls[4][0] == "GET"
-    assert f"/systems/{RANDOM_SITE_ID}/inverter_data_x/energy.json" in methods_urls[4][1]
+    assert f"/systems/{RANDOM_SITE_ID}/inverter_status_x.json" in methods_urls[4][1]
+    assert methods_urls[5][0] == "GET"
+    assert f"/systems/{RANDOM_SITE_ID}/inverter_data_x/energy.json" in methods_urls[5][1]
     # Final three calls should be start/stop/trigger in order, regardless of fallback GETs
     start_call = methods_urls[-3]
     stop_call = methods_urls[-2]

--- a/tests/components/enphase_ev/test_calendar_module.py
+++ b/tests/components/enphase_ev/test_calendar_module.py
@@ -1,0 +1,343 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.enphase_ev import DOMAIN
+from custom_components.enphase_ev.calendar import (
+    BackupHistoryCalendarEntity,
+    async_setup_entry,
+)
+
+
+def test_site_has_battery_helper_defaults_and_strict() -> None:
+    from custom_components.enphase_ev import calendar as calendar_mod
+
+    coord = SimpleNamespace()
+    assert calendar_mod._site_has_battery(coord) is True
+    assert calendar_mod._site_has_battery(coord, strict=True) is False
+
+    coord._battery_has_encharge = False
+    assert calendar_mod._site_has_battery(coord) is False
+    assert calendar_mod._site_has_battery(coord, strict=True) is False
+
+    coord._battery_has_encharge = True
+    assert calendar_mod._site_has_battery(coord) is True
+    assert calendar_mod._site_has_battery(coord, strict=True) is True
+
+
+def test_calendar_type_available_falls_back_to_has_type() -> None:
+    from custom_components.enphase_ev import calendar as calendar_mod
+
+    coord = SimpleNamespace(has_type=lambda type_key: type_key == "encharge")
+    assert calendar_mod._type_available(coord, "encharge") is True
+    assert calendar_mod._type_available(coord, "envoy") is False
+
+    coord_no_helpers = SimpleNamespace()
+    assert calendar_mod._type_available(coord_no_helpers, "encharge") is True
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_adds_backup_history_calendar(
+    hass, config_entry, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+
+    added = []
+
+    def _capture(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _capture)
+
+    assert len([ent for ent in added if isinstance(ent, BackupHistoryCalendarEntity)]) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_does_not_duplicate_backup_history_calendar(
+    hass, config_entry, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    callbacks: list = []
+
+    def _capture_listener(callback):
+        callbacks.append(callback)
+        return lambda: None
+
+    coord.async_add_listener = _capture_listener  # type: ignore[assignment]
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+
+    added = []
+
+    def _capture(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _capture)
+    assert len([ent for ent in added if isinstance(ent, BackupHistoryCalendarEntity)]) == 1
+    assert callbacks
+
+    callbacks[0]()
+    assert len([ent for ent in added if isinstance(ent, BackupHistoryCalendarEntity)]) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_waits_for_explicit_battery_detection(
+    hass, config_entry, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = None  # noqa: SLF001
+    callbacks: list = []
+
+    def _capture_listener(callback):
+        callbacks.append(callback)
+        return lambda: None
+
+    coord.async_add_listener = _capture_listener  # type: ignore[assignment]
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+
+    added = []
+
+    def _capture(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _capture)
+    assert not any(isinstance(ent, BackupHistoryCalendarEntity) for ent in added)
+    assert callbacks
+
+    coord._battery_has_encharge = True  # noqa: SLF001
+    callbacks[0]()
+    assert len([ent for ent in added if isinstance(ent, BackupHistoryCalendarEntity)]) == 1
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_backup_history_calendar_without_battery(
+    hass, config_entry, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = False  # noqa: SLF001
+    hass.data.setdefault(DOMAIN, {})[config_entry.entry_id] = {"coordinator": coord}
+
+    added = []
+
+    def _capture(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _capture)
+
+    assert not any(isinstance(ent, BackupHistoryCalendarEntity) for ent in added)
+
+
+def test_backup_history_calendar_available_gating(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.last_update_success = True
+    coord._battery_has_encharge = True  # noqa: SLF001
+    entity = BackupHistoryCalendarEntity(coord)
+
+    assert entity.available is True
+
+    coord.last_update_success = False
+    assert entity.available is False
+
+    coord.last_update_success = True
+    coord.has_type_for_entities = lambda _type_key: False
+    assert entity.available is False
+
+    coord.has_type_for_entities = lambda _type_key: True
+    coord._battery_has_encharge = False  # noqa: SLF001
+    assert entity.available is False
+
+
+def test_backup_history_calendar_device_info_uses_encharge(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    entity = BackupHistoryCalendarEntity(coord)
+
+    info = entity.device_info
+    assert (DOMAIN, f"type:{coord.site_id}:encharge") in info["identifiers"]
+
+
+def test_backup_history_calendar_device_info_fallback(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.type_device_info = lambda _type_key: None
+    entity = BackupHistoryCalendarEntity(coord)
+
+    info = entity.device_info
+    assert info["manufacturer"] == "Enphase"
+    assert (DOMAIN, f"type:{coord.site_id}:encharge") in info["identifiers"]
+
+
+def test_backup_history_calendar_iter_history_events_filters_invalid_rows(
+    coordinator_factory,
+    monkeypatch,
+) -> None:
+    coord = coordinator_factory()
+    now = datetime.now(timezone.utc)
+    monkeypatch.setattr(
+        type(coord),
+        "battery_backup_history_events",
+        property(
+            lambda self: [  # noqa: ARG005
+                "bad-row",
+                {"start": "bad", "end": now + timedelta(minutes=1), "duration_seconds": 60},
+                {"start": datetime(2026, 2, 1, 10, 0), "end": now, "duration_seconds": 60},
+                {
+                    "start": now + timedelta(minutes=5),
+                    "end": now + timedelta(minutes=4),
+                    "duration_seconds": 60,
+                },
+                {
+                    "start": now + timedelta(minutes=1),
+                    "end": now + timedelta(minutes=2),
+                    "duration_seconds": 60,
+                },
+            ]
+        ),
+    )
+    entity = BackupHistoryCalendarEntity(coord)
+
+    events = entity._iter_history_events()  # noqa: SLF001
+    assert len(events) == 1
+    assert events[0][0] == now + timedelta(minutes=1)
+    assert events[0][1] == now + timedelta(minutes=2)
+
+
+def test_backup_history_calendar_to_calendar_event_summary_prefers_name(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    entity = BackupHistoryCalendarEntity(coord)
+    monkeypatch.setattr(
+        BackupHistoryCalendarEntity,
+        "name",
+        property(lambda self: " Backup History "),
+    )
+
+    event = entity._to_calendar_event(  # noqa: SLF001
+        datetime(2026, 2, 1, 8, 0, tzinfo=timezone.utc),
+        datetime(2026, 2, 1, 8, 1, tzinfo=timezone.utc),
+    )
+    assert event.summary == "Backup History"
+
+
+def test_backup_history_calendar_to_calendar_event_summary_uses_entity_id(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    entity = BackupHistoryCalendarEntity(coord)
+    monkeypatch.setattr(
+        BackupHistoryCalendarEntity,
+        "name",
+        property(lambda self: "   "),
+    )
+    monkeypatch.setattr(
+        BackupHistoryCalendarEntity,
+        "entity_id",
+        property(lambda self: " calendar.backup_history "),
+        raising=False,
+    )
+
+    event = entity._to_calendar_event(  # noqa: SLF001
+        datetime(2026, 2, 1, 8, 0, tzinfo=timezone.utc),
+        datetime(2026, 2, 1, 8, 1, tzinfo=timezone.utc),
+    )
+    assert event.summary == "calendar.backup_history"
+
+
+def test_backup_history_calendar_event_current_next_none(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.last_update_success = True
+    now = datetime.now(timezone.utc)
+    coord._battery_backup_history_events = [  # noqa: SLF001
+        {
+            "start": now - timedelta(minutes=3),
+            "end": now - timedelta(minutes=1),
+            "duration_seconds": 120,
+        },
+        {
+            "start": now - timedelta(minutes=1),
+            "end": now + timedelta(minutes=1),
+            "duration_seconds": 120,
+        },
+        {
+            "start": now + timedelta(minutes=3),
+            "end": now + timedelta(minutes=4),
+            "duration_seconds": 60,
+        },
+    ]
+    entity = BackupHistoryCalendarEntity(coord)
+
+    current = entity.event
+    assert current is not None
+    assert current.start <= now <= current.end
+
+    coord._battery_backup_history_events = [  # noqa: SLF001
+        {
+            "start": now + timedelta(minutes=2),
+            "end": now + timedelta(minutes=4),
+            "duration_seconds": 120,
+        }
+    ]
+    upcoming = entity.event
+    assert upcoming is not None
+    assert upcoming.start > now
+
+    coord._battery_backup_history_events = []  # noqa: SLF001
+    assert entity.event is None
+
+
+@pytest.mark.asyncio
+async def test_backup_history_calendar_get_events_range_filter(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.last_update_success = True
+    start = datetime(2026, 2, 1, 0, 0, tzinfo=timezone.utc)
+    coord._battery_backup_history_events = [  # noqa: SLF001
+        {
+            "start": datetime(2026, 2, 1, 8, 0, tzinfo=timezone.utc),
+            "end": datetime(2026, 2, 1, 8, 2, tzinfo=timezone.utc),
+            "duration_seconds": 120,
+        },
+        {
+            "start": datetime(2026, 2, 2, 8, 0, tzinfo=timezone.utc),
+            "end": datetime(2026, 2, 2, 8, 1, tzinfo=timezone.utc),
+            "duration_seconds": 60,
+        },
+        {
+            "start": datetime(2026, 2, 10, 8, 0, tzinfo=timezone.utc),
+            "end": datetime(2026, 2, 10, 8, 1, tzinfo=timezone.utc),
+            "duration_seconds": 60,
+        },
+    ]
+    entity = BackupHistoryCalendarEntity(coord)
+
+    events = await entity.async_get_events(
+        None, start, datetime(2026, 2, 3, 0, 0, tzinfo=timezone.utc)
+    )
+    assert len(events) == 2
+    assert all(event.start < datetime(2026, 2, 3, 0, 0, tzinfo=timezone.utc) for event in events)
+
+
+@pytest.mark.asyncio
+async def test_backup_history_calendar_get_events_accepts_naive_range(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.last_update_success = True
+    coord._battery_backup_history_events = [  # noqa: SLF001
+        {
+            "start": datetime(2026, 2, 1, 8, 0, tzinfo=timezone.utc),
+            "end": datetime(2026, 2, 1, 8, 2, tzinfo=timezone.utc),
+            "duration_seconds": 120,
+        }
+    ]
+    entity = BackupHistoryCalendarEntity(coord)
+
+    events = await entity.async_get_events(
+        None,
+        datetime(2026, 2, 1, 0, 0),
+        datetime(2026, 2, 2, 0, 0),
+    )
+    assert len(events) == 1

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -63,6 +63,10 @@ class DummyCoordinator(SimpleNamespace):
             "current_charge": "48%",
             "storages": [{"serial_number": "BT0001", "status": "normal"}],
         }
+        self._battery_backup_history_payload = {
+            "total_records": 1,
+            "histories": [{"start_time": "2025-10-17T14:38:30+11:00", "duration": 121}],
+        }
         self._devices_inventory_payload = {"result": [{"type": "encharge"}]}
         self.include_inverters = True
         self._inverter_summary_counts = {
@@ -117,6 +121,10 @@ async def test_config_entry_diagnostics_includes_coordinator(hass, config_entry)
         == "ImportExport"
     )
     assert diag["coordinator"]["battery_config"]["status_payload"]["current_charge"] == "48%"
+    assert (
+        diag["coordinator"]["battery_config"]["backup_history_payload"]["total_records"]
+        == 1
+    )
     assert diag["coordinator"]["battery_config"]["devices_inventory_payload"] == {
         "result": [{"type": "encharge"}]
     }

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -91,6 +91,7 @@ def test_battery_settings_entity_strings_exist_for_all_locales() -> None:
         "entity.switch.charge_from_grid_schedule.name",
         "entity.time.charge_from_grid_start_time.name",
         "entity.time.charge_from_grid_end_time.name",
+        "entity.calendar.backup_history.name",
     ]
     for locale in translations_dir.glob("*.json"):
         data = json.loads(locale.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- Add Backup History endpoint support in the API client and coordinator refresh loop, including parsed outage intervals, failure backoff caching, diagnostics payload capture, and phase timing metrics.
- Add a new `calendar` platform with a site-level `Backup History` calendar entity attached to the Battery (`encharge`) type device.
- Add translations for `entity.calendar.backup_history.name`, update the changelog Unreleased section, and expand tests for API URL/method coverage, coordinator behavior, diagnostics, calendar behavior, and edge-case handling.

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "coverage erase && coverage run -m pytest tests/components/enphase_ev -q && coverage report --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/calendar.py,custom_components/enphase_ev/diagnostics.py --show-missing"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_service_translations.py -q"`
