### PR TITLE
Align microinverter diagnostics and harden edge cases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 ### ✨ New features
 - Added site-level battery telemetry sensors for available energy, available power, and inactive microinverter count on the `Battery` device.
 - Added per-battery diagnostic sensors for status, health (SoH), cycle count, and last reported timestamp, with dynamic add/remove lifecycle sync.
+- Added site-level microinverter diagnostic sensors (`Microinverter Connectivity Status`, `Microinverter Reporting Count`, and `Microinverter Last Reported`) on the shared `Microinverters` device.
 
 ### 🐛 Bug fixes
 - Translate battery profile write failures (including HTTP 403/401 responses) into actionable validation errors and enforce read-only user write restrictions.
@@ -34,9 +35,12 @@ All notable changes to this project will be documented in this file.
 - Migrate charge-from-grid schedule time entities to deterministic `from`/`to` IDs and preserve start-then-end ordering under the schedule control.
 - Promote primary battery status fields to first-class entities while keeping detailed/raw data in diagnostic attributes and diagnostics payloads.
 - Localize newly added battery telemetry labels across all non-English locale files and add translation guard coverage to prevent English fallback regressions.
+- Enriched microinverter type inventory and diagnostics with additional inverter API metadata: status-type counts, panel info, firmware and array summaries, latest-reported inverter details, and production-window dates.
+- Filter retired microinverters from inverter inventory/status rollups so entity counts and status summaries reflect only active members.
 
 ### 🔄 Other changes
 - Expanded battery controls/sensors/time-entity test coverage and maintained 100% coverage for touched integration modules.
