### PR TITLE
Handle optional dashboard and unsupported HEMS endpoints

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -138,16 +138,15 @@ def _is_hems_invalid_site_error(err: aiohttp.ClientResponseError) -> bool:
         return "invalid_site" in text or "not a valid hems site" in text
     if not isinstance(payload, dict):
         return False
-    if str(payload.get("type") or "").strip().lower() == "hemsintegrationerror":
-        error = payload.get("error")
-        if isinstance(error, dict):
-            status = str(error.get("status") or "").strip().upper()
-            code = error.get("code")
-            message_text = str(error.get("message") or "").strip().lower()
-            if status == "INVALID_SITE":
-                return True
-            if str(code).strip() == "900" and "valid hems site" in message_text:
-                return True
+    error = payload.get("error")
+    if isinstance(error, dict):
+        status = str(error.get("status") or "").strip().upper()
+        code = error.get("code")
+        message_text = str(error.get("message") or "").strip().lower()
+        if status == "INVALID_SITE":
+            return True
+        if str(code).strip() == "900" and "valid hems site" in message_text:
+            return True
     return False
 
 
@@ -1163,6 +1162,7 @@ class EnphaseEVClient:
         self._stop_variant_idx: int | None = None
         self._cookie = cookie or ""
         self._eauth = eauth or None
