### PR TITLE
Use documented device UIDs for heat pump power

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -2204,13 +2204,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             for member in members:
                 if self._heatpump_member_device_type(member) != preferred:
                     continue
-                uid = self._type_member_text(
-                    member, "device_uid", "uid", "serial_number"
-                )
+                uid = self._type_member_text(member, "device_uid")
                 if uid:
                     return uid
         for member in members:
-            uid = self._type_member_text(member, "device_uid", "uid", "serial_number")
+            uid = self._type_member_text(member, "device_uid")
             if uid:
                 return uid
         return None
@@ -2229,7 +2227,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
         _add(self._heatpump_primary_device_uid())
         for member in self._type_bucket_members("heatpump"):
-            _add(self._type_member_text(member, "device_uid", "uid", "serial_number"))
+            _add(self._type_member_text(member, "device_uid"))
         candidates.append(None)
         return candidates
 

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1602,12 +1602,24 @@ def test_heatpump_primary_helpers_and_metadata_fallbacks(coordinator_factory) ->
             "heatpump": {
                 "type_key": "heatpump",
                 "count": 1,
+                "devices": [{"device_type": "OTHER", "device_uid": "HP-DEVICE-UID"}],
+            }
+        },
+        ["heatpump"],
+    )
+    assert coord._heatpump_primary_device_uid() == "HP-DEVICE-UID"  # noqa: SLF001
+
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
                 "devices": [{"device_type": "OTHER", "uid": "HP-FALLBACK"}],
             }
         },
         ["heatpump"],
     )
-    assert coord._heatpump_primary_device_uid() == "HP-FALLBACK"  # noqa: SLF001
+    assert coord._heatpump_primary_device_uid() is None  # noqa: SLF001
 
     coord._set_type_device_buckets(  # noqa: SLF001
         {
@@ -1776,6 +1788,22 @@ def test_heatpump_power_helper_guards(coordinator_factory) -> None:
 
     assert coord._heatpump_power_candidate_device_uids() == [None]  # noqa: SLF001
     assert coord._heatpump_latest_power_sample(["not-a-dict"]) is None  # noqa: SLF001
+
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 2,
+                "devices": [
+                    {"device_type": "HEAT_PUMP", "uid": "HP-UID"},
+                    {"device_type": "ENERGY_METER", "serial_number": "HP-SERIAL"},
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    assert coord._heatpump_primary_device_uid() is None  # noqa: SLF001
+    assert coord._heatpump_power_candidate_device_uids() == [None]  # noqa: SLF001
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- restrict heat-pump power timeseries filtering to documented HEMS `device_uid` values
- keep unfiltered fallback behavior when inventory metadata lacks a valid `device_uid`
- add coordinator tests covering documented and fallback identifier selection paths

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
