### PR TITLE
Fix stuck System Profile Status pending state and release v2.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,36 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
-- Added an IQ Gateway `Storm Alert Opt Out` button that bulk-opt-outs all active (non-opted-out) Storm Guard alerts with one request per alert and no-ops when no active alerts exist.
+- None
 
 ### 🐛 Bug fixes
 - None
 
 ### 🔧 Improvements
-- Improved Storm Alert diagnostic sensor accuracy so `Active` reflects alerts that are not opted out, including robust handling of mixed/legacy alert payload shapes.
+- None
 
 ### 🔄 Other changes
 - None
+
+## v2.0.3 - 2026-02-24
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Added an IQ Gateway `Storm Alert Opt Out` button that bulk-opt-outs all active (non-opted-out) Storm Guard alerts with one request per alert and no-ops when no active alerts exist.
+
+### 🐛 Bug fixes
+- Fixed `System Profile Status` getting stuck on `Updating...` after cloud-side profile convergence by reducing stale cache effects during pending profile updates.
+- Fixed pending profile resolution by clearing pending state from both storm-guard profile and battery settings payload convergence paths.
+- Fixed pending profile matching for `select`-driven system-profile changes to clear once the effective profile matches, even when backend reserve/subtype echo differs.
+
+### 🔧 Improvements
+- Improved Storm Alert diagnostic sensor accuracy so `Active` reflects alerts that are not opted out, including robust handling of mixed/legacy alert payload shapes.
+- Added pending-profile debug visibility with `pending_requires_exact_settings` on `system_profile_status` attributes.
+
+### 🔄 Other changes
+- Added regression coverage for pending-profile cache bypass and convergence clearing paths.
 
 ## v2.0.2 - 2026-02-23
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -476,6 +476,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._battery_pending_reserve: int | None = None
         self._battery_pending_sub_type: str | None = None
         self._battery_pending_requested_at: datetime | None = None
+        self._battery_pending_require_exact_settings: bool = True
         self._battery_profile_reserve_memory: dict[str, int] = dict(
             BATTERY_PROFILE_DEFAULT_RESERVE
         )
@@ -6135,6 +6136,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._battery_pending_reserve = None
         self._battery_pending_sub_type = None
         self._battery_pending_requested_at = None
+        self._battery_pending_require_exact_settings = True
         self._sync_battery_profile_pending_issue()
 
     def _set_battery_pending(
@@ -6143,6 +6145,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         profile: str,
         reserve: int,
         sub_type: str | None,
+        require_exact_settings: bool = True,
     ) -> None:
         self._battery_pending_profile = profile
         self._battery_pending_reserve = reserve
@@ -6152,6 +6155,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             else None
         )
         self._battery_pending_requested_at = dt_util.utcnow()
+        self._battery_pending_require_exact_settings = bool(require_exact_settings)
         self._sync_battery_profile_pending_issue()
 
     def _assert_battery_profile_write_allowed(self) -> None:
@@ -6191,6 +6195,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             return False
         if self._battery_profile != pending_profile:
             return False
+        if not getattr(self, "_battery_pending_require_exact_settings", True):
+            return True
         if self._battery_pending_reserve is not None:
             if self._battery_backup_percentage != self._battery_pending_reserve:
                 return False
@@ -6392,6 +6398,17 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     settings_reserve,
                 )
             )
+            self._remember_battery_reserve(
+                settings_profile or self._battery_profile,
+                self._battery_backup_percentage,
+            )
+        settings_subtype = self._normalize_battery_sub_type(
+            data.get("operationModeSubType")
+        )
+        if settings_subtype is not None:
+            self._battery_operation_mode_sub_type = settings_subtype
+        elif (settings_profile or self._battery_profile) != "cost_savings":
+            self._battery_operation_mode_sub_type = None
         storm_state = self._normalize_storm_guard_state(data.get("stormGuardState"))
         if storm_state is not None:
             self._storm_guard_state = storm_state