+- Added focused coordinator/sensor/diagnostics regression tests for the new microinverter alignment paths and translation keys.
 
 ## v2.0.0b1 – 2026-02-13
 

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -801,6 +801,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Microinverter Connectivity Status"
+      },
+      "microinverter_reporting_count": {
+        "name": "Microinverter Reporting Count"
+      },
+      "microinverter_last_reported": {
+        "name": "Microinverter Last Reported"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Последно докладван шлюз"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Състояние на свързаността на микроинверторите"
+      },
+      "microinverter_reporting_count": {
+        "name": "Брой отчитащи микроинвертори"
+      },
+      "microinverter_last_reported": {
+        "name": "Последно отчитане на микроинвертори"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Brána naposledy hlášena"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Stav připojení mikroinvertorů"
+      },
+      "microinverter_reporting_count": {
+        "name": "Počet hlásících mikroinvertorů"
+      },
+      "microinverter_last_reported": {
+        "name": "Poslední hlášení mikroinvertorů"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway sidst rapporteret"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Forbindelsesstatus for mikroinvertere"
+      },
+      "microinverter_reporting_count": {
+        "name": "Antal rapporterende mikroinvertere"
+      },
+      "microinverter_last_reported": {
+        "name": "Senest rapporteret fra mikroinvertere"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Zuletzt gemeldetes Gateway"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Konnektivitätsstatus der Mikrowechselrichter"
+      },
+      "microinverter_reporting_count": {
+        "name": "Anzahl meldender Mikrowechselrichter"
+      },
+      "microinverter_last_reported": {
+        "name": "Letzte Meldung der Mikrowechselrichter"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Τελευταία αναφορά Gateway"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Κατάσταση συνδεσιμότητας μικρομετατροπέων"
+      },
+      "microinverter_reporting_count": {
+        "name": "Πλήθος μικρομετατροπέων με αναφορά"
+      },
+      "microinverter_last_reported": {
+        "name": "Τελευταία αναφορά μικρομετατροπέων"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Microinverter Connectivity Status"
+      },
+      "microinverter_reporting_count": {
+        "name": "Microinverter Reporting Count"
+      },
+      "microinverter_last_reported": {
+        "name": "Microinverter Last Reported"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Microinverter Connectivity Status"
+      },
+      "microinverter_reporting_count": {
+        "name": "Microinverter Reporting Count"
+      },
+      "microinverter_last_reported": {
+        "name": "Microinverter Last Reported"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Microinverter Connectivity Status"
+      },
+      "microinverter_reporting_count": {
+        "name": "Microinverter Reporting Count"
+      },
+      "microinverter_last_reported": {
+        "name": "Microinverter Last Reported"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Microinverter Connectivity Status"
+      },
+      "microinverter_reporting_count": {
+        "name": "Microinverter Reporting Count"
+      },
+      "microinverter_last_reported": {
+        "name": "Microinverter Last Reported"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Microinverter Connectivity Status"
+      },
+      "microinverter_reporting_count": {
+        "name": "Microinverter Reporting Count"
+      },
+      "microinverter_last_reported": {
+        "name": "Microinverter Last Reported"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Microinverter Connectivity Status"
+      },
+      "microinverter_reporting_count": {
+        "name": "Microinverter Reporting Count"
+      },
+      "microinverter_last_reported": {
+        "name": "Microinverter Last Reported"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Puerta de enlace reportada por última vez"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Estado de conectividad de microinversores"
+      },
+      "microinverter_reporting_count": {
+        "name": "Recuento de microinversores con reporte"
+      },
+      "microinverter_last_reported": {
+        "name": "Último reporte de microinversores"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway viimati teatatud"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Mikroinverterite ühenduvuse olek"
+      },
+      "microinverter_reporting_count": {
+        "name": "Raporteerivate mikroinverterite arv"
+      },
+      "microinverter_last_reported": {
+        "name": "Mikroinverterite viimane raport"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway viimeksi raportoitu"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Mikroinvertterien yhteystila"
+      },
+      "microinverter_reporting_count": {
+        "name": "Raportoivien mikroinvertterien määrä"
+      },
+      "microinverter_last_reported": {
+        "name": "Mikroinvertterien viimeisin raportti"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Passerelle signalée pour la dernière fois"
+      },
+      "microinverter_connectivity_status": {
+        "name": "État de connectivité des micro-onduleurs"
+      },
+      "microinverter_reporting_count": {
+        "name": "Nombre de micro-onduleurs en communication"
+      },
+      "microinverter_last_reported": {
+        "name": "Dernier rapport des micro-onduleurs"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "A Gateway legutóbbi jelentése"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Mikroinverterek kapcsolati állapota"
+      },
+      "microinverter_reporting_count": {
+        "name": "Jelentő mikroinverterek száma"
+      },
+      "microinverter_last_reported": {
+        "name": "Mikroinverterek utolsó jelentése"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Ultimo gateway segnalato"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Stato connettività microinverter"
+      },
+      "microinverter_reporting_count": {
+        "name": "Conteggio microinverter in comunicazione"
+      },
+      "microinverter_last_reported": {
+        "name": "Ultima segnalazione microinverter"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Vartai paskutinį kartą pranešta"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Mikroinverterių ryšio būsena"
+      },
+      "microinverter_reporting_count": {
+        "name": "Ataskaitas teikiančių mikroinverterių skaičius"
+      },
+      "microinverter_last_reported": {
+        "name": "Paskutinis mikroinverterių pranešimas"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway pēdējo reizi ziņots"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Mikroinvertoru savienojuma statuss"
+      },
+      "microinverter_reporting_count": {
+        "name": "Ziņojošo mikroinvertoru skaits"
+      },
+      "microinverter_last_reported": {
+        "name": "Pēdējais mikroinvertoru ziņojums"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway sist rapportert"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Tilkoblingsstatus for mikroinvertere"
+      },
+      "microinverter_reporting_count": {
+        "name": "Antall rapporterende mikroinvertere"
+      },
+      "microinverter_last_reported": {
+        "name": "Sist rapportert fra mikroinvertere"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway Laatst gerapporteerd"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Verbindingsstatus micro-omvormers"
+      },
+      "microinverter_reporting_count": {
+        "name": "Aantal rapporterende micro-omvormers"
+      },
+      "microinverter_last_reported": {
+        "name": "Laatst gemeld door micro-omvormers"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Ostatni raport dotyczący bramy"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Stan łączności mikroinwerterów"
+      },
+      "microinverter_reporting_count": {
+        "name": "Liczba raportujących mikroinwerterów"
+      },
+      "microinverter_last_reported": {
+        "name": "Ostatni raport mikroinwerterów"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway relatado pela última vez"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Status de conectividade dos microinversores"
+      },
+      "microinverter_reporting_count": {
+        "name": "Contagem de microinversores reportando"
+      },
+      "microinverter_last_reported": {
+        "name": "Último reporte dos microinversores"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway Raportat ultima dată"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Stare conectivitate microinvertoare"
+      },
+      "microinverter_reporting_count": {
+        "name": "Număr microinvertoare care raportează"
+      },
+      "microinverter_last_reported": {
+        "name": "Ultima raportare microinvertoare"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -771,6 +771,15 @@
       },
       "gateway_last_reported": {
         "name": "Gateway senast rapporterad"
+      },
+      "microinverter_connectivity_status": {
+        "name": "Anslutningsstatus för mikroväxelriktare"
+      },
+      "microinverter_reporting_count": {
+        "name": "Antal rapporterande mikroväxelriktare"
+      },
+      "microinverter_last_reported": {
+        "name": "Senaste rapport från mikroväxelriktare"
       }
     },
     "number": {

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -166,6 +166,15 @@ def test_coordinator_public_diagnostics_helpers(coordinator_factory) -> None:
     coord._scheduler_last_error = None  # noqa: SLF001
     coord._battery_profile_payload = {"profile": "cost_savings"}  # noqa: SLF001
     coord._inverter_summary_counts = {"total": 1}  # noqa: SLF001
+    coord._inverter_panel_info = {"pv_module_manufacturer": "Acme"}  # noqa: SLF001
+    coord._inverter_status_type_counts = {"IQ7A": 1}  # noqa: SLF001
+    coord._type_device_buckets = {  # noqa: SLF001
+        "microinverter": {
+            "type_key": "microinverter",
+            "count": 1,
+            "devices": [{"serial_number": "INV-A"}],
+        }
+    }
 
     assert coord.charge_mode_cache_snapshot() == {SERIAL_ONE: "FAST"}
     assert coord.session_history_diagnostics() == {
@@ -191,6 +200,11 @@ def test_coordinator_public_diagnostics_helpers(coordinator_factory) -> None:
         "profile": "cost_savings"
     }
     assert coord.inverter_diagnostics_payloads()["summary_counts"] == {"total": 1}
+    assert coord.inverter_diagnostics_payloads()["panel_info"] == {
+        "pv_module_manufacturer": "Acme"
+    }
+    assert coord.inverter_diagnostics_payloads()["status_type_counts"] == {"IQ7A": 1}
+    assert coord.inverter_diagnostics_payloads()["bucket_snapshot"]["count"] == 1
     assert coord.scheduler_backoff_active() is True
 
 

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -146,6 +146,33 @@ def test_battery_inventory_strings_localized_for_non_english_locales() -> None:
                 )
 
 
