### PR TITLE
Refresh device info panel metadata across device types

### DIFF
--- a/custom_components/enphase_ev/device_info_helpers.py
+++ b/custom_components/enphase_ev/device_info_helpers.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+
+def _normalize_evse_model_name(value: object) -> str | None:
+    if value is None:
+        return None
+    try:
+        text = str(value).strip()
+    except Exception:
+        return None
+    if not text:
+        return None
+
+    text_upper = text.upper()
+    if not text_upper.startswith("IQ-EVSE-"):
+        return text
+
+    parts = text_upper.split("-")
+    if (
+        len(parts) >= 5
+        and parts[0] == "IQ"
+        and parts[1] == "EVSE"
+        and parts[2]
+        and parts[3].isdigit()
+        and len(parts[3]) == 4
+    ):
+        return "-".join(parts[:4])
+
+    return text
+
+
+def _compose_charger_model_display(
+    display_name: str | None,
+    model_name: object,
+    fallback_name: str | None = None,
+) -> str | None:
+    display = display_name.strip() if isinstance(display_name, str) else None
+    if not display:
+        display = None
+    fallback = fallback_name.strip() if isinstance(fallback_name, str) else None
+    if not fallback:
+        fallback = None
+    model = _normalize_evse_model_name(model_name)
+    if display and model:
+        if model.casefold() in display.casefold():
+            return display
+        return f"{display} ({model})"
+    if model:
+        return model
+    if display:
+        return display
+    return fallback

--- a/custom_components/enphase_ev/entity.py
+++ b/custom_components/enphase_ev/entity.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import EnphaseCoordinator
+from .device_info_helpers import _compose_charger_model_display, _normalize_evse_model_name
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -79,7 +80,7 @@ class EnphaseBaseEntity(CoordinatorEntity[EnphaseCoordinator]):
         display_name_raw = d.get("display_name") or d.get("name")
         display_name = str(display_name_raw) if display_name_raw else None
         model_name_raw = d.get("model_name")
-        model_name = str(model_name_raw) if model_name_raw else None
+        model_name = _normalize_evse_model_name(model_name_raw)
 
         if display_name:
             dev_name = display_name
@@ -88,13 +89,7 @@ class EnphaseBaseEntity(CoordinatorEntity[EnphaseCoordinator]):
         else:
             dev_name = "Enphase EV Charger"
 
-        model_display: str | None = None
-        if display_name and model_name:
-            model_display = f"{display_name} ({model_name})"
-        elif model_name:
-            model_display = model_name
-        elif display_name:
-            model_display = display_name
+        model_display = _compose_charger_model_display(display_name, model_name_raw)
         # Build DeviceInfo using keyword arguments as per HA dev docs
         info_kwargs: dict[str, object] = {
             "identifiers": {(DOMAIN, self._sn)},

--- a/tests/components/enphase_ev/test_entity_wiring.py
+++ b/tests/components/enphase_ev/test_entity_wiring.py
@@ -60,3 +60,59 @@ def test_device_info_includes_model_name_when_available():
     info = ent.device_info
     assert info["name"] == "IQ EV Charger"
     assert info["model"] == "IQ EV Charger (IQ-EVSE-EU-3032)"
+
+
+def test_device_info_suppresses_duplicate_extended_evse_model_suffix():
+    from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
+
+    class DummyCoord:
+        def __init__(self):
+            self.data = {}
+            self.serials = {RANDOM_SERIAL_ALT}
+            self.site_id = RANDOM_SITE_ID
+            self.last_update_success = True
+
+    coord = DummyCoord()
+    coord.data = {
+        RANDOM_SERIAL_ALT: {
+            "sn": RANDOM_SERIAL_ALT,
+            "display_name": "IQ EV Charger (IQ-EVSE-EU-3032)",
+            "model_name": "IQ-EVSE-EU-3032-0105-1300",
+            "connected": True,
+        }
+    }
+
+    ent = EnphaseEnergyTodaySensor(coord, RANDOM_SERIAL_ALT)
+    info = ent.device_info
+    assert info["name"] == "IQ EV Charger (IQ-EVSE-EU-3032)"
+    assert info["model"] == "IQ EV Charger (IQ-EVSE-EU-3032)"
+
+
+def test_device_info_handles_empty_or_invalid_model_name():
+    from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
+
+    class _BadStr:
+        def __str__(self):
+            raise ValueError("boom")
+
+    class DummyCoord:
+        def __init__(self):
+            self.data = {}
+            self.serials = {RANDOM_SERIAL_ALT}
+            self.site_id = RANDOM_SITE_ID
+            self.last_update_success = True
+
+    coord = DummyCoord()
+    coord.data = {
+        RANDOM_SERIAL_ALT: {
+            "sn": RANDOM_SERIAL_ALT,
+            "display_name": "Garage Charger",
+            "model_name": "   ",
+            "connected": True,
+        }
+    }
+    ent = EnphaseEnergyTodaySensor(coord, RANDOM_SERIAL_ALT)
+    assert ent.device_info["model"] == "Garage Charger"
+
+    coord.data[RANDOM_SERIAL_ALT]["model_name"] = _BadStr()
+    assert ent.device_info["model"] == "Garage Charger"


### PR DESCRIPTION
## Summary
- refresh type-device metadata generation so Gateway/Battery/Microinverter device info exposes consistent `serial_number`, `model_id`, `sw_version`, and SKU-based hardware summaries
- update Gateway naming to prefer System Controller metadata with stronger channel/name detection fallbacks and keep meter serial details in aggregated metadata
- de-duplicate EVSE model display composition by introducing shared helper logic and normalize extended EVSE model forms before composing device model text
- harden registry sync semantics to clear stale type-device metadata when helper methods are present but return empty values, while preserving existing values when helpers are unavailable
- expand test coverage for stale metadata clearing, helper-missing preservation behavior, broader controller-type detection, and EVSE normalization edge cases

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/entity.py,custom_components/enphase_ev/device_info_helpers.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_entity_wiring.py -q"`

