### PR TITLE
Merge dry contacts into IQ Gateway diagnostics sensor

### DIFF
--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -353,7 +353,11 @@ async def async_setup_entry(
                 EnphaseSystemControllerInventorySensor(coord),
             )
             dry_contacts_present = _gateway_dry_contact_present()
-            if dry_contacts_present is True or not inventory_ready:
+            if (
+                dry_contacts_present is True
+                or dry_contacts_present is None
+                or not inventory_ready
+            ):
                 _add_site_entity(
                     "dry_contacts_inventory",
                     EnphaseDryContactsInventorySensor(coord),

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -3288,6 +3288,7 @@ async def test_async_setup_entry_keeps_gateway_meters_when_meter_detection_error
     hass, config_entry, coordinator_factory
 ) -> None:
     from custom_components.enphase_ev.sensor import (
+        EnphaseDryContactsInventorySensor,
         EnphaseGatewayConsumptionMeterSensor,
         EnphaseGatewayProductionMeterSensor,
         async_setup_entry,
@@ -3309,8 +3310,43 @@ async def test_async_setup_entry_keeps_gateway_meters_when_meter_detection_error
 
     await async_setup_entry(hass, config_entry, _capture)
 
+    assert any(isinstance(ent, EnphaseDryContactsInventorySensor) for ent in added)
     assert any(isinstance(ent, EnphaseGatewayProductionMeterSensor) for ent in added)
     assert any(isinstance(ent, EnphaseGatewayConsumptionMeterSensor) for ent in added)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_dry_contacts_when_inventory_ready_and_absent(
+    hass, config_entry, coordinator_factory
+) -> None:
+    from custom_components.enphase_ev.sensor import (
+        EnphaseDryContactsInventorySensor,
+        async_setup_entry,
+    )
+
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "type_label": "Gateway",
+                "count": 1,
+                "devices": [{"name": "System Controller", "channel_type": "enpower"}],
+            }
+        },
+        ["envoy"],
+    )
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    added: list[Any] = []
+
+    def _capture(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _capture)
+
+    assert not any(isinstance(ent, EnphaseDryContactsInventorySensor) for ent in added)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add a consolidated `Dry Contacts` diagnostic sensor under the IQ Gateway/System Controller device context instead of separate dry-contact type inventory devices.
- Make dry-contact aggregation deterministic and robust for multi-contact sites (stable ordering, improved dedupe identity/fingerprint fallback, and stable status output).
- Add per-contact diagnostics attributes (`contacts` entries with properties plus visible/enabled/in-use counts) and expand tests for edge cases, pruning behavior, and multi-contact scenarios.

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_sensor_additional_coverage.py -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_sensors.py -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/sensor.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
