### PR TITLE
Prepare release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,29 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v2.2.0 - 2026-03-10
+
+### 🚧 Breaking changes
+- Raised the minimum supported Home Assistant version to `2024.12.0` to align the integration and development environment with Python 3.13.
+
+### ✨ New features
+- Added IQ EV charger firmware-details support, including per-charger firmware update entities.
+- Added HEMS-first inventory sourcing for Heat Pump and IQ Energy Router discovery, including support for HEMS-only router entities.
+
+### 🐛 Bug fixes
+- Normalized dry-contact device mapping and migrated legacy standalone dry-contact registry entries back to the gateway device.
+- Fixed heat-pump power timeseries filtering to prefer documented HEMS `device_uid` values while preserving fallback behavior when metadata is missing.
+- Treated EVSE feature flags as advisory hints so runtime-supported charger controls remain available even when cloud feature-flag payloads are stale or misleading.
+- Fixed battery reserve and charge-from-grid control availability on EMEA sites by preferring `cfgControl` visibility flags when they are present.
+
+### 🔧 Improvements
+- Modernized Python 3.13 compatibility paths by switching to stdlib timeout helpers, tightening runtime dataclasses/serialization, and removing obsolete compatibility branches.
+- Expanded diagnostics and API documentation for charger firmware details, EVSE feature flags, HEMS inventory sourcing, and battery control support provenance.
+- Added regression coverage for charger firmware updates, HEMS-first inventory, dry-contact normalization, cfgControl-based battery control availability, and Python 3.13 compatibility paths.
+
+### 🔄 Other changes
+- None
+
 ## v2.1.4 - 2026-03-08
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -4195,7 +4195,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                         auth_required = any(values)
 
             charge_mode_support, charge_mode_support_source = _support_value_and_source(
-                True if charge_mode_pref is not None or has_embedded_charge_mode else None,
+                (
+                    True
+                    if charge_mode_pref is not None or has_embedded_charge_mode
+                    else None
+                ),
                 self.evse_feature_flag_enabled("evse_charging_mode", sn),
             )
             charging_amps_hint = self.evse_feature_flag_enabled(

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.1.4"
+  "version": "2.2.0"
 }


### PR DESCRIPTION
## Summary
- bump the integration manifest version to 2.2.0 for the next release
- add the v2.2.0 changelog entry covering merged PRs #332 through #339 since v2.1.4
- apply the Black-required formatting update in coordinator.py so the repository quality gates pass cleanly

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev/test_manifest.py -q && python3 -m coverage report -m --include=tests/components/enphase_ev/test_manifest.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
