### PR TITLE
Prune historical charger sensor entities

### DIFF
--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -49,6 +49,23 @@ BATTERY_RETIRED_UNIQUE_SUFFIXES: tuple[str, ...] = (
     "_last_reported",
     "_last_reported_at",
 )
+HISTORICAL_CHARGER_SENSOR_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_connector_reason",
+    "_session_miles",
+    "_plg_in_at",
+    "_plg_out_at",
+    "_schedule_type",
+    "_schedule_start",
+    "_schedule_end",
+    "_session_kwh",
+    "_charging_level",
+    "_session_duration",
+    "_phase_mode",
+    "_max_current",
+    "_min_amp",
+    "_max_amp",
+    "_connection",
+)
 
 
 def _site_has_battery(coord: EnphaseCoordinator) -> bool:
@@ -240,6 +257,31 @@ async def async_setup_entry(
 
     def _legacy_microinverter_inventory_unique_id() -> str:
         return f"{DOMAIN}_site_{coord.site_id}_type_microinverter_inventory"
+
+    @callback
+    def _async_prune_historical_charger_sensor_entities() -> None:
+        entities = getattr(ent_reg, "entities", None)
+        if not isinstance(entities, dict):
+            return
+        unique_prefix = f"{DOMAIN}_"
+        for reg_entry in list(entities.values()):
+            entry_domain = getattr(reg_entry, "domain", None)
+            if entry_domain is None:
+                entry_domain = reg_entry.entity_id.partition(".")[0]
+            if entry_domain != "sensor":
+                continue
+            entry_platform = getattr(reg_entry, "platform", None)
+            if entry_platform is not None and entry_platform != DOMAIN:
+                continue
+            entry_config_id = getattr(reg_entry, "config_entry_id", None)
+            if entry_config_id is not None and entry_config_id != entry.entry_id:
+                continue
+            unique_id = getattr(reg_entry, "unique_id", None)
+            if not isinstance(unique_id, str) or not unique_id.startswith(unique_prefix):
+                continue
+            if not unique_id.endswith(HISTORICAL_CHARGER_SENSOR_UNIQUE_SUFFIXES):
+                continue
+            ent_reg.async_remove(reg_entry.entity_id)
 
     @callback
     def _async_prune_removed_site_entities() -> None:
@@ -703,6 +745,7 @@ async def async_setup_entry(
     entry.async_on_unload(unsubscribe_batteries)
     unsubscribe_inverters = coord.async_add_listener(_async_sync_inverters)
     entry.async_on_unload(unsubscribe_inverters)
+    _async_prune_historical_charger_sensor_entities()
     _async_prune_removed_site_entities()
     _async_sync_site_entities()
     _async_sync_type_inventory()

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -166,6 +166,143 @@ async def test_async_setup_entry_prunes_removed_gateway_connected_devices_entity
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_prunes_historical_charger_sensor_entities(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.const import DOMAIN
+    from custom_components.enphase_ev.sensor import async_setup_entry
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord.async_add_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    removed_ids: list[str] = []
+    stale_suffixes = (
+        "_connector_reason",
+        "_session_miles",
+        "_plg_in_at",
+        "_plg_out_at",
+        "_schedule_type",
+        "_schedule_start",
+        "_schedule_end",
+        "_session_kwh",
+        "_charging_level",
+        "_session_duration",
+        "_phase_mode",
+        "_max_current",
+        "_min_amp",
+        "_max_amp",
+        "_connection",
+    )
+
+    entities: dict[str, Any] = {}
+    expected_removed_ids: list[str] = []
+    for index, suffix in enumerate(stale_suffixes):
+        entity_id = f"sensor.historical_{index}"
+        entities[entity_id] = SimpleNamespace(
+            entity_id=entity_id,
+            domain="sensor",
+            platform=DOMAIN,
+            unique_id=f"{DOMAIN}_{RANDOM_SERIAL}{suffix}",
+            config_entry_id=config_entry.entry_id,
+        )
+        expected_removed_ids.append(entity_id)
+
+    entities["sensor.keep_energy_today"] = SimpleNamespace(
+        entity_id="sensor.keep_energy_today",
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id=f"{DOMAIN}_{RANDOM_SERIAL}_energy_today",
+        config_entry_id=config_entry.entry_id,
+    )
+    entities["sensor.keep_power"] = SimpleNamespace(
+        entity_id="sensor.keep_power",
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id=f"{DOMAIN}_{RANDOM_SERIAL}_power",
+        config_entry_id=config_entry.entry_id,
+    )
+    entities["sensor.keep_status"] = SimpleNamespace(
+        entity_id="sensor.keep_status",
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id=f"{DOMAIN}_{RANDOM_SERIAL}_status",
+        config_entry_id=config_entry.entry_id,
+    )
+    entities["sensor.keep_charging_amps"] = SimpleNamespace(
+        entity_id="sensor.keep_charging_amps",
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id=f"{DOMAIN}_{RANDOM_SERIAL}_charging_amps",
+        config_entry_id=config_entry.entry_id,
+    )
+    entities["sensor.keep_last_reported"] = SimpleNamespace(
+        entity_id="sensor.keep_last_reported",
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id=f"{DOMAIN}_{RANDOM_SERIAL}_last_rpt",
+        config_entry_id=config_entry.entry_id,
+    )
+    entities["sensor.keep_electrical_phase"] = SimpleNamespace(
+        entity_id="sensor.keep_electrical_phase",
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id=f"{DOMAIN}_{RANDOM_SERIAL}_electrical_phase",
+        config_entry_id=config_entry.entry_id,
+    )
+    entities["switch.ignore_domain"] = SimpleNamespace(
+        entity_id="switch.ignore_domain",
+        domain="switch",
+        platform=DOMAIN,
+        unique_id=f"{DOMAIN}_{RANDOM_SERIAL}_session_duration",
+        config_entry_id=config_entry.entry_id,
+    )
+    entities["sensor.ignore_platform"] = SimpleNamespace(
+        entity_id="sensor.ignore_platform",
+        domain="sensor",
+        platform="other_domain",
+        unique_id=f"{DOMAIN}_{RANDOM_SERIAL}_phase_mode",
+        config_entry_id=config_entry.entry_id,
+    )
+    entities["sensor.ignore_config_entry"] = SimpleNamespace(
+        entity_id="sensor.ignore_config_entry",
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id=f"{DOMAIN}_{RANDOM_SERIAL}_max_current",
+        config_entry_id="other-entry-id",
+    )
+
+    class FakeRegistry:
+        def __init__(self) -> None:
+            self.entities = dict(entities)
+
+        def async_remove(self, entity_id: str) -> None:
+            removed_ids.append(entity_id)
+            self.entities.pop(entity_id, None)
+
+        def async_get_entity_id(
+            self, domain: str, platform: str, unique_id: str
+        ) -> str | None:
+            return None
+
+    fake_registry = FakeRegistry()
+    monkeypatch.setattr(sensor_mod.er, "async_get", lambda _hass: fake_registry)
+
+    await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
+
+    assert sorted(removed_ids) == sorted(expected_removed_ids)
+    assert "sensor.keep_energy_today" in fake_registry.entities
+    assert "sensor.keep_power" in fake_registry.entities
+    assert "sensor.keep_status" in fake_registry.entities
+    assert "sensor.keep_charging_amps" in fake_registry.entities
+    assert "sensor.keep_last_reported" in fake_registry.entities
+    assert "sensor.keep_electrical_phase" in fake_registry.entities
+    assert "switch.ignore_domain" in fake_registry.entities
+    assert "sensor.ignore_platform" in fake_registry.entities
+    assert "sensor.ignore_config_entry" in fake_registry.entities
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_skips_battery_entities_without_battery(
     hass, config_entry, coordinator_factory
 ):


### PR DESCRIPTION
## Summary
- add setup-time cleanup for historical charger sensor registry entries that are no longer created
- add regression coverage to verify only owned stale charger sensor entities are pruned

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/sensor.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_sensor_additional_coverage.py"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_entity_wiring.py tests/components/enphase_ev/test_sensors.py tests/components/enphase_ev/test_sensor_additional_coverage.py -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
