### PR TITLE
Modernize Python 3.13 integration helpers

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import base64
 import json
 import logging
@@ -9,7 +10,6 @@ from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Iterable
 
 import aiohttp
-import async_timeout
 from yarl import URL
 
 from .const import (
@@ -107,7 +107,7 @@ class InvalidPayloadError(aiohttp.ClientError):
         super().__init__(self.summary)
 
 
-@dataclass
+@dataclass(slots=True)
 class AuthTokens:
     """Container for Enlighten authentication state."""
 
@@ -118,7 +118,7 @@ class AuthTokens:
     raw_cookies: dict[str, str] | None = None
 
 
-@dataclass
+@dataclass(slots=True)
 class SiteInfo:
     """Basic representation of an Enlighten site."""
 
@@ -126,7 +126,7 @@ class SiteInfo:
     name: str | None = None
 
 
-@dataclass
+@dataclass(slots=True)
 class ChargerInfo:
     """Metadata about a charger discovered for a site."""
 
@@ -436,7 +436,7 @@ async def _request_json(
     if json_data is not None:
         req_kwargs["json"] = json_data
 
-    async with async_timeout.timeout(timeout):
+    async with asyncio.timeout(timeout):
         async with session.request(
             method, url, allow_redirects=True, **req_kwargs
         ) as resp:
@@ -469,7 +469,7 @@ async def _request_mfa_json(
     if data is not None:
         req_kwargs["data"] = data
 
-    async with async_timeout.timeout(timeout):
+    async with asyncio.timeout(timeout):
         async with session.request(
             method, url, allow_redirects=True, **req_kwargs
         ) as resp:
@@ -1264,7 +1264,7 @@ class EnphaseEVClient:
             if isinstance(attempt_headers, dict):
                 base_headers.update(attempt_headers)
 
-            async with async_timeout.timeout(self._timeout):
+            async with asyncio.timeout(self._timeout):
                 async with self._s.request(
                     method, url, headers=base_headers, **kwargs
                 ) as r:

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -954,11 +954,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
 class OptionsFlowHandler(config_entries.OptionsFlow):
     def __init__(self, config_entry: ConfigEntry) -> None:
-        try:
-            super().__init__(config_entry)
-        except TypeError:
-            # Older cores lacked the config_entry parameter; fall back to parameterless init.
-            super().__init__()
+        super().__init__()
         self._entry = config_entry
 
     @staticmethod

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -17,30 +17,7 @@ import aiohttp
 from email.utils import parsedate_to_datetime
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryAuthFailed
-
-try:
-    from homeassistant.exceptions import ServiceValidationError
-except ImportError:  # pragma: no cover - older HA cores
-    from homeassistant.exceptions import HomeAssistantError
-
-    class ServiceValidationError(HomeAssistantError):
-        """Fallback for Home Assistant cores lacking ServiceValidationError."""
-
-        def __init__(
-            self,
-            message: str | None = None,
-            *,
-            translation_domain: str | None = None,
-            translation_key: str | None = None,
-            translation_placeholders: dict[str, object] | None = None,
-            **_: object,
-        ) -> None:
-            super().__init__(message)
-            self.translation_domain = translation_domain
-            self.translation_key = translation_key
-            self.translation_placeholders = translation_placeholders
-
-
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -190,7 +167,7 @@ STORM_ALERT_INACTIVE_STATUSES = frozenset(
 )
 
 
-@dataclass
+@dataclass(slots=True)
 class ChargerState:
     sn: str
     name: str | None
@@ -203,7 +180,7 @@ class ChargerState:
     session_start: int | None
 
 
-@dataclass
+@dataclass(slots=True)
 class ChargeModeStartPreferences:
     mode: str | None = None
     include_level: bool | None = None
@@ -544,23 +521,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         }
         if config_entry is not None:
             super_kwargs["config_entry"] = config_entry
-        try:
-            super().__init__(
-                hass,
-                _LOGGER,
-                **super_kwargs,
-            )
-        except TypeError:
-            # Older HA cores (used in some test harnesses) do not accept the
-            # config_entry kwarg yet. Retry without it for compatibility.
-            super_kwargs.pop("config_entry", None)
-            super().__init__(
-                hass,
-                _LOGGER,
-                **super_kwargs,
-            )
-        # Ensure config_entry is stored after super().__init__ in case older
-        # cores overwrite the attribute with None.
+        super().__init__(
+            hass,
+            _LOGGER,
+            **super_kwargs,
+        )
         self.config_entry = config_entry
         self.session_history = SessionHistoryManager(
             hass,
@@ -6153,12 +6118,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         }
         if message is None:
             raise ServiceValidationError(**kwargs)
-        try:
-            raise ServiceValidationError(message=message, **kwargs)
-        except TypeError:
-            # Some HA cores only accept positional message while still supporting
-            # translation kwargs.
-            raise ServiceValidationError(message, **kwargs)
+        raise ServiceValidationError(message, **kwargs)
 
     def _grid_envoy_serial(self) -> str | None:
         bucket = self.type_bucket("envoy")

--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -8,6 +8,7 @@ from homeassistant.helpers import device_registry as dr
 
 from .const import CONF_EMAIL, DOMAIN
 from .device_types import parse_type_identifier
+from .energy import SiteEnergyFlow
 from .runtime_data import get_runtime_data
 
 DIAGNOSTIC_CAPTURE_ERRORS = (RuntimeError, TypeError, ValueError, AttributeError)
@@ -382,7 +383,19 @@ async def async_get_config_entry_diagnostics(hass, entry):
             if flow is None:
                 continue
             raw = flow
-            if hasattr(flow, "__dict__"):
+            if isinstance(flow, SiteEnergyFlow):
+                raw = {
+                    "value_kwh": flow.value_kwh,
+                    "bucket_count": flow.bucket_count,
+                    "fields_used": flow.fields_used,
+                    "start_date": flow.start_date,
+                    "last_report_date": flow.last_report_date,
+                    "update_pending": flow.update_pending,
+                    "source_unit": flow.source_unit,
+                    "last_reset_at": flow.last_reset_at,
+                    "interval_minutes": flow.interval_minutes,
+                }
+            elif hasattr(flow, "__dict__"):
                 raw = flow.__dict__
             if not isinstance(raw, dict):
                 continue

--- a/custom_components/enphase_ev/energy.py
+++ b/custom_components/enphase_ev/energy.py
@@ -26,7 +26,7 @@ HEMS_LIFETIME_FAILURE_BACKOFF_S = 60 * 60
 DEVICE_LIFETIME_CHANNELS: tuple[str, ...] = ("evse", "heatpump", "water_heater")
 
 
-@dataclass
+@dataclass(slots=True)
 class LifetimeGuardState:
     last: float | None = None
     pending_value: float | None = None
@@ -34,7 +34,7 @@ class LifetimeGuardState:
     pending_count: int = 0
 
 
-@dataclass
+@dataclass(slots=True)
 class SiteEnergyFlow:
     """Aggregated site-level energy flow."""
 

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -4462,10 +4462,17 @@ class EnphaseSiteEnergySensor(_SiteBaseEntity, RestoreSensor):
         ) or {}
         entry = flows.get(self._flow_key)
         if isinstance(entry, SiteEnergyFlow):
-            try:
-                return entry.__dict__
-            except Exception:  # noqa: BLE001
-                return {}
+            return {
+                "value_kwh": entry.value_kwh,
+                "bucket_count": entry.bucket_count,
+                "fields_used": entry.fields_used,
+                "start_date": entry.start_date,
+                "last_report_date": entry.last_report_date,
+                "update_pending": entry.update_pending,
+                "source_unit": entry.source_unit,
+                "last_reset_at": entry.last_reset_at,
+                "interval_minutes": entry.interval_minutes,
+            }
         if isinstance(entry, dict):
             return entry
         return {}

--- a/custom_components/enphase_ev/session_history.py
+++ b/custom_components/enphase_ev/session_history.py
@@ -217,13 +217,10 @@ class SessionHistoryManager:
                 for sn in pending:
                     self._refresh_in_progress.discard(sn)
 
-        try:
-            task = self._hass.async_create_task(
-                _run(),
-                name="enphase_ev_session_enrichment",
-            )
-        except TypeError:
-            task = self._hass.async_create_task(_run())
+        task = self._hass.async_create_task(
+            _run(),
+            name="enphase_ev_session_enrichment",
+        )
         self._enrichment_tasks.add(task)
         task.add_done_callback(self._enrichment_tasks.discard)
 

--- a/tests/components/enphase_ev/test_config_flow_coverage.py
+++ b/tests/components/enphase_ev/test_config_flow_coverage.py
@@ -1677,14 +1677,14 @@ def test_async_get_options_flow_returns_handler(hass) -> None:
     assert isinstance(handler, OptionsFlowHandler)
 
 
-def test_options_flow_init_fallback(monkeypatch, hass) -> None:
+def test_options_flow_init_uses_parameterless_super(monkeypatch, hass) -> None:
     entry = MockConfigEntry(domain=DOMAIN, data={})
 
     original_init = config_entries.OptionsFlow.__init__
+    init_args: list[tuple[tuple[object, ...], dict[str, object]]] = []
 
     def maybe_raise(self, *args, **kwargs):
-        if args or kwargs:
-            raise TypeError
+        init_args.append((args, kwargs))
         return original_init(self)
 
     monkeypatch.setattr(
@@ -1693,6 +1693,7 @@ def test_options_flow_init_fallback(monkeypatch, hass) -> None:
 
     handler = OptionsFlowHandler(entry)
     assert handler._entry is entry
+    assert init_args == [((), {})]
 
 
 def test_options_flow_normalize_helpers_cover_string_and_fallback(hass) -> None:

--- a/tests/components/enphase_ev/test_coordinator_edge_cases.py
+++ b/tests/components/enphase_ev/test_coordinator_edge_cases.py
@@ -86,8 +86,6 @@ async def test_coordinator_init_handles_bad_scalar_serial_and_legacy_super(hass,
 
     def fake_coord_init(self, hass_arg, logger, **kwargs):
         init_calls.append(dict(kwargs))
-        if "config_entry" in kwargs:
-            raise TypeError("legacy core missing config_entry kwarg")
         # Mimic Coordinator init side effects used later
         self.hass = hass_arg
         self.logger = logger
@@ -109,9 +107,8 @@ async def test_coordinator_init_handles_bad_scalar_serial_and_legacy_super(hass,
 
     assert coord.serials == set()
     assert coord._serial_order == []
-    assert len(init_calls) == 2
+    assert len(init_calls) == 1
     assert "config_entry" in init_calls[0]
-    assert "config_entry" not in init_calls[1]
 
 
 def test_collect_site_metrics_handles_unfriendly_datetime(hass):

--- a/tests/components/enphase_ev/test_coordinator_grid_control.py
+++ b/tests/components/enphase_ev/test_coordinator_grid_control.py
@@ -579,9 +579,7 @@ async def test_async_set_grid_connection_maps_bool_and_requires_otp(
 
 
 @pytest.mark.asyncio
-async def test_async_set_grid_mode_additional_error_paths(
-    coordinator_factory, monkeypatch
-) -> None:
+async def test_async_set_grid_mode_additional_error_paths(coordinator_factory) -> None:
     from custom_components.enphase_ev.coordinator import ServiceValidationError
 
     coord = coordinator_factory()
@@ -621,17 +619,7 @@ async def test_async_set_grid_mode_additional_error_paths(
     with pytest.raises(ServiceValidationError):
         await coord.async_set_grid_mode("off_grid", "1234")
 
-    class _ServiceValidationCompat(Exception):
-        def __init__(self, *args, **kwargs):
-            if "message" in kwargs:
-                raise TypeError("message kw not supported")
-            super().__init__(*args)
-
-    monkeypatch.setattr(
-        "custom_components.enphase_ev.coordinator.ServiceValidationError",
-        _ServiceValidationCompat,
-    )
-    with pytest.raises(_ServiceValidationCompat):
+    with pytest.raises(ServiceValidationError, match="bad mode"):
         coord._raise_grid_validation("grid_mode_invalid", message="bad mode")  # noqa: SLF001
 
 

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -10,6 +10,7 @@ import pytest
 from homeassistant.helpers import device_registry as dr
 
 from custom_components.enphase_ev import diagnostics
+from custom_components.enphase_ev.energy import SiteEnergyFlow
 from custom_components.enphase_ev.const import DOMAIN
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL, RANDOM_SITE_ID
@@ -460,7 +461,7 @@ async def test_config_entry_diagnostics_includes_site_energy(hass, config_entry)
     coord = DummyCoordinator()
     coord.energy = SimpleNamespace(
         site_energy={
-            "grid_import": SimpleNamespace(
+            "grid_import": SiteEnergyFlow(
                 value_kwh=1.0,
                 bucket_count=2,
                 fields_used=["import"],
@@ -469,7 +470,19 @@ async def test_config_entry_diagnostics_includes_site_energy(hass, config_entry)
                 update_pending=True,
                 source_unit="Wh",
                 last_reset_at=None,
-            )
+                interval_minutes=60,
+            ),
+            "legacy_flow": SimpleNamespace(
+                value_kwh=2.0,
+                bucket_count=1,
+                fields_used=["legacy"],
+                start_date="2024-01-02",
+                last_report_date=datetime(2024, 1, 4, tzinfo=timezone.utc),
+                update_pending=False,
+                source_unit="Wh",
+                last_reset_at="2024-01-05T00:00:00+00:00",
+                interval_minutes=30,
+            ),
         },
         site_energy_meta={
             "start_date": "2024-01-01",
@@ -482,6 +495,8 @@ async def test_config_entry_diagnostics_includes_site_energy(hass, config_entry)
     diag = await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
     site_energy = diag["site_energy"]
     assert "grid_import" in site_energy["flows"]
+    assert site_energy["flows"]["grid_import"]["interval_minutes"] == 60
+    assert site_energy["flows"]["legacy_flow"]["interval_minutes"] == 30
     assert site_energy["meta"]["last_report_date"].startswith("2024-01-03")
 
 

--- a/tests/components/enphase_ev/test_helper_modules.py
+++ b/tests/components/enphase_ev/test_helper_modules.py
@@ -318,7 +318,7 @@ async def test_session_history_async_fetch_handles_errors(hass) -> None:
 
 
 @pytest.mark.asyncio
-async def test_session_history_schedule_enrichment_runs(hass, monkeypatch) -> None:
+async def test_session_history_schedule_enrichment_runs(hass) -> None:
     """Background enrichment should call through to the manager."""
     await hass.config.async_set_time_zone("UTC")
     published: list[dict] = []
@@ -330,11 +330,7 @@ async def test_session_history_schedule_enrichment_runs(hass, monkeypatch) -> No
         publish_callback=lambda data: published.append(data),
     )
     updates = {"EV-01": [{"energy_kwh": 2.0}]}
-    monkeypatch.setattr(
-        manager,
-        "_async_enrich_sessions",
-        AsyncMock(return_value=updates),
-    )
+    manager._async_enrich_sessions = AsyncMock(return_value=updates)  # type: ignore[method-assign]
 
     manager.schedule_enrichment(
         ["EV-01", "EV-01", "EV-02"],
@@ -344,23 +340,6 @@ async def test_session_history_schedule_enrichment_runs(hass, monkeypatch) -> No
     assert published and published[-1]["EV-01"]["energy_today_sessions_kwh"] == 2.0
 
     manager.schedule_enrichment([], datetime.now(tz=timezone.utc))
-
-    # Trigger the TypeError fallback path
-    class _FlakyTask:
-        def __init__(self, hass_obj):
-            self.hass = hass_obj
-            self.calls = 0
-
-        def __call__(self, coro, *args, **kwargs):
-            self.calls += 1
-            if self.calls == 1:
-                coro.close()
-                raise TypeError("legacy hass")
-            return self.hass.loop.create_task(coro)
-
-    monkeypatch.setattr(hass, "async_create_task", _FlakyTask(hass))
-    manager.schedule_enrichment(["EV-03"], datetime.now(tz=timezone.utc))
-    await hass.async_block_till_done()
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from homeassistant.const import UnitOfPower
 
 from custom_components.enphase_ev.api import SiteEnergyUnavailable
 from custom_components.enphase_ev.energy import SiteEnergyFlow
@@ -769,7 +770,17 @@ async def test_site_energy_sensor_restoration(monkeypatch, hass, coordinator_fac
             return super().__getattribute__(name)
 
     coord.energy.site_energy = {"battery_charge": BadFlow(None, 0, [], None, None, None)}
-    assert sensor3._flow_data() == {}
+    assert sensor3._flow_data() == {
+        "value_kwh": None,
+        "bucket_count": 0,
+        "fields_used": [],
+        "start_date": None,
+        "last_report_date": None,
+        "update_pending": None,
+        "source_unit": UnitOfPower.WATT,
+        "last_reset_at": None,
+        "interval_minutes": None,
+    }
     class BadStr:
         def __str__(self):
             raise ValueError("bad str")


### PR DESCRIPTION
## Summary
- replace `async_timeout` usage with stdlib `asyncio.timeout()` in the Enphase API client
- slot lightweight runtime dataclasses and update site-energy serialization paths that relied on `__dict__`
- remove obsolete coordinator/session-history compatibility branches and align tests with the current Home Assistant API surface

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/config_flow.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/diagnostics.py,custom_components/enphase_ev/energy.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/session_history.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