+        self._hems_site_supported: bool | None = None
         self._reauth_cb: Callable[[], Awaitable[bool]] | None = reauth_callback
         self._h = {
             "Accept": "application/json, text/plain, */*",
@@ -1235,6 +1235,12 @@ class EnphaseEVClient:
         """Return True when scheduler bearer auth can be derived."""
 
         return bool(self.scheduler_bearer())
+
+    @property
+    def hems_site_supported(self) -> bool | None:
+        """Return whether HEMS has been positively identified for this site."""
+
+        return self._hems_site_supported
 
     def base_header_names(self) -> list[str]:
         """Return base header names without exposing values."""
@@ -2402,6 +2408,7 @@ class EnphaseEVClient:
         url = f"{BASE_URL}/systems/{self._site}/hems_consumption_lifetime"
         try:
             data = await self._json("GET", url, headers=self._hems_headers)
+            self._hems_site_supported = True
         except InvalidPayloadError as err:
             if _is_optional_non_json_payload(err):
                 _LOGGER.debug(
@@ -2413,6 +2420,8 @@ class EnphaseEVClient:
             raise
         except aiohttp.ClientResponseError as err:
             if err.status in (401, 403, 404) or _is_hems_invalid_site_error(err):
+                if _is_hems_invalid_site_error(err):
+                    self._hems_site_supported = False
                 _LOGGER.debug(
                     "HEMS lifetime endpoint unavailable for site %s (status=%s)",
                     self._site,
@@ -2526,6 +2535,7 @@ class EnphaseEVClient:
             url = str(URL(url).update_query({"device-uid": str(device_uid)}))
         try:
             data = await self._json("GET", url, headers=self._hems_headers)
+            self._hems_site_supported = True
         except Unauthorized:
             _LOGGER.debug(
                 "HEMS power endpoint unavailable for site %s (unauthorized)",
@@ -2558,6 +2568,7 @@ class EnphaseEVClient:
                 )
                 try:
                     data = await self._json("GET", base_url, headers=self._hems_headers)
+                    self._hems_site_supported = True
                 except Unauthorized:
                     _LOGGER.debug(
                         "HEMS power endpoint unavailable for site %s (unauthorized)",
@@ -2578,9 +2589,11 @@ class EnphaseEVClient:
                         retry_err.status in (401, 403, 404)
                         or _is_hems_invalid_site_error(retry_err)
                         or self._is_hems_invalid_date_error(
-                        retry_err
+                            retry_err
                         )
                     ):
+                        if _is_hems_invalid_site_error(retry_err):
+                            self._hems_site_supported = False
                         _LOGGER.debug(
                             "HEMS power endpoint unavailable for site %s (status=%s)",
                             self._site,
@@ -2590,6 +2603,8 @@ class EnphaseEVClient:
                     raise
                 return self._normalize_hems_power_timeseries_payload(data)
             if err.status in (401, 403, 404) or _is_hems_invalid_site_error(err):
+                if _is_hems_invalid_site_error(err):
+                    self._hems_site_supported = False
                 _LOGGER.debug(
                     "HEMS power endpoint unavailable for site %s (status=%s)",
                     self._site,
@@ -2788,6 +2803,7 @@ class EnphaseEVClient:
         )
         try:
             data = await self._json("GET", url, headers=self._hems_headers)
+            self._hems_site_supported = True
         except Unauthorized:
             _LOGGER.debug(
                 "HEMS devices endpoint unavailable for site %s (unauthorized)",
@@ -2805,6 +2821,8 @@ class EnphaseEVClient:
             raise
         except aiohttp.ClientResponseError as err:
             if err.status in (401, 403, 404) or _is_hems_invalid_site_error(err):
+                if _is_hems_invalid_site_error(err):
+                    self._hems_site_supported = False
                 _LOGGER.debug(
                     "HEMS devices endpoint unavailable for site %s (status=%s)",
                     self._site,

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1506,6 +1506,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         if not force and self._hems_devices_cache_until:
             if now < self._hems_devices_cache_until:
                 return
+        if not force and getattr(self.client, "hems_site_supported", None) is False:
+            self._hems_devices_payload = None
+            self._merge_heatpump_type_bucket()
+            self._hems_devices_cache_until = now + DEVICES_INVENTORY_CACHE_TTL
+            return
         fetcher = getattr(self.client, "hems_devices", None)
         if not callable(fetcher):
             return
@@ -3023,6 +3028,16 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         if not force and self._heatpump_power_backoff_until is not None:
             if now < self._heatpump_power_backoff_until:
                 return
+        if not force and getattr(self.client, "hems_site_supported", None) is False:
+            self._heatpump_power_w = None
+            self._heatpump_power_sample_utc = None
+            self._heatpump_power_start_utc = None
+            self._heatpump_power_device_uid = None
+            self._heatpump_power_source = None
+            self._heatpump_power_cache_until = now + HEATPUMP_POWER_CACHE_TTL
+            self._heatpump_power_backoff_until = None
+            self._heatpump_power_last_error = None
+            return
 
         fetcher = getattr(self.client, "hems_power_timeseries", None)
         if not callable(fetcher):

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -2178,6 +2178,7 @@ async def test_hems_devices_uses_dedicated_endpoint_and_headers() -> None:
     payload = await client.hems_devices()
 
     assert payload == {"data": {"hems-devices": {}}}
+    assert client.hems_site_supported is True
     args, kwargs = client._json.await_args
     assert args[0] == "GET"
     assert args[1].endswith("/api/v1/hems/SITE/hems-devices?refreshData=false")
@@ -2239,6 +2240,7 @@ async def test_hems_devices_invalid_site_error_returns_none(monkeypatch, message
     monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
 
     assert await client.hems_devices() is None
+    assert client.hems_site_supported is False
 
 
 @pytest.mark.asyncio
@@ -2318,6 +2320,15 @@ def test_is_hems_invalid_site_error_handles_non_matching_json_dict() -> None:
     assert api._is_hems_invalid_site_error(err) is False
 
 
+def test_is_hems_invalid_site_error_accepts_missing_type_with_invalid_status() -> None:
+    err = _make_cre(
+        550,
+        '{"error":{"code":900,"status":"INVALID_SITE","message":"Site is not a valid HEMS site"}}',
+    )
+
+    assert api._is_hems_invalid_site_error(err) is True
+
+
 def test_is_hems_invalid_site_error_accepts_code_and_message_fallback() -> None:
     err = _make_cre(
         550,
@@ -2393,6 +2404,7 @@ async def test_hems_consumption_lifetime_invalid_site_error_returns_none(
     monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
 
     assert await client.hems_consumption_lifetime() is None
+    assert client.hems_site_supported is False
 
 
 @pytest.mark.asyncio
@@ -2458,6 +2470,7 @@ async def test_hems_power_timeseries_normalization() -> None:
         "start_date": "2026-02-27T00:00:00Z",
         "interval_minutes": 5.0,
     }
+    assert client.hems_site_supported is True
     awaited = client._json.await_args
     assert awaited.args[0] == "GET"
     assert awaited.args[1].endswith("/systems/SITE/hems_power_timeseries?device-uid=HP-1")
@@ -2510,6 +2523,7 @@ async def test_hems_power_timeseries_invalid_site_error_returns_none(monkeypatch
     )
 
     assert await client.hems_power_timeseries() is None
+    assert client.hems_site_supported is False
 
 
 @pytest.mark.asyncio
@@ -2619,6 +2633,24 @@ async def test_hems_power_timeseries_retry_unauthorized_returns_none() -> None:
     )
 
     assert await client.hems_power_timeseries(device_uid="HP-1") is None
+    assert client._json.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_hems_power_timeseries_retry_invalid_site_returns_none() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=[
+            _make_cre(422, '{"reason":"Please enter a valid date."}'),
+            _make_cre(
+                550,
+                '{"type":"hemsIntegrationError","error":{"code":900,"status":"INVALID_SITE","message":"Site is not a valid HEMS site"}}',
+            ),
+        ]
+    )
+
+    assert await client.hems_power_timeseries(device_uid="HP-1") is None
+    assert client.hems_site_supported is False
     assert client._json.await_count == 2
 
 

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -678,6 +678,15 @@ async def test_hems_devices_refresh_cache_and_exception_paths(
     coord.client.hems_devices = None
     await coord._async_refresh_hems_devices()
 
+    coord.client._hems_site_supported = False  # noqa: SLF001
+    coord._hems_devices_cache_until = None  # noqa: SLF001
+    coord.client.hems_devices = AsyncMock(side_effect=AssertionError("no fetch"))
+    await coord._async_refresh_hems_devices()
+    coord.client.hems_devices.assert_not_awaited()
+    assert coord._hems_devices_payload is None  # noqa: SLF001
+    assert coord._hems_devices_cache_until is not None  # noqa: SLF001
+
+    coord.client._hems_site_supported = None  # noqa: SLF001
     coord._hems_devices_cache_until = None  # noqa: SLF001
     coord.client.hems_devices = AsyncMock(return_value=None)
     await coord._async_refresh_hems_devices()
@@ -1837,6 +1846,15 @@ async def test_refresh_heatpump_power_covers_cache_and_payload_edge_paths(
     coord.client.hems_power_timeseries = None
     await coord._async_refresh_heatpump_power(force=True)  # noqa: SLF001
 
+    coord.client._hems_site_supported = False  # noqa: SLF001
+    blocked_fetch = AsyncMock(side_effect=AssertionError("no fetch"))
+    coord.client.hems_power_timeseries = blocked_fetch
+    await coord._async_refresh_heatpump_power()  # noqa: SLF001
+    blocked_fetch.assert_not_awaited()
+    assert coord.heatpump_power_w is None
+    assert coord._heatpump_power_cache_until is not None  # noqa: SLF001
+
+    coord.client._hems_site_supported = None  # noqa: SLF001
     coord.client.hems_power_timeseries = AsyncMock(return_value="bad-payload")
     await coord._async_refresh_heatpump_power(force=True)  # noqa: SLF001
     assert coord.heatpump_power_w is None


### PR DESCRIPTION
## Summary
- Treat optional system dashboard HTML responses as unavailable instead of noisy payload failures
- Cache confirmed HEMS INVALID_SITE responses as unsupported runtime state to avoid repeated normal refresh probes
- Add API and coordinator regression coverage for HEMS/site-dashboard optional endpoint handling

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/api.py custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_behavior.py"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_behavior.py -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py --fail-under=100"
