### PR TITLE
Add dry contact settings diagnostics and fix site discovery

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2645,6 +2645,18 @@ class EnphaseEVClient:
             return data
         return {}
 
+    async def dry_contacts_settings(self) -> dict:
+        """Return dry-contact settings payload used by site settings views.
+
+        GET /pv/settings/<site_id>/dry_contacts
+        """
+
+        url = f"{BASE_URL}/pv/settings/{self._site}/dry_contacts"
+        data = await self._json("GET", url)
+        if isinstance(data, dict):
+            return data
+        return {}
+
     async def inverters_inventory(
         self,
         *,

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -110,6 +110,9 @@ STORM_ALERT_CACHE_TTL = 60.0
 STORM_GUARD_PENDING_HOLD_S = 90.0
 GRID_CONTROL_CHECK_CACHE_TTL = 60.0
 GRID_CONTROL_CHECK_STALE_AFTER_S = 180.0
+DRY_CONTACT_SETTINGS_CACHE_TTL = 300.0
+DRY_CONTACT_SETTINGS_FAILURE_CACHE_TTL = 15.0
+DRY_CONTACT_SETTINGS_STALE_AFTER_S = 900.0
 EVSE_FEATURE_FLAGS_CACHE_TTL = 1800.0
 BATTERY_SITE_SETTINGS_CACHE_TTL = 300.0
 BATTERY_SETTINGS_CACHE_TTL = 300.0
@@ -432,6 +435,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._grid_control_grid_outage_check: bool | None = None
         self._grid_control_user_initiated_toggle: bool | None = None
         self._grid_control_supported: bool | None = None
+        self._dry_contact_settings_cache_until: float | None = None
+        self._dry_contact_settings_last_success_mono: float | None = None
+        self._dry_contact_settings_failures: int = 0
+        self._dry_contact_settings_payload: dict[str, object] | None = None
+        self._dry_contact_settings_supported: bool | None = None
+        self._dry_contact_settings_entries: list[dict[str, object]] = []
+        self._dry_contact_unmatched_settings: list[dict[str, object]] = []
         self._evse_feature_flags_cache_until: float | None = None
         self._evse_feature_flags_payload: dict[str, object] | None = None
         self._evse_site_feature_flags: dict[str, object] = {}
@@ -3189,12 +3199,31 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 self, "_grid_control_check_failures", 0
             ),
             "grid_control_data_stale": self.grid_control_supported is None,
+            "dry_contact_settings_supported": self.dry_contact_settings_supported,
+            "dry_contact_settings_contact_count": len(
+                getattr(self, "_dry_contact_settings_entries", []) or []
+            ),
+            "dry_contact_settings_unmatched_count": len(
+                getattr(self, "_dry_contact_unmatched_settings", []) or []
+            ),
+            "dry_contact_settings_fetch_failures": getattr(
+                self, "_dry_contact_settings_failures", 0
+            ),
+            "dry_contact_settings_data_stale": self.dry_contact_settings_supported
+            is None,
         }
         grid_last_success = getattr(self, "_grid_control_check_last_success_mono", None)
         if isinstance(grid_last_success, (int, float)):
             age = time.monotonic() - float(grid_last_success)
             if age >= 0:
                 metrics["grid_control_last_success_age_s"] = round(age, 1)
