### PR TITLE
Fix three-phase power estimate clamp

### DIFF
--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -1715,6 +1715,21 @@ class EnphasePowerSensor(EnphaseBaseEntity, SensorEntity, RestoreEntity):
                 return "single_phase"
         return "unknown"
 
+    @classmethod
+    def _three_phase_multiplier(cls, data: dict) -> float:
+        wiring = data.get("wiring_configuration")
+        explicit_neutral = False
+        if isinstance(wiring, dict):
+            for raw in (*wiring.keys(), *wiring.values()):
+                try:
+                    token = str(raw).strip().lower().replace("-", "_").replace(" ", "_")
+                except Exception:  # noqa: BLE001
+                    continue
+                if token in {"n", "neutral", "l1n", "l2n", "l3n", "ln"}:
+                    explicit_neutral = True
+                    break
+        return 3.0 if explicit_neutral else math.sqrt(3)
+
     @staticmethod
     def _is_actually_charging(data: dict) -> bool:
         status = data.get("connector_status")
@@ -1745,9 +1760,9 @@ class EnphasePowerSensor(EnphaseBaseEntity, SensorEntity, RestoreEntity):
             if amps is None or amps <= 0:
                 continue
             if topology == "three_phase":
-                # Enphase appears to report per-phase voltage on some installs and
-                # line-to-line voltage on others; pick the appropriate conversion.
-                phase_multiplier = math.sqrt(3) if voltage > 300 else 3.0
+                # Default to the conservative line-to-line formula unless the
+                # payload explicitly suggests line-to-neutral wiring.
+                phase_multiplier = self._three_phase_multiplier(data)
             unbounded = int(round(voltage * amps * phase_multiplier))
             if unbounded <= 0:
                 continue

--- a/tests/components/enphase_ev/test_power_and_lifetime_edges.py
+++ b/tests/components/enphase_ev/test_power_and_lifetime_edges.py
@@ -126,6 +126,13 @@ def test_power_topology_normalization_and_fallbacks(coordinator_factory):
     assert sensor._power_topology({"phase_count": 1}) == "single_phase"
     assert sensor._power_topology({"phase_count": 3}) == "three_phase"
     assert sensor._power_topology({"phase_count": 2}) == "unknown"
+    assert sensor._three_phase_multiplier(
+        {"wiring_configuration": {BadStr(): "L1"}}
+    ) == pytest.approx(1.7320508075688772)
+    assert sensor._three_phase_multiplier({"wiring_configuration": {"L1": "L1"}}) == pytest.approx(1.7320508075688772)
+    assert sensor._three_phase_multiplier(
+        {"wiring_configuration": {"L1": "L1", "Neutral": "N"}}
+    ) == pytest.approx(3.0)
 
 
 def test_power_native_value_idle_and_defaults(monkeypatch, coordinator_factory):

--- a/tests/components/enphase_ev/test_power_sensor_dynamic_max.py
+++ b/tests/components/enphase_ev/test_power_sensor_dynamic_max.py
@@ -84,14 +84,38 @@ async def test_power_sensor_three_phase_cap_uses_phase_count():
         }
     )
 
+    assert sensor.native_value == 6374
+
+    attrs = sensor.extra_state_attributes
+    assert attrs["max_throughput_w"] == 6374
+    assert attrs["max_throughput_unbounded_w"] == 6374
+    assert attrs["max_throughput_source"] == "charging_level"
+    assert attrs["max_throughput_amps"] == 16
+    assert attrs["max_throughput_voltage"] == 230
+    assert attrs["max_throughput_topology"] == "three_phase"
+    assert attrs["max_throughput_phase_multiplier"] == pytest.approx(1.7320508075688772)
+
+
+@pytest.mark.asyncio
+async def test_power_sensor_three_phase_neutral_wiring_uses_phase_voltage():
+    coord, sensor, base_ts = _build_sensor()
+    sn = next(iter(coord.data.keys()))
+    coord.data[sn].update(
+        {
+            "lifetime_kwh": 1.25,
+            "last_reported_at": (base_ts + _dt.timedelta(seconds=60)).isoformat(),
+            "operating_v": 230,
+            "charging_level": 16,
+            "phase_count": 3,
+            "wiring_configuration": {"L1": "L1", "L2": "L2", "L3": "L3", "N": "N"},
+        }
+    )
+
     assert sensor.native_value == 11040
 
     attrs = sensor.extra_state_attributes
     assert attrs["max_throughput_w"] == 11040
     assert attrs["max_throughput_unbounded_w"] == 11040
-    assert attrs["max_throughput_source"] == "charging_level"
-    assert attrs["max_throughput_amps"] == 16
-    assert attrs["max_throughput_voltage"] == 230
     assert attrs["max_throughput_topology"] == "three_phase"
     assert attrs["max_throughput_phase_multiplier"] == 3.0
 


### PR DESCRIPTION
## Summary
- make the EV power sensor clamp topology-aware so three-phase chargers are no longer clipped to a single-phase ceiling
- add regression coverage for three-phase, split-phase, and power topology fallback paths while keeping sensor.py at 100% coverage

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/sensor.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