+def test_microinverter_inventory_strings_localized_for_non_english_locales() -> None:
+    """Guard microinverter inventory labels from silently falling back to English."""
+
+    translations_dir = (
+        pathlib.Path(__file__).resolve().parents[3]
+        / "custom_components"
+        / "enphase_ev"
+        / "translations"
+    )
+    en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
+    paths = [
+        "entity.sensor.microinverter_connectivity_status.name",
+        "entity.sensor.microinverter_reporting_count.name",
+        "entity.sensor.microinverter_last_reported.name",
+    ]
+    for locale in translations_dir.glob("*.json"):
+        name = locale.name
+        data = json.loads(locale.read_text(encoding="utf-8"))
+        for path in paths:
+            value = _at_path(data, path)
+            assert value.strip(), f"{name} missing value for {path}"
+            if name != "en.json" and not name.startswith("en-"):
+                assert value != _at_path(en_data, path), (
+                    f"{name} should localize {path} (still matches English)"
+                )
+
+
 def test_grid_control_strings_exist_for_all_locales() -> None:
     """Ensure OTP/grid-control strings exist across services, entities, and errors."""
 


### PR DESCRIPTION
## Summary
- Align microinverter type-device and site-level diagnostics with existing gateway/entity layout patterns.
- Add site-level microinverter diagnostic sensors (`Microinverter Connectivity Status`, `Microinverter Reporting Count`, `Microinverter Last Reported`) and enrich microinverter inventory/diagnostics attributes (status-type counts, panel info, firmware/array summaries, latest-reported device, production window).
- Harden edge-case handling for malformed or inconsistent status payloads by normalizing status buckets, introducing explicit `unknown` handling, and avoiding optimistic online states when status breakdowns are missing.
- Decouple microinverter site-entity creation from gateway type availability, update changelog/translation coverage, and extend regression tests.

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_service_translations.py -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/diagnostics.py --fail-under=100"`
