### PR TITLE
Fix battery energy state class and expand service status checks

### DIFF
--- a/.github/workflows/service-status.yml
+++ b/.github/workflows/service-status.yml
@@ -34,6 +34,7 @@ jobs:
           ENPHASE_PASSWORD: ${{ secrets.ENPHASE_PASSWORD }}
           ENPHASE_SITE_ID: ${{ secrets.ENPHASE_SITE_ID }}
           ENPHASE_SERIAL: ${{ secrets.ENPHASE_SERIAL }}
+          ENPHASE_LOCALE: ${{ secrets.ENPHASE_LOCALE }}
         run: |
           set -euo pipefail
           python3 scripts/service_status.py --output-dir "${RUNNER_TEMP}/service-status"

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -3884,7 +3884,6 @@ class EnphaseBatteryAvailableEnergySensor(_SiteBaseEntity):
     _attr_translation_key = "battery_available_energy"
     _attr_device_class = SensorDeviceClass.ENERGY
     _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
-    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(self, coord: EnphaseCoordinator):
         super().__init__(

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -610,6 +610,7 @@ def test_battery_site_summary_sensors_state_and_attributes():
     power = EnphaseBatteryAvailablePowerSensor(coord)
     inactive = EnphaseBatteryInactiveMicroinvertersSensor(coord)
 
+    assert energy.state_class is None
     assert energy.available is True
     assert energy.native_value == 4.75
     assert energy.extra_state_attributes["site_max_capacity_kwh"] == 10.0


### PR DESCRIPTION
## Summary
- fix `battery_available_energy` sensor metadata by removing the invalid `measurement` state class for an energy device class sensor
- add a regression assertion to lock `EnphaseBatteryAvailableEnergySensor.state_class` to `None`
- expand service-status monitoring to cover the latest read endpoints used by the integration (BatteryConfig, device/grid/battery diagnostics, inverter inventory/status/production)
- pass optional `ENPHASE_LOCALE` in the service-status workflow for BatteryConfig locale-aware checks

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/sensor.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_sensors.py -q -k battery_site_summary_sensors_state_and_attributes"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 scripts/service_status.py --output-dir /tmp/service-status-dry"`