+        dry_contacts_last_success = getattr(
+            self, "_dry_contact_settings_last_success_mono", None
+        )
+        if isinstance(dry_contacts_last_success, (int, float)):
+            age = time.monotonic() - float(dry_contacts_last_success)
+            if age >= 0:
+                metrics["dry_contact_settings_last_success_age_s"] = round(age, 1)
         session_manager = getattr(self, "session_history", None)
         if session_manager is not None:
             metrics["session_history_available"] = getattr(
@@ -3330,6 +3359,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             "status_payload": getattr(self, "_battery_status_payload", None),
             "grid_control_check_payload": getattr(
                 self, "_grid_control_check_payload", None
+            ),
+            "dry_contacts_payload": getattr(
+                self, "_dry_contact_settings_payload", None
             ),
             "backup_history_payload": getattr(
                 self, "_battery_backup_history_payload", None
@@ -3486,6 +3518,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 await self._async_refresh_devices_inventory()
             except Exception as err:  # noqa: BLE001
                 _LOGGER.debug("Skipping device inventory refresh: %s", err)
+            try:
+                await self._async_refresh_dry_contact_settings()
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug("Skipping dry contact settings refresh: %s", err)
             try:
                 await self._async_refresh_hems_devices()
             except Exception as err:  # noqa: BLE001
@@ -3862,6 +3898,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             _LOGGER.debug("Skipping device inventory refresh: %s", err)
         phase_timings["devices_inventory_s"] = round(
             time.monotonic() - inventory_start, 3
+        )
+        dry_contact_settings_start = time.monotonic()
+        try:
+            await self._async_refresh_dry_contact_settings()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug("Skipping dry contact settings refresh: %s", err)
+        phase_timings["dry_contact_settings_s"] = round(
+            time.monotonic() - dry_contact_settings_start, 3
         )
         hems_inventory_start = time.monotonic()
         try:
@@ -6237,6 +6281,47 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             return None
         return True
 
+    def _dry_contact_settings_is_stale(self) -> bool:
+        raw_supported = getattr(self, "_dry_contact_settings_supported", None)
+        if raw_supported is None:
+            return True
+        last_success = getattr(self, "_dry_contact_settings_last_success_mono", None)
+        if not isinstance(last_success, (int, float)):
+            return False
+        age = time.monotonic() - float(last_success)
+        if age < 0:
+            return False
+        return age >= DRY_CONTACT_SETTINGS_STALE_AFTER_S
+
+    @property
+    def dry_contact_settings_supported(self) -> bool | None:
+        raw_supported = getattr(self, "_dry_contact_settings_supported", None)
+        if raw_supported is None:
+            return None
+        if self._dry_contact_settings_is_stale():
+            return None
+        return raw_supported
+
+    def dry_contact_settings_entries(self) -> list[dict[str, object]]:
+        entries = getattr(self, "_dry_contact_settings_entries", [])
+        if not isinstance(entries, list):
+            return []
+        return [
+            self._copy_dry_contact_settings_entry(entry)
+            for entry in entries
+            if isinstance(entry, dict)
+        ]
+
+    def dry_contact_unmatched_settings(self) -> list[dict[str, object]]:
+        entries = getattr(self, "_dry_contact_unmatched_settings", [])
+        if not isinstance(entries, list):
+            return []
+        return [
+            self._copy_dry_contact_settings_entry(entry)
+            for entry in entries
+            if isinstance(entry, dict)
+        ]
+
     @staticmethod
     def _normalize_grid_mode_value(value: object) -> str | None:
         text = EnphaseCoordinator._coerce_optional_text(value)
@@ -7773,6 +7858,779 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._battery_site_status_text = _as_text(site_status.get("text"))
             self._battery_site_status_severity = _as_text(site_status.get("severity"))
 
+    @staticmethod
+    def _copy_dry_contact_settings_entry(entry: dict[str, object]) -> dict[str, object]:
+        copied: dict[str, object] = {}
+        for key, value in entry.items():
+            if isinstance(value, dict):
+                copied[key] = dict(value)
+            elif isinstance(value, list):
+                copied[key] = [
+                    dict(item) if isinstance(item, dict) else item for item in value
+                ]
+            else:
+                copied[key] = value
+        return copied
+
+    @classmethod
+    def _normalize_dry_contact_schedule_windows(
+        cls, value: object
+    ) -> list[dict[str, object]]:
+        if isinstance(value, list):
+            candidates = [item for item in value if isinstance(item, dict)]
+        elif isinstance(value, dict):
+            candidates = [value]
+        else:
+            return []
+        windows: list[dict[str, object]] = []
+        seen: set[tuple[str | None, str | None]] = set()
+        for item in candidates:
+            start = cls._coerce_optional_text(
+                item.get("start")
+                if item.get("start") is not None
+                else (
+                    item.get("startTime")
+                    if item.get("startTime") is not None
+                    else (
+                        item.get("begin")
+                        if item.get("begin") is not None
+                        else (
+                            item.get("beginTime")
+                            if item.get("beginTime") is not None
+                            else (
+                                item.get("from")
+                                if item.get("from") is not None
+                                else item.get("windowStart")
+                            )
+                        )
+                    )
+                )
+            )
+            end = cls._coerce_optional_text(
+                item.get("end")
+                if item.get("end") is not None
+                else (
+                    item.get("endTime")
+                    if item.get("endTime") is not None
+                    else (
+                        item.get("finish")
+                        if item.get("finish") is not None
+                        else (
+                            item.get("finishTime")
+                            if item.get("finishTime") is not None
+                            else (
+                                item.get("to")
+                                if item.get("to") is not None
+                                else item.get("windowEnd")
+                            )
+                        )
+                    )
+                )
+            )
+            if start is None and end is None:
+                continue
+            key = (start, end)
+            if key in seen:
+                continue
+            seen.add(key)
+            window: dict[str, object] = {}
+            if start is not None:
+                window["start"] = start
+            if end is not None:
+                window["end"] = end
+            windows.append(window)
+        return windows
+
+    @classmethod
+    def _dry_contact_settings_looks_like_entry(cls, value: object) -> bool:
+        if not isinstance(value, dict):
+            return False
+        keys = (
+            "serial_number",
+            "serial",
+            "serialNumber",
+            "device_uid",
+            "device-uid",
+            "deviceUid",
+            "uid",
+            "contact_id",
+            "contactId",
+            "id",
+            "channel_type",
+            "channelType",
+            "meter_type",
+            "name",
+            "displayName",
+            "configuredName",
+            "overrideSupported",
+            "overrideActive",
+            "controlMode",
+            "pollingInterval",
+            "pollingIntervalSeconds",
+            "socThreshold",
+            "socThresholdMin",
+            "socThresholdMax",
+            "scheduleWindows",
+            "schedule_windows",
+            "schedule",
+            "schedules",
+            "windows",
+        )
+        return any(key in value for key in keys)
+
+    @classmethod
+    def _dry_contact_identity_candidates(
+        cls, value: dict[str, object]
+    ) -> list[tuple[str, str]]:
+        candidates: list[tuple[str, str]] = []
+
+        def _add(identity_key: str, raw_value: object) -> None:
+            text = cls._coerce_optional_text(raw_value)
+            if text is None:
+                return
+            candidates.append((identity_key, text.casefold()))
+
+        _add(
+            "serial_number",
+            (
+                value.get("serial_number")
+                if value.get("serial_number") is not None
+                else (
+                    value.get("serial")
+                    if value.get("serial") is not None
+                    else value.get("serialNumber")
+                )
+            ),
+        )
+        _add(
+            "device_uid",
+            (
+                value.get("device_uid")
+                if value.get("device_uid") is not None
+                else (
+                    value.get("device-uid")
+                    if value.get("device-uid") is not None
+                    else (
+                        value.get("deviceUid")
+                        if value.get("deviceUid") is not None
+                        else (
+                            value.get("iqer_uid")
+                            if value.get("iqer_uid") is not None
+                            else value.get("iqer-uid")
+                        )
+                    )
+                )
+            ),
+        )
+        _add("uid", value.get("uid"))
+        _add(
+            "contact_id",
+            (
+                value.get("contact_id")
+                if value.get("contact_id") is not None
+                else (
+                    value.get("contactId")
+                    if value.get("contactId") is not None
+                    else value.get("id")
+                )
+            ),
+        )
+        _add(
+            "channel_type",
+            (
+                value.get("channel_type")
+                if value.get("channel_type") is not None
+                else (
+                    value.get("channelType")
+                    if value.get("channelType") is not None
+                    else (
+                        value.get("meter_type")
+                        if value.get("meter_type") is not None
+                        else value.get("type")
+                    )
+                )
+            ),
+        )
+        _add(
+            "name",
+            (
+                value.get("configured_name")
+                if value.get("configured_name") is not None
+                else (
+                    value.get("display_name")
+                    if value.get("display_name") is not None
+                    else (
+                        value.get("name")
+                        if value.get("name") is not None
+                        else (
+                            value.get("displayName")
+                            if value.get("displayName") is not None
+                            else (
+                                value.get("configuredName")
+                                if value.get("configuredName") is not None
+                                else value.get("label")
+                            )
+                        )
+                    )
+                )
+            ),
+        )
+        return candidates
+
+    @classmethod
+    def _dry_contact_identity_map(cls, value: dict[str, object]) -> dict[str, str]:
+        return dict(cls._dry_contact_identity_candidates(value))
+
+    @staticmethod
+    def _dry_contact_member_dedupe_key(
+        identities: dict[str, str], index: int
+    ) -> tuple[tuple[str, str], ...]:
+        for keys in (
+            ("device_uid", "contact_id"),
+            ("device_uid", "channel_type"),
+            ("uid", "contact_id"),
+            ("uid", "channel_type"),
+            ("contact_id", "channel_type"),
+            ("serial_number", "channel_type"),
+            ("serial_number", "contact_id"),
+            ("contact_id",),
+            ("channel_type",),
+            ("serial_number",),
+            ("device_uid",),
+            ("uid",),
+            ("name",),
+        ):
+            if all(identities.get(key) is not None for key in keys):
+                return tuple((key, identities[key]) for key in keys)
+        return (("idx", str(index)),)
+
+    @staticmethod
+    def _dry_contact_match_conflicts(
+        member_identities: dict[str, str],
+        entry_identities: dict[str, str],
+    ) -> bool:
+        for key in (
+            "contact_id",
+            "channel_type",
+            "serial_number",
+            "device_uid",
+            "uid",
+        ):
+            member_value = member_identities.get(key)
+            entry_value = entry_identities.get(key)
+            if member_value is None or entry_value is None:
+                continue
+            if member_value != entry_value:
+                return True
+        return False
+
+    @classmethod
+    def _dry_contact_member_is_dry_contact(cls, member: object) -> bool:
+        if not isinstance(member, dict):
+            return False
+        for key in ("channel_type", "channelType", "meter_type", "type", "name"):
+            value = cls._coerce_optional_text(member.get(key))
+            if value is None:
+                continue
+            compact = (
+                value.casefold().replace("-", "").replace("_", "").replace(" ", "")
+            )
+            if compact in {"nc1", "nc2", "no1", "no2"}:
+                return True
+            if "drycontact" in compact:
+                return True
+            if "relay" in compact and any(token in compact for token in ("nc", "no")):
+                return True
+        return False
+
+    def _dry_contact_members_for_settings(self) -> list[dict[str, object]]:
+        members: list[dict[str, object]] = []
+        seen_keys: set[tuple[tuple[str, str], ...]] = set()
+
+        def _append_member(raw_member: object) -> None:
+            if not isinstance(raw_member, dict):
+                return
+            if member_is_retired(raw_member):
+                return
+            sanitized = sanitize_member(raw_member)
+            if not sanitized:
+                return
+            identities = self._dry_contact_identity_map(sanitized)
+            key = self._dry_contact_member_dedupe_key(identities, len(members))
+            if key in seen_keys:
+                return
+            seen_keys.add(key)
+            members.append(sanitized)
+
+        buckets = getattr(self, "_type_device_buckets", None)
+        envoy_bucket = buckets.get("envoy", {}) if isinstance(buckets, dict) else {}
+        envoy_members = (
+            envoy_bucket.get("devices") if isinstance(envoy_bucket, dict) else None
+        )
+        if isinstance(envoy_members, list):
+            for member in envoy_members:
+                if self._dry_contact_member_is_dry_contact(member):
+                    _append_member(member)
+
+        dry_bucket = buckets.get("dry_contact", {}) if isinstance(buckets, dict) else {}
+        dry_members = (
+            dry_bucket.get("devices") if isinstance(dry_bucket, dict) else None
+        )
+        if isinstance(dry_members, list):
+            for member in dry_members:
+                _append_member(member)
+
+        return members
+
+    def _match_dry_contact_settings(
+        self,
+        members: Iterable[dict[str, object]],
+        *,
+        settings_entries: list[dict[str, object]] | None = None,
+    ) -> tuple[list[dict[str, object] | None], list[dict[str, object]]]:
+        members_list = [dict(member) for member in members if isinstance(member, dict)]
+        member_identity_maps = [
+            self._dry_contact_identity_map(member) for member in members_list
+        ]
+        index_by_key: dict[str, dict[str, list[int]]] = {
+            key: {}
+            for key in (
+                "contact_id",
+                "channel_type",
+                "serial_number",
+                "device_uid",
+                "uid",
+                "name",
+            )
+        }
+        for index, identities in enumerate(member_identity_maps):
+            for key, mapping in index_by_key.items():
+                value = identities.get(key)
+                if value is None:
+                    continue
+                mapping.setdefault(value, []).append(index)
+
+        entries = [
+            self._copy_dry_contact_settings_entry(entry)
+            for entry in (
+                settings_entries
+                if settings_entries is not None
+                else getattr(self, "_dry_contact_settings_entries", [])
+            )
+            if isinstance(entry, dict)
+        ]
+        matches: list[dict[str, object] | None] = [None] * len(members_list)
+        unmatched: list[dict[str, object]] = []
+        used_member_indexes: set[int] = set()
+
+        for entry in entries:
+            entry_identities = self._dry_contact_identity_map(entry)
+            matched_member_index: int | None = None
+            for key in (
+                "contact_id",
+                "channel_type",
+                "serial_number",
+                "device_uid",
+                "uid",
+                "name",
+            ):
+                value = entry_identities.get(key)
+                if value is None:
+                    continue
+                candidate_indexes = [
+                    index
+                    for index in index_by_key[key].get(value, [])
+                    if index not in used_member_indexes
+                ]
+                if len(candidate_indexes) != 1:
+                    continue
+                candidate_index = candidate_indexes[0]
+                if self._dry_contact_match_conflicts(
+                    member_identity_maps[candidate_index], entry_identities
+                ):
+                    continue
+                matched_member_index = candidate_index
+                break
+            if matched_member_index is None:
+                unmatched.append(entry)
+                continue
+            used_member_indexes.add(matched_member_index)
+            matches[matched_member_index] = entry
+        return matches, unmatched
+
+    def dry_contact_settings_matches(
+        self, members: Iterable[dict[str, object]]
+    ) -> tuple[list[dict[str, object] | None], list[dict[str, object]]]:
+        matches, unmatched = self._match_dry_contact_settings(members)
+        return (
+            [
+                (
+                    self._copy_dry_contact_settings_entry(entry)
+                    if isinstance(entry, dict)
+                    else None
+                )
+                for entry in matches
+            ],
+            [
+                self._copy_dry_contact_settings_entry(entry)
+                for entry in unmatched
+                if isinstance(entry, dict)
+            ],
+        )
+
+    def _parse_dry_contact_settings_payload(self, payload: object) -> None:
+        self._dry_contact_settings_entries = []
+        self._dry_contact_unmatched_settings = []
+        if not isinstance(payload, dict):
+            self._dry_contact_settings_supported = False
+            return
+
+        data = payload.get("data")
+        if not isinstance(data, dict):
+            data = payload
+
+        raw_entries: list[dict[str, object]] = []
+        visited: set[int] = set()
+
+        def _visit(node: object, depth: int = 0) -> None:
+            if depth > 4:
+                return
+            if isinstance(node, dict):
+                node_id = id(node)
+                if node_id in visited:
+                    return
+                visited.add(node_id)
+                if self._dry_contact_settings_looks_like_entry(node):
+                    raw_entries.append(node)
+                for value in node.values():
+                    if isinstance(value, (dict, list)):
+                        _visit(value, depth + 1)
+            elif isinstance(node, list):
+                for item in node:
+                    if isinstance(item, (dict, list)):
+                        _visit(item, depth + 1)
+
+        _visit(data)
+
+        entries: list[dict[str, object]] = []
+        seen_signatures: set[tuple[object, ...]] = set()
+        for entry in raw_entries:
+            normalized: dict[str, object] = {}
+            serial_number = self._coerce_optional_text(
+                entry.get("serial_number")
+                if entry.get("serial_number") is not None
+                else (
+                    entry.get("serial")
+                    if entry.get("serial") is not None
+                    else (
+                        entry.get("serialNumber")
+                        if entry.get("serialNumber") is not None
+                        else entry.get("deviceSerial")
+                    )
+                )
+            )
+            if serial_number is not None:
+                normalized["serial_number"] = serial_number
+            device_uid = self._coerce_optional_text(
+                entry.get("device_uid")
+                if entry.get("device_uid") is not None
+                else (
+                    entry.get("device-uid")
+                    if entry.get("device-uid") is not None
+                    else (
+                        entry.get("deviceUid")
+                        if entry.get("deviceUid") is not None
+                        else (
+                            entry.get("iqer_uid")
+                            if entry.get("iqer_uid") is not None
+                            else entry.get("iqer-uid")
+                        )
+                    )
+                )
+            )
+            if device_uid is not None:
+                normalized["device_uid"] = device_uid
+            uid = self._coerce_optional_text(entry.get("uid"))
+            if uid is not None:
+                normalized["uid"] = uid
+            contact_id = self._coerce_optional_text(
+                entry.get("contact_id")
+                if entry.get("contact_id") is not None
+                else (
+                    entry.get("contactId")
+                    if entry.get("contactId") is not None
+                    else entry.get("id")
+                )
+            )
+            if contact_id is not None:
+                normalized["contact_id"] = contact_id
+            channel_type = self._coerce_optional_text(
+                entry.get("channel_type")
+                if entry.get("channel_type") is not None
+                else (
+                    entry.get("channelType")
+                    if entry.get("channelType") is not None
+                    else (
+                        entry.get("meter_type")
+                        if entry.get("meter_type") is not None
+                        else entry.get("type")
+                    )
+                )
+            )
+            if channel_type is not None:
+                normalized["channel_type"] = channel_type
+            configured_name = self._coerce_optional_text(
+                entry.get("configured_name")
+                if entry.get("configured_name") is not None
+                else (
+                    entry.get("configuredName")
+                    if entry.get("configuredName") is not None
+                    else (
+                        entry.get("display_name")
+                        if entry.get("display_name") is not None
+                        else (
+                            entry.get("displayName")
+                            if entry.get("displayName") is not None
+                            else (
+                                entry.get("name")
+                                if entry.get("name") is not None
+                                else entry.get("label")
+                            )
+                        )
+                    )
+                )
+            )
+            if configured_name is not None:
+                normalized["configured_name"] = configured_name
+            override_supported = self._coerce_optional_bool(
+                entry.get("override_supported")
+                if entry.get("override_supported") is not None
+                else (
+                    entry.get("overrideSupported")
+                    if entry.get("overrideSupported") is not None
+                    else (
+                        entry.get("isOverrideSupported")
+                        if entry.get("isOverrideSupported") is not None
+                        else (
+                            entry.get("supportsOverride")
+                            if entry.get("supportsOverride") is not None
+                            else (
+                                entry.get("allowOverride")
+                                if entry.get("allowOverride") is not None
+                                else entry.get("canOverride")
+                            )
+                        )
+                    )
+                )
+            )
+            if override_supported is not None:
+                normalized["override_supported"] = override_supported
+            override_active = self._coerce_optional_bool(
+                entry.get("override_active")
+                if entry.get("override_active") is not None
+                else (
+                    entry.get("overrideActive")
+                    if entry.get("overrideActive") is not None
+                    else (
+                        entry.get("override")
+                        if entry.get("override") is not None
+                        else (
+                            entry.get("isOverrideActive")
+                            if entry.get("isOverrideActive") is not None
+                            else entry.get("manualOverride")
+                        )
+                    )
+                )
+            )
+            if override_active is not None:
+                normalized["override_active"] = override_active
+            control_mode = self._coerce_optional_text(
+                entry.get("control_mode")
+                if entry.get("control_mode") is not None
+                else (
+                    entry.get("controlMode")
+                    if entry.get("controlMode") is not None
+                    else (
+                        entry.get("mode")
+                        if entry.get("mode") is not None
+                        else entry.get("operatingMode")
+                    )
+                )
+            )
+            if control_mode is not None:
+                normalized["control_mode"] = control_mode
+            polling_interval = self._coerce_optional_int(
+                entry.get("polling_interval_seconds")
+                if entry.get("polling_interval_seconds") is not None
+                else (
+                    entry.get("pollingIntervalSeconds")
+                    if entry.get("pollingIntervalSeconds") is not None
+                    else (
+                        entry.get("pollingInterval")
+                        if entry.get("pollingInterval") is not None
+                        else entry.get("polling_interval")
+                    )
+                )
+            )
+            if polling_interval is not None:
+                normalized["polling_interval_seconds"] = polling_interval
+            soc_threshold = self._coerce_optional_int(
+                entry.get("soc_threshold")
+                if entry.get("soc_threshold") is not None
+                else (
+                    entry.get("socThreshold")
+                    if entry.get("socThreshold") is not None
+                    else (
+                        entry.get("thresholdSoc")
+                        if entry.get("thresholdSoc") is not None
+                        else (
+                            entry.get("targetSoc")
+                            if entry.get("targetSoc") is not None
+                            else (
+                                entry.get("setPointSoc")
+                                if entry.get("setPointSoc") is not None
+                                else entry.get("soc")
+                            )
+                        )
+                    )
+                )
+            )
+            if soc_threshold is not None:
+                normalized["soc_threshold"] = soc_threshold
+            soc_threshold_min = self._coerce_optional_int(
+                entry.get("soc_threshold_min")
+                if entry.get("soc_threshold_min") is not None
+                else (
+                    entry.get("socThresholdMin")
+                    if entry.get("socThresholdMin") is not None
+                    else (
+                        entry.get("minimumSoc")
+                        if entry.get("minimumSoc") is not None
+                        else (
+                            entry.get("minSoc")
+                            if entry.get("minSoc") is not None
+                            else entry.get("minSocThreshold")
+                        )
+                    )
+                )
+            )
+            if soc_threshold_min is not None:
+                normalized["soc_threshold_min"] = soc_threshold_min
+            soc_threshold_max = self._coerce_optional_int(
+                entry.get("soc_threshold_max")
+                if entry.get("soc_threshold_max") is not None
+                else (
+                    entry.get("socThresholdMax")
+                    if entry.get("socThresholdMax") is not None
+                    else (
+                        entry.get("maximumSoc")
+                        if entry.get("maximumSoc") is not None
+                        else (
+                            entry.get("maxSoc")
+                            if entry.get("maxSoc") is not None
+                            else entry.get("maxSocThreshold")
+                        )
+                    )
+                )
+            )
+            if soc_threshold_max is not None:
+                normalized["soc_threshold_max"] = soc_threshold_max
+            schedule_windows = self._normalize_dry_contact_schedule_windows(
+                entry.get("schedule_windows")
+                if entry.get("schedule_windows") is not None
+                else (
+                    entry.get("scheduleWindows")
+                    if entry.get("scheduleWindows") is not None
+                    else (
+                        entry.get("schedule")
+                        if entry.get("schedule") is not None
+                        else (
+                            entry.get("schedules")
+                            if entry.get("schedules") is not None
+                            else (
+                                entry.get("windows")
+                                if entry.get("windows") is not None
+                                else entry.get("window")
+                            )
+                        )
+                    )
+                )
+            )
+            if not schedule_windows:
+                fallback_start = self._coerce_optional_text(
+                    entry.get("scheduleStart")
+                    if entry.get("scheduleStart") is not None
+                    else (
+                        entry.get("schedule_start")
+                        if entry.get("schedule_start") is not None
+                        else (
+                            entry.get("windowStart")
+                            if entry.get("windowStart") is not None
+                            else entry.get("startTime")
+                        )
+                    )
+                )
+                fallback_end = self._coerce_optional_text(
+                    entry.get("scheduleEnd")
+                    if entry.get("scheduleEnd") is not None
+                    else (
+                        entry.get("schedule_end")
+                        if entry.get("schedule_end") is not None
+                        else (
+                            entry.get("windowEnd")
+                            if entry.get("windowEnd") is not None
+                            else entry.get("endTime")
+                        )
+                    )
+                )
+                if fallback_start is not None or fallback_end is not None:
+                    schedule_window: dict[str, object] = {}
+                    if fallback_start is not None:
+                        schedule_window["start"] = fallback_start
+                    if fallback_end is not None:
+                        schedule_window["end"] = fallback_end
+                    schedule_windows = [schedule_window]
+            if schedule_windows:
+                normalized["schedule_windows"] = schedule_windows
+            if not normalized:
+                continue
+            signature = (
+                normalized.get("serial_number"),
+                normalized.get("device_uid"),
+                normalized.get("uid"),
+                normalized.get("contact_id"),
+                normalized.get("channel_type"),
+                normalized.get("configured_name"),
+                normalized.get("override_supported"),
+                normalized.get("override_active"),
+                normalized.get("control_mode"),
+                normalized.get("polling_interval_seconds"),
+                normalized.get("soc_threshold"),
+                normalized.get("soc_threshold_min"),
+                normalized.get("soc_threshold_max"),
+                tuple(
+                    (
+                        window.get("start") if isinstance(window, dict) else None,
+                        window.get("end") if isinstance(window, dict) else None,
+                    )
+                    for window in normalized.get("schedule_windows", [])
+                    if isinstance(window, dict)
+                ),
+            )
+            if signature in seen_signatures:
+                continue
+            seen_signatures.add(signature)
+            entries.append(normalized)
+
+        matches, unmatched = self._match_dry_contact_settings(
+            self._dry_contact_members_for_settings(),
+            settings_entries=entries,
+        )
+        _ = matches
+        self._dry_contact_settings_entries = entries
+        self._dry_contact_unmatched_settings = unmatched
+        self._dry_contact_settings_supported = True
+
     def _parse_grid_control_check_payload(self, payload: object) -> None:
         keys = (
             "disableGridControl",
@@ -8192,6 +9050,46 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._grid_control_check_failures = 0
         self._grid_control_check_last_success_mono = now
         self._grid_control_check_cache_until = now + GRID_CONTROL_CHECK_CACHE_TTL
+
+    async def _async_refresh_dry_contact_settings(self, *, force: bool = False) -> None:
+        now = time.monotonic()
+        if not force and self._dry_contact_settings_cache_until:
+            if now < self._dry_contact_settings_cache_until:
+                return
+        fetcher = getattr(self.client, "dry_contacts_settings", None)
+        if not callable(fetcher):
+            self._dry_contact_settings_supported = None
+            return
+        try:
+            payload = await fetcher()
+        except Exception as err:  # noqa: BLE001
+            self._dry_contact_settings_failures += 1
+            last_success = getattr(
+                self, "_dry_contact_settings_last_success_mono", None
+            )
+            if (
+                not isinstance(last_success, (int, float))
+                or (now - float(last_success)) >= DRY_CONTACT_SETTINGS_STALE_AFTER_S
+            ):
+                self._dry_contact_settings_supported = None
+            self._dry_contact_settings_cache_until = (
+                now + DRY_CONTACT_SETTINGS_FAILURE_CACHE_TTL
+            )
+            _LOGGER.debug(
+                "Dry contact settings fetch failed for site %s: %s",
+                self.site_id,
+                err,
+            )
+            return
+        redacted_payload = self._redact_battery_payload(payload)
+        if isinstance(redacted_payload, dict):
+            self._dry_contact_settings_payload = redacted_payload
+        else:
+            self._dry_contact_settings_payload = {"value": redacted_payload}
+        self._parse_dry_contact_settings_payload(payload)
+        self._dry_contact_settings_failures = 0
+        self._dry_contact_settings_last_success_mono = now
+        self._dry_contact_settings_cache_until = now + DRY_CONTACT_SETTINGS_CACHE_TTL
 
     async def async_set_system_profile(self, profile_key: str) -> None:
         profile = self._normalize_battery_profile_key(profile_key)

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -4875,6 +4875,7 @@ class EnphaseDryContactsInventorySensor(_SiteBaseEntity):
         {
             "members",
             "contacts",
+            "unmatched_settings",
             "last_reported_utc",
         }
     )
@@ -4917,6 +4918,10 @@ class EnphaseDryContactsInventorySensor(_SiteBaseEntity):
         members = self._members()
         if not members:
             return {}
+        settings_matches, unmatched_settings = self._coord.dry_contact_settings_matches(
+            members
+        )
+        dry_contact_settings_supported = self._coord.dry_contact_settings_supported
         latest_reported: datetime | None = None
         visible_count = 0
         visible_seen = False
@@ -4973,32 +4978,55 @@ class EnphaseDryContactsInventorySensor(_SiteBaseEntity):
             )
             terminal_values = _gateway_terminal_values(member)
             terminal_descriptions = _gateway_terminal_descriptions(member)
-            contacts.append(
-                {
-                    "index": index,
-                    "name": _gateway_clean_text(member.get("name"))
-                    or f"Dry Contact {index}",
-                    "status_text": _gateway_meter_status_text(member),
-                    "status_raw": status_raw,
-                    "connected": _gateway_optional_bool(member.get("connected")),
-                    "channel_type": _gateway_clean_text(
-                        member.get("channel_type")
-                        if member.get("channel_type") is not None
-                        else member.get("channelType")
-                    ),
-                    "serial_number": _gateway_clean_text(
-                        member.get("serial_number")
-                        if member.get("serial_number") is not None
-                        else member.get("serial")
-                    ),
-                    "visible": visible,
-                    "enabled": enabled,
-                    "in_use": in_use,
-                    "properties": dict(member),
-                    **terminal_values,
-                    "terminal_descriptions": terminal_descriptions,
-                }
+            contact: dict[str, object] = {
+                "index": index,
+                "name": _gateway_clean_text(member.get("name")) or f"Dry Contact {index}",
+                "status_text": _gateway_meter_status_text(member),
+                "status_raw": status_raw,
+                "connected": _gateway_optional_bool(member.get("connected")),
+                "channel_type": _gateway_clean_text(
+                    member.get("channel_type")
+                    if member.get("channel_type") is not None
+                    else member.get("channelType")
+                ),
+                "serial_number": _gateway_clean_text(
+                    member.get("serial_number")
+                    if member.get("serial_number") is not None
+                    else member.get("serial")
+                ),
+                "visible": visible,
+                "enabled": enabled,
+                "in_use": in_use,
+                "properties": dict(member),
+                **terminal_values,
+                "terminal_descriptions": terminal_descriptions,
+            }
+            matched_settings = (
+                settings_matches[index - 1]
+                if (index - 1) < len(settings_matches)
+                else None
             )
+            if isinstance(matched_settings, dict):
+                for key in (
+                    "configured_name",
+                    "override_supported",
+                    "override_active",
+                    "control_mode",
+                    "polling_interval_seconds",
+                    "soc_threshold",
+                    "soc_threshold_min",
+                    "soc_threshold_max",
+                ):
+                    value = matched_settings.get(key)
+                    if value is not None:
+                        contact[key] = value
+                schedule_windows = matched_settings.get("schedule_windows")
+                if isinstance(schedule_windows, list) and schedule_windows:
+                    contact["schedule_windows"] = [
+                        dict(window) if isinstance(window, dict) else window
+                        for window in schedule_windows
+                    ]
+            contacts.append(contact)
 
         attrs: dict[str, object] = {
             "name": "Dry Contacts",
@@ -5009,7 +5037,16 @@ class EnphaseDryContactsInventorySensor(_SiteBaseEntity):
             ),
             "contacts": contacts,
             "members": [dict(member) for member in members],
+            "dry_contact_settings_supported": dry_contact_settings_supported,
+            "dry_contact_settings_contact_count": len(
+                self._coord.dry_contact_settings_entries()
+            ),
         }
+        if unmatched_settings:
+            attrs["unmatched_settings"] = [
+                dict(entry) if isinstance(entry, dict) else entry
+                for entry in unmatched_settings
+            ]
         if visible_seen:
             attrs["visible_contact_count"] = visible_count
         if enabled_seen:
@@ -5018,6 +5055,7 @@ class EnphaseDryContactsInventorySensor(_SiteBaseEntity):
             attrs["in_use_contact_count"] = in_use_count
         if len(members) == 1:
             member = members[0]
+            matched_settings = settings_matches[0] if settings_matches else None
             attrs.update(
                 {
                     "channel_type": _gateway_clean_text(
@@ -5042,6 +5080,26 @@ class EnphaseDryContactsInventorySensor(_SiteBaseEntity):
             attrs.update(_gateway_terminal_values(member))
             if terminal_descriptions:
                 attrs["terminal_descriptions"] = terminal_descriptions
+            if isinstance(matched_settings, dict):
+                for key in (
+                    "configured_name",
+                    "override_supported",
+                    "override_active",
+                    "control_mode",
+                    "polling_interval_seconds",
+                    "soc_threshold",
+                    "soc_threshold_min",
+                    "soc_threshold_max",
+                ):
+                    value = matched_settings.get(key)
+                    if value is not None:
+                        attrs[key] = value
+                schedule_windows = matched_settings.get("schedule_windows")
+                if isinstance(schedule_windows, list) and schedule_windows:
+                    attrs["schedule_windows"] = [
+                        dict(window) if isinstance(window, dict) else window
+                        for window in schedule_windows
+                    ]
             attrs.update(
                 _gateway_flat_member_attributes(
                     member,

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -717,6 +717,29 @@ async def test_battery_status_returns_empty_when_payload_not_dict() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dry_contacts_settings_uses_endpoint() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value={"contacts": []})
+
+    result = await client.dry_contacts_settings()
+
+    assert result == {"contacts": []}
+    client._json.assert_awaited_once_with(
+        "GET", f"{api.BASE_URL}/pv/settings/SITE/dry_contacts"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dry_contacts_settings_returns_empty_when_payload_not_dict() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value=["bad"])
+
+    result = await client.dry_contacts_settings()
+
+    assert result == {}
+
+
+@pytest.mark.asyncio
 async def test_inverters_inventory_uses_inverters_json_endpoint() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"inverters": []})

--- a/tests/components/enphase_ev/test_api_urls.py
+++ b/tests/components/enphase_ev/test_api_urls.py
@@ -23,6 +23,7 @@ async def test_api_builds_urls_correctly():
     c = StubClient(site_id=RANDOM_SITE_ID)
     await c.status()
     await c.battery_status()
+    await c.dry_contacts_settings()
     await c.grid_control_check()
     await c.request_grid_toggle_otp()
     await c.validate_grid_toggle_otp("1234")
@@ -49,23 +50,25 @@ async def test_api_builds_urls_correctly():
     assert methods_urls[1][0] == "GET"
     assert f"/pv/settings/{RANDOM_SITE_ID}/battery_status.json" in methods_urls[1][1]
     assert methods_urls[2][0] == "GET"
-    assert f"/app-api/{RANDOM_SITE_ID}/grid_control_check.json" in methods_urls[2][1]
+    assert f"/pv/settings/{RANDOM_SITE_ID}/dry_contacts" in methods_urls[2][1]
     assert methods_urls[3][0] == "GET"
-    assert f"/app-api/{RANDOM_SITE_ID}/grid_toggle_otp.json" in methods_urls[3][1]
-    assert methods_urls[4][0] == "POST"
-    assert "/app-api/grid_toggle_otp.json" in methods_urls[4][1]
+    assert f"/app-api/{RANDOM_SITE_ID}/grid_control_check.json" in methods_urls[3][1]
+    assert methods_urls[4][0] == "GET"
+    assert f"/app-api/{RANDOM_SITE_ID}/grid_toggle_otp.json" in methods_urls[4][1]
     assert methods_urls[5][0] == "POST"
-    assert "/pv/settings/grid_state.json" in methods_urls[5][1]
+    assert "/app-api/grid_toggle_otp.json" in methods_urls[5][1]
     assert methods_urls[6][0] == "POST"
-    assert "/pv/settings/log_grid_change.json" in methods_urls[6][1]
-    assert methods_urls[7][0] == "GET"
-    assert f"/app-api/{RANDOM_SITE_ID}/battery_backup_history.json" in methods_urls[7][1]
+    assert "/pv/settings/grid_state.json" in methods_urls[6][1]
+    assert methods_urls[7][0] == "POST"
+    assert "/pv/settings/log_grid_change.json" in methods_urls[7][1]
     assert methods_urls[8][0] == "GET"
-    assert f"/app-api/{RANDOM_SITE_ID}/inverters.json" in methods_urls[8][1]
+    assert f"/app-api/{RANDOM_SITE_ID}/battery_backup_history.json" in methods_urls[8][1]
     assert methods_urls[9][0] == "GET"
-    assert f"/systems/{RANDOM_SITE_ID}/inverter_status_x.json" in methods_urls[9][1]
+    assert f"/app-api/{RANDOM_SITE_ID}/inverters.json" in methods_urls[9][1]
     assert methods_urls[10][0] == "GET"
-    assert f"/systems/{RANDOM_SITE_ID}/inverter_data_x/energy.json" in methods_urls[10][1]
+    assert f"/systems/{RANDOM_SITE_ID}/inverter_status_x.json" in methods_urls[10][1]
+    assert methods_urls[11][0] == "GET"
+    assert f"/systems/{RANDOM_SITE_ID}/inverter_data_x/energy.json" in methods_urls[11][1]
     opt_out_call = next(
         (
             (method, url)

--- a/tests/components/enphase_ev/test_coordinator_dry_contact_settings.py
+++ b/tests/components/enphase_ev/test_coordinator_dry_contact_settings.py
@@ -1,0 +1,468 @@
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
+
+
+def _seed_dry_contact_members(coord) -> None:
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "type_label": "Gateway",
+                "count": 1,
+                "devices": [{"name": "System Controller", "channel_type": "enpower"}],
+            },
+            "dry_contact": {
+                "type_key": "dry_contact",
+                "type_label": "Dry Contacts",
+                "count": 2,
+                "devices": [
+                    {
+                        "name": "Dry Contact 1",
+                        "serial_number": "DC-1",
+                        "channel_type": "dry_contact_1",
+                        "device_uid": "UID-1",
+                        "contact_id": "CID-1",
+                    },
+                    {
+                        "name": "Dry Contact 2",
+                        "serial_number": "DC-2",
+                        "channel_type": "dry_contact_2",
+                        "device_uid": "UID-2",
+                        "contact_id": "CID-2",
+                    },
+                ],
+            },
+        },
+        ["envoy", "dry_contact"],
+    )
+
+
+def test_parse_dry_contact_settings_payload_normalizes_and_tracks_unmatched(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    _seed_dry_contact_members(coord)
+
+    coord._parse_dry_contact_settings_payload(  # noqa: SLF001
+        {
+            "data": {
+                "contacts": [
+                    {
+                        "serial": "DC-1",
+                        "displayName": "Solar Diverter",
+                        "overrideSupported": True,
+                        "overrideActive": False,
+                        "controlMode": "soc_threshold",
+                        "pollingInterval": 30,
+                        "socThreshold": 45,
+                        "socThresholdMin": 20,
+                        "socThresholdMax": 80,
+                        "scheduleWindows": [
+                            {"startTime": "22:00", "endTime": "06:00"},
+                        ],
+                    },
+                    {
+                        "channelType": "dry_contact_9",
+                        "name": "Spare Contact",
+                        "overrideSupported": False,
+                    },
+                ]
+            }
+        }
+    )
+
+    assert coord.dry_contact_settings_supported is True
+    entries = coord.dry_contact_settings_entries()
+    assert len(entries) == 2
+    assert entries[0]["serial_number"] == "DC-1"
+    assert entries[0]["configured_name"] == "Solar Diverter"
+    assert entries[0]["override_supported"] is True
+    assert entries[0]["override_active"] is False
+    assert entries[0]["control_mode"] == "soc_threshold"
+    assert entries[0]["polling_interval_seconds"] == 30
+    assert entries[0]["soc_threshold"] == 45
+    assert entries[0]["soc_threshold_min"] == 20
+    assert entries[0]["soc_threshold_max"] == 80
+    assert entries[0]["schedule_windows"] == [{"start": "22:00", "end": "06:00"}]
+
+    matches, unmatched = coord.dry_contact_settings_matches(
+        [
+            {
+                "serial_number": "DC-1",
+                "channel_type": "dry_contact_1",
+                "name": "Dry Contact 1",
+            },
+            {
+                "serial_number": "DC-2",
+                "channel_type": "dry_contact_2",
+                "name": "Dry Contact 2",
+            },
+        ]
+    )
+    assert matches[0] is not None
+    assert matches[0]["configured_name"] == "Solar Diverter"
+    assert matches[1] is None
+    assert unmatched == coord.dry_contact_unmatched_settings()
+    assert unmatched[0]["configured_name"] == "Spare Contact"
+
+
+def test_parse_dry_contact_settings_payload_invalid_marks_unsupported(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+
+    coord._parse_dry_contact_settings_payload(["bad"])  # noqa: SLF001
+
+    assert coord.dry_contact_settings_supported is False
+    assert coord.dry_contact_settings_entries() == []
+    assert coord.dry_contact_unmatched_settings() == []
+
+
+def test_parse_dry_contact_settings_payload_empty_dict_marks_supported_with_no_entries(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+
+    coord._parse_dry_contact_settings_payload({})  # noqa: SLF001
+
+    assert coord.dry_contact_settings_supported is True
+    assert coord.dry_contact_settings_entries() == []
+    assert coord.dry_contact_unmatched_settings() == []
+
+
+def test_dry_contact_settings_helper_edge_cases(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+
+    assert coord._dry_contact_settings_is_stale() is True  # noqa: SLF001
+
+    coord._dry_contact_settings_supported = True  # noqa: SLF001
+    coord._dry_contact_settings_last_success_mono = time.monotonic() + 5  # noqa: SLF001
+    assert coord._dry_contact_settings_is_stale() is False  # noqa: SLF001
+    coord._dry_contact_settings_last_success_mono = time.monotonic() - 999  # noqa: SLF001
+    assert coord.dry_contact_settings_supported is None
+
+    coord._dry_contact_settings_entries = "bad"  # type: ignore[assignment]  # noqa: SLF001
+    coord._dry_contact_unmatched_settings = "bad"  # type: ignore[assignment]  # noqa: SLF001
+    assert coord.dry_contact_settings_entries() == []
+    assert coord.dry_contact_unmatched_settings() == []
+
+    copied = coord._copy_dry_contact_settings_entry(  # noqa: SLF001
+        {"nested": {"a": 1}, "windows": [{"start": "01:00", "end": "02:00"}]}
+    )
+    assert copied["nested"] == {"a": 1}
+    assert copied["windows"] == [{"start": "01:00", "end": "02:00"}]
+
+    assert coord._normalize_dry_contact_schedule_windows(  # noqa: SLF001
+        {"startTime": "01:00", "endTime": "02:00"}
+    ) == [{"start": "01:00", "end": "02:00"}]
+    assert coord._normalize_dry_contact_schedule_windows(  # noqa: SLF001
+        [{}, {"start": "01:00", "end": "02:00"}, {"start": "01:00", "end": "02:00"}]
+    ) == [{"start": "01:00", "end": "02:00"}]
+    assert coord._dry_contact_settings_looks_like_entry("bad") is False  # noqa: SLF001
+
+    identities = coord._dry_contact_identity_candidates(  # noqa: SLF001
+        {"serial": "DC-1", "configured_name": "Contact A", "name": "Contact A"}
+    )
+    assert identities[0] == ("serial_number", "dc-1")
+    assert identities[-1] == ("name", "contact a")
+
+    assert coord._dry_contact_member_is_dry_contact("bad") is False  # noqa: SLF001
+    assert coord._dry_contact_member_is_dry_contact({"channel_type": "NC1"}) is True  # noqa: SLF001
+    assert coord._dry_contact_member_is_dry_contact({"name": "drycontactloads"}) is True  # noqa: SLF001
+    assert coord._dry_contact_member_is_dry_contact({"name": "Load-control relay NO2"}) is True  # noqa: SLF001
+    assert coord._dry_contact_member_dedupe_key({}, 3) == (("idx", "3"),)  # noqa: SLF001
+    assert coord._dry_contact_match_conflicts(  # noqa: SLF001
+        {"serial_number": "dc-1"},
+        {"serial_number": "dc-2"},
+    ) is True
+
+
+def test_parse_dry_contact_settings_payload_edge_paths(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    _seed_dry_contact_members(coord)
+    loop: dict[str, object] = {}
+    loop["self"] = loop
+
+    coord._parse_dry_contact_settings_payload(  # noqa: SLF001
+        {
+            "data": {
+                "deep": {"a": {"b": {"c": {"d": {"serial": "TOO-DEEP"}}}}},
+                "loop": loop,
+                "contacts": [
+                    {
+                        "device-uid": "DU-1",
+                        "uid": "UID-ALT-1",
+                        "contactId": "CID-ALT-1",
+                        "displayName": "Contact Edge",
+                        "scheduleStart": "07:00",
+                        "scheduleEnd": "08:00",
+                    },
+                    {"windows": [{}]},
+                    {
+                        "device-uid": "DU-1",
+                        "uid": "UID-ALT-1",
+                        "contactId": "CID-ALT-1",
+                        "displayName": "Contact Edge",
+                        "scheduleStart": "07:00",
+                        "scheduleEnd": "08:00",
+                    },
+                ],
+            }
+        }
+    )
+
+    entries = coord.dry_contact_settings_entries()
+    assert entries == [
+        {
+            "device_uid": "DU-1",
+            "uid": "UID-ALT-1",
+            "contact_id": "CID-ALT-1",
+            "configured_name": "Contact Edge",
+            "schedule_windows": [{"start": "07:00", "end": "08:00"}],
+        }
+    ]
+
+
+def test_dry_contact_members_for_settings_filters_invalid_and_duplicate_members(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._type_device_buckets = {  # noqa: SLF001
+        "envoy": {
+            "type_key": "envoy",
+            "type_label": "Gateway",
+            "count": 1,
+            "devices": [
+                {"name": "Dry Contact Gateway", "channel_type": "dry_contact_1", "serial_number": "DC-ENV"},
+                "bad",
+                {"status": "retired"},
+                {},
+            ],
+        },
+        "dry_contact": {
+            "type_key": "dry_contact",
+            "type_label": "Dry Contacts",
+            "count": 3,
+            "devices": [
+                "bad",
+                {"serial_number": "DC-ENV", "channel_type": "dry_contact_1"},
+                {"serial_number": "DC-ENV", "channel_type": "dry_contact_2"},
+                {"serial_number": "DC-2", "channel_type": "dry_contact_2"},
+                {"status": "retired"},
+                {},
+            ],
+        },
+    }
+
+    members = coord._dry_contact_members_for_settings()  # noqa: SLF001
+
+    assert members == [
+        {
+            "name": "Dry Contact Gateway",
+            "channel_type": "dry_contact_1",
+            "serial_number": "DC-ENV",
+        },
+        {
+            "serial_number": "DC-ENV",
+            "channel_type": "dry_contact_2",
+        },
+        {
+            "serial_number": "DC-2",
+            "channel_type": "dry_contact_2",
+        },
+    ]
+
+
+def test_dry_contact_settings_matches_leave_ambiguous_same_serial_unmatched(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+
+    matches, unmatched = coord._match_dry_contact_settings(  # noqa: SLF001
+        [
+            {"serial_number": "DC-1", "channel_type": "dry_contact_1"},
+            {"serial_number": "DC-1", "channel_type": "dry_contact_2"},
+        ],
+        settings_entries=[
+            {"serial_number": "DC-1", "configured_name": "Shared Serial Only"},
+            {
+                "serial_number": "DC-1",
+                "channel_type": "dry_contact_2",
+                "configured_name": "Contact Two",
+            },
+        ],
+    )
+
+    assert matches == [
+        None,
+        {
+            "serial_number": "DC-1",
+            "channel_type": "dry_contact_2",
+            "configured_name": "Contact Two",
+        },
+    ]
+    assert unmatched == [
+        {"serial_number": "DC-1", "configured_name": "Shared Serial Only"}
+    ]
+
+
+def test_dry_contact_settings_matches_skip_conflicting_unique_candidate(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+
+    matches, unmatched = coord._match_dry_contact_settings(  # noqa: SLF001
+        [
+            {
+                "serial_number": "DC-1",
+                "channel_type": "dry_contact_1",
+            }
+        ],
+        settings_entries=[
+            {
+                "serial_number": "DC-1",
+                "channel_type": "dry_contact_9",
+                "configured_name": "Wrong Channel",
+            }
+        ],
+    )
+
+    assert matches == [None]
+    assert unmatched == [
+        {
+            "serial_number": "DC-1",
+            "channel_type": "dry_contact_9",
+            "configured_name": "Wrong Channel",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_refresh_dry_contact_settings_caches_and_redacts(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    _seed_dry_contact_members(coord)
+    coord.client.dry_contacts_settings = AsyncMock(
+        return_value={
+            "data": {
+                "contacts": [
+                    {
+                        "serial": "DC-1",
+                        "displayName": "Solar Diverter",
+                    }
+                ]
+            },
+            "token": "secret-token",
+        }
+    )
+
+    await coord._async_refresh_dry_contact_settings(force=True)  # noqa: SLF001
+
+    assert coord._dry_contact_settings_payload is not None  # noqa: SLF001
+    assert coord._dry_contact_settings_payload["token"] == "[redacted]"  # noqa: SLF001
+    assert coord.dry_contact_settings_supported is True
+    assert coord.dry_contact_settings_entries()[0]["configured_name"] == "Solar Diverter"
+
+    coord._dry_contact_settings_cache_until = time.monotonic() + 300  # noqa: SLF001
+    coord.client.dry_contacts_settings.reset_mock()
+    await coord._async_refresh_dry_contact_settings()  # noqa: SLF001
+    coord.client.dry_contacts_settings.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_dry_contact_settings_wraps_non_dict_redaction(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord.client.dry_contacts_settings = AsyncMock(return_value={"contacts": []})
+    coord._redact_battery_payload = lambda _payload: "masked"  # type: ignore[method-assign]  # noqa: SLF001
+
+    await coord._async_refresh_dry_contact_settings(force=True)  # noqa: SLF001
+
+    assert coord._dry_contact_settings_payload == {"value": "masked"}  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_refresh_dry_contact_settings_failure_stale_and_recent_behavior(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._dry_contact_settings_supported = True  # noqa: SLF001
+    coord._dry_contact_settings_last_success_mono = time.monotonic() - 999  # noqa: SLF001
+    coord.client.dry_contacts_settings = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await coord._async_refresh_dry_contact_settings(force=True)  # noqa: SLF001
+
+    assert coord.dry_contact_settings_supported is None
+    assert coord._dry_contact_settings_failures == 1  # noqa: SLF001
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._dry_contact_settings_supported = True  # noqa: SLF001
+    coord._dry_contact_settings_last_success_mono = time.monotonic()  # noqa: SLF001
+    coord._dry_contact_settings_entries = [{"serial_number": "DC-1"}]  # noqa: SLF001
+    coord.client.dry_contacts_settings = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await coord._async_refresh_dry_contact_settings(force=True)  # noqa: SLF001
+
+    assert coord.dry_contact_settings_supported is True
+    assert coord._dry_contact_settings_failures == 1  # noqa: SLF001
+    assert coord.dry_contact_settings_entries() == [{"serial_number": "DC-1"}]
+
+
+def test_collect_site_metrics_includes_dry_contact_settings_fields(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    _seed_dry_contact_members(coord)
+    coord._parse_dry_contact_settings_payload(  # noqa: SLF001
+        {
+            "contacts": [
+                {"serial": "DC-1", "name": "Solar Diverter"},
+                {"channelType": "dry_contact_9", "name": "Spare Contact"},
+            ]
+        }
+    )
+    coord._dry_contact_settings_last_success_mono = time.monotonic() - 1.0  # noqa: SLF001
+
+    metrics = coord.collect_site_metrics()
+
+    assert metrics["dry_contact_settings_supported"] is True
+    assert metrics["dry_contact_settings_contact_count"] == 2
+    assert metrics["dry_contact_settings_unmatched_count"] == 1
+    assert metrics["dry_contact_settings_fetch_failures"] == 0
+    assert metrics["dry_contact_settings_data_stale"] is False
+    assert "dry_contact_settings_last_success_age_s" in metrics
+
+
+@pytest.mark.asyncio
+async def test_update_data_ignores_dry_contact_settings_refresh_errors(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.site_only = True
+    coord._async_refresh_dry_contact_settings = AsyncMock(  # noqa: SLF001
+        side_effect=RuntimeError("boom")
+    )
+
+    result = await coord._async_update_data()  # noqa: SLF001
+
+    assert result == {}
+
+    coord = coordinator_factory()
+    coord.client.status = AsyncMock(return_value={"evChargerData": [], "ts": 0})
+    coord._async_refresh_dry_contact_settings = AsyncMock(  # noqa: SLF001
+        side_effect=RuntimeError("boom")
+    )
+
+    await coord._async_update_data()  # noqa: SLF001

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -175,6 +175,14 @@ class DummyCoordinator(SimpleNamespace):
             "disableGridControl": False,
             "activeDownload": False,
         }
+        self._dry_contact_settings_payload = {
+            "data": {
+                "contacts": [
+                    {"serial": "DC0001", "displayName": "Solar Diverter"},
+                ]
+            },
+            "token": "[redacted]",
+        }
         self._battery_backup_history_payload = {
             "total_records": 1,
             "histories": [{"start_time": "2025-10-17T14:38:30+11:00", "duration": 121}],
@@ -252,6 +260,11 @@ class DummyCoordinator(SimpleNamespace):
             "last_error": self._last_error,
             "phase_timings": self.phase_timings,
             "session_cache_ttl_s": self._session_history_cache_ttl,
+            "dry_contact_settings_supported": True,
+            "dry_contact_settings_contact_count": 1,
+            "dry_contact_settings_unmatched_count": 0,
+            "dry_contact_settings_fetch_failures": 0,
+            "dry_contact_settings_data_stale": False,
         }
 
     def charge_mode_cache_snapshot(self):
@@ -273,6 +286,7 @@ class DummyCoordinator(SimpleNamespace):
             "settings_payload": self._battery_settings_payload,
             "status_payload": self._battery_status_payload,
             "grid_control_check_payload": self._grid_control_check_payload,
+            "dry_contacts_payload": self._dry_contact_settings_payload,
             "backup_history_payload": self._battery_backup_history_payload,
             "hems_devices_payload": self._hems_devices_payload,
             "devices_inventory_payload": self._devices_inventory_payload,
@@ -349,6 +363,10 @@ async def test_config_entry_diagnostics_includes_coordinator(hass, config_entry)
         is False
     )
     assert (
+        diag["coordinator"]["battery_config"]["dry_contacts_payload"]["token"]
+        == "[redacted]"
+    )
+    assert (
         diag["coordinator"]["battery_config"]["backup_history_payload"]["total_records"]
         == 1
     )
@@ -367,6 +385,10 @@ async def test_config_entry_diagnostics_includes_coordinator(hass, config_entry)
     assert diag["coordinator"]["battery_config"]["devices_inventory_payload"] == {
         "result": [{"type": "encharge"}]
     }
+    assert (
+        diag["coordinator"]["site_metrics"]["dry_contact_settings_supported"] is True
+    )
+    assert diag["coordinator"]["site_metrics"]["dry_contact_settings_contact_count"] == 1
     assert diag["coordinator"]["evse"]["site_feature_flags"]["evse_charging_mode"] is True
     assert (
         diag["coordinator"]["evse"]["charger_feature_flags"][0]["serial"]

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -2657,6 +2657,138 @@ def test_dry_contacts_inventory_sensor_single_member_attributes(
     assert attrs["contacts"][0]["in_use"] is None
 
 
+def test_dry_contacts_inventory_sensor_merges_settings_into_contact_attributes(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseDryContactsInventorySensor
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "type_label": "Gateway",
+                "count": 1,
+                "devices": [{"name": "System Controller", "channel_type": "enpower"}],
+            },
+            "dry_contact": {
+                "type_key": "dry_contact",
+                "type_label": "Dry Contact",
+                "count": 2,
+                "devices": [
+                    {
+                        "name": "Dry Contact 1",
+                        "channel_type": "dry_contact_1",
+                        "serial_number": "DC-1",
+                        "statusText": "Closed",
+                    },
+                    {
+                        "name": "Dry Contact 2",
+                        "channel_type": "dry_contact_2",
+                        "serial_number": "DC-2",
+                        "statusText": "Open",
+                    },
+                ],
+            },
+        },
+        ["envoy", "dry_contact"],
+    )
+    coord._parse_dry_contact_settings_payload(  # noqa: SLF001
+        {
+            "contacts": [
+                {
+                    "serial": "DC-1",
+                    "displayName": "Solar Diverter",
+                    "overrideSupported": True,
+                    "overrideActive": False,
+                    "controlMode": "schedule",
+                    "pollingInterval": 30,
+                    "socThreshold": 55,
+                    "socThresholdMin": 20,
+                    "socThresholdMax": 80,
+                    "scheduleWindows": [{"startTime": "22:00", "endTime": "06:00"}],
+                },
+                {
+                    "channelType": "dry_contact_9",
+                    "name": "Unmatched Contact",
+                    "overrideSupported": False,
+                },
+            ]
+        }
+    )
+
+    attrs = EnphaseDryContactsInventorySensor(coord).extra_state_attributes
+
+    assert attrs["dry_contact_settings_supported"] is True
+    assert attrs["dry_contact_settings_contact_count"] == 2
+    assert attrs["unmatched_settings"][0]["configured_name"] == "Unmatched Contact"
+    assert attrs["contacts"][0]["configured_name"] == "Solar Diverter"
+    assert attrs["contacts"][0]["override_supported"] is True
+    assert attrs["contacts"][0]["override_active"] is False
+    assert attrs["contacts"][0]["control_mode"] == "schedule"
+    assert attrs["contacts"][0]["polling_interval_seconds"] == 30
+    assert attrs["contacts"][0]["soc_threshold"] == 55
+    assert attrs["contacts"][0]["soc_threshold_min"] == 20
+    assert attrs["contacts"][0]["soc_threshold_max"] == 80
+    assert attrs["contacts"][0]["schedule_windows"] == [
+        {"start": "22:00", "end": "06:00"}
+    ]
+    assert "configured_name" not in attrs["contacts"][1]
+
+
+def test_dry_contacts_inventory_sensor_single_contact_flattens_settings_attributes(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseDryContactsInventorySensor
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "type_label": "Gateway",
+                "count": 1,
+                "devices": [{"name": "System Controller", "channel_type": "enpower"}],
+            },
+            "dry_contact": {
+                "type_key": "dry_contact",
+                "type_label": "Dry Contact",
+                "count": 1,
+                "devices": [
+                    {
+                        "name": "Dry Contact 1",
+                        "channel_type": "dry_contact_1",
+                        "serial_number": "DC-1",
+                        "statusText": "Closed",
+                    }
+                ],
+            },
+        },
+        ["envoy", "dry_contact"],
+    )
+    coord._parse_dry_contact_settings_payload(  # noqa: SLF001
+        {
+            "contacts": [
+                {
+                    "serial": "DC-1",
+                    "displayName": "Solar Diverter",
+                    "overrideSupported": True,
+                    "controlMode": "soc_threshold",
+                    "scheduleWindows": [{"startTime": "21:00", "endTime": "23:00"}],
+                }
+            ]
+        }
+    )
+
+    attrs = EnphaseDryContactsInventorySensor(coord).extra_state_attributes
+
+    assert attrs["configured_name"] == "Solar Diverter"
+    assert attrs["override_supported"] is True
+    assert attrs["control_mode"] == "soc_threshold"
+    assert attrs["schedule_windows"] == [{"start": "21:00", "end": "23:00"}]
+    assert attrs["contacts"][0]["configured_name"] == "Solar Diverter"
+
+
 def test_dry_contacts_inventory_sensor_multi_contact_state_is_stable(
     coordinator_factory,
 ) -> None:


### PR DESCRIPTION
## Summary
- add dry-contact settings API fetching, coordinator parsing/cache state, and redacted diagnostics payload exposure for `pv/settings/<site>/dry_contacts`
- enrich the dry contacts diagnostics sensor with matched settings details while preserving live status as the entity state
- fix microinverter setup discovery by paginating legacy inverter inventory fallback, clearing false setup warnings after fallback succeeds, and preventing phantom site water-heater energy sensors when no real channel exists
- add regression coverage for dry-contact diagnostics, legacy inverter payload shapes and fallback paths, and site-energy entity gating while keeping touched modules at 100% coverage

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/config_flow.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/diagnostics.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
