### PR TITLE
Forward-port green-mode auto-resume safeguard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Prevent auto-resume from issuing a start request when a charger is in `GREEN_CHARGING` mode after cloud reconnects or temporary outages ([issue #274](https://github.com/barneyonline/ha-enphase-ev-charger/issues/274)).
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -3297,6 +3297,19 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 status_norm = status_raw.strip().upper()
             if status_norm != SUSPENDED_EVSE_STATUS:
                 continue
+            mode_raw = info.get("charge_mode_pref") or info.get("charge_mode")
+            mode = ""
+            if mode_raw is not None:
+                try:
+                    mode = str(mode_raw).strip().upper()
+                except Exception:
+                    mode = ""
+            if mode == "GREEN_CHARGING":
+                _LOGGER.debug(
+                    "Skipping auto-resume for charger %s because mode is GREEN_CHARGING",
+                    sn_str,
+                )
+                continue
             last_attempt = self._auto_resume_attempts.get(sn_str)
             if last_attempt is not None and (now - last_attempt) < 120:
                 continue


### PR DESCRIPTION
## Summary
- Forward-port the green-mode auto-resume safeguard from the 1.9.1 hotfix into `main`.
- Skip auto-resume scheduling when a charger is in `GREEN_CHARGING` mode after reconnect/outage recovery.
- Add coordinator regression tests for green-mode suppression and defensive handling of non-stringable mode values.
- Update `Unreleased` changelog bug fixes to reference [issue #274](https://github.com/barneyonline/ha-enphase-ev-charger/issues/274).

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_coordinator_remaining_coverage.py -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"`
