### PR TITLE
Fix site discovery and site energy gating

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -956,6 +956,104 @@ async def async_fetch_devices_inventory(
     return None
 
 
+async def async_fetch_inverters_inventory(
+    session: aiohttp.ClientSession,
+    site_id: str,
+    tokens: AuthTokens,
+    *,
+    timeout: int = DEFAULT_AUTH_TIMEOUT,
+) -> dict[str, object] | None:
+    """Fetch legacy inverter inventory for config-flow microinverter discovery."""
+
+    if not site_id:
+        return {}
+
+    client = EnphaseEVClient(
+        session,
+        site_id,
+        tokens.access_token,
+        tokens.cookie,
+        timeout=timeout,
+    )
+
+    def _payload_inverters(payload: dict[str, object]) -> tuple[list[dict[str, object]], str]:
+        inverters = payload.get("inverters")
+        if isinstance(inverters, list):
+            return ([item for item in inverters if isinstance(item, dict)], "root")
+        result = payload.get("result")
+        if isinstance(result, dict):
+            inverters = result.get("inverters")
+            if isinstance(inverters, list):
+                return ([item for item in inverters if isinstance(item, dict)], "result")
+        return ([], "")
+
+    def _payload_total(payload: dict[str, object], default: int) -> int:
+        raw_total = payload.get("total")
+        try:
+            total = int(raw_total)
+        except (TypeError, ValueError):
+            return default
+        return total if total >= 0 else default
+
+    async def _fetch_page(offset: int) -> dict[str, object] | None:
+        try:
+            payload = await client.inverters_inventory(limit=1000, offset=offset, search="")
+        except TypeError:
+            if offset != 0:
+                return None
+            try:
+                payload = await client.inverters_inventory()
+            except Exception as err:  # noqa: BLE001 - best-effort for flow UX
+                _LOGGER.debug(
+                    "Failed to fetch inverter inventory for site %s: %s", site_id, err
+                )
+                return None
+        except Exception as err:  # noqa: BLE001 - best-effort for flow UX
+            _LOGGER.debug(
+                "Failed to fetch inverter inventory for site %s: %s", site_id, err
+            )
+            return None
+        if isinstance(payload, dict):
+            return payload
+        return None
+
+    try:
+        payload = await _fetch_page(0)
+        if payload is None:
+            return None
+
+        inverters, storage_key = _payload_inverters(payload)
+        total_expected = _payload_total(payload, len(inverters))
+        if storage_key and total_expected > len(inverters):
+            merged = list(inverters)
+            next_offset = len(merged)
+            while next_offset < total_expected:
+                next_payload = await _fetch_page(next_offset)
+                if next_payload is None:
+                    break
+                next_inverters, _ = _payload_inverters(next_payload)
+                if not next_inverters:
+                    break
+                merged.extend(next_inverters)
+                total_expected = max(
+                    total_expected,
+                    _payload_total(next_payload, total_expected),
+                )
+                next_offset += len(next_inverters)
+            payload = dict(payload)
+            if storage_key == "root":
+                payload["inverters"] = merged
+            else:
+                result = payload.get("result")
+                result_dict = dict(result) if isinstance(result, dict) else {}
+                result_dict["inverters"] = merged
+                payload["result"] = result_dict
+        return payload
+    except Exception as err:  # noqa: BLE001 - best-effort for flow UX
+        _LOGGER.debug("Failed to assemble inverter inventory for site %s: %s", site_id, err)
+        return None
+
+
 async def async_fetch_hems_devices(
     session: aiohttp.ClientSession,
     site_id: str,

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -25,6 +25,7 @@ from .api import (
     async_authenticate,
     async_fetch_hems_devices,
     async_fetch_devices_inventory,
+    async_fetch_inverters_inventory,
     async_fetch_chargers,
     async_resend_login_otp,
     async_validate_login_otp,
@@ -130,6 +131,24 @@ def _hems_heatpump_available(payload: object) -> bool:
             ):
                 return True
     return False
+
+
+def _legacy_microinverters_available(payload: object) -> bool:
+    """Return True when legacy inverter inventory exposes active members."""
+
+    if not isinstance(payload, dict):
+        return False
+    inverters = payload.get("inverters")
+    if not isinstance(inverters, list):
+        result = payload.get("result")
+        if isinstance(result, dict):
+            inverters = result.get("inverters")
+    if not isinstance(inverters, list):
+        return False
+    return any(
+        isinstance(member, dict) and not member_is_retired(member)
+        for member in inverters
+    )
 
 
 class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
@@ -638,6 +657,13 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 )
                 if key in _TYPE_FIELD_BY_KEY
             ]
