### PR TITLE
Prepare v2.1.1 release and disable firmware version checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,29 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🔧 Improvements
-- Avoid creating site lifetime energy sensors for Heat Pump and Water Heater when those device channels are not available for the site, preventing permanently unavailable entities.
+- None
+
+### 🔄 Other changes
+- None
+
+## v2.1.1 - 2026-03-02
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Added firmware catalog discovery and firmware update entities for IQ Gateway and Microinverter firmware tracking.
+- Added region-specific firmware catalog routing so release metadata resolves correctly across locales/countries.
+- Merged dry-contact details into the IQ Gateway diagnostics sensor payload.
+
+### 🐛 Bug fixes
+- Fixed Heat Pump power becoming unavailable when HEMS pointers do not align with site payload paths.
+- Handled HEMS power `422 date-validation` responses gracefully to preserve sensor availability.
+- Fixed Heat Pump sensor labels across all shipped locale files.
+
+### 🔧 Improvements
+- Avoid creating Heat Pump and Water Heater site lifetime-energy sensors when those channels are not available for the site.
+- Disabled firmware version checks in the integration by default (firmware catalog/update code remains in place for re-enable later).
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -40,6 +40,10 @@ if cv is not None:
 else:  # pragma: no cover - fallback for non-HA unit test imports
     CONFIG_SCHEMA = {}
 
+# Keep firmware catalog/update implementation in-tree, but disable exposing
+# firmware version checks in the integration for now.
+_ENABLE_FIRMWARE_VERSION_CHECKS = False
+
 PLATFORMS: list[str] = [
     "sensor",
     "binary_sensor",
@@ -49,7 +53,7 @@ PLATFORMS: list[str] = [
     "switch",
     "time",
     "calendar",
-    "update",
+    *(["update"] if _ENABLE_FIRMWARE_VERSION_CHECKS else []),
 ]
 
 _LEGACY_GATEWAY_TYPE_KEYS: tuple[str, ...] = ("meter", "enpower")

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.1.0"
+  "version": "2.1.1"
 }

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -145,8 +145,8 @@ def _catalog_payload() -> dict:
     }
 
 
-def test_platform_registers_update() -> None:
-    assert "update" in PLATFORMS
+def test_platform_disables_update_by_default() -> None:
+    assert "update" not in PLATFORMS
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- disable firmware version checks by default while keeping firmware catalog/update implementation in place
- bump integration manifest version to `2.1.1`
- add `v2.1.1` changelog entries for all changes since `v2.1.0`
- update update-platform test expectation to match disabled firmware checks

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/__init__.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
