### PR TITLE
Prepare release v2.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,25 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v2.1.2 - 2026-03-03
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Pruned coordinator/session-history runtime caches by active charger serial/day to prevent stale state from persisting across refreshes.
+- Hardened unload cleanup so schedule-sync shutdown and runtime cache cleanup run after platform unload succeeds.
+- Removed stale schedule-slot switch entities after repeated missing slot refreshes to prevent orphaned toggle entities.
+
+### 🔧 Improvements
+- Updated repository URLs after rename across docs, blueprints, manifest metadata, and firmware catalog fetch URLs.
+
+### 🔄 Other changes
+- Added regression coverage for runtime cache pruning, unload cleanup, session-history state pruning, and stale schedule-slot cleanup.
+
 ## v2.1.1 - 2026-03-02
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.1.1"
+  "version": "2.1.2"
 }


### PR DESCRIPTION
## Summary
- Bump integration manifest version to `2.1.2` for the release.
- Add `v2.1.2` changelog notes for changes since `v2.1.1`.

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
- Coverage gate not run because this PR only changes `custom_components/enphase_ev/manifest.json` and `CHANGELOG.md` (no touched Python modules).
