### PR TITLE
Prune runtime caches and harden unload cleanup

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -878,10 +878,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> 
         coord = get_runtime_data(entry).coordinator
     except RuntimeError:
         pass
-    if coord is not None and hasattr(coord, "schedule_sync"):
-        await coord.schedule_sync.async_stop()
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
     if unload_ok:
+        if coord is not None and hasattr(coord, "schedule_sync"):
+            await coord.schedule_sync.async_stop()
+        if coord is not None and hasattr(coord, "cleanup_runtime_state"):
+            coord.cleanup_runtime_state()
         entry.runtime_data = None
         loaded_state = getattr(ConfigEntryState, "LOADED", None)
         has_loaded_entries = any(

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -112,6 +112,7 @@ from .device_info_helpers import _is_redundant_model_id
 from .energy import EnergyManager
 from .session_history import (
     MIN_SESSION_HISTORY_CACHE_TTL,
+    SESSION_HISTORY_CACHE_DAY_RETENTION,
     SESSION_HISTORY_CONCURRENCY,
     SESSION_HISTORY_FAILURE_BACKOFF_S,
     SessionHistoryManager,
@@ -416,6 +417,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._session_history_cache_ttl_value = max(
             MIN_SESSION_HISTORY_CACHE_TTL, self._session_history_interval_min * 60
         )
+        self._session_history_day_retention = SESSION_HISTORY_CACHE_DAY_RETENTION
         # Per-serial operating voltage learned from summary v2; used for power estimation
         self._operating_v: dict[str, int] = {}
         # Temporary fast polling window after user actions (start/stop/etc.)
@@ -763,6 +765,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             local_dt = dt_util.as_local(day_ref)
         day_key = local_dt.strftime("%Y-%m-%d")
         cache_key = (str(sn), day_key)
+        tracked_serials = set(self.iter_serials())
+        tracked_serials.add(str(sn))
+        self._prune_session_history_cache_shim(
+            active_serials=tracked_serials,
+            keep_day_keys={day_key},
+        )
         cached = self._session_history_cache_shim.get(cache_key)
         ttl = self._session_history_cache_ttl or MIN_SESSION_HISTORY_CACHE_TTL
         if cached:
@@ -775,8 +783,145 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             )
         else:
             sessions = []
-        self._session_history_cache_shim[cache_key] = (time.monotonic(), sessions)
+        self._set_session_history_cache_shim_entry(str(sn), day_key, sessions)
         return sessions
+
+    @staticmethod
+    def _normalize_serials(serials: Iterable[str] | None) -> set[str]:
+        normalized: set[str] = set()
+        if serials is None:
+            return normalized
+        for serial in serials:
+            if serial is None:
+                continue
+            try:
+                sn = str(serial).strip()
+            except Exception:  # noqa: BLE001
+                continue
+            if sn:
+                normalized.add(sn)
+        return normalized
+
+    def _retained_session_history_days(
+        self, keep_day_keys: Iterable[str] | None = None
+    ) -> set[str]:
+        retained = {
+            str(day_key).strip()
+            for day_key in keep_day_keys or ()
+            if day_key is not None and str(day_key).strip()
+        }
+        try:
+            now_local = dt_util.as_local(dt_util.now())
+        except Exception:
+            now_local = datetime.now(tz=_tz.utc)
+        day_retention = max(1, int(getattr(self, "_session_history_day_retention", 1)))
+        for day_offset in range(day_retention):
+            retained.add((now_local - timedelta(days=day_offset)).strftime("%Y-%m-%d"))
+        return retained
+
+    def _prune_session_history_cache_shim(
+        self,
+        *,
+        active_serials: Iterable[str] | None,
+        keep_day_keys: Iterable[str] | None = None,
+    ) -> None:
+        if not isinstance(getattr(self, "_session_history_cache_shim", None), dict):
+            self._session_history_cache_shim = {}
+            return
+
+        active_set = (
+            None if active_serials is None else self._normalize_serials(active_serials)
+        )
+        retained_days = self._retained_session_history_days(keep_day_keys)
+        self._session_history_cache_shim = {
+            (sn, day_key): entry
+            for (sn, day_key), entry in self._session_history_cache_shim.items()
+            if day_key in retained_days and (active_set is None or sn in active_set)
+        }
+
+    def _set_session_history_cache_shim_entry(
+        self,
+        serial: str,
+        day_key: str,
+        sessions: list[dict],
+    ) -> None:
+        self._session_history_cache_shim[(serial, day_key)] = (
+            time.monotonic(),
+            sessions,
+        )
+        keep_serials = self._normalize_serials(self.iter_serials())
+        keep_serials.add(serial)
+        self._prune_session_history_cache_shim(
+            active_serials=keep_serials,
+            keep_day_keys={day_key},
+        )
+
+    def _prune_serial_runtime_state(self, active_serials: Iterable[str]) -> set[str]:
+        keep_serials = self._normalize_serials(active_serials)
+        keep_serials.update(
+            self._normalize_serials(getattr(self, "_configured_serials", ()))
+        )
+
+        if isinstance(getattr(self, "serials", None), set):
+            self.serials.intersection_update(keep_serials)
+        else:
+            self.serials = set(keep_serials)
+
+        serial_order = getattr(self, "_serial_order", None)
+        if isinstance(serial_order, list):
+            self._serial_order = [sn for sn in serial_order if sn in keep_serials]
+        else:
+            self._serial_order = [sn for sn in keep_serials]
+
+        for attr_name in (
+            "last_set_amps",
+            "_operating_v",
+            "_charge_mode_cache",
+            "_green_battery_cache",
+            "_auth_settings_cache",
+            "_last_charging",
+            "_last_actual_charging",
+            "_pending_charging",
+            "_desired_charging",
+            "_auto_resume_attempts",
+            "_session_end_fix",
+            "_streaming_targets",
+        ):
+            cache = getattr(self, attr_name, None)
+            if not isinstance(cache, dict):
+                continue
+            for key in list(cache):
+                key_sn = str(key).strip()
+                if key_sn not in keep_serials:
+                    cache.pop(key, None)
+
+        return keep_serials
+
+    def _prune_runtime_caches(
+        self,
+        *,
+        active_serials: Iterable[str],
+        keep_day_keys: Iterable[str] | None = None,
+    ) -> None:
+        keep_serials = self._prune_serial_runtime_state(active_serials)
+        self._prune_session_history_cache_shim(
+            active_serials=keep_serials,
+            keep_day_keys=keep_day_keys,
+        )
+        session_manager = getattr(self, "session_history", None)
+        if session_manager is not None and hasattr(session_manager, "prune"):
+            session_manager.prune(
+                active_serials=keep_serials,
+                keep_day_keys=keep_day_keys,
+            )
+
+    def cleanup_runtime_state(self) -> None:
+        """Release runtime caches/listeners to make unload deterministic."""
+        session_manager = getattr(self, "session_history", None)
+        if session_manager is not None and hasattr(session_manager, "clear"):
+            session_manager.clear()
+        self._session_history_cache_shim.clear()
+        self._prune_runtime_caches(active_serials=(), keep_day_keys=())
 
     def _parse_devices_inventory_payload(
         self, payload: object
@@ -3146,6 +3291,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 await self._async_refresh_heatpump_power()
             except Exception as err:  # noqa: BLE001
                 _LOGGER.debug("Skipping heat pump power refresh: %s", err)
+            self._prune_runtime_caches(active_serials=(), keep_day_keys=())
             self._sync_battery_profile_pending_issue()
             self.last_success_utc = dt_util.utcnow()
             self.latency_ms = int((time.monotonic() - t0) * 1000)
@@ -4222,6 +4368,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 continue
             target = background_by_day if first_refresh else immediate_by_day
             target.setdefault(day_key, []).append(sn)
+        # Prune after day-keys are known so historical session-day entries in use
+        # by current chargers are retained for normal TTL behavior.
+        self._prune_runtime_caches(active_serials=out.keys(), keep_day_keys=day_locals)
 
         for day_key, serials in immediate_by_day.items():
             updates = await self._async_enrich_sessions(

--- a/custom_components/enphase_ev/session_history.py
+++ b/custom_components/enphase_ev/session_history.py
@@ -21,6 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 MIN_SESSION_HISTORY_CACHE_TTL = 60  # seconds
 SESSION_HISTORY_FAILURE_BACKOFF_S = 15 * 60
 SESSION_HISTORY_CONCURRENCY = 3
+SESSION_HISTORY_CACHE_DAY_RETENTION = 3
 
 
 @dataclass(slots=True)
@@ -42,6 +43,7 @@ class SessionHistoryManager:
         client_getter: Callable[[], Any],
         *,
         cache_ttl: float,
+        cache_day_retention: int = SESSION_HISTORY_CACHE_DAY_RETENTION,
         failure_backoff: float = SESSION_HISTORY_FAILURE_BACKOFF_S,
         concurrency: int = SESSION_HISTORY_CONCURRENCY,
         data_supplier: Callable[[], dict[str, dict] | None] | None = None,
@@ -55,10 +57,12 @@ class SessionHistoryManager:
             MIN_SESSION_HISTORY_CACHE_TTL, float(failure_backoff)
         )
         self._concurrency = max(1, int(concurrency))
+        self._cache_day_retention = max(1, int(cache_day_retention))
         self._cache: dict[tuple[str, str], tuple[float, list[dict]]] = {}
         self._block_until: dict[str, float] = {}
         self._refresh_in_progress: set[str] = set()
         self._criteria_cache: dict[str, float] = {}
+        self._enrichment_tasks: set[asyncio.Task[None]] = set()
         self._data_supplier = data_supplier
         self._publish_callback = publish_callback
         self._logger = logger or _LOGGER
@@ -214,12 +218,14 @@ class SessionHistoryManager:
                     self._refresh_in_progress.discard(sn)
 
         try:
-            self._hass.async_create_task(
+            task = self._hass.async_create_task(
                 _run(),
                 name="enphase_ev_session_enrichment",
             )
         except TypeError:
-            self._hass.async_create_task(_run())
+            task = self._hass.async_create_task(_run())
+        self._enrichment_tasks.add(task)
+        task.add_done_callback(self._enrichment_tasks.discard)
 
     async def async_enrich(
         self,
@@ -324,6 +330,10 @@ class SessionHistoryManager:
         day_key = local_dt.strftime("%Y-%m-%d")
         cache_key = (sn, day_key)
         now_mono = time.monotonic()
+        active_serials = self._active_serials_from_data_supplier()
+        if active_serials is not None:
+            active_serials.add(sn)
+        self.prune(active_serials=active_serials, keep_day_keys={day_key})
         cached = self._cache.get(cache_key)
         if cached and (now_mono - cached[0] < self._cache_ttl):
             return cached[1]
@@ -352,13 +362,13 @@ class SessionHistoryManager:
                         "Session history criteria unavailable for %s: %s", sn, err
                     )
                     self._note_service_unavailable(err)
-                    self._cache[cache_key] = (now_mono, [])
+                    self._set_cache_entry(sn, day_key, now_mono, [])
                     return []
                 except Unauthorized as err:
                     self._logger.debug(
                         "Session history criteria unauthorized for %s: %s", sn, err
                     )
-                    self._cache[cache_key] = (now_mono, [])
+                    self._set_cache_entry(sn, day_key, now_mono, [])
                     return []
                 except aiohttp.ClientResponseError as err:
                     self._logger.debug(
@@ -369,13 +379,13 @@ class SessionHistoryManager:
                     )
                     if err.status in (500, 502, 503, 504, 550):
                         self._block_until[sn] = now_mono + self._failure_backoff
-                    self._cache[cache_key] = (now_mono, [])
+                    self._set_cache_entry(sn, day_key, now_mono, [])
                     return []
                 except Exception as err:  # noqa: BLE001
                     self._logger.debug(
                         "Session history criteria failed for %s: %s", sn, err
                     )
-                    self._cache[cache_key] = (now_mono, [])
+                    self._set_cache_entry(sn, day_key, now_mono, [])
                     return []
 
         async def _fetch_page(offset: int, limit: int) -> tuple[list[dict], bool]:
@@ -414,7 +424,7 @@ class SessionHistoryManager:
                 err,
             )
             self._note_service_unavailable(err)
-            self._cache[cache_key] = (now_mono, [])
+            self._set_cache_entry(sn, day_key, now_mono, [])
             return []
         except Unauthorized as err:
             self._logger.debug(
@@ -423,7 +433,7 @@ class SessionHistoryManager:
                 api_day,
                 err,
             )
-            self._cache[cache_key] = (now_mono, [])
+            self._set_cache_entry(sn, day_key, now_mono, [])
             return []
         except aiohttp.ClientResponseError as err:
             self._logger.debug(
@@ -435,20 +445,112 @@ class SessionHistoryManager:
             )
             if err.status in (500, 502, 503, 504, 550):
                 self._block_until[sn] = now_mono + self._failure_backoff
-            self._cache[cache_key] = (now_mono, [])
+            self._set_cache_entry(sn, day_key, now_mono, [])
             return []
         except Exception as err:  # noqa: BLE001
             self._logger.debug(
                 "Session history fetch failed for %s on %s: %s", sn, api_day, err
             )
-            self._cache[cache_key] = (now_mono, [])
+            self._set_cache_entry(sn, day_key, now_mono, [])
             return []
 
         sessions = self._normalise_sessions_for_day(local_dt=local_dt, results=results)
         self._mark_service_available()
         self._block_until.pop(sn, None)
-        self._cache[cache_key] = (now_mono, sessions)
+        self._set_cache_entry(sn, day_key, now_mono, sessions)
         return sessions
+
+    @staticmethod
+    def _normalize_serials(serials: Iterable[str] | None) -> set[str] | None:
+        if serials is None:
+            return None
+        normalized: set[str] = set()
+        for serial in serials:
+            if serial is None:
+                continue
+            try:
+                sn = str(serial).strip()
+            except Exception:  # noqa: BLE001
+                continue
+            if sn:
+                normalized.add(sn)
+        return normalized
+
+    def _active_serials_from_data_supplier(self) -> set[str] | None:
+        if not callable(self._data_supplier):
+            return None
+        try:
+            data = self._data_supplier()
+        except Exception:  # noqa: BLE001
+            return None
+        if not isinstance(data, dict):
+            return None
+        return self._normalize_serials(data.keys())
+
+    def _retained_day_keys(self, keep_day_keys: Iterable[str] | None) -> set[str]:
+        day_keys = {
+            str(day_key).strip()
+            for day_key in keep_day_keys or ()
+            if day_key is not None and str(day_key).strip()
+        }
+        try:
+            now_local = dt_util.as_local(dt_util.now())
+        except Exception:
+            now_local = datetime.now(tz=_tz.utc)
+        for day_offset in range(self._cache_day_retention):
+            day_keys.add((now_local - timedelta(days=day_offset)).strftime("%Y-%m-%d"))
+        return day_keys
+
+    def _set_cache_entry(
+        self,
+        serial: str,
+        day_key: str,
+        now_mono: float,
+        sessions: list[dict],
+    ) -> None:
+        self._cache[(serial, day_key)] = (now_mono, sessions)
+        active_serials = self._active_serials_from_data_supplier()
+        if active_serials is not None:
+            active_serials.add(serial)
+        self.prune(active_serials=active_serials, keep_day_keys={day_key})
+
+    def prune(
+        self,
+        *,
+        active_serials: Iterable[str] | None = None,
+        keep_day_keys: Iterable[str] | None = None,
+    ) -> None:
+        """Prune stale serial/day cache entries and serial-scoped state."""
+        active_set = self._normalize_serials(active_serials)
+        retained_days = self._retained_day_keys(keep_day_keys)
+
+        if self._cache:
+            self._cache = {
+                (sn, day_key): cache
+                for (sn, day_key), cache in self._cache.items()
+                if day_key in retained_days and (active_set is None or sn in active_set)
+            }
+
+        now_mono = time.monotonic()
+        for sn, until in list(self._block_until.items()):
+            if until <= now_mono or (active_set is not None and sn not in active_set):
+                self._block_until.pop(sn, None)
+
+        if active_set is not None:
+            for sn in list(self._criteria_cache):
+                if sn not in active_set:
+                    self._criteria_cache.pop(sn, None)
+            self._refresh_in_progress.intersection_update(active_set)
+
+    def clear(self) -> None:
+        """Drop cached state and cancel in-flight background enrichment tasks."""
+        for task in list(self._enrichment_tasks):
+            task.cancel()
+        self._enrichment_tasks.clear()
+        self._cache.clear()
+        self._block_until.clear()
+        self._criteria_cache.clear()
+        self._refresh_in_progress.clear()
 
     def set_fetch_override(
         self,

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -107,6 +107,7 @@ async def async_setup_entry(
     site_entity_keys: set[str] = set()
     known_serials: set[str] = set()
     known_slots: set[tuple[str, str]] = set()
+    stale_slot_miss_counts: dict[tuple[str, str], int] = {}
     known_green_battery: set[str] = set()
     known_app_auth: set[str] = set()
 
@@ -184,14 +185,37 @@ async def async_setup_entry(
         if schedule_sync is None:
             return
         entities: list[SwitchEntity] = []
+        active_slot_keys: set[tuple[str, str]] = set()
         for sn, slot_id, slot in schedule_sync.iter_slots():
             key = (sn, slot_id)
-            if key in known_slots:
-                continue
             if not _slot_is_toggleable(sn, slot):
+                continue
+            active_slot_keys.add(key)
+            stale_slot_miss_counts.pop(key, None)
+            if key in known_slots:
                 continue
             entities.append(ScheduleSlotSwitch(coord, schedule_sync, sn, slot_id))
             known_slots.add(key)
+        stale_slot_keys = known_slots - active_slot_keys
+        for sn, slot_id in stale_slot_keys:
+            key = (sn, slot_id)
+            misses = stale_slot_miss_counts.get(key, 0) + 1
+            stale_slot_miss_counts[key] = misses
+            if misses < 2:
+                continue
+            known_slots.discard((sn, slot_id))
+            stale_slot_miss_counts.pop(key, None)
+            unique_id = f"{DOMAIN}:{sn}:schedule:{slot_id}:enabled"
+            entity_id = ent_reg.async_get_entity_id("switch", DOMAIN, unique_id)
+            if entity_id:
+                try:
+                    ent_reg.async_remove(entity_id)
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.debug(
+                        "Failed removing stale schedule slot switch %s: %s",
+                        entity_id,
+                        err,
+                    )
         if entities:
             async_add_entities(entities, update_before_add=False)
 

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -653,6 +653,215 @@ async def test_session_history_shims_without_manager(coordinator_factory, monkey
     assert await coord._async_fetch_sessions_today("SN", day_local=None) == []
 
 
+def test_prune_runtime_caches_removes_stale_serial_state(coordinator_factory):
+    coord = coordinator_factory(serials=["EV1", "EV2"])
+    coord._configured_serials = {"EV1"}  # noqa: SLF001
+    coord.serials = {"EV1", "EV2", "EV3"}
+    coord._serial_order = ["EV1", "EV2", "EV3"]  # noqa: SLF001
+    coord.last_set_amps = {"EV1": 16, "EV2": 32}
+    coord._charge_mode_cache = {"EV1": ("A", 1.0), "EV2": ("B", 1.0)}  # noqa: SLF001
+    coord._green_battery_cache = {  # noqa: SLF001
+        "EV1": (True, True, 1.0),
+        "EV2": (False, True, 1.0),
+    }
+    coord._auth_settings_cache = {  # noqa: SLF001
+        "EV1": (True, False, True, True, 1.0),
+        "EV3": (False, False, True, True, 1.0),
+    }
+    coord._desired_charging = {"EV1": True, "EV2": False}  # noqa: SLF001
+    coord._session_history_cache_shim = {  # noqa: SLF001
+        ("EV1", "2020-01-02"): (1.0, [{"session_id": "keep"}]),
+        ("EV2", "2020-01-02"): (1.0, [{"session_id": "drop-serial"}]),
+        ("EV1", "2020-01-01"): (1.0, [{"session_id": "drop-day"}]),
+    }
+    coord.session_history = SimpleNamespace(prune=MagicMock(), clear=MagicMock())
+
+    coord._prune_runtime_caches(  # noqa: SLF001
+        active_serials={"EV1"},
+        keep_day_keys={"2020-01-02"},
+    )
+
+    assert coord.serials == {"EV1"}
+    assert coord._serial_order == ["EV1"]  # noqa: SLF001
+    assert coord.last_set_amps == {"EV1": 16}
+    assert "EV2" not in coord._charge_mode_cache  # noqa: SLF001
+    assert "EV2" not in coord._green_battery_cache  # noqa: SLF001
+    assert "EV3" not in coord._auth_settings_cache  # noqa: SLF001
+    assert coord._desired_charging == {"EV1": True}  # noqa: SLF001
+    assert coord._session_history_cache_shim == {  # noqa: SLF001
+        ("EV1", "2020-01-02"): (1.0, [{"session_id": "keep"}])
+    }
+    coord.session_history.prune.assert_called_once()
+
+
+def test_cleanup_runtime_state_clears_session_history(coordinator_factory):
+    coord = coordinator_factory(serials=["EV1"])
+    clear = MagicMock()
+    prune = MagicMock()
+    coord.session_history = SimpleNamespace(clear=clear, prune=prune)
+    coord._session_history_cache_shim = {("EV1", "2020-01-02"): (1.0, [])}  # noqa: SLF001
+
+    coord.cleanup_runtime_state()
+
+    clear.assert_called_once()
+    assert coord._session_history_cache_shim == {}  # noqa: SLF001
+
+
+def test_prune_helpers_cover_edge_branches(monkeypatch):
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+
+    class BadSerial:
+        def __str__(self) -> str:
+            raise RuntimeError("bad")
+
+    assert coord._normalize_serials(None) == set()  # noqa: SLF001
+    assert coord._normalize_serials([None, BadSerial(), " EV1 "]) == {"EV1"}  # noqa: SLF001
+
+    coord._session_history_cache_shim = []  # noqa: SLF001
+    monkeypatch.setattr(
+        coord_mod.dt_util,
+        "now",
+        lambda: datetime(2025, 1, 1, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(coord_mod.dt_util, "as_local", lambda value: value)
+    coord._prune_session_history_cache_shim(  # noqa: SLF001
+        active_serials=None,
+        keep_day_keys={"2025-01-01"},
+    )
+    assert coord._session_history_cache_shim == {}  # noqa: SLF001
+
+    coord._configured_serials = set()  # noqa: SLF001
+    coord.serials = None
+    coord._serial_order = None  # noqa: SLF001
+    coord.last_set_amps = []
+    coord._operating_v = {}  # noqa: SLF001
+    coord._charge_mode_cache = {}  # noqa: SLF001
+    coord._green_battery_cache = {}  # noqa: SLF001
+    coord._auth_settings_cache = {}  # noqa: SLF001
+    coord._last_charging = {}  # noqa: SLF001
+    coord._last_actual_charging = {}  # noqa: SLF001
+    coord._pending_charging = {}  # noqa: SLF001
+    coord._desired_charging = {}  # noqa: SLF001
+    coord._auto_resume_attempts = {}  # noqa: SLF001
+    coord._session_end_fix = {}  # noqa: SLF001
+    coord._streaming_targets = {}  # noqa: SLF001
+
+    keep = coord._prune_serial_runtime_state(["EV1"])  # noqa: SLF001
+    assert keep == {"EV1"}
+    assert coord.serials == {"EV1"}
+    assert coord._serial_order == ["EV1"]  # noqa: SLF001
+
+
+def _make_minimal_history() -> SimpleNamespace:
+    return SimpleNamespace(
+        cache_ttl=60,
+        get_cache_view=lambda *_args, **_kwargs: SimpleNamespace(
+            sessions=[],
+            needs_refresh=False,
+            blocked=False,
+        ),
+        async_enrich=AsyncMock(return_value={}),
+        schedule_enrichment=lambda *_args, **_kwargs: None,
+        sum_energy=lambda *_args, **_kwargs: 0.0,
+        prune=MagicMock(),
+    )
+
+
+def _prepare_minimal_success_update(coord, sn: str) -> None:
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": sn,
+                    "name": "Driveway",
+                    "charging": False,
+                    "pluggedIn": True,
+                    "faulted": False,
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {"status": "enabled", "info": [{}]},
+                }
+            ],
+            "ts": 1700000000,
+        }
+    )
+    coord._async_resolve_charge_modes = AsyncMock(return_value={})
+    coord._async_resolve_green_battery_settings = AsyncMock(return_value={})
+    coord._async_resolve_auth_settings = AsyncMock(return_value={})
+    coord.summary = SimpleNamespace(
+        prepare_refresh=lambda **_kwargs: False,
+        async_fetch=AsyncMock(return_value=[]),
+        invalidate=lambda: None,
+    )
+    coord.session_history = _make_minimal_history()
+    coord.energy._async_refresh_site_energy = AsyncMock()
+    coord._sync_site_energy_issue = MagicMock()
+    coord._sync_battery_profile_pending_issue = MagicMock()
+    coord._async_refresh_inverters = AsyncMock()
+    coord._async_refresh_heatpump_power = AsyncMock()
+    coord._async_refresh_battery_site_settings = AsyncMock()
+    coord._async_refresh_battery_status = AsyncMock()
+    coord._async_refresh_battery_backup_history = AsyncMock()
+    coord._async_refresh_battery_settings = AsyncMock()
+    coord._async_refresh_storm_guard_profile = AsyncMock()
+    coord._async_refresh_storm_alert = AsyncMock()
+    coord._async_refresh_grid_control_check = AsyncMock()
+    coord._async_refresh_devices_inventory = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_session_day_handles_now_error(
+    coordinator_factory, monkeypatch
+):
+    sn = "EVX"
+    coord = coordinator_factory(serials=[sn])
+    _prepare_minimal_success_update(coord, sn)
+    monkeypatch.setattr(
+        coord_mod.dt_util,
+        "now",
+        MagicMock(side_effect=RuntimeError("boom")),
+    )
+
+    result = await coord._async_update_data()
+    assert sn in result
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_session_day_handles_naive_now(
+    coordinator_factory, monkeypatch
+):
+    sn = "EVY"
+    coord = coordinator_factory(serials=[sn])
+    _prepare_minimal_success_update(coord, sn)
+    coord._prune_runtime_caches = MagicMock()  # noqa: SLF001
+    naive_now = datetime(2025, 1, 2, 9, 0, 0)
+    monkeypatch.setattr(coord_mod.dt_util, "now", lambda: naive_now)
+    original_as_local = coord_mod.dt_util.as_local
+    raised = {"value": False}
+
+    def _fake_as_local(value):
+        if (
+            isinstance(value, datetime)
+            and value == naive_now
+            and value.tzinfo is None
+            and not raised["value"]
+        ):
+            raised["value"] = True
+            raise ValueError("boom")
+        return original_as_local(value)
+
+    monkeypatch.setattr(coord_mod.dt_util, "as_local", _fake_as_local)
+
+    result = await coord._async_update_data()
+    assert sn in result
+    assert raised["value"] is True
+    coord._prune_runtime_caches.assert_called_once()  # noqa: SLF001
+    prune_kwargs = coord._prune_runtime_caches.call_args.kwargs  # noqa: SLF001
+    assert prune_kwargs.get("active_serials") == result.keys()
+    assert isinstance(prune_kwargs.get("keep_day_keys"), dict)
+    assert prune_kwargs["keep_day_keys"]
+
+
 def test_sum_session_energy_handles_conversion_error(coordinator_factory):
     coord = coordinator_factory()
     coord.__dict__.pop("session_history", None)

--- a/tests/components/enphase_ev/test_helper_modules.py
+++ b/tests/components/enphase_ev/test_helper_modules.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
@@ -491,6 +491,95 @@ def test_session_history_cache_ttl_accessor(hass) -> None:
     assert manager.cache_ttl == MIN_SESSION_HISTORY_CACHE_TTL
     assert manager.cache_key_count == 0
     assert manager.in_progress == 0
+
+
+def test_session_history_prune_bounds_cache_and_serial_state(hass) -> None:
+    manager = SessionHistoryManager(
+        hass,
+        lambda: None,
+        cache_ttl=60,
+        data_supplier=lambda: {},
+        publish_callback=lambda _: None,
+    )
+    manager._cache = {
+        ("EV-01", "2020-01-01"): (1.0, [{"session_id": "old"}]),
+        ("EV-01", "2020-01-02"): (2.0, [{"session_id": "keep"}]),
+        ("EV-OLD", "2020-01-02"): (3.0, [{"session_id": "stale-serial"}]),
+    }
+    manager._block_until = {
+        "EV-01": time.monotonic() - 1,
+        "EV-OLD": time.monotonic() + 60,
+    }
+    manager._criteria_cache = {"EV-01": 1.0, "EV-OLD": 2.0}
+    manager._refresh_in_progress = {"EV-01", "EV-OLD"}
+
+    manager.prune(active_serials={"EV-01"}, keep_day_keys={"2020-01-02"})
+
+    assert manager._cache == {
+        ("EV-01", "2020-01-02"): (2.0, [{"session_id": "keep"}])
+    }
+    assert "EV-OLD" not in manager._block_until
+    assert "EV-01" not in manager._block_until
+    assert manager._criteria_cache == {"EV-01": 1.0}
+    assert manager._refresh_in_progress == {"EV-01"}
+
+
+@pytest.mark.asyncio
+async def test_session_history_clear_cancels_tasks_and_clears_state(hass) -> None:
+    manager = SessionHistoryManager(
+        hass,
+        lambda: None,
+        cache_ttl=60,
+        data_supplier=lambda: {},
+        publish_callback=lambda _: None,
+    )
+    manager._cache[("EV-01", "2020-01-02")] = (time.monotonic(), [])
+    manager._block_until["EV-01"] = time.monotonic() + 60
+    manager._criteria_cache["EV-01"] = time.monotonic()
+    manager._refresh_in_progress.add("EV-01")
+    task = hass.loop.create_task(asyncio.sleep(30))
+    manager._enrichment_tasks.add(task)
+
+    manager.clear()
+    await asyncio.sleep(0)
+
+    assert task.cancelled()
+    assert manager._cache == {}
+    assert manager._block_until == {}
+    assert manager._criteria_cache == {}
+    assert manager._refresh_in_progress == set()
+    assert manager._enrichment_tasks == set()
+
+
+def test_session_history_prune_helpers_cover_edge_paths(monkeypatch, hass) -> None:
+    manager = SessionHistoryManager(
+        hass,
+        lambda: None,
+        cache_ttl=60,
+        data_supplier=lambda: {},
+        publish_callback=lambda _: None,
+    )
+
+    class BadSerial:
+        def __str__(self) -> str:
+            raise RuntimeError("bad")
+
+    assert manager._normalize_serials(None) is None
+    assert manager._normalize_serials([None, BadSerial(), " EV1 "]) == {"EV1"}
+
+    def _raise_supplier():
+        raise RuntimeError("boom")
+
+    manager._data_supplier = _raise_supplier
+    assert manager._active_serials_from_data_supplier() is None
+
+    monkeypatch.setattr(
+        sh_mod.dt_util,
+        "now",
+        MagicMock(side_effect=RuntimeError("boom")),
+    )
+    retained = manager._retained_day_keys({"2025-01-01"})
+    assert "2025-01-01" in retained
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import importlib
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock, call
+from unittest.mock import AsyncMock, MagicMock, Mock, call
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -596,7 +596,7 @@ async def test_async_unload_entry_stops_schedule_sync(
     hass: HomeAssistant, config_entry, monkeypatch
 ) -> None:
     schedule_sync = SimpleNamespace(async_stop=AsyncMock())
-    coord = SimpleNamespace(schedule_sync=schedule_sync)
+    coord = SimpleNamespace(schedule_sync=schedule_sync, cleanup_runtime_state=MagicMock())
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     unload = AsyncMock(return_value=True)
@@ -604,8 +604,28 @@ async def test_async_unload_entry_stops_schedule_sync(
 
     assert await async_unload_entry(hass, config_entry)
     schedule_sync.async_stop.assert_awaited_once()
+    coord.cleanup_runtime_state.assert_called_once()
     unload.assert_awaited_once()
     assert config_entry.runtime_data is None
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_does_not_cleanup_when_unload_fails(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    schedule_sync = SimpleNamespace(async_stop=AsyncMock())
+    coord = SimpleNamespace(schedule_sync=schedule_sync, cleanup_runtime_state=MagicMock())
+    runtime_data = EnphaseRuntimeData(coordinator=coord)
+    config_entry.runtime_data = runtime_data
+
+    unload = AsyncMock(return_value=False)
+    monkeypatch.setattr(hass.config_entries, "async_unload_platforms", unload)
+
+    assert await async_unload_entry(hass, config_entry) is False
+    schedule_sync.async_stop.assert_not_awaited()
+    coord.cleanup_runtime_state.assert_not_called()
+    unload.assert_awaited_once()
+    assert config_entry.runtime_data is runtime_data
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -503,6 +503,56 @@ async def test_async_setup_entry_skips_duplicate_schedule_switches(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_prunes_stale_schedule_slot_switches(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    slot_id = f"site:{RANDOM_SERIAL}:slot-stale"
+    coord.schedule_sync._slot_cache = {
+        RANDOM_SERIAL: {
+            slot_id: {
+                "id": slot_id,
+                "startTime": "08:00",
+                "endTime": "09:00",
+                "scheduleType": "CUSTOM",
+                "enabled": True,
+            }
+        }
+    }
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    added: list = []
+    callback_holder: dict[str, object] = {}
+
+    def _capture(entities, update_before_add=False):
+        added.extend(entities)
+
+    def _capture_listener(callback):
+        callback_holder["callback"] = callback
+        return MagicMock()
+
+    coord.schedule_sync.async_add_listener = MagicMock(side_effect=_capture_listener)
+    ent_reg = er.async_get(hass)
+    remove_spy = MagicMock(wraps=ent_reg.async_remove)
+    monkeypatch.setattr(ent_reg, "async_remove", remove_spy)
+    monkeypatch.setattr(
+        ent_reg,
+        "async_get_entity_id",
+        MagicMock(return_value="switch.enphase_ev_stale_slot"),
+    )
+
+    await async_setup_entry(hass, config_entry, _capture)
+    assert any(isinstance(entity, ScheduleSlotSwitch) for entity in added)
+
+    coord.schedule_sync._slot_cache = {}
+    callback_holder["callback"]()
+    remove_spy.assert_not_called()
+
+    callback_holder["callback"]()
+    remove_spy.assert_called_once_with("switch.enphase_ev_stale_slot")
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_skips_read_only_slots(
     hass, config_entry, coordinator_factory
 ) -> None:


### PR DESCRIPTION
## Summary
- prune coordinator and session-history runtime caches by active serial/day retention to reduce long-lived memory growth while preserving cache TTL behavior for active chargers
- run integration unload cleanup only after platform unload succeeds to avoid partial teardown on failed unloads
- reduce schedule-slot switch churn by requiring two consecutive missing syncs before removing stale slot entities

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
