### PR TITLE
Prepare v2.0.0b3 beta release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,43 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
-- Reworked onboarding to a category-based `Select Devices` step that shows available integration device groups (instead of charger-only selection), defaults all discovered categories to enabled, keeps the shared scan interval control, and stores category selections for runtime entity gating.
+- None
 
 ### 🐛 Bug fixes
-- Prevent auto-resume from issuing a start request when a charger is in `GREEN_CHARGING` mode after cloud reconnects or temporary outages ([issue #274](https://github.com/barneyonline/ha-enphase-ev-charger/issues/274)).
+- None
 
 ### 🔧 Improvements
 - None
 
 ### 🔄 Other changes
 - None
+
+## v2.0.0b3 – 2026-02-21
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Reworked onboarding to a category-based `Select Devices` step that shows integration device groups (instead of charger-only selection), defaults discovered categories to enabled, keeps the shared scan interval control, and stores category selections for runtime entity gating ([#279](https://github.com/barneyonline/ha-enphase-ev-charger/pull/279)).
+- Added category-based device toggles in Configure Options, preserved unknown stored type keys, and forced integration entry titles to numeric site IDs across setup/reconfigure/reauth paths ([#280](https://github.com/barneyonline/ha-enphase-ev-charger/pull/280)).
+- Split out a dedicated `Enphase Cloud` device and moved cloud diagnostics to it; added a battery `Last Reported` type-level sensor with aggregate reporting attributes ([#283](https://github.com/barneyonline/ha-enphase-ev-charger/pull/283)).
+- Moved site energy flow sensors to the cloud device and enabled them by default, with migration support for existing entities ([#286](https://github.com/barneyonline/ha-enphase-ev-charger/pull/286)).
+- Switched the grid OTP helper blueprint to a Companion App actionable-notification reply flow and kept runtime OTP prompts in the script blueprint ([#287](https://github.com/barneyonline/ha-enphase-ev-charger/pull/287)).
+
+### 🐛 Bug fixes
+- Prevent auto-resume from issuing a start request when a charger is in `GREEN_CHARGING` mode after cloud reconnects or temporary outages ([#276](https://github.com/barneyonline/ha-enphase-ev-charger/pull/276), [issue #274](https://github.com/barneyonline/ha-enphase-ev-charger/issues/274)).
+- Fixed `battery_available_energy` metadata by removing the invalid energy `state_class` assignment ([#277](https://github.com/barneyonline/ha-enphase-ev-charger/pull/277)).
+- Fixed Safe Mode 8A fallback behavior so `Set Amps` is forced to the safe limit only while charging is actively true; idle states now use configured/fallback setpoints ([#284](https://github.com/barneyonline/ha-enphase-ev-charger/pull/284)).
+
+### 🔧 Improvements
+- Expanded service-status checks to cover newer BatteryConfig, diagnostics, and inverter endpoints and added optional locale-aware service-status execution support ([#277](https://github.com/barneyonline/ha-enphase-ev-charger/pull/277)).
+- Refreshed type-device metadata generation (serial/model/hardware/software summaries), improved gateway/system-controller naming fallbacks, normalized EVSE model composition, and hardened stale metadata clearing rules ([#281](https://github.com/barneyonline/ha-enphase-ev-charger/pull/281)).
+- Stabilized battery entity ordering migrations for charge-from-grid schedule controls, hardened battery health parsing/validation, and simplified battery/microinverter diagnostics attributes ([#282](https://github.com/barneyonline/ha-enphase-ev-charger/pull/282)).
+- Refined EV charger status presentation by normalizing status labels and storm-guard naming/category behavior, with `status_raw` retained for migration/debug visibility ([#284](https://github.com/barneyonline/ha-enphase-ev-charger/pull/284)).
+- Aligned microinverter diagnostics state evaluation, retired the legacy microinverter inventory sensor, and repurposed reporting-count behavior into user-facing active microinverter reporting ([#285](https://github.com/barneyonline/ha-enphase-ev-charger/pull/285)).
+
+### 🔄 Other changes
+- Updated translations (`strings.json` + all locale files) and expanded regression coverage across onboarding/options/device migration/diagnostics flows to preserve 100% coverage on touched modules ([#280](https://github.com/barneyonline/ha-enphase-ev-charger/pull/280), [#283](https://github.com/barneyonline/ha-enphase-ev-charger/pull/283), [#284](https://github.com/barneyonline/ha-enphase-ev-charger/pull/284), [#285](https://github.com/barneyonline/ha-enphase-ev-charger/pull/285)).
 
 ## v2.0.0b2 – 2026-02-17
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ pre-commit run --all-files
 
 ## Release Process
 
-Maintainers cut releases by updating the manifest version, changelog, and tagging the release. Contributors generally do not publish releases directly, but you can help by keeping entries in `CHANGELOG.md` clear and actionable.
+Maintainers cut releases by updating the manifest version, changelog, and tagging the release. For beta tags (for example `v2.0.0b3`), publish the GitHub release as a **pre-release** so default HACS users stay on the latest stable line (currently `v1.9.1`) unless they explicitly enable beta releases. Contributors generally do not publish releases directly, but you can help by keeping entries in `CHANGELOG.md` clear and actionable.
 
 ## Getting Help
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.0.0b2"
+  "version": "2.0.0b3"
 }


### PR DESCRIPTION
## Summary
- Bump integration manifest version to `2.0.0b3` for the upcoming beta release.
- Update `CHANGELOG.md` with a `v2.0.0b3` section that captures all PRs merged since `v2.0.0b2`.
- Clarify release process guidance so beta tags are published as GitHub pre-releases and stable users remain on `v1.9.1` by default.

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/__init__.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
