### PR TITLE
Fix reauth and unload lifecycle handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,27 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v2.2.1 - 2026-03-11
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Added dry-contact settings diagnostics and expanded dry-contact debug visibility. (#342)
+- Added system dashboard device diagnostics sourced from Enphase's dashboard endpoints. (#344)
+
+### 🐛 Bug fixes
+- Fixed microinverter discovery and tightened site-energy entity gating so unsupported site-energy paths do not surface incorrectly. (#343)
+- Fixed Home Assistant reauthentication flow compatibility for cores that expect the standard `reauth_confirm` step, preventing `Invalid flow specified` failures during reauth.
+- Hardened unload/update-listener handling so disabled or failed entries do not trigger self-reloads and partial setup states no longer fall into `ConfigEntryState.FAILED_UNLOAD` when unloading.
+- Treated optional HEMS HTML/non-JSON fallback pages as endpoint unavailability instead of payload failures to reduce noisy logs and avoid misleading optional-endpoint errors.
+
+### 🔧 Improvements
+- Added regression coverage for reauth compatibility, partial-unload handling, optional HEMS non-JSON responses, and related config-entry lifecycle paths.
+
+### 🔄 Other changes
+- None
+
 ## v2.2.0 - 2026-03-10
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import re
 
-from homeassistant.config_entries import ConfigEntryState
+from homeassistant.config_entries import ConfigEntryState, OperationNotAllowed
 from homeassistant.core import HomeAssistant, SupportsResponse
 from homeassistant.helpers import (
     config_validation as cv,
@@ -135,7 +136,40 @@ def _is_disabled_by_integration(disabled_by: object) -> bool:
 async def _async_update_listener(
     hass: HomeAssistant, entry: EnphaseConfigEntry
 ) -> None:
-    await hass.config_entries.async_reload(entry.entry_id)
+    if getattr(entry, "disabled_by", None) is not None:
+        return
+    loaded_state = getattr(ConfigEntryState, "LOADED", None)
+    if loaded_state is not None and entry.state is not loaded_state:
+        return
+    try:
+        await hass.config_entries.async_reload(entry.entry_id)
+    except OperationNotAllowed as err:
+        _LOGGER.debug(
+            "Skipping reload for entry %s while state is changing: %s",
+            entry.entry_id,
+            err,
+        )
+
+
+async def _async_unload_platforms_safe(
+    hass: HomeAssistant, entry: EnphaseConfigEntry
+) -> bool:
+    """Unload forwarded platforms, tolerating components that never loaded the entry."""
+
+    async def _unload_platform(platform: str) -> bool:
+        try:
+            return await hass.config_entries.async_forward_entry_unload(entry, platform)
+        except ValueError as err:
+            if str(err) != "Config entry was never loaded!":
+                raise
+            _LOGGER.debug(
+                "Skipping unload for platform %s on entry %s because it never loaded",
+                platform,
+                entry.entry_id,
+            )
+            return True
+
+    return all(await asyncio.gather(*(_unload_platform(platform) for platform in PLATFORMS)))
 
 
 async def async_setup(hass: HomeAssistant, _config: dict) -> bool:
@@ -913,7 +947,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> 
         coord = get_runtime_data(entry).coordinator
     except RuntimeError:
         pass
-    unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    unload_ok = await _async_unload_platforms_safe(hass, entry)
     if unload_ok:
         if coord is not None and hasattr(coord, "schedule_sync"):
             await coord.schedule_sync.async_stop()

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -106,6 +106,19 @@ class InvalidPayloadError(aiohttp.ClientError):
         super().__init__(self.summary)
 
 
+def _is_optional_non_json_payload(err: InvalidPayloadError) -> bool:
+    """Return True when an optional endpoint returned a non-JSON success page."""
+
+    try:
+        status = int(err.status or 0)
+    except Exception:
+        status = 0
+    if status < 200 or status >= 300:
+        return False
+    content_type = str(err.content_type or "").lower()
+    return "json" not in content_type
+
+
 @dataclass(slots=True)
 class AuthTokens:
     """Container for Enlighten authentication state."""
@@ -2357,6 +2370,15 @@ class EnphaseEVClient:
         url = f"{BASE_URL}/systems/{self._site}/hems_consumption_lifetime"
         try:
             data = await self._json("GET", url, headers=self._hems_headers)
+        except InvalidPayloadError as err:
+            if _is_optional_non_json_payload(err):
+                _LOGGER.debug(
+                    "HEMS lifetime endpoint unavailable for site %s (%s)",
+                    self._site,
+                    err.summary,
+                )
+                return None
+            raise
         except aiohttp.ClientResponseError as err:
             if err.status in (401, 403, 404):
                 _LOGGER.debug(
@@ -2478,6 +2500,15 @@ class EnphaseEVClient:
                 self._site,
             )
             return None
+        except InvalidPayloadError as err:
+            if _is_optional_non_json_payload(err):
+                _LOGGER.debug(
+                    "HEMS power endpoint unavailable for site %s (%s)",
+                    self._site,
+                    err.summary,
+                )
+                return None
+            raise
         except aiohttp.ClientResponseError as err:
             if self._is_hems_invalid_date_error(err):
                 if not device_uid:
@@ -2501,6 +2532,15 @@ class EnphaseEVClient:
                         self._site,
                     )
                     return None
+                except InvalidPayloadError as retry_err:
+                    if _is_optional_non_json_payload(retry_err):
+                        _LOGGER.debug(
+                            "HEMS power endpoint unavailable for site %s (%s)",
+                            self._site,
+                            retry_err.summary,
+                        )
+                        return None
+                    raise
                 except aiohttp.ClientResponseError as retry_err:
                     if retry_err.status in (401, 403, 404) or self._is_hems_invalid_date_error(
                         retry_err
@@ -2699,6 +2739,15 @@ class EnphaseEVClient:
                 self._site,
             )
             return None
+        except InvalidPayloadError as err:
+            if _is_optional_non_json_payload(err):
+                _LOGGER.debug(
+                    "HEMS devices endpoint unavailable for site %s (%s)",
+                    self._site,
+                    err.summary,
+                )
+                return None
+            raise
         except aiohttp.ClientResponseError as err:
             if err.status in (401, 403, 404):
                 _LOGGER.debug(

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -903,6 +903,17 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         current = self._async_current_entries()
         return current[0] if current else None
 
+    def _get_reauth_entry(self) -> ConfigEntry | None:
+        if hasattr(super(), "_get_reauth_entry"):
+            try:
+                return super()._get_reauth_entry()  # type: ignore[misc]
+            except Exception:
+                pass
+        entry_id = self.context.get("entry_id") if hasattr(self, "context") else None
+        if entry_id and self.hass:
+            return self.hass.config_entries.async_get_entry(entry_id)
+        return None
+
     def _abort_if_unique_id_mismatch(self, *, reason: str) -> None:
         from homeassistant.data_entry_flow import AbortFlow
 
@@ -951,9 +962,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle reauthentication across HA cores with differing call signatures."""
         _ = entry_data
-        self._reauth_entry = self.hass.config_entries.async_get_entry(
-            self.context.get("entry_id")
-        )
+        self._reauth_entry = self._get_reauth_entry()
         self._reconfigure_entry = self._reauth_entry
         if not self._reauth_entry:
             return self.async_abort(reason="unknown")
@@ -970,7 +979,19 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         )
         if self._remember_password:
             self._password = self._reauth_entry.data.get(CONF_PASSWORD)
-        return await self.async_step_user()
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Handle HA reauth flows that expect the standard confirm step."""
+
+        if not self._reauth_entry:
+            self._reauth_entry = self._get_reauth_entry()
+            self._reconfigure_entry = self._reauth_entry
+        if not self._reauth_entry:
+            return self.async_abort(reason="unknown")
+        return await self.async_step_user(user_input)
 
     @staticmethod
     @callback

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.2.0"
+  "version": "2.2.1"
 }

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -2168,6 +2168,58 @@ async def test_hems_devices_optional_errors_return_none(monkeypatch, status) -> 
 
 
 @pytest.mark.asyncio
+async def test_hems_devices_non_json_payload_returns_none(monkeypatch) -> None:
+    client = _make_client()
+    err = api.InvalidPayloadError(
+        "Invalid JSON response (status=200, content_type=text/html, endpoint=/api/v1/hems/SITE/hems-devices, decode_error=ContentTypeError)",
+        status=200,
+        content_type="text/html",
+        endpoint="/api/v1/hems/SITE/hems-devices",
+    )
+    monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
+
+    assert await client.hems_devices() is None
+
+
+@pytest.mark.asyncio
+async def test_hems_devices_json_invalid_payload_reraises(monkeypatch) -> None:
+    client = _make_client()
+    err = api.InvalidPayloadError(
+        "Invalid JSON response (status=200, content_type=application/json, endpoint=/api/v1/hems/SITE/hems-devices, decode_error=ValueError)",
+        status=200,
+        content_type="application/json",
+        endpoint="/api/v1/hems/SITE/hems-devices",
+    )
+    monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
+
+    with pytest.raises(api.InvalidPayloadError):
+        await client.hems_devices()
+
+
+def test_is_optional_non_json_payload_false_for_invalid_status() -> None:
+    err = api.InvalidPayloadError(
+        "Invalid JSON response",
+        status=200,
+        content_type="text/html",
+        endpoint="/systems/SITE/hems_power_timeseries",
+    )
+    err.status = "bad"  # type: ignore[assignment]
+
+    assert api._is_optional_non_json_payload(err) is False
+
+
+def test_is_optional_non_json_payload_false_for_non_2xx_status() -> None:
+    err = api.InvalidPayloadError(
+        "Invalid JSON response",
+        status=500,
+        content_type="text/html",
+        endpoint="/systems/SITE/hems_power_timeseries",
+    )
+
+    assert api._is_optional_non_json_payload(err) is False
+
+
+@pytest.mark.asyncio
 async def test_hems_devices_reraises_non_optional_error(monkeypatch) -> None:
     client = _make_client()
     err = _make_cre(500, "Server Error")
@@ -2222,6 +2274,22 @@ async def test_hems_consumption_lifetime_optional_errors_return_none(
 
 
 @pytest.mark.asyncio
+async def test_hems_consumption_lifetime_non_json_payload_returns_none(
+    monkeypatch,
+) -> None:
+    client = _make_client()
+    err = api.InvalidPayloadError(
+        "Invalid JSON response (status=200, content_type=text/html, endpoint=/systems/SITE/hems_consumption_lifetime, decode_error=ContentTypeError)",
+        status=200,
+        content_type="text/html",
+        endpoint="/systems/SITE/hems_consumption_lifetime",
+    )
+    monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
+
+    assert await client.hems_consumption_lifetime() is None
+
+
+@pytest.mark.asyncio
 async def test_hems_consumption_lifetime_reraises_non_optional_error(
     monkeypatch,
 ) -> None:
@@ -2230,6 +2298,23 @@ async def test_hems_consumption_lifetime_reraises_non_optional_error(
     monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
 
     with pytest.raises(aiohttp.ClientResponseError):
+        await client.hems_consumption_lifetime()
+
+
+@pytest.mark.asyncio
+async def test_hems_consumption_lifetime_json_invalid_payload_reraises(
+    monkeypatch,
+) -> None:
+    client = _make_client()
+    err = api.InvalidPayloadError(
+        "Invalid JSON response (status=200, content_type=application/json, endpoint=/systems/SITE/hems_consumption_lifetime, decode_error=ValueError)",
+        status=200,
+        content_type="application/json",
+        endpoint="/systems/SITE/hems_consumption_lifetime",
+    )
+    monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
+
+    with pytest.raises(api.InvalidPayloadError):
         await client.hems_consumption_lifetime()
 
 
@@ -2294,6 +2379,35 @@ async def test_hems_power_timeseries_unauthorized_returns_none(monkeypatch) -> N
     monkeypatch.setattr(client, "_json", AsyncMock(side_effect=api.Unauthorized()))
 
     assert await client.hems_power_timeseries() is None
+
+
+@pytest.mark.asyncio
+async def test_hems_power_timeseries_non_json_payload_returns_none(monkeypatch) -> None:
+    client = _make_client()
+    err = api.InvalidPayloadError(
+        "Invalid JSON response (status=200, content_type=text/html, endpoint=/systems/SITE/hems_power_timeseries, decode_error=ContentTypeError)",
+        status=200,
+        content_type="text/html",
+        endpoint="/systems/SITE/hems_power_timeseries",
+    )
+    monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
+
+    assert await client.hems_power_timeseries() is None
+
+
+@pytest.mark.asyncio
+async def test_hems_power_timeseries_json_invalid_payload_reraises(monkeypatch) -> None:
+    client = _make_client()
+    err = api.InvalidPayloadError(
+        "Invalid JSON response (status=200, content_type=application/json, endpoint=/systems/SITE/hems_power_timeseries, decode_error=ValueError)",
+        status=200,
+        content_type="application/json",
+        endpoint="/systems/SITE/hems_power_timeseries",
+    )
+    monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
+
+    with pytest.raises(api.InvalidPayloadError):
+        await client.hems_power_timeseries()
 
 
 @pytest.mark.asyncio
@@ -2367,6 +2481,44 @@ async def test_hems_power_timeseries_retry_unauthorized_returns_none() -> None:
 
     assert await client.hems_power_timeseries(device_uid="HP-1") is None
     assert client._json.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_hems_power_timeseries_retry_non_json_payload_returns_none() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=[
+            _make_cre(422, '{"reason":"Please enter a valid date."}'),
+            api.InvalidPayloadError(
+                "Invalid JSON response (status=200, content_type=text/html, endpoint=/systems/SITE/hems_power_timeseries, decode_error=ContentTypeError)",
+                status=200,
+                content_type="text/html",
+                endpoint="/systems/SITE/hems_power_timeseries",
+            ),
+        ]
+    )
+
+    assert await client.hems_power_timeseries(device_uid="HP-1") is None
+    assert client._json.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_hems_power_timeseries_retry_json_invalid_payload_reraises() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=[
+            _make_cre(422, '{"reason":"Please enter a valid date."}'),
+            api.InvalidPayloadError(
+                "Invalid JSON response (status=200, content_type=application/json, endpoint=/systems/SITE/hems_power_timeseries, decode_error=ValueError)",
+                status=200,
+                content_type="application/json",
+                endpoint="/systems/SITE/hems_power_timeseries",
+            ),
+        ]
+    )
+
+    with pytest.raises(api.InvalidPayloadError):
+        await client.hems_power_timeseries(device_uid="HP-1")
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_config_flow_coverage.py
+++ b/tests/components/enphase_ev/test_config_flow_coverage.py
@@ -1721,6 +1721,16 @@ def test_get_reconfigure_entry_falls_back_to_context(hass) -> None:
         assert flow._get_reconfigure_entry() == entry
 
 
+def test_get_reauth_entry_requires_entry_id(hass) -> None:
+    flow = _make_flow(hass)
+    flow.context = {"source": config_entries.SOURCE_REAUTH}
+
+    with patch.object(
+        config_entries.ConfigFlow, "_get_reauth_entry", side_effect=Exception
+    ):
+        assert flow._get_reauth_entry() is None
+
+
 @pytest.mark.asyncio
 async def test_abort_if_unique_id_mismatch_fallback(hass) -> None:
     flow = _make_flow(hass)
@@ -1797,6 +1807,15 @@ async def test_async_step_reauth_missing_entry_aborts(hass) -> None:
         hass.config_entries, "async_get_entry", return_value=None
     ):
         result = await flow.async_step_reauth()
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_async_step_reauth_confirm_missing_entry_aborts(hass) -> None:
+    flow = _make_flow(hass)
+    flow.context = {"source": config_entries.SOURCE_REAUTH, "entry_id": "missing"}
+    result = await flow.async_step_reauth_confirm()
     assert result["type"] is FlowResultType.ABORT
     assert result["reason"] == "unknown"
 

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock, MagicMock, Mock, call
 
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
+from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 
@@ -622,12 +623,12 @@ async def test_async_unload_entry_stops_schedule_sync(
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     unload = AsyncMock(return_value=True)
-    monkeypatch.setattr(hass.config_entries, "async_unload_platforms", unload)
+    monkeypatch.setattr(hass.config_entries, "async_forward_entry_unload", unload)
 
     assert await async_unload_entry(hass, config_entry)
     schedule_sync.async_stop.assert_awaited_once()
     coord.cleanup_runtime_state.assert_called_once()
-    unload.assert_awaited_once()
+    assert unload.await_count == 8
     assert config_entry.runtime_data is None
 
 
@@ -640,13 +641,14 @@ async def test_async_unload_entry_does_not_cleanup_when_unload_fails(
     runtime_data = EnphaseRuntimeData(coordinator=coord)
     config_entry.runtime_data = runtime_data
 
-    unload = AsyncMock(return_value=False)
-    monkeypatch.setattr(hass.config_entries, "async_unload_platforms", unload)
+    async def unload(_entry, platform):
+        return platform != "calendar"
+
+    monkeypatch.setattr(hass.config_entries, "async_forward_entry_unload", unload)
 
     assert await async_unload_entry(hass, config_entry) is False
     schedule_sync.async_stop.assert_not_awaited()
     coord.cleanup_runtime_state.assert_not_called()
-    unload.assert_awaited_once()
     assert config_entry.runtime_data is runtime_data
 
 
@@ -655,10 +657,10 @@ async def test_async_unload_entry_handles_missing_runtime_data(
     hass: HomeAssistant, config_entry, monkeypatch
 ) -> None:
     unload = AsyncMock(return_value=True)
-    monkeypatch.setattr(hass.config_entries, "async_unload_platforms", unload)
+    monkeypatch.setattr(hass.config_entries, "async_forward_entry_unload", unload)
 
     assert await async_unload_entry(hass, config_entry)
-    unload.assert_awaited_once()
+    assert unload.await_count == 8
 
 
 @pytest.mark.asyncio
@@ -667,10 +669,97 @@ async def test_update_listener_reloads_entry(
 ) -> None:
     reload = AsyncMock()
     monkeypatch.setattr(hass.config_entries, "async_reload", reload)
+    object.__setattr__(config_entry, "state", config_entries.ConfigEntryState.LOADED)
 
     await _async_update_listener(hass, config_entry)
 
     reload.assert_awaited_once_with(config_entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_update_listener_skips_reload_for_disabled_entry(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    reload = AsyncMock()
+    monkeypatch.setattr(hass.config_entries, "async_reload", reload)
+    object.__setattr__(config_entry, "state", config_entries.ConfigEntryState.LOADED)
+    object.__setattr__(config_entry, "disabled_by", "user")
+
+    await _async_update_listener(hass, config_entry)
+
+    reload.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_listener_skips_reload_when_not_loaded(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    reload = AsyncMock()
+    monkeypatch.setattr(hass.config_entries, "async_reload", reload)
+    object.__setattr__(
+        config_entry, "state", config_entries.ConfigEntryState.FAILED_UNLOAD
+    )
+
+    await _async_update_listener(hass, config_entry)
+
+    reload.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_listener_ignores_operation_not_allowed(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    reload = AsyncMock(side_effect=config_entries.OperationNotAllowed("race"))
+    monkeypatch.setattr(hass.config_entries, "async_reload", reload)
+    object.__setattr__(config_entry, "state", config_entries.ConfigEntryState.LOADED)
+
+    await _async_update_listener(hass, config_entry)
+
+    reload.assert_awaited_once_with(config_entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_tolerates_platform_never_loaded(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    schedule_sync = SimpleNamespace(async_stop=AsyncMock())
+    coord = SimpleNamespace(schedule_sync=schedule_sync, cleanup_runtime_state=MagicMock())
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    async def unload(_entry, platform):
+        if platform == "calendar":
+            raise ValueError("Config entry was never loaded!")
+        return True
+
+    monkeypatch.setattr(hass.config_entries, "async_forward_entry_unload", unload)
+
+    assert await async_unload_entry(hass, config_entry)
+
+    schedule_sync.async_stop.assert_awaited_once()
+    coord.cleanup_runtime_state.assert_called_once()
+    assert config_entry.runtime_data is None
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_reraises_unexpected_value_error(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    schedule_sync = SimpleNamespace(async_stop=AsyncMock())
+    coord = SimpleNamespace(schedule_sync=schedule_sync, cleanup_runtime_state=MagicMock())
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    async def unload(_entry, platform):
+        if platform == "calendar":
+            raise ValueError("unexpected")
+        return True
+
+    monkeypatch.setattr(hass.config_entries, "async_forward_entry_unload", unload)
+
+    with pytest.raises(ValueError, match="unexpected"):
+        await async_unload_entry(hass, config_entry)
+
+    schedule_sync.async_stop.assert_not_awaited()
+    coord.cleanup_runtime_state.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_reconfigure_flow.py
+++ b/tests/components/enphase_ev/test_reconfigure_flow.py
@@ -384,6 +384,69 @@ async def test_reauth_skips_site_selection(hass) -> None:
 
 
 @pytest.mark.asyncio
+async def test_reauth_flow_manager_submit_uses_compat_path(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SITE_ID: "12345",
+            CONF_SITE_NAME: "Garage Site",
+            CONF_EMAIL: "user@example.com",
+            CONF_REMEMBER_PASSWORD: True,
+            CONF_PASSWORD: "secret",
+        },
+    )
+    entry.add_to_hass(hass)
+
+    tokens = AuthTokens(
+        cookie="jar=1",
+        session_id="sid123",
+        access_token="token123",
+        token_expires_at=1_700_000_000,
+    )
+    sites = [
+        SiteInfo(site_id="12345", name="Garage Site"),
+        SiteInfo(site_id="67890", name="Backup Site"),
+    ]
+    chargers = [ChargerInfo(serial="EV123", name="Driveway Charger")]
+
+    with (
+        patch(
+            "custom_components.enphase_ev.config_flow.async_authenticate",
+            AsyncMock(return_value=(tokens, sites)),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_chargers",
+            AsyncMock(return_value=chargers),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_devices_inventory",
+            AsyncMock(return_value={"result": []}),
+        ),
+    ):
+        init = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={
+                "source": config_entries.SOURCE_REAUTH,
+                "entry_id": entry.entry_id,
+            },
+        )
+        assert init["type"] is FlowResultType.FORM
+        assert init["step_id"] == "user"
+
+        result = await hass.config_entries.flow.async_configure(
+            init["flow_id"],
+            {
+                CONF_EMAIL: "user@example.com",
+                CONF_PASSWORD: "secret",
+                CONF_REMEMBER_PASSWORD: True,
+            },
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "devices"
+
+
+@pytest.mark.asyncio
 async def test_reauth_allows_empty_device_selection(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,


### PR DESCRIPTION
## Summary
- fix Home Assistant reauthentication and unload lifecycle handling so reauth no longer falls back to the wrong entry and unload tolerates platforms that never fully loaded
- treat optional HEMS HTML/non-JSON fallback pages as unavailable endpoints instead of payload failures
- bump the integration version to 2.2.1 and document PRs #342-#344 plus these fixes in the changelog

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/api.py,custom_components/enphase_ev/config_flow.py,custom_components/enphase_ev/runtime_data.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
