### PR TITLE
Add bulk Storm Alert opt-out button on IQ Gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,13 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
-- None
+- Added an IQ Gateway `Storm Alert Opt Out` button that bulk-opt-outs all active (non-opted-out) Storm Guard alerts with one request per alert and no-ops when no active alerts exist.
 
 ### 🐛 Bug fixes
 - None
 
 ### 🔧 Improvements
-- None
+- Improved Storm Alert diagnostic sensor accuracy so `Active` reflects alerts that are not opted out, including robust handling of mixed/legacy alert payload shapes.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -1770,6 +1770,29 @@ class EnphaseEVClient:
         headers = self._battery_config_headers()
         return await self._json("GET", url, headers=headers)
 
+    async def opt_out_storm_alert(self, *, alert_id: str, name: str) -> dict:
+        """Opt out of a specific Storm Guard alert.
+
+        PUT /service/batteryConfig/api/v1/stormGuard/<site_id>/stormAlert
+        Body: {
+          "stormAlerts": [
+            {"id": "<alert_id>", "name": "<alert_name>", "status": "opted-out"}
+          ]
+        }
+        """
+        url = f"{BASE_URL}/service/batteryConfig/api/v1/stormGuard/{self._site}/stormAlert"
+        headers = self._battery_config_headers(include_xsrf=True)
+        payload = {
+            "stormAlerts": [
+                {
+                    "id": str(alert_id),
+                    "name": str(name),
+                    "status": "opted-out",
+                }
+            ]
+        }
+        return await self._json("PUT", url, json=payload, headers=headers)
+
     async def storm_guard_profile(self, *, locale: str | None = None) -> dict:
         """Return Storm Guard state and EVSE settings for the site.
 

--- a/custom_components/enphase_ev/button.py
+++ b/custom_components/enphase_ev/button.py
@@ -32,6 +32,11 @@ def _type_available(coord: EnphaseCoordinator, type_key: str) -> bool:
     return bool(has_type(type_key)) if callable(has_type) else True
 
 
+def _storm_guard_visible(coord: EnphaseCoordinator) -> bool:
+    show_storm_guard = getattr(coord, "battery_show_storm_guard", None)
+    return show_storm_guard is not False
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: EnphaseConfigEntry,
@@ -57,6 +62,14 @@ async def async_setup_entry(
         ):
             site_entities.append(RequestGridToggleOtpButton(coord))
             site_entity_keys.add("request_grid_toggle_otp")
+        if (
+            "storm_alert_opt_out" not in site_entity_keys
+            and _site_has_battery(coord)
+            and _type_available(coord, "envoy")
+            and _storm_guard_visible(coord)
+        ):
+            site_entities.append(StormAlertOptOutButton(coord))
+            site_entity_keys.add("storm_alert_opt_out")
         if site_entities:
             async_add_entities(site_entities, update_before_add=False)
         serials = [sn for sn in coord.iter_serials() if sn and sn not in known_serials]
@@ -144,6 +157,39 @@ class RequestGridToggleOtpButton(CoordinatorEntity, ButtonEntity):
                 info = type_device_info(type_key)
                 if info is not None:
                     return info
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"type:{self._coord.site_id}:envoy")},
+            manufacturer="Enphase",
+        )
+
+
+class StormAlertOptOutButton(CoordinatorEntity, ButtonEntity):
+    _attr_has_entity_name = True
+    _attr_translation_key = "storm_alert_opt_out"
+
+    def __init__(self, coord: EnphaseCoordinator):
+        super().__init__(coord)
+        self._coord = coord
+        self._attr_unique_id = f"{DOMAIN}_site_{coord.site_id}_storm_alert_opt_out"
+
+    @property
+    def available(self) -> bool:  # type: ignore[override]
+        return (
+            super().available
+            and _site_has_battery(self._coord)
+            and _type_available(self._coord, "envoy")
+            and _storm_guard_visible(self._coord)
+        )
+
+    async def async_press(self) -> None:
+        await self._coord.async_opt_out_all_storm_alerts()
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        type_device_info = getattr(self._coord, "type_device_info", None)
+        info = type_device_info("envoy") if callable(type_device_info) else None
+        if info is not None:
+            return info
         return DeviceInfo(
             identifiers={(DOMAIN, f"type:{self._coord.site_id}:envoy")},
             manufacturer="Enphase",

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -174,6 +174,16 @@ SUSPENDED_EVSE_STATUS = "SUSPENDED_EVSE"
 FAST_TOGGLE_POLL_HOLD_S = 60
 AMP_RESTART_DELAY_S = 30.0
 STREAMING_DEFAULT_DURATION_S = 900.0
+STORM_ALERT_INACTIVE_STATUSES = frozenset(
+    {
+        "opted-out",
+        "inactive",
+        "expired",
+        "cleared",
+        "ended",
+        "resolved",
+    }
+)
 
 
 @dataclass
@@ -7139,12 +7149,20 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         )
         alerts = payload.get("stormAlerts")
         normalized_alerts: list[dict[str, object]] = []
+        derived_alert_active: bool | None = None
         if isinstance(alerts, list):
+            derived_alert_active = False
             for alert in alerts:
+                alert_active = False
                 if isinstance(alert, dict):
                     normalized: dict[str, object] = {}
                     for key in (
                         "id",
+                        "name",
+                        "source",
+                        "status",
+                        "active",
+                        "critical",
                         "type",
                         "severity",
                         "message",
@@ -7162,18 +7180,38 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                         normalized_alerts.append(normalized)
                     else:
                         normalized_alerts.append({"active": True})
+                    alert_active = self._storm_alert_is_active(alert)
                 elif alert is not None:
                     try:
                         normalized_alerts.append({"value": str(alert)})
                     except Exception:  # noqa: BLE001
                         normalized_alerts.append({"active": True})
+                    alert_active = True
+                if alert_active:
+                    derived_alert_active = True
         self._storm_alerts = normalized_alerts
-        active = self._coerce_optional_bool(payload.get("criticalAlertActive"))
-        if active is not None:
-            return active
-        if isinstance(alerts, list):
-            return bool(alerts)
-        return None
+        critical_active = self._coerce_optional_bool(payload.get("criticalAlertActive"))
+        if derived_alert_active is None:
+            return critical_active
+        if critical_active is None:
+            return derived_alert_active
+        return critical_active or derived_alert_active
+
+    def _storm_alert_status_is_inactive(self, status: str | None) -> bool:
+        if status is None:
+            return False
+        return status in STORM_ALERT_INACTIVE_STATUSES
+
+    def _storm_alert_is_active(self, alert: dict[str, object]) -> bool:
+        explicit_active = self._coerce_optional_bool(alert.get("active"))
+        if explicit_active is not None:
+            return explicit_active
+        status = self._coerce_optional_text(alert.get("status"))
+        if status:
+            normalized_status = status.strip().lower().replace("_", "-")
+            if normalized_status:
+                return not self._storm_alert_status_is_inactive(normalized_status)
+        return True
 
     async def _async_refresh_storm_guard_profile(self, *, force: bool = False) -> None:
         now = time.monotonic()
@@ -7216,6 +7254,64 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         if active is not None:
             self._storm_alert_active = active
         self._storm_alert_cache_until = now + STORM_ALERT_CACHE_TTL
+
+    async def async_opt_out_all_storm_alerts(self) -> None:
+        await self._async_refresh_storm_alert(force=True)
+
+        actionable: list[tuple[str, str]] = []
+        seen_ids: set[str] = set()
+        for alert in self.storm_alerts:
+            if not isinstance(alert, dict):
+                continue
+            alert_id = self._coerce_optional_text(alert.get("id"))
+            if not alert_id or alert_id in seen_ids:
+                continue
+            if not self._storm_alert_is_active(alert):
+                continue
+            name = self._coerce_optional_text(alert.get("name")) or "Storm Alert"
+            actionable.append((alert_id, name))
+            seen_ids.add(alert_id)
+
+        if not actionable:
+            return
+
+        opt_out = getattr(self.client, "opt_out_storm_alert", None)
+        if not callable(opt_out):
+            raise ServiceValidationError("Storm Alert opt-out is unavailable.")
+
+        failures: list[tuple[str, Exception]] = []
+        for alert_id, name in actionable:
+            try:
+                await opt_out(alert_id=alert_id, name=name)
+            except Exception as err:  # noqa: BLE001
+                failures.append((alert_id, err))
+                _LOGGER.warning(
+                    "Storm Alert opt-out failed for site %s alert %s: %s",
+                    self.site_id,
+                    alert_id,
+                    err,
+                )
+
+        refresh_err: Exception | None = None
+        self._storm_alert_cache_until = None
+        try:
+            await self._async_refresh_storm_alert(force=True)
+            self.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
+            await self.async_request_refresh()
+        except Exception as err:  # noqa: BLE001
+            refresh_err = err
+            _LOGGER.warning(
+                "Storm Alert opt-out refresh failed for site %s: %s",
+                self.site_id,
+                err,
+            )
+
+        if failures:
+            raise ServiceValidationError(
+                f"Storm Alert opt-out failed for {len(failures)} alert(s)."
+            )
+        if refresh_err is not None:
+            raise refresh_err
 
     async def async_set_storm_guard_enabled(self, enabled: bool) -> None:
         await self._async_refresh_storm_guard_profile(force=True)

--- a/custom_components/enphase_ev/icons.json
+++ b/custom_components/enphase_ev/icons.json
@@ -352,7 +352,8 @@
     "button": {
       "start_charging": { "default": "mdi:play" },
       "stop_charging": { "default": "mdi:stop" },
-      "request_grid_toggle_otp": { "default": "mdi:message-lock" }
+      "request_grid_toggle_otp": { "default": "mdi:message-lock" },
+      "storm_alert_opt_out": { "default": "mdi:shield-off-outline" }
     }
   }
 }

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -937,6 +937,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Request Grid Toggle OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Storm Alert Opt Out"
       }
     }
   },

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Заявка за превключване на решетка OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Отказ от предупреждение за буря"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Požadavek na přepínání sítě OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Odhlásit upozornění na bouři"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Anmod om Grid Toggle OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Fravælg stormadvarsel"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Fordern Sie Grid Toggle OTP an"
+      },
+      "storm_alert_opt_out": {
+        "name": "Sturmwarnung abwählen"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Αίτημα Εναλλαγής Πλέγματος OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Εξαίρεση από ειδοποίηση καταιγίδας"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Request Grid Toggle OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Storm Alert Opt Out"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Request Grid Toggle OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Storm Alert Opt Out"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Request Grid Toggle OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Storm Alert Opt Out"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Request Grid Toggle OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Storm Alert Opt Out"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Request Grid Toggle OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Storm Alert Opt Out"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Request Grid Toggle OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Storm Alert Opt Out"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Solicitar OTP de alternancia de cuadrícula"
+      },
+      "storm_alert_opt_out": {
+        "name": "Excluir alerta de tormenta"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Taotle ruudustiku sisselülitamise OTP-d"
+      },
+      "storm_alert_opt_out": {
+        "name": "Loobu tormihoiatusest"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Pyydä ruudukon OTP:tä"
+      },
+      "storm_alert_opt_out": {
+        "name": "Poista myrskyhälytys käytöstä"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Demander la grille de basculement OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Se désinscrire de l'alerte de tempête"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Rács váltás OTP kérése"
+      },
+      "storm_alert_opt_out": {
+        "name": "Viharriasztás letiltása"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Richiedi griglia Attiva/disattiva OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Disattiva avviso tempesta"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Prašyti tinklelio perjungimo OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Atsisakyti audros įspėjimo"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Pieprasīt režģa pārslēgšanu OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Atteikties no vētras brīdinājuma"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Be om Grid Toggle OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Meld deg av stormvarsel"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Verzoek raster Toggle OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Afmelden voor stormwaarschuwing"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Żądanie przełączenia siatki OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Zrezygnuj z alertu burzowego"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Solicitar alternância de grade OTP"
+      },
+      "storm_alert_opt_out": {
+        "name": "Desativar alerta de tempestade"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Solicită OTP pentru comutare rețea"
+      },
+      "storm_alert_opt_out": {
+        "name": "Renunță la alerta de furtună"
       }
     },
     "time": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -883,6 +883,9 @@
       },
       "request_grid_toggle_otp": {
         "name": "Begär OTP för nätväxling"
+      },
+      "storm_alert_opt_out": {
+        "name": "Välj bort stormvarning"
       }
     },
     "time": {

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -1546,19 +1546,54 @@ Notes:
 - When the schedule is enabled, the status payload reports `chargeFromGridScheduleEnabled: true` and `cfgControl.forceScheduleOpted: true`.
 - `veryLowSoc` drives the "Battery shutdown level" slider, clamped between `veryLowSocMin` and `veryLowSocMax`.
 
-### 5.6 Storm Guard Status + Toggle
+### 5.6 Storm Guard Alert Status, Opt-Out, and Toggle
 ```
 GET /service/batteryConfig/api/v1/stormGuard/<site_id>/stormAlert
 ```
 Returns Storm Guard alert state and critical alert override status.
 
-Example response (anonymized):
+Example response with no active alerts (anonymized):
 ```json
 {
   "criticalAlertsOverride": true,
   "stormAlerts": [],
   "criticalAlertActive": false
 }
+```
+
+Example response with an active non-critical alert (anonymized):
+```json
+{
+  "criticalAlertsOverride": true,
+  "stormAlerts": [
+    {
+      "id": "<alert_id>",
+      "name": "Severe Weather",
+      "source": "<weather_provider>",
+      "status": "active",
+      "startTime": 1771895761000,
+      "endTime": 1771920000000,
+      "critical": false
+    }
+  ],
+  "criticalAlertActive": false
+}
+```
+
+```
+PUT /service/batteryConfig/api/v1/stormGuard/<site_id>/stormAlert
+Headers: X-XSRF-Token: <token>
+Body: {
+  "stormAlerts": [
+    { "id": "<alert_id>", "name": "Severe Weather", "status": "opted-out" }
+  ]
+}
+```
+Used when the user clicks **Opt Out** for a specific active alert in the Storm Guard UI.
+
+Example response:
+```json
+{ "message": "success" }
 ```
 
 ```
@@ -1579,6 +1614,8 @@ Example responses:
 Notes:
 - `stormGuardState` accepts `enabled` or `disabled`.
 - `evseStormEnabled` controls the EV Charging option ("Charges EV to 100% when Storm Alert is On"); the UI warns this may cause grid import costs.
+- Alert opt-out uses `PUT /stormGuard/<site_id>/stormAlert` with `status: "opted-out"` per alert ID.
+- Observed behavior: if that opt-out removes the last active Storm Alert and Storm Guard remains enabled, the system profile exits storm-driven Full Backup and returns to the normal configured profile.
 - The web UI prompts with a confirmation dialog before enabling Storm Guard; once enabled, the profile automatically switches to Full Backup during severe weather alerts and reserves full battery capacity.
 
 ---

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -1520,6 +1520,44 @@ async def test_set_storm_guard_passes_payload_and_xsrf() -> None:
 
 
 @pytest.mark.asyncio
+async def test_opt_out_storm_alert_passes_payload_and_xsrf() -> None:
+    token = _make_token({"user_id": "99"})
+    client = _make_client()
+    client.update_credentials(
+        eauth=token,
+        cookie="XSRF-TOKEN=xsrf-token; other=1",
+    )
+    client._json = AsyncMock(return_value={"message": "success"})
+
+    out = await client.opt_out_storm_alert(alert_id="IDV21037", name="Severe Weather")
+
+    assert out == {"message": "success"}
+    args, kwargs = client._json.await_args
+    assert args[0] == "PUT"
+    assert "stormGuard/" in args[1]
+    assert args[1].endswith("/stormAlert")
+    assert kwargs["json"] == {
+        "stormAlerts": [
+            {"id": "IDV21037", "name": "Severe Weather", "status": "opted-out"}
+        ]
+    }
+    assert kwargs["headers"]["X-XSRF-Token"] == "xsrf-token"
+    assert "params" not in kwargs
+
+
+@pytest.mark.asyncio
+async def test_opt_out_storm_alert_handles_missing_xsrf() -> None:
+    client = _make_client()
+    client.update_credentials(cookie="cookie=1")
+    client._json = AsyncMock(return_value={"message": "success"})
+
+    await client.opt_out_storm_alert(alert_id="IDV21037", name="Severe Weather")
+
+    _args, kwargs = client._json.await_args
+    assert "X-XSRF-Token" not in kwargs["headers"]
+
+
+@pytest.mark.asyncio
 async def test_battery_config_prefers_cookie_bearer_when_it_has_user_id() -> None:
     eauth_token = _make_token({"user_id": "99"})
     cookie_token = _make_token({"user_id": "123"})

--- a/tests/components/enphase_ev/test_api_urls.py
+++ b/tests/components/enphase_ev/test_api_urls.py
@@ -30,6 +30,7 @@ async def test_api_builds_urls_correctly():
     await c.inverters_inventory()
     await c.inverter_status()
     await c.inverter_production(start_date="2022-01-01", end_date="2026-01-01")
+    await c.opt_out_storm_alert(alert_id="IDV21037", name="Severe Weather")
     await c.start_charging(RANDOM_SERIAL, 32, connector_id=1)
     await c.stop_charging(RANDOM_SERIAL)
     await c.trigger_message(RANDOM_SERIAL, "MeterValues")
@@ -61,6 +62,17 @@ async def test_api_builds_urls_correctly():
     assert f"/systems/{RANDOM_SITE_ID}/inverter_status_x.json" in methods_urls[9][1]
     assert methods_urls[10][0] == "GET"
     assert f"/systems/{RANDOM_SITE_ID}/inverter_data_x/energy.json" in methods_urls[10][1]
+    opt_out_call = next(
+        (
+            (method, url)
+            for method, url in methods_urls
+            if f"/service/batteryConfig/api/v1/stormGuard/{RANDOM_SITE_ID}/stormAlert"
+            in url
+        ),
+        None,
+    )
+    assert opt_out_call is not None
+    assert opt_out_call[0] == "PUT"
     # Final three calls should be start/stop/trigger in order, regardless of fallback GETs
     start_call = methods_urls[-3]
     stop_call = methods_urls[-2]
@@ -83,3 +95,19 @@ async def test_api_builds_urls_correctly():
 
     _, _, payload, _ = c.calls[-3]
     assert payload == {"chargingLevel": 32, "connectorId": 1}
+
+    opt_out_payload = next(
+        (
+            payload
+            for method, url, payload, _data in c.calls
+            if method == "PUT"
+            and f"/service/batteryConfig/api/v1/stormGuard/{RANDOM_SITE_ID}/stormAlert"
+            in url
+        ),
+        None,
+    )
+    assert opt_out_payload == {
+        "stormAlerts": [
+            {"id": "IDV21037", "name": "Severe Weather", "status": "opted-out"}
+        ]
+    }

--- a/tests/components/enphase_ev/test_buttons_and_fast.py
+++ b/tests/components/enphase_ev/test_buttons_and_fast.py
@@ -442,6 +442,7 @@ async def test_button_platform_async_setup_entry_filters_known_serials(
     from custom_components.enphase_ev.button import (
         CancelPendingProfileChangeButton,
         RequestGridToggleOtpButton,
+        StormAlertOptOutButton,
         StartChargeButton,
         StopChargeButton,
         async_setup_entry,
@@ -469,6 +470,7 @@ async def test_button_platform_async_setup_entry_filters_known_serials(
     assert len(added) == 2
     assert isinstance(added[0][0], CancelPendingProfileChangeButton)
     assert isinstance(added[0][1], RequestGridToggleOtpButton)
+    assert isinstance(added[0][2], StormAlertOptOutButton)
     start_entity, stop_entity = added[1]
     assert isinstance(start_entity, StartChargeButton)
     assert isinstance(stop_entity, StopChargeButton)
@@ -597,6 +599,59 @@ async def test_request_grid_toggle_otp_button(hass, monkeypatch) -> None:
     assert button.available is False
 
 
+@pytest.mark.asyncio
+async def test_storm_alert_opt_out_button(hass, monkeypatch) -> None:
+    from custom_components.enphase_ev.button import StormAlertOptOutButton
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+
+    cfg = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 30,
+    }
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    coord = EnphaseCoordinator(hass, cfg)
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "type_label": "Gateway",
+                "count": 1,
+                "devices": [{"name": "IQ Gateway"}],
+            },
+            "encharge": {
+                "type_key": "encharge",
+                "type_label": "Battery",
+                "count": 1,
+                "devices": [{"name": "Battery"}],
+            },
+        },
+        ["envoy", "encharge"],
+    )
+    coord.async_opt_out_all_storm_alerts = AsyncMock()
+
+    button = StormAlertOptOutButton(coord)
+    assert button.available is True
+    await button.async_press()
+    coord.async_opt_out_all_storm_alerts.assert_awaited_once()
+
+    coord._battery_show_storm_guard = False  # noqa: SLF001
+    assert button.available is False
+
+
 def test_request_grid_toggle_otp_button_availability_guards() -> None:
     from custom_components.enphase_ev.button import RequestGridToggleOtpButton
 
@@ -620,3 +675,68 @@ def test_request_grid_toggle_otp_button_availability_guards() -> None:
     coord.battery_has_encharge = True
     coord.has_type = lambda _key: False
     assert button.available is False
+
+
+def test_storm_alert_opt_out_button_availability_guards() -> None:
+    from custom_components.enphase_ev.button import StormAlertOptOutButton
+
+    coord = SimpleNamespace(
+        site_id="site",
+        last_update_success=False,
+        battery_has_encharge=True,
+        battery_has_enpower=True,
+        battery_show_storm_guard=True,
+        has_type=lambda key: key == "envoy",
+    )
+    button = StormAlertOptOutButton(coord)
+    assert button.available is False
+
+    coord.last_update_success = True
+    assert button.available is True
+
+    coord.battery_show_storm_guard = False
+    assert button.available is False
+
+    coord.battery_show_storm_guard = True
+    coord.has_type = lambda _key: False
+    assert button.available is False
+
+
+def test_storm_alert_opt_out_button_device_info_fallback() -> None:
+    from custom_components.enphase_ev.button import StormAlertOptOutButton
+
+    coord = SimpleNamespace(
+        site_id="site",
+        last_update_success=True,
+        battery_has_encharge=True,
+        battery_has_enpower=True,
+        battery_show_storm_guard=True,
+        has_type=lambda key: key == "envoy",
+    )
+    button = StormAlertOptOutButton(coord)
+    info = button.device_info
+
+    assert info["identifiers"] == {("enphase_ev", "type:site:envoy")}
+    assert info["manufacturer"] == "Enphase"
+
+
+def test_storm_alert_opt_out_button_device_info_prefers_type_info() -> None:
+    from custom_components.enphase_ev.button import StormAlertOptOutButton
+
+    expected = {
+        "identifiers": {("enphase_ev", "type:site:envoy")},
+        "manufacturer": "Enphase",
+        "name": "IQ Gateway",
+    }
+    coord = SimpleNamespace(
+        site_id="site",
+        last_update_success=True,
+        battery_has_encharge=True,
+        battery_has_enpower=True,
+        battery_show_storm_guard=True,
+        has_type=lambda key: key == "envoy",
+        type_device_info=lambda key: expected if key == "envoy" else None,
+    )
+    button = StormAlertOptOutButton(coord)
+
+    assert button.device_info is expected

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -7,7 +7,7 @@ import time
 from collections import deque
 from datetime import datetime, timedelta, timezone
 from types import MappingProxyType, SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import aiohttp
 import pytest
@@ -2128,6 +2128,74 @@ async def test_refresh_storm_alert_parses_payload(coordinator_factory):
     assert coord.storm_alerts[0]["type"] == "wind"
     assert coord.storm_alerts[1]["value"] == "legacy-alert"
 
+    coord.client.storm_guard_alert = AsyncMock(
+        return_value={
+            "criticalAlertActive": False,
+            "stormAlerts": [
+                {"id": "IDV21037", "name": "Severe Weather", "status": "active"},
+            ],
+        }
+    )
+    await coord._async_refresh_storm_alert(force=True)  # noqa: SLF001
+    assert coord.storm_alert_active is True
+    assert coord.storm_alerts[0]["status"] == "active"
+
+    coord.client.storm_guard_alert = AsyncMock(
+        return_value={
+            "criticalAlertActive": False,
+            "stormAlerts": [
+                {"id": "IDV21037", "name": "Severe Weather", "status": "opted-out"},
+            ],
+        }
+    )
+    await coord._async_refresh_storm_alert(force=True)  # noqa: SLF001
+    assert coord.storm_alert_active is False
+    assert coord.storm_alerts[0]["status"] == "opted-out"
+
+    coord.client.storm_guard_alert = AsyncMock(
+        return_value={
+            "stormAlerts": [
+                {"id": "IDV21037", "name": "Severe Weather", "status": "   "},
+            ]
+        }
+    )
+    await coord._async_refresh_storm_alert(force=True)  # noqa: SLF001
+    assert coord.storm_alert_active is True
+
+    coord.client.storm_guard_alert = AsyncMock(
+        return_value={
+            "criticalAlertActive": True,
+            "stormAlerts": [
+                {"id": "IDV21037", "name": "Severe Weather", "active": False},
+            ],
+        }
+    )
+    await coord._async_refresh_storm_alert(force=True)  # noqa: SLF001
+    assert coord.storm_alert_active is True
+    assert coord.storm_alerts[0]["active"] is False
+
+    coord.client.storm_guard_alert = AsyncMock(
+        return_value={
+            "criticalAlertActive": False,
+            "stormAlerts": [
+                {"id": "IDV21037", "name": "Severe Weather", "active": False},
+            ],
+        }
+    )
+    await coord._async_refresh_storm_alert(force=True)  # noqa: SLF001
+    assert coord.storm_alert_active is False
+
+    coord.client.storm_guard_alert = AsyncMock(
+        return_value={
+            "criticalAlertActive": False,
+            "stormAlerts": [
+                {"id": "IDV21037", "name": "Severe Weather", "status": "inactive"},
+            ],
+        }
+    )
+    await coord._async_refresh_storm_alert(force=True)  # noqa: SLF001
+    assert coord.storm_alert_active is False
+
     class BadStr:
         def __str__(self) -> str:
             raise ValueError("boom")
@@ -2145,6 +2213,208 @@ async def test_refresh_storm_alert_parses_payload(coordinator_factory):
     assert coord.storm_alerts[0]["custom"] == "value"
     assert coord.storm_alerts[1]["active"] is True
     assert coord.storm_alerts[2]["active"] is True
+
+
+@pytest.mark.asyncio
+async def test_async_opt_out_all_storm_alerts_no_active_is_noop(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.client.storm_guard_alert = AsyncMock(
+        return_value={
+            "stormAlerts": [
+                {"id": "IDV21037", "name": "Severe Weather", "status": "opted-out"}
+            ]
+        }
+    )
+    coord.client.opt_out_storm_alert = AsyncMock(return_value={"message": "success"})
+    coord.kick_fast = MagicMock()
+    coord.async_request_refresh = AsyncMock()
+
+    await coord.async_opt_out_all_storm_alerts()
+
+    coord.client.storm_guard_alert.assert_awaited_once()
+    coord.client.opt_out_storm_alert.assert_not_awaited()
+    coord.kick_fast.assert_not_called()
+    coord.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_opt_out_all_storm_alerts_targets_active_alerts(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.client.storm_guard_alert = AsyncMock(
+        side_effect=[
+            {
+                "stormAlerts": [
+                    {"id": "IDV21037", "name": "Severe Weather", "status": "active"},
+                    {"id": "IDV21038", "name": "Flood Warning"},
+                    {"id": "IDV21037", "name": "Duplicate", "status": "active"},
+                    {"id": "IDV21039", "name": "Wind", "status": "opted_out"},
+                    {"id": "IDV21040", "name": "Cleared", "status": "inactive"},
+                ]
+            },
+            {"stormAlerts": []},
+        ]
+    )
+    coord.client.opt_out_storm_alert = AsyncMock(return_value={"message": "success"})
+    coord.kick_fast = MagicMock()
+    coord.async_request_refresh = AsyncMock()
+
+    await coord.async_opt_out_all_storm_alerts()
+
+    assert coord.client.opt_out_storm_alert.await_args_list == [
+        call(alert_id="IDV21037", name="Severe Weather"),
+        call(alert_id="IDV21038", name="Flood Warning"),
+    ]
+    assert coord.client.storm_guard_alert.await_count == 2
+    coord.kick_fast.assert_called_once_with(FAST_TOGGLE_POLL_HOLD_S)
+    coord.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_opt_out_all_storm_alerts_requires_client_method(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.client.storm_guard_alert = AsyncMock(
+        return_value={
+            "stormAlerts": [
+                {"id": "IDV21037", "name": "Severe Weather", "status": "active"}
+            ]
+        }
+    )
+    coord.client.opt_out_storm_alert = None
+
+    with pytest.raises(
+        ServiceValidationError, match="Storm Alert opt-out is unavailable."
+    ):
+        await coord.async_opt_out_all_storm_alerts()
+
+
+@pytest.mark.asyncio
+async def test_async_opt_out_all_storm_alerts_skips_non_dict_and_active_false(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord._async_refresh_storm_alert = AsyncMock()  # noqa: SLF001
+    coord.client.opt_out_storm_alert = AsyncMock(return_value={"message": "success"})
+    coord.kick_fast = MagicMock()
+    coord.async_request_refresh = AsyncMock()
+
+    monkeypatch.setattr(
+        EnphaseCoordinator,
+        "storm_alerts",
+        property(
+            lambda _self: [
+                1,
+                {"id": "IDV21037", "active": False},
+                {"id": "IDV21038", "name": "Flood Warning"},
+            ]
+        ),
+    )
+
+    await coord.async_opt_out_all_storm_alerts()
+
+    coord.client.opt_out_storm_alert.assert_awaited_once_with(
+        alert_id="IDV21038", name="Flood Warning"
+    )
+    coord.kick_fast.assert_called_once_with(FAST_TOGGLE_POLL_HOLD_S)
+    coord.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_opt_out_all_storm_alerts_partial_failure_raises(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.client.storm_guard_alert = AsyncMock(
+        side_effect=[
+            {
+                "stormAlerts": [
+                    {"id": "IDV21037", "name": "Severe Weather", "status": "active"},
+                    {"id": "IDV21038", "name": "Flood Warning", "status": "active"},
+                ]
+            },
+            {"stormAlerts": []},
+        ]
+    )
+    coord.client.opt_out_storm_alert = AsyncMock(
+        side_effect=[RuntimeError("boom"), {"message": "success"}]
+    )
+    coord.kick_fast = MagicMock()
+    coord.async_request_refresh = AsyncMock()
+
+    with pytest.raises(
+        ServiceValidationError, match=r"Storm Alert opt-out failed for 1 alert\(s\)\."
+    ):
+        await coord.async_opt_out_all_storm_alerts()
+
+    assert coord.client.opt_out_storm_alert.await_count == 2
+    assert coord.client.storm_guard_alert.await_count == 2
+    coord.kick_fast.assert_called_once_with(FAST_TOGGLE_POLL_HOLD_S)
+    coord.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_opt_out_all_storm_alerts_failure_not_masked_by_refresh_error(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.client.storm_guard_alert = AsyncMock(
+        side_effect=[
+            {
+                "stormAlerts": [
+                    {"id": "IDV21037", "name": "Severe Weather", "status": "active"},
+                ]
+            },
+            RuntimeError("refresh"),
+        ]
+    )
+    coord.client.opt_out_storm_alert = AsyncMock(side_effect=RuntimeError("boom"))
+    coord.kick_fast = MagicMock()
+    coord.async_request_refresh = AsyncMock()
+
+    with pytest.raises(
+        ServiceValidationError, match=r"Storm Alert opt-out failed for 1 alert\(s\)\."
+    ):
+        await coord.async_opt_out_all_storm_alerts()
+
+    assert coord.client.storm_guard_alert.await_count == 2
+    coord.kick_fast.assert_not_called()
+    coord.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_opt_out_all_storm_alerts_refresh_error_raised_when_no_failures(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.client.storm_guard_alert = AsyncMock(
+        side_effect=[
+            {
+                "stormAlerts": [
+                    {"id": "IDV21037", "name": "Severe Weather", "status": "active"},
+                ]
+            },
+            RuntimeError("refresh"),
+        ]
+    )
+    coord.client.opt_out_storm_alert = AsyncMock(return_value={"message": "success"})
+    coord.kick_fast = MagicMock()
+    coord.async_request_refresh = AsyncMock()
+
+    with pytest.raises(RuntimeError, match="refresh"):
+        await coord.async_opt_out_all_storm_alerts()
+
+    coord.kick_fast.assert_not_called()
+    coord.async_request_refresh.assert_not_awaited()
+
+
+def test_storm_alert_status_is_inactive_none_returns_false(coordinator_factory) -> None:
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    assert coord._storm_alert_status_is_inactive(None) is False  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -47,6 +47,7 @@ def test_battery_profile_strings_localized_for_non_english_locales() -> None:
         "entity.sensor.system_profile_status.name",
         "entity.sensor.system_profile_status.state.pending",
         "entity.button.cancel_pending_profile_change.name",
+        "entity.button.storm_alert_opt_out.name",
         "issues.battery_profile_pending.title",
         "issues.battery_profile_pending.description",
     ]


### PR DESCRIPTION
## Summary
- Add an IQ Gateway `Storm Alert Opt Out` button that bulk-opt-outs all active (non-opted-out) storm alerts, no-ops when none are active, and sends one request per alert.
- Add API and coordinator support for storm-alert opt-out, including dedupe-by-id, mixed payload compatibility, cache invalidation, and consolidated partial-failure handling.
- Improve Storm Alert diagnostic sensor accuracy by deriving `Active` from non-opted-out alerts while honoring explicit `active` flags and additional inactive statuses.
- Update API docs/changelog and add regression coverage for API URL/method/payload, coordinator edge cases, button registration/availability, and translation key enforcement.

## Testing
- `docker exec ha_pr_gate bash -lc 'cd /workspace && ruff check .'`
- `docker exec ha_pr_gate bash -lc 'cd /workspace && python3 -m pre_commit run --all-files'`
- `docker exec ha_pr_gate bash -lc 'cd /workspace && python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/button.py --fail-under=100'`
- `docker exec ha_pr_gate bash -lc 'cd /workspace && pytest tests/components/enphase_ev/test_service_translations.py -q'`
- `docker exec ha_pr_gate bash -lc 'cd /workspace && pytest tests/components/enphase_ev -q'`
- `docker exec ha_pr_gate bash -lc 'cd /workspace && pytest -q'`