@@ -6405,6 +6422,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 )
                 if use_battery is not None:
                     self._battery_use_battery_for_self_consumption = use_battery
+
+        if self._effective_profile_matches_pending():
+            self._clear_battery_pending()
 
     def _parse_battery_site_settings(self, payload: object) -> None:
         if not isinstance(payload, dict):
@@ -6583,6 +6603,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         profile: str,
         reserve: int,
         sub_type: str | None = None,
+        require_exact_pending_match: bool = True,
     ) -> None:
         self._assert_battery_profile_write_allowed()
         normalized_profile = self._normalize_battery_profile_key(profile)
@@ -6626,8 +6647,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             profile=normalized_profile,
             reserve=normalized_reserve,
             sub_type=normalized_sub_type,
+            require_exact_settings=require_exact_pending_match,
         )
         self._storm_guard_cache_until = None
+        self._battery_settings_cache_until = None
         self.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
         await self.async_request_refresh()
 
@@ -6821,7 +6844,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     async def _async_refresh_battery_settings(self, *, force: bool = False) -> None:
         now = time.monotonic()
-        if not force and self._battery_settings_cache_until:
+        pending_profile = getattr(self, "_battery_pending_profile", None)
+        if not force and not pending_profile and self._battery_settings_cache_until:
             if now < self._battery_settings_cache_until:
                 return
         fetcher = getattr(self.client, "battery_settings_details", None)
@@ -6913,6 +6937,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             profile=profile,
             reserve=reserve,
             sub_type=sub_type,
+            require_exact_pending_match=False,
         )
 
     async def async_set_battery_reserve(self, reserve: int) -> None:
@@ -7215,7 +7240,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     async def _async_refresh_storm_guard_profile(self, *, force: bool = False) -> None:
         now = time.monotonic()
-        if not force and self._storm_guard_cache_until:
+        pending_profile = getattr(self, "_battery_pending_profile", None)
+        if not force and not pending_profile and self._storm_guard_cache_until:
             if now < self._storm_guard_cache_until:
                 return
         locale = None

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.0.2"
+  "version": "2.0.3"
 }

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -4668,6 +4668,9 @@ class EnphaseSystemProfileStatusSensor(_SiteBaseEntity):
             "requested_reserve_percentage": self._coord.battery_pending_backup_percentage,
             "requested_operation_mode_sub_type": self._coord.battery_pending_operation_mode_sub_type,
             "pending": self._coord.battery_profile_pending,
