### PR TITLE
Prepare 2.0.0b2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v2.0.0b2 – 2026-02-17
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
 - Added site-level battery telemetry sensors for available energy, available power, and inactive microinverter count on the `Battery` device.
 - Added per-battery diagnostic sensors for status, health (SoH), cycle count, and last reported timestamp, with dynamic add/remove lifecycle sync.
 - Added site-level microinverter diagnostic sensors (`Microinverter Connectivity Status`, `Microinverter Reporting Count`, and `Microinverter Last Reported`) on the shared `Microinverters` device.

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.0.0b1"
+  "version": "2.0.0b2"
 }


### PR DESCRIPTION
## Summary
- Bump integration manifest version from `2.0.0b1` to `2.0.0b2` for the next beta release.
- Promote the current `Unreleased` notes into `v2.0.0b2 – 2026-02-17` in the changelog.
- Reset `Unreleased` sections back to `None` placeholders for ongoing development.

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
