### PR TITLE
Prepare v2.0.0b1 beta release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v2.0.0b1 – 2026-02-13
+
+### 🚧 Breaking changes
 - Replaced the legacy `Enphase Site <site_id>` device anchor with inventory type devices (`Gateway`, `Battery`, `System Controller`, `EV Chargers`, etc.); site-level entities/controls are now attached to type-specific devices and are skipped when that type is not present.
 
 ### ✨ New features
@@ -23,6 +40,9 @@ All notable changes to this project will be documented in this file.
 - Added inverter endpoint integration (`inverters.json`, `inverter_status_x`, `inverter_data_x`) with ID-to-serial mapping, site-local date handling, and dynamic add/remove entity lifecycle updates.
 - Added battery status endpoint integration (`/pv/settings/<site_id>/battery_status.json`) with per-battery charge sensors, aggregate battery charge/status sensors, dynamic add/remove lifecycle handling, and diagnostics payload capture under the shared `Battery` type device.
 - Added a site-level `Backup History` calendar entity on the `Battery` type device, backed by `/app-api/<site_id>/battery_backup_history.json` with normalized outage intervals, coordinator caching, and diagnostics payload capture.
+
+### 🐛 Bug fixes
+- None
 
 ### 🔧 Improvements
 - Improved Battery Settings write handling with optimistic updates, disclaimer auto-stamping when enabling charge-from-grid, and dedicated write lock/debounce safeguards.

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "1.9.0"
+  "version": "2.0.0b1"
 }


### PR DESCRIPTION
## Summary
- Bump the integration manifest version to `2.0.0b1` for the beta release.
- Promote the current unreleased changelog notes into `v2.0.0b1` dated `2026-02-13` and reset `Unreleased` placeholders.

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