+            "pending_requires_exact_settings": getattr(
+                self._coord, "_battery_pending_require_exact_settings", None
+            ),
             "pending_requested_at": (
                 self._coord.battery_pending_requested_at.isoformat()
                 if self._coord.battery_pending_requested_at

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -2104,6 +2104,12 @@ async def test_refresh_storm_guard_profile_caches(coordinator_factory):
     await coord._async_refresh_storm_guard_profile()  # noqa: SLF001
     coord.client.storm_guard_profile.assert_awaited_once()
 
+    coord._battery_pending_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_pending_reserve = 20  # noqa: SLF001
+    coord._battery_pending_requested_at = datetime.now(timezone.utc)  # noqa: SLF001
+    await coord._async_refresh_storm_guard_profile()  # noqa: SLF001
+    assert coord.client.storm_guard_profile.await_count == 2
+
 
 @pytest.mark.asyncio
 async def test_refresh_storm_alert_parses_payload(coordinator_factory):

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -111,6 +111,7 @@ async def test_set_system_profile_uses_remembered_reserve(coordinator_factory) -
     assert kwargs["battery_backup_percentage"] == 35
     assert coord.battery_pending_profile == "cost_savings"
     assert coord.battery_pending_backup_percentage == 35
+    assert coord._battery_pending_require_exact_settings is False  # noqa: SLF001
 
     # Unknown regional profile should remain selectable as passthrough.
     coord.client.set_battery_profile.reset_mock()
@@ -155,6 +156,7 @@ async def test_savings_subtype_payload_on_and_off(coordinator_factory) -> None:
     await coord.async_set_savings_use_battery_after_peak(True)
     kwargs = coord.client.set_battery_profile.await_args.kwargs
     assert kwargs["operation_mode_sub_type"] == "prioritize-energy"
+    assert coord._battery_pending_require_exact_settings is True  # noqa: SLF001
 
     coord.client.set_battery_profile.reset_mock()
     coord._battery_profile_last_write_mono = time.monotonic() - 10  # noqa: SLF001
@@ -844,6 +846,18 @@ async def test_battery_profile_setter_validation_and_fallbacks(
     await coord.async_set_savings_use_battery_after_peak(True)
     kwargs = coord.client.set_battery_profile.await_args.kwargs
     assert kwargs["battery_backup_percentage"] == 20
+
+
+def test_profile_only_pending_match_allows_reserve_drift(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord._battery_pending_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_pending_reserve = 20  # noqa: SLF001
+    coord._battery_pending_sub_type = None  # noqa: SLF001
+    coord._battery_pending_require_exact_settings = False  # noqa: SLF001
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_backup_percentage = 45  # noqa: SLF001
+
+    assert coord._effective_profile_matches_pending() is True  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_battery_settings.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_settings.py
@@ -56,6 +56,32 @@ def test_parse_battery_settings_payload_maps_mode_and_controls(
     assert coord.battery_use_battery_for_self_consumption is True
 
 
+def test_parse_battery_settings_payload_clears_pending_when_matching(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_pending_profile = "cost_savings"  # noqa: SLF001
+    coord._battery_pending_reserve = 20  # noqa: SLF001
+    coord._battery_pending_sub_type = "prioritize-energy"  # noqa: SLF001
+    coord._battery_pending_requested_at = datetime.now(timezone.utc)  # noqa: SLF001
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_backup_percentage = 35  # noqa: SLF001
+    coord._battery_operation_mode_sub_type = None  # noqa: SLF001
+
+    coord._parse_battery_settings_payload(  # noqa: SLF001
+        {
+            "data": {
+                "profile": "cost_savings",
+                "batteryBackupPercentage": 20,
+                "operationModeSubType": "prioritize-energy",
+            }
+        }
+    )
+
+    assert coord.battery_profile_pending is False
+    assert coord.battery_pending_profile is None
+
+
 def test_battery_soc_min_floor_applies_to_reserve_and_shutdown(
     coordinator_factory,
 ) -> None:
@@ -116,6 +142,32 @@ async def test_refresh_battery_settings_caches_and_redacts(coordinator_factory) 
     coord.client.battery_settings_details.reset_mock()
     await coord._async_refresh_battery_settings()  # noqa: SLF001
     coord.client.battery_settings_details.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_battery_settings_bypasses_cache_when_profile_pending(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_settings_cache_until = time.monotonic() + 300  # noqa: SLF001
+    coord._battery_pending_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_pending_reserve = 20  # noqa: SLF001
+    coord._battery_pending_requested_at = datetime.now(timezone.utc)  # noqa: SLF001
+    coord._battery_profile = "backup_only"  # noqa: SLF001
+    coord._battery_backup_percentage = 100  # noqa: SLF001
+    coord.client.battery_settings_details = AsyncMock(
+        return_value={
+            "data": {
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 20,
+            }
+        }
+    )
+
+    await coord._async_refresh_battery_settings()  # noqa: SLF001
+
+    coord.client.battery_settings_details.assert_awaited_once()
+    assert coord.battery_profile_pending is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fix System Profile Status pending-state convergence so profile changes stop showing `Updating...` once the effective profile matches.
- Bypass stale BatteryConfig cache windows while a profile update is pending and clear pending from both storm-guard profile and battery settings payload convergence paths.
- Add regression tests for pending cache bypass and convergence behavior, expose `pending_requires_exact_settings` diagnostic attribute, and prepare release metadata for `v2.0.3`.

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/sensor.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