+        if "microinverter" not in self._available_type_keys:
+            legacy_inverters = await async_fetch_inverters_inventory(
+                session, self._selected_site_id, self._auth_tokens
+            )
+            if _legacy_microinverters_available(legacy_inverters):
+                self._inventory_unknown = False
+                self._available_type_keys.append("microinverter")
         if _hems_heatpump_available(hems_payload) and "heatpump" in _TYPE_FIELD_BY_KEY:
             if "heatpump" not in self._available_type_keys:
                 self._available_type_keys.append("heatpump")

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -380,7 +380,13 @@ async def async_setup_entry(
             known_site_entity_keys.add(key)
 
         def _site_energy_channel_present(flow_key: str, payload_key: str) -> bool:
-            return flow_key in site_energy or payload_key in site_energy_bucket_lengths
+            if flow_key in site_energy:
+                return True
+            bucket_length = site_energy_bucket_lengths.get(payload_key)
+            try:
+                return int(bucket_length) > 0
+            except (TypeError, ValueError):
+                return bool(bucket_length)
 
         if gateway_available:
             _add_site_entity("site_last_update", EnphaseSiteLastUpdateSensor(coord))

--- a/tests/components/enphase_ev/test_api_http_flow.py
+++ b/tests/components/enphase_ev/test_api_http_flow.py
@@ -1039,6 +1039,196 @@ async def test_async_fetch_devices_inventory_returns_dict_payload(monkeypatch) -
 
 
 @pytest.mark.asyncio
+async def test_async_fetch_inverters_inventory_requires_site_id() -> None:
+    tokens = api.AuthTokens(cookie="")
+    assert await api.async_fetch_inverters_inventory(MagicMock(), "", tokens) == {}
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_inverters_inventory_handles_non_dict_payload(
+    monkeypatch,
+) -> None:
+    class StubClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.inverters_inventory = AsyncMock(return_value=["bad"])
+
+    monkeypatch.setattr(api, "EnphaseEVClient", StubClient)
+    tokens = api.AuthTokens(cookie="cook", access_token="tok")
+    payload = await api.async_fetch_inverters_inventory(MagicMock(), "site", tokens)
+    assert payload is None
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_inverters_inventory_handles_fetch_error(monkeypatch) -> None:
+    class StubClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.inverters_inventory = AsyncMock(side_effect=RuntimeError("boom"))
+
+    monkeypatch.setattr(api, "EnphaseEVClient", StubClient)
+    tokens = api.AuthTokens(cookie="cook", access_token="tok")
+    payload = await api.async_fetch_inverters_inventory(MagicMock(), "site", tokens)
+    assert payload is None
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_inverters_inventory_returns_dict_payload(monkeypatch) -> None:
+    fetch_mock = AsyncMock(return_value={"inverters": [{"serial_number": "INV-1"}]})
+
+    class StubClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.inverters_inventory = fetch_mock
+
+    monkeypatch.setattr(api, "EnphaseEVClient", StubClient)
+    tokens = api.AuthTokens(cookie="cook", access_token="tok")
+    payload = await api.async_fetch_inverters_inventory(MagicMock(), "site", tokens)
+    assert payload == {"inverters": [{"serial_number": "INV-1"}]}
+    fetch_mock.assert_awaited_once_with(limit=1000, offset=0, search="")
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_inverters_inventory_paginates(monkeypatch) -> None:
+    fetch_mock = AsyncMock(
+        side_effect=[
+            {
+                "total": 2,
+                "inverters": [{"serial_number": "INV-1"}],
+            },
+            {
+                "total": 2,
+                "inverters": [{"serial_number": "INV-2"}],
+            },
+        ]
+    )
+
+    class StubClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.inverters_inventory = fetch_mock
+
+    monkeypatch.setattr(api, "EnphaseEVClient", StubClient)
+    tokens = api.AuthTokens(cookie="cook", access_token="tok")
+    payload = await api.async_fetch_inverters_inventory(MagicMock(), "site", tokens)
+    assert payload == {
+        "total": 2,
+        "inverters": [
+            {"serial_number": "INV-1"},
+            {"serial_number": "INV-2"},
+        ],
+    }
+    assert [call.kwargs for call in fetch_mock.await_args_list] == [
+        {"limit": 1000, "offset": 0, "search": ""},
+        {"limit": 1000, "offset": 1, "search": ""},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_inverters_inventory_paginates_nested_result_payload(
+    monkeypatch,
+) -> None:
+    fetch_mock = AsyncMock(
+        side_effect=[
+            {
+                "total": 2,
+                "result": {"inverters": [{"serial_number": "INV-1"}]},
+            },
+            {
+                "total": 2,
+                "result": {"inverters": []},
+            },
+        ]
+    )
+
+    class StubClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.inverters_inventory = fetch_mock
+
+    monkeypatch.setattr(api, "EnphaseEVClient", StubClient)
+    tokens = api.AuthTokens(cookie="cook", access_token="tok")
+    payload = await api.async_fetch_inverters_inventory(MagicMock(), "site", tokens)
+    assert payload == {
+        "total": 2,
+        "result": {"inverters": [{"serial_number": "INV-1"}]},
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_inverters_inventory_legacy_kwargs_fallback_failure(
+    monkeypatch,
+) -> None:
+    class StubClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.inverters_inventory = AsyncMock(side_effect=self._fetch)
+
+        async def _fetch(self, *args, **kwargs):
+            if kwargs:
+                raise TypeError("legacy signature")
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(api, "EnphaseEVClient", StubClient)
+    tokens = api.AuthTokens(cookie="cook", access_token="tok")
+    payload = await api.async_fetch_inverters_inventory(MagicMock(), "site", tokens)
+    assert payload is None
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_inverters_inventory_stops_when_legacy_signature_rejects_next_page(
+    monkeypatch,
+) -> None:
+    class StubClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.inverters_inventory = AsyncMock(side_effect=self._fetch)
+
+        async def _fetch(self, *args, **kwargs):
+            if kwargs.get("offset") == 0:
+                return {
+                    "total": 2,
+                    "inverters": [{"serial_number": "INV-1"}],
+                }
+            raise TypeError("legacy signature")
+
+    monkeypatch.setattr(api, "EnphaseEVClient", StubClient)
+    tokens = api.AuthTokens(cookie="cook", access_token="tok")
+    payload = await api.async_fetch_inverters_inventory(MagicMock(), "site", tokens)
+    assert payload == {
+        "total": 2,
+        "inverters": [{"serial_number": "INV-1"}],
+    }
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_inverters_inventory_handles_assembly_error(monkeypatch) -> None:
+    class ExplodingDict(dict):
+        def get(self, key, default=None):
+            if key == "inverters":
+                raise RuntimeError("explode")
+            return super().get(key, default)
+
+    class StubClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.inverters_inventory = AsyncMock(
+                return_value=ExplodingDict({"total": 1, "inverters": []})
+            )
+
+    monkeypatch.setattr(api, "EnphaseEVClient", StubClient)
+    tokens = api.AuthTokens(cookie="cook", access_token="tok")
+    payload = await api.async_fetch_inverters_inventory(MagicMock(), "site", tokens)
+    assert payload is None
+
+
+@pytest.mark.asyncio
+async def test_async_fetch_inverters_inventory_handles_missing_inverter_shapes(
+    monkeypatch,
+) -> None:
+    class StubClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.inverters_inventory = AsyncMock(return_value={"total": 0, "result": []})
+
+    monkeypatch.setattr(api, "EnphaseEVClient", StubClient)
+    tokens = api.AuthTokens(cookie="cook", access_token="tok")
+    payload = await api.async_fetch_inverters_inventory(MagicMock(), "site", tokens)
+    assert payload == {"total": 0, "result": []}
+
+
+@pytest.mark.asyncio
 async def test_async_fetch_hems_devices_requires_site_id() -> None:
     tokens = api.AuthTokens(cookie="")
     assert await api.async_fetch_hems_devices(MagicMock(), "", tokens) == {}

--- a/tests/components/enphase_ev/test_config_flow_coverage.py
+++ b/tests/components/enphase_ev/test_config_flow_coverage.py
@@ -1370,6 +1370,136 @@ async def test_ensure_available_type_keys_ignores_retired_hems_heatpump(hass) ->
     assert flow._available_type_keys == []
 
 
+@pytest.mark.asyncio
+async def test_ensure_available_type_keys_falls_back_to_legacy_microinverters(
+    hass,
+) -> None:
+    flow = _make_flow(hass)
+    flow._auth_tokens = TOKENS
+    flow._selected_site_id = "12345"
+
+    with (
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_devices_inventory",
+            AsyncMock(
+                return_value={
+                    "result": [
+                        {
+                            "type": "envoy",
+                            "devices": [{"serial_number": "GW-1", "status": "normal"}],
+                        }
+                    ]
+                }
+            ),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_inverters_inventory",
+            AsyncMock(
+                return_value={
+                    "inverters": [{"serial_number": "INV-1", "status": "normal"}]
+                }
+            ),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_hems_devices",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await flow._ensure_available_type_keys()
+
+    assert flow._available_type_keys == ["envoy", "microinverter"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_available_type_keys_ignores_retired_legacy_microinverters(
+    hass,
+) -> None:
+    flow = _make_flow(hass)
+    flow._auth_tokens = TOKENS
+    flow._selected_site_id = "12345"
+
+    with (
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_devices_inventory",
+            AsyncMock(
+                return_value={
+                    "result": [
+                        {
+                            "type": "envoy",
+                            "devices": [{"serial_number": "GW-1", "status": "normal"}],
+                        }
+                    ]
+                }
+            ),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_inverters_inventory",
+            AsyncMock(
+                return_value={
+                    "inverters": [{"serial_number": "INV-1", "status": "retired"}]
+                }
+            ),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_hems_devices",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await flow._ensure_available_type_keys()
+
+    assert flow._available_type_keys == ["envoy"]
+
+
+@pytest.mark.asyncio
+async def test_ensure_available_type_keys_clears_unknown_when_legacy_fallback_succeeds(
+    hass,
+) -> None:
+    flow = _make_flow(hass)
+    flow._auth_tokens = TOKENS
+    flow._selected_site_id = "12345"
+
+    with (
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_devices_inventory",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_inverters_inventory",
+            AsyncMock(
+                return_value={
+                    "inverters": [{"serial_number": "INV-1", "status": "normal"}]
+                }
+            ),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_hems_devices",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await flow._ensure_available_type_keys()
+
+    assert flow._inventory_unknown is False
+    assert flow._available_type_keys == ["microinverter"]
+
+
+def test_legacy_microinverters_available_from_nested_result() -> None:
+    assert config_flow._legacy_microinverters_available(
+        {
+            "result": {
+                "inverters": [
+                    {"serial_number": "INV-1", "status": "normal"},
+                ]
+            }
+        }
+    )
+
+
+def test_legacy_microinverters_available_rejects_invalid_nested_shape() -> None:
+    assert not config_flow._legacy_microinverters_available(
+        {"result": {"inverters": {"serial_number": "INV-1"}}}
+    )
+
+
 def test_hems_devices_groups_handles_invalid_shapes() -> None:
     assert config_flow._hems_devices_groups({"data": []}) == []
     assert config_flow._hems_devices_groups({"data": {"hems-devices": []}}) == []

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -3397,7 +3397,7 @@ async def test_async_setup_entry_adds_optional_site_energy_entities_when_support
         ["heatpump"],
     )
     coord._devices_inventory_ready = True  # noqa: SLF001
-    coord.energy._site_energy_meta = {"bucket_lengths": {"water_heater": 0}}  # noqa: SLF001
+    coord.energy._site_energy_meta = {"bucket_lengths": {"water_heater": 1}}  # noqa: SLF001
 
     callbacks: list = []
 
@@ -3423,6 +3423,92 @@ async def test_async_setup_entry_adds_optional_site_energy_entities_when_support
 
     assert any(ent._flow_key == "heat_pump" for ent in created)
     assert any(ent.translation_key == "site_heat_pump_consumption" for ent in created)
+    assert any(ent._flow_key == "water_heater" for ent in created)
+    assert any(
+        ent.translation_key == "site_water_heater_consumption" for ent in created
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_water_heater_site_energy_without_device_channel(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.sensor import async_setup_entry
+
+    coord = coordinator_factory(serials=[])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord.energy._site_energy_meta = {"bucket_lengths": {"water_heater": 0}}  # noqa: SLF001
+
+    callbacks: list = []
+
+    def fake_add_listener(cb):
+        callbacks.append(cb)
+        return lambda: None
+
+    coord.async_add_listener = fake_add_listener  # type: ignore[assignment]
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    created: list = []
+
+    class StubSiteEnergy(sensor_mod.EnphaseSiteEnergySensor):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+    monkeypatch.setattr(sensor_mod, "EnphaseSiteEnergySensor", StubSiteEnergy)
+
+    await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
+    for cb in callbacks:
+        cb()
+
+    assert not any(ent._flow_key == "water_heater" for ent in created)
+    assert not any(
+        ent.translation_key == "site_water_heater_consumption" for ent in created
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_keeps_water_heater_site_energy_when_flow_exists(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.sensor import async_setup_entry
+
+    coord = coordinator_factory(serials=[])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord.energy.site_energy = {
+        "water_heater": {
+            "value_kwh": 1.25,
+            "bucket_count": 1,
+            "fields_used": ["water_heater"],
+            "start_date": "2026-03-10",
+            "last_report_date": None,
+            "source_unit": "Wh",
+        }
+    }
+    coord.energy._site_energy_meta = {"bucket_lengths": {"water_heater": 0}}  # noqa: SLF001
+
+    callbacks: list = []
+
+    def fake_add_listener(cb):
+        callbacks.append(cb)
+        return lambda: None
+
+    coord.async_add_listener = fake_add_listener  # type: ignore[assignment]
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    created: list = []
+
+    class StubSiteEnergy(sensor_mod.EnphaseSiteEnergySensor):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            created.append(self)
+
+    monkeypatch.setattr(sensor_mod, "EnphaseSiteEnergySensor", StubSiteEnergy)
+
+    await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
+    for cb in callbacks:
+        cb()
+
     assert any(ent._flow_key == "water_heater" for ent in created)
     assert any(
         ent.translation_key == "site_water_heater_consumption" for ent in created


### PR DESCRIPTION
## Summary
- paginate legacy inverter inventory during config flow so microinverters are discovered when they are only exposed through the legacy inventory endpoint
- clear false setup warnings after legacy inverter fallback succeeds and prevent phantom site water-heater energy sensors when no real site-energy channel exists
- add regression coverage for legacy inverter payload shapes, fallback paths, and site-energy entity gating while keeping touched modules at 100% coverage

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/config_flow.py,custom_components/enphase_ev/sensor.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
