### PR TITLE
Document 1.9.1 to 2.0 migration breaking changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### 🚧 Breaking changes
-- None
+- Upgrading from v1.9.1 migrates away from the legacy Enphase Site device anchor to type devices (Gateway, Battery, EV Chargers, etc.). Device-targeted automations/scripts/services bound to the old site device may need re-selection after upgrade.
+- Per-charger selection has been replaced by category-based device selection. In v2.0, enabling EV Chargers includes discovered chargers as a group, so setups that previously kept only a subset of chargers may need post-upgrade entity disablement/reconfiguration.
 
 ### ✨ New features
 - None


### PR DESCRIPTION
## Summary
- document confirmed functional migration impacts for direct upgrades from v1.9.1 to v2.0 under Unreleased breaking changes
- clarify that legacy site-device targets may require re-selection after migration to type devices
- clarify that category-based EV Charger selection in v2.0 can require post-upgrade disablement/reconfiguration for prior subset-charger setups

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/config_flow.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
