### PR TITLE
Add EVSE timeseries energy fallback

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import json
 import logging
+from datetime import date, datetime, timedelta, timezone
 from urllib.parse import unquote
 import uuid
 from dataclasses import dataclass
@@ -77,6 +78,10 @@ class SessionHistoryUnavailable(Exception):
 
 class SiteEnergyUnavailable(Exception):
     """Raised when the site energy service is unavailable."""
+
+
+class EVSETimeseriesUnavailable(Exception):
+    """Raised when the EVSE timeseries service is unavailable."""
 
 
 class AuthSettingsUnavailable(Exception):
@@ -441,6 +446,38 @@ def is_site_energy_unavailable_error(
     if url_text and "/pv/systems/" in url_text and "lifetime_energy" in url_text:
         if status in (500, 502, 503, 504):
             return True
+    if "lifetime_energy" in text and "service unavailable" in text:
+        return True
+    return False
+
+
+def is_evse_timeseries_unavailable_error(
+    message: str | None,
+    status: int | None = None,
+    url: str | URL | None = None,
+) -> bool:
+    """Return True if the error payload indicates EVSE timeseries unavailability."""
+
+    try:
+        text = str(message or "").lower()
+    except Exception:
+        text = ""
+    url_text = ""
+    if url:
+        try:
+            url_text = str(url).lower()
+        except Exception:
+            url_text = ""
+    if (
+        url_text
+        and "/service/timeseries/evse/timeseries/" in url_text
+        and status in (500, 502, 503, 504)
+    ):
+        return True
+    if "evse" in text and "timeseries" in text and "unavailable" in text:
+        return True
+    if "daily_energy" in text and "service unavailable" in text:
+        return True
     if "lifetime_energy" in text and "service unavailable" in text:
         return True
     return False
@@ -1276,6 +1313,15 @@ class EnphaseEVClient:
         if username:
             headers["username"] = username
         return headers
+
+    def _evse_timeseries_headers(
+        self,
+        request_id: str | None,
+        username: str | None,
+    ) -> dict[str, str]:
+        """Return headers for EVSE timeseries endpoints."""
+
+        return self._session_history_headers(request_id, username)
 
     def _control_headers(self) -> dict[str, str]:
         """Return Authorization header overrides for control-plane requests."""
@@ -2300,6 +2346,441 @@ class EnphaseEVClient:
                 raise SiteEnergyUnavailable(str(err)) from err
             raise
         return self._normalize_lifetime_energy_payload(data)
+
+    @staticmethod
+    def _normalize_evse_timeseries_serial(value: object) -> str | None:
+        if value is None:
+            return None
+        try:
+            text = str(value).strip()
+        except Exception:  # noqa: BLE001
+            return None
+        return text or None
+
+    @staticmethod
+    def _parse_evse_timeseries_date_key(value: object) -> str | None:
+        if value is None:
+            return None
+        if isinstance(value, datetime):
+            return value.date().isoformat()
+        if isinstance(value, date):
+            return value.isoformat()
+        if isinstance(value, (int, float)):
+            try:
+                ts_val = float(value)
+                if ts_val > 10**12:
+                    ts_val /= 1000.0
+                return datetime.fromtimestamp(ts_val, tz=timezone.utc).date().isoformat()
+            except Exception:  # noqa: BLE001
+                return None
+        if not isinstance(value, str):
+            return None
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        if len(cleaned) >= 10:
+            try:
+                return datetime.fromisoformat(
+                    cleaned.replace("Z", "+00:00")
+                ).date().isoformat()
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                datetime.strptime(cleaned[:10], "%Y-%m-%d")
+                return cleaned[:10]
+            except Exception:  # noqa: BLE001
+                pass
+        return None
+
+    @classmethod
+    def _coerce_evse_timeseries_energy(
+        cls,
+        value: object,
+        *,
+        key_hint: str | None = None,
+        unit_hint: object | None = None,
+    ) -> float | None:
+        numeric = cls._coerce_lifetime_energy_value(value)
+        if numeric is None:
+            return None
+        try:
+            unit_text = str(unit_hint).strip().lower() if unit_hint is not None else ""
+        except Exception:  # noqa: BLE001
+            unit_text = ""
+        hint = (key_hint or "").lower()
+        if "wh" in hint and "kwh" not in hint:
+            return round(numeric / 1000.0, 6)
+        if unit_text in {"wh", "watt_hour", "watt-hours", "watt_hours"}:
+            return round(numeric / 1000.0, 6)
+        return round(numeric, 6)
+
+    @classmethod
+    def _normalize_evse_timeseries_metadata(cls, payload: object) -> dict[str, object]:
+        if not isinstance(payload, dict):
+            return {}
+        interval = cls._coerce_lifetime_energy_value(
+            payload.get("interval_minutes")
+            or payload.get("interval")
+            or payload.get("interval_min")
+            or payload.get("intervalMinutes")
+        )
+        metadata: dict[str, object] = {}
+        if interval is not None and interval > 0:
+            metadata["interval_minutes"] = interval
+        last_report = (
+            payload.get("last_report_date")
+            or payload.get("lastReportDate")
+            or payload.get("last_reported_at")
+            or payload.get("lastReportedAt")
+        )
+        if last_report is not None:
+            metadata["last_report_date"] = last_report
+        return metadata
+
+    @classmethod
+    def _daily_values_from_mapping(
+        cls,
+        payload: dict[str, object],
+    ) -> tuple[dict[str, float], float | None]:
+        day_values: dict[str, float] = {}
+        current_value: float | None = None
+        unit_hint = payload.get("unit") or payload.get("source_unit")
+        for key, raw in payload.items():
+            day_key = cls._parse_evse_timeseries_date_key(key)
+            if day_key is None:
+                continue
+            numeric = cls._coerce_evse_timeseries_energy(
+                raw, key_hint=str(key), unit_hint=unit_hint
+            )
+            if numeric is None:
+                continue
+            day_values[day_key] = numeric
+        for key in (
+            "energy_kwh",
+            "value_kwh",
+            "daily_energy_kwh",
+            "daily_kwh",
+            "energy",
+            "value",
+            "energy_wh",
+            "daily_energy_wh",
+        ):
+            if key not in payload:
+                continue
+            current_value = cls._coerce_evse_timeseries_energy(
+                payload.get(key), key_hint=key, unit_hint=unit_hint
+            )
+            break
+        return day_values, current_value
+
+    @classmethod
+    def _daily_values_from_sequence(
+        cls,
+        values: list[object],
+        *,
+        start_date_value: object | None = None,
+        unit_hint: object | None = None,
+    ) -> tuple[dict[str, float], float | None]:
+        day_values: dict[str, float] = {}
+        current_value: float | None = None
+        start_day = cls._parse_evse_timeseries_date_key(start_date_value)
+        start_dt = None
+        if start_day is not None:
+            try:
+                start_dt = datetime.fromisoformat(start_day)
+            except Exception:  # noqa: BLE001
+                start_dt = None
+        for idx, item in enumerate(values):
+            if isinstance(item, dict):
+                day_key = cls._parse_evse_timeseries_date_key(
+                    item.get("date")
+                    or item.get("day")
+                    or item.get("start_date")
+                    or item.get("startDate")
+                    or item.get("timestamp")
+                    or item.get("time")
+                )
+                item_unit = item.get("unit") or unit_hint
+                for key in (
+                    "energy_kwh",
+                    "value_kwh",
+                    "daily_energy_kwh",
+                    "energy",
+                    "value",
+                    "energy_wh",
+                    "daily_energy_wh",
+                ):
+                    if key not in item:
+                        continue
+                    numeric = cls._coerce_evse_timeseries_energy(
+                        item.get(key), key_hint=key, unit_hint=item_unit
+                    )
+                    if numeric is None:
+                        continue
+                    if day_key is not None:
+                        day_values[day_key] = numeric
+                    else:
+                        current_value = numeric
+                    break
+                continue
+            numeric = cls._coerce_evse_timeseries_energy(item, unit_hint=unit_hint)
+            if numeric is None:
+                continue
+            if start_dt is not None:
+                day_values[(start_dt + timedelta(days=idx)).date().isoformat()] = numeric
+            else:
+                current_value = numeric
+        return day_values, current_value
+
+    @classmethod
+    def _normalize_evse_daily_entry(
+        cls,
+        serial: str,
+        payload: object,
+        *,
+        base_metadata: dict[str, object] | None = None,
+    ) -> dict[str, object] | None:
+        metadata = dict(base_metadata or {})
+        day_values: dict[str, float] = {}
+        current_value: float | None = None
+        if isinstance(payload, dict):
+            metadata.update(cls._normalize_evse_timeseries_metadata(payload))
+            record_serial = cls._normalize_evse_timeseries_serial(
+                payload.get("serial")
+                or payload.get("serial_number")
+                or payload.get("device_serial")
+                or payload.get("charger_serial")
+                or payload.get("sn")
+            )
+            if record_serial and record_serial != serial:
+                serial = record_serial
+            nested = (
+                payload.get("days")
+                or payload.get("daily")
+                or payload.get("values")
+                or payload.get("series")
+                or payload.get("data")
+            )
+            if isinstance(nested, list):
+                day_values, current_value = cls._daily_values_from_sequence(
+                    nested,
+                    start_date_value=payload.get("start_date")
+                    or payload.get("startDate"),
+                    unit_hint=payload.get("unit") or payload.get("source_unit"),
+                )
+            elif isinstance(nested, dict):
+                day_values, current_value = cls._daily_values_from_mapping(nested)
+            else:
+                day_values, current_value = cls._daily_values_from_mapping(payload)
+        elif isinstance(payload, list):
+            day_values, current_value = cls._daily_values_from_sequence(payload)
+        else:
+            current_value = cls._coerce_evse_timeseries_energy(payload)
+        if not day_values and current_value is None:
+            return None
+        current_day = max(day_values) if day_values else None
+        return {
+            "serial": serial,
+            "day_values_kwh": day_values,
+            "energy_kwh": (
+                day_values.get(current_day) if current_day is not None else current_value
+            ),
+            "current_value_kwh": current_value,
+            **metadata,
+        }
+
+    @classmethod
+    def _normalize_evse_lifetime_entry(
+        cls,
+        serial: str,
+        payload: object,
+        *,
+        base_metadata: dict[str, object] | None = None,
+    ) -> dict[str, object] | None:
+        metadata = dict(base_metadata or {})
+        energy_kwh: float | None = None
+        if isinstance(payload, dict):
+            metadata.update(cls._normalize_evse_timeseries_metadata(payload))
+            record_serial = cls._normalize_evse_timeseries_serial(
+                payload.get("serial")
+                or payload.get("serial_number")
+                or payload.get("device_serial")
+                or payload.get("charger_serial")
+                or payload.get("sn")
+            )
+            if record_serial and record_serial != serial:
+                serial = record_serial
+            unit_hint = payload.get("unit") or payload.get("source_unit")
+            for key in (
+                "energy_kwh",
+                "value_kwh",
+                "lifetime_energy_kwh",
+                "lifetime_kwh",
+                "total_kwh",
+                "energy_wh",
+                "lifetime_energy_wh",
+                "value_wh",
+                "energy",
+                "value",
+            ):
+                if key not in payload:
+                    continue
+                energy_kwh = cls._coerce_evse_timeseries_energy(
+                    payload.get(key), key_hint=key, unit_hint=unit_hint
+                )
+                if energy_kwh is not None:
+                    break
+            if energy_kwh is None:
+                values = payload.get("values") or payload.get("series") or payload.get("data")
+                if isinstance(values, list):
+                    for item in reversed(values):
+                        if isinstance(item, dict):
+                            for key in (
+                                "energy_kwh",
+                                "value_kwh",
+                                "lifetime_energy_kwh",
+                                "energy_wh",
+                                "value_wh",
+                                "value",
+                            ):
+                                if key not in item:
+                                    continue
+                                energy_kwh = cls._coerce_evse_timeseries_energy(
+                                    item.get(key),
+                                    key_hint=key,
+                                    unit_hint=item.get("unit") or unit_hint,
+                                )
+                                if energy_kwh is not None:
+                                    break
+                            if energy_kwh is not None:
+                                break
+                        else:
+                            energy_kwh = cls._coerce_evse_timeseries_energy(
+                                item, unit_hint=unit_hint
+                            )
+                            if energy_kwh is not None:
+                                break
+        else:
+            energy_kwh = cls._coerce_evse_timeseries_energy(payload)
+        if energy_kwh is None:
+            return None
+        return {"serial": serial, "energy_kwh": energy_kwh, **metadata}
+
+    @classmethod
+    def _normalize_evse_timeseries_payload(
+        cls,
+        payload: object,
+        *,
+        daily: bool,
+    ) -> dict[str, dict[str, object]] | None:
+        data = payload
+        if isinstance(data, dict) and isinstance(data.get("data"), (dict, list)):
+            data = data.get("data")
+        base_metadata = cls._normalize_evse_timeseries_metadata(
+            payload if isinstance(payload, dict) else {}
+        )
+        if isinstance(data, dict):
+            candidates = (
+                data.get("results")
+                or data.get("chargers")
+                or data.get("devices")
+                or data.get("timeseries")
+            )
+            if isinstance(candidates, list):
+                data = candidates
+        normalized: dict[str, dict[str, object]] = {}
+        if isinstance(data, list):
+            for item in data:
+                if not isinstance(item, dict):
+                    continue
+                serial = cls._normalize_evse_timeseries_serial(
+                    item.get("serial")
+                    or item.get("serial_number")
+                    or item.get("device_serial")
+                    or item.get("charger_serial")
+                    or item.get("sn")
+                )
+                if not serial:
+                    continue
+                entry = (
+                    cls._normalize_evse_daily_entry(
+                        serial, item, base_metadata=base_metadata
+                    )
+                    if daily
+                    else cls._normalize_evse_lifetime_entry(
+                        serial, item, base_metadata=base_metadata
+                    )
+                )
+                if entry is not None:
+                    normalized[serial] = entry
+            return normalized
+        if not isinstance(data, dict):
+            return None
+        for key, value in data.items():
+            serial = cls._normalize_evse_timeseries_serial(key)
+            if not serial:
+                continue
+            entry = (
+                cls._normalize_evse_daily_entry(
+                    serial, value, base_metadata=base_metadata
+                )
+                if daily
+                else cls._normalize_evse_lifetime_entry(
+                    serial, value, base_metadata=base_metadata
+                )
+            )
+            if entry is None:
+                continue
+            normalized[serial] = entry
+        return normalized
+
+    async def evse_timeseries_daily_energy(
+        self,
+        *,
+        request_id: str | None = None,
+        username: str | None = None,
+    ) -> dict[str, dict[str, object]] | None:
+        """Return EVSE daily timeseries keyed by charger serial."""
+
+        request_id = request_id or str(uuid.uuid4())
+        if username is None:
+            username = self._session_history_username()
+        query = {"siteId": self._site, "source": "evse", "requestId": request_id}
+        if username:
+            query["username"] = username
+        url = URL(f"{BASE_URL}/service/timeseries/evse/timeseries/daily_energy").with_query(query)
+        headers = self._evse_timeseries_headers(request_id, username)
+        try:
+            data = await self._json("GET", str(url), headers=headers)
+        except aiohttp.ClientResponseError as err:
+            if is_evse_timeseries_unavailable_error(err.message, err.status, url):
+                raise EVSETimeseriesUnavailable(str(err)) from err
+            raise
+        return self._normalize_evse_timeseries_payload(data, daily=True)
+
+    async def evse_timeseries_lifetime_energy(
+        self,
+        *,
+        request_id: str | None = None,
+        username: str | None = None,
+    ) -> dict[str, dict[str, object]] | None:
+        """Return EVSE lifetime timeseries keyed by charger serial."""
+
+        request_id = request_id or str(uuid.uuid4())
+        if username is None:
+            username = self._session_history_username()
+        query = {"siteId": self._site, "source": "evse", "requestId": request_id}
+        if username:
+            query["username"] = username
+        url = URL(f"{BASE_URL}/service/timeseries/evse/timeseries/lifetime_energy").with_query(query)
+        headers = self._evse_timeseries_headers(request_id, username)
+        try:
+            data = await self._json("GET", str(url), headers=headers)
+        except aiohttp.ClientResponseError as err:
+            if is_evse_timeseries_unavailable_error(err.message, err.status, url):
+                raise EVSETimeseriesUnavailable(str(err)) from err
+            raise
+        return self._normalize_evse_timeseries_payload(data, daily=False)
 
     @staticmethod
     def _coerce_lifetime_energy_value(value: object) -> float | None:

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -88,6 +88,7 @@ from .device_types import (
 )
 from .device_info_helpers import _is_redundant_model_id
 from .energy import EnergyManager
+from .evse_timeseries import EVSETimeseriesManager
 from .session_history import (
     MIN_SESSION_HISTORY_CACHE_TTL,
     SESSION_HISTORY_CACHE_DAY_RETENTION,
@@ -399,6 +400,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             logger=_LOGGER,
             summary_invalidator=self.summary.invalidate,
         )
+        self.evse_timeseries = EVSETimeseriesManager(
+            hass,
+            lambda: self.client,
+            logger=_LOGGER,
+        )
         self._session_history_cache_shim: dict[
             tuple[str, str], tuple[float, list[dict]]
         ] = {}
@@ -590,6 +596,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             )
             self.__dict__["energy"] = energy
             return energy
+        if name == "evse_timeseries":
+            manager = EVSETimeseriesManager(
+                self.__dict__.get("hass"),
+                lambda: self.__dict__.get("client"),
+                logger=_LOGGER,
+            )
+            self.__dict__["evse_timeseries"] = manager
+            return manager
         raise AttributeError(f"{type(self).__name__} has no attribute {name!r}")
 
     async def _async_setup(self) -> None:
@@ -4052,6 +4066,26 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             metrics["site_energy_backoff_ends_utc"] = _iso(
                 getattr(energy_manager, "service_backoff_ends_utc", None)
             )
+        evse_timeseries = getattr(self, "evse_timeseries", None)
+        if evse_timeseries is not None:
+            metrics["evse_timeseries_available"] = getattr(
+                evse_timeseries, "service_available", None
+            )
+            metrics["evse_timeseries_failures"] = getattr(
+                evse_timeseries, "service_failures", None
+            )
+            metrics["evse_timeseries_last_error"] = getattr(
+                evse_timeseries, "service_last_error", None
+            )
+            metrics["evse_timeseries_last_failure"] = _iso(
+                getattr(evse_timeseries, "service_last_failure_utc", None)
+            )
+            metrics["evse_timeseries_backoff_active"] = getattr(
+                evse_timeseries, "service_backoff_active", None
+            )
+            metrics["evse_timeseries_backoff_ends_utc"] = _iso(
+                getattr(evse_timeseries, "service_backoff_ends_utc", None)
+            )
         site_energy_age = None
         site_flows = {}
         site_meta = {}
@@ -4070,6 +4104,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 "update_pending": site_meta.get("update_pending"),
                 "interval_minutes": site_meta.get("interval_minutes"),
             }
+        if evse_timeseries is not None:
+            metrics["evse_timeseries"] = evse_timeseries.diagnostics()
         firmware_catalog_manager = getattr(self, "firmware_catalog_manager", None)
         status_snapshot = getattr(firmware_catalog_manager, "status_snapshot", None)
         if callable(status_snapshot):
@@ -4120,6 +4156,20 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             "interval_minutes": getattr(self, "_session_history_interval_min", None),
             "in_progress": session_manager.in_progress,
         }
+
+    def evse_timeseries_diagnostics(self) -> dict[str, object]:
+        """Return EVSE-timeseries cache and service diagnostics."""
+
+        manager = getattr(self, "evse_timeseries", None)
+        if manager is None:
+            return {
+                "cache_ttl_seconds": None,
+                "daily_cache_days": [],
+                "daily_cache_age_seconds": {},
+                "lifetime_cache_age_seconds": None,
+                "lifetime_serial_count": 0,
+            }
+        return manager.diagnostics()
 
     def scheduler_diagnostics(self) -> dict[str, object]:
         """Return scheduler availability and failure diagnostics."""
@@ -4203,6 +4253,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             ),
             "charger_feature_flags": charger_feature_flags,
             "charger_support_sources": charger_support_sources,
+            "timeseries": self.evse_timeseries_diagnostics(),
         }
 
     def inverter_diagnostics_payloads(self) -> dict[str, object]:
@@ -5613,6 +5664,18 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             )
         phase_timings["sessions_s"] = round(time.monotonic() - sessions_start, 3)
         self._sync_session_history_issue()
+
+        evse_timeseries_start = time.monotonic()
+        try:
+            await self.evse_timeseries.async_refresh(day_local=day_local_default)
+            self.evse_timeseries.merge_charger_payloads(
+                out, day_local=day_local_default
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        phase_timings["evse_timeseries_s"] = round(
+            time.monotonic() - evse_timeseries_start, 3
+        )
 
         site_energy_start = time.monotonic()
         await self.energy._async_refresh_site_energy()

--- a/custom_components/enphase_ev/evse_timeseries.py
+++ b/custom_components/enphase_ev/evse_timeseries.py
@@ -1,0 +1,379 @@
+"""EVSE timeseries helpers for charger energy fallback data."""
+
+from __future__ import annotations
+
+import logging
+import time
+from datetime import datetime, timedelta
+from typing import Callable
+
+from homeassistant.core import HomeAssistant
+from homeassistant.util import dt as dt_util
+
+from .api import EVSETimeseriesUnavailable
+
+_LOGGER = logging.getLogger(__name__)
+
+EVSE_TIMESERIES_CACHE_TTL = 15 * 60
+EVSE_TIMESERIES_FAILURE_BACKOFF_S = 15 * 60
+
+
+class EVSETimeseriesManager:
+    """Cache and merge EVSE daily/lifetime timeseries payloads."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        client_provider: Callable[[], object],
+        *,
+        logger: logging.Logger | None = None,
+        cache_ttl: float = EVSE_TIMESERIES_CACHE_TTL,
+        failure_backoff: float = EVSE_TIMESERIES_FAILURE_BACKOFF_S,
+    ) -> None:
+        self._hass = hass
+        self._client_provider = client_provider
+        self._logger = logger or _LOGGER
+        self._cache_ttl = max(60.0, float(cache_ttl or 0))
+        self._failure_backoff = max(60.0, float(failure_backoff or 0))
+        self._daily_cache: dict[str, tuple[float, dict[str, dict[str, object]]]] = {}
+        self._lifetime_cache: tuple[float, dict[str, dict[str, object]]] | None = None
+        self._endpoint_state: dict[str, dict[str, object]] = {
+            "daily": {
+                "available": True,
+                "failures": 0,
+                "last_error": None,
+                "last_failure_utc": None,
+                "backoff_until": None,
+                "backoff_ends_utc": None,
+            },
+            "lifetime": {
+                "available": True,
+                "failures": 0,
+                "last_error": None,
+                "last_failure_utc": None,
+                "backoff_until": None,
+                "backoff_ends_utc": None,
+            },
+        }
+
+    @property
+    def cache_ttl(self) -> float:
+        return self._cache_ttl
+
+    @property
+    def service_available(self) -> bool:
+        return bool(self.daily_available or self.lifetime_available)
+
+    @property
+    def service_last_error(self) -> str | None:
+        failures = [
+            (
+                state.get("last_failure_utc"),
+                state.get("last_error"),
+            )
+            for state in self._endpoint_state.values()
+            if state.get("last_error") is not None
+        ]
+        if not failures:
+            return None
+        failures.sort(
+            key=lambda item: item[0].timestamp()
+            if isinstance(item[0], datetime)
+            else float("-inf")
+        )
+        return failures[-1][1]  # type: ignore[return-value]
+
+    @property
+    def service_failures(self) -> int:
+        return sum(int(state.get("failures", 0) or 0) for state in self._endpoint_state.values())
+
+    @property
+    def service_backoff_active(self) -> bool:
+        return bool(
+            self.daily_backoff_active or self.lifetime_backoff_active
+        )
+
+    @property
+    def service_backoff_ends_utc(self) -> datetime | None:
+        ends = [
+            state.get("backoff_ends_utc")
+            for state in self._endpoint_state.values()
+            if isinstance(state.get("backoff_ends_utc"), datetime)
+        ]
+        if not ends:
+            return None
+        return max(ends)
+
+    @property
+    def service_last_failure_utc(self) -> datetime | None:
+        failures = [
+            state.get("last_failure_utc")
+            for state in self._endpoint_state.values()
+            if isinstance(state.get("last_failure_utc"), datetime)
+        ]
+        if not failures:
+            return None
+        return max(failures)
+
+    @property
+    def daily_available(self) -> bool:
+        return self._endpoint_available("daily")
+
+    @property
+    def lifetime_available(self) -> bool:
+        return self._endpoint_available("lifetime")
+
+    @property
+    def daily_backoff_active(self) -> bool:
+        return self._endpoint_backoff_active("daily")
+
+    @property
+    def lifetime_backoff_active(self) -> bool:
+        return self._endpoint_backoff_active("lifetime")
+
+    @property
+    def daily_cache_age(self) -> dict[str, float]:
+        now = time.monotonic()
+        ages: dict[str, float] = {}
+        for day_key, (cached_at, _data) in self._daily_cache.items():
+            try:
+                age = now - cached_at
+            except Exception:
+                continue
+            if age >= 0:
+                ages[day_key] = round(age, 3)
+        return ages
+
+    @property
+    def lifetime_cache_age(self) -> float | None:
+        cached = self._lifetime_cache
+        if cached is None:
+            return None
+        try:
+            age = time.monotonic() - cached[0]
+        except Exception:
+            return None
+        return round(age, 3) if age >= 0 else None
+
+    @property
+    def daily_cache_days(self) -> list[str]:
+        return sorted(self._daily_cache.keys())
+
+    @property
+    def lifetime_serial_count(self) -> int:
+        if self._lifetime_cache is None:
+            return 0
+        return len(self._lifetime_cache[1])
+
+    def _endpoint_state_for(self, endpoint: str) -> dict[str, object]:
+        return self._endpoint_state[endpoint]
+
+    def _endpoint_available(self, endpoint: str) -> bool:
+        state = self._endpoint_state_for(endpoint)
+        return bool(state.get("available", True) and not self._endpoint_backoff_active(endpoint))
+
+    def _endpoint_backoff_active(self, endpoint: str) -> bool:
+        state = self._endpoint_state_for(endpoint)
+        backoff_until = state.get("backoff_until")
+        return bool(backoff_until and time.monotonic() < float(backoff_until))
+
+    def _mark_endpoint_available(self, endpoint: str) -> None:
+        state = self._endpoint_state_for(endpoint)
+        state["available"] = True
+        state["failures"] = 0
+        state["last_error"] = None
+        state["last_failure_utc"] = None
+        state["backoff_until"] = None
+        state["backoff_ends_utc"] = None
+
+    def _note_service_unavailable(
+        self,
+        endpoint: str,
+        err: Exception | str | None,
+    ) -> None:
+        state = self._endpoint_state_for(endpoint)
+        reason = str(err).strip() if err else "EVSE timeseries unavailable"
+        state["available"] = False
+        state["failures"] = int(state.get("failures", 0) or 0) + 1
+        state["last_error"] = reason
+        state["last_failure_utc"] = dt_util.utcnow()
+        delay = max(self._failure_backoff, 60.0)
+        state["backoff_until"] = time.monotonic() + delay
+        try:
+            state["backoff_ends_utc"] = dt_util.utcnow() + timedelta(seconds=delay)
+        except Exception:
+            state["backoff_ends_utc"] = None
+
+    @staticmethod
+    def _day_key(day_local: datetime) -> str:
+        return day_local.strftime("%Y-%m-%d")
+
+    def _lifetime_cache_fresh(self) -> bool:
+        cached = self._lifetime_cache
+        if cached is None:
+            return False
+        try:
+            return (time.monotonic() - cached[0]) < self._cache_ttl
+        except Exception:
+            return False
+
+    def _daily_cache_fresh(self, day_key: str) -> bool:
+        cached = self._daily_cache.get(day_key)
+        if cached is None:
+            return False
+        try:
+            return (time.monotonic() - cached[0]) < self._cache_ttl
+        except Exception:
+            return False
+
+    async def async_refresh(
+        self,
+        *,
+        day_local: datetime | None = None,
+        force: bool = False,
+    ) -> None:
+        if day_local is None:
+            day_local = dt_util.as_local(dt_util.now())
+        day_key = self._day_key(day_local)
+
+        client = self._client_provider()
+        refresh_lifetime = (
+            (force or not self._lifetime_cache_fresh())
+            and (force or not self.lifetime_backoff_active)
+        )
+        refresh_daily = (
+            (force or not self._daily_cache_fresh(day_key))
+            and (force or not self.daily_backoff_active)
+        )
+        if not refresh_lifetime and not refresh_daily:
+            return
+
+        if refresh_lifetime:
+            fetcher = getattr(client, "evse_timeseries_lifetime_energy", None)
+            if callable(fetcher):
+                try:
+                    payload = await fetcher()
+                except EVSETimeseriesUnavailable as err:
+                    self._note_service_unavailable("lifetime", err)
+                except Exception as err:  # noqa: BLE001
+                    self._logger.debug(
+                        "Failed to refresh EVSE lifetime timeseries: %s", err
+                    )
+                else:
+                    if isinstance(payload, dict):
+                        self._lifetime_cache = (time.monotonic(), payload)
+                        self._mark_endpoint_available("lifetime")
+
+        if refresh_daily:
+            fetcher = getattr(client, "evse_timeseries_daily_energy", None)
+            if callable(fetcher):
+                try:
+                    payload = await fetcher()
+                except EVSETimeseriesUnavailable as err:
+                    self._note_service_unavailable("daily", err)
+                except Exception as err:  # noqa: BLE001
+                    self._logger.debug(
+                        "Failed to refresh EVSE daily timeseries for %s: %s",
+                        day_key,
+                        err,
+                    )
+                else:
+                    if isinstance(payload, dict):
+                        self._daily_cache[day_key] = (time.monotonic(), payload)
+                        self._mark_endpoint_available("daily")
+
+    def daily_entry(
+        self,
+        serial: str,
+        *,
+        day_local: datetime,
+    ) -> dict[str, object] | None:
+        cached = self._daily_cache.get(self._day_key(day_local))
+        if cached is None:
+            return None
+        return cached[1].get(serial)
+
+    def lifetime_entry(self, serial: str) -> dict[str, object] | None:
+        cached = self._lifetime_cache
+        if cached is None:
+            return None
+        return cached[1].get(serial)
+
+    def merge_charger_payloads(
+        self,
+        payloads: dict[str, dict],
+        *,
+        day_local: datetime,
+    ) -> None:
+        for serial, entry in payloads.items():
+            daily = self.daily_entry(serial, day_local=day_local)
+            lifetime = self.lifetime_entry(serial)
+            if isinstance(daily, dict):
+                value = daily.get("energy_kwh")
+                if value is not None:
+                    entry["evse_daily_energy_kwh"] = value
+                interval = daily.get("interval_minutes")
+                if interval is not None:
+                    entry["evse_timeseries_interval_minutes"] = interval
+            if isinstance(lifetime, dict):
+                value = lifetime.get("energy_kwh")
+                if value is not None:
+                    entry["evse_lifetime_energy_kwh"] = value
+                interval = lifetime.get("interval_minutes")
+                if (
+                    interval is not None
+                    and entry.get("evse_timeseries_interval_minutes") is None
+                ):
+                    entry["evse_timeseries_interval_minutes"] = interval
+            last_report = None
+            if isinstance(lifetime, dict):
+                last_report = lifetime.get("last_report_date")
+            if last_report is None and isinstance(daily, dict):
+                last_report = daily.get("last_report_date")
+            if last_report is not None:
+                entry["evse_timeseries_last_reported_at"] = last_report
+            if isinstance(daily, dict) or isinstance(lifetime, dict):
+                entry["evse_timeseries_source"] = "evse_timeseries"
+
+    def diagnostics(self) -> dict[str, object]:
+        endpoint_details: dict[str, dict[str, object]] = {}
+        for key, state in self._endpoint_state.items():
+            endpoint_details[key] = {
+                "available": bool(state.get("available", True)),
+                "failures": int(state.get("failures", 0) or 0),
+                "last_error": state.get("last_error"),
+                "last_failure_utc": (
+                    state.get("last_failure_utc").isoformat()
+                    if isinstance(state.get("last_failure_utc"), datetime)
+                    else None
+                ),
+                "backoff_until": state.get("backoff_until"),
+                "backoff_ends_utc": (
+                    state.get("backoff_ends_utc").isoformat()
+                    if isinstance(state.get("backoff_ends_utc"), datetime)
+                    else None
+                ),
+            }
+        return {
+            "available": self.service_available,
+            "failures": self.service_failures,
+            "last_error": self.service_last_error,
+            "last_failure_utc": (
+                self.service_last_failure_utc.isoformat()
+                if self.service_last_failure_utc is not None
+                else None
+            ),
+            "backoff_active": self.service_backoff_active,
+            "backoff_ends_utc": (
+                self.service_backoff_ends_utc.isoformat()
+                if self.service_backoff_ends_utc is not None
+                else None
+            ),
+            "cache_ttl_seconds": self.cache_ttl,
+            "daily_cache_days": self.daily_cache_days,
+            "daily_cache_age_seconds": self.daily_cache_age,
+            "lifetime_cache_age_seconds": self.lifetime_cache_age,
+            "lifetime_serial_count": self.lifetime_serial_count,
+            "daily": endpoint_details["daily"],
+            "lifetime": endpoint_details["lifetime"],
+        }

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -2364,12 +2364,20 @@ class EnphaseLifetimeEnergySensor(EnphaseBaseEntity, RestoreSensor):
     @property
     def native_value(self):
         raw = self.data.get("lifetime_kwh")
+        if raw is None:
+            raw = self.data.get("evse_lifetime_energy_kwh")
         # Parse and validate
         val: float | None
         try:
             val = float(raw) if raw is not None else None
         except Exception:
             val = None
+        if val is None:
+            fallback = self.data.get("evse_lifetime_energy_kwh")
+            try:
+                val = float(fallback) if fallback is not None else None
+            except Exception:
+                val = None
 
         # Reject missing or negative samples outright; keep prior value
         if val is None or val < 0:

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import datetime
 import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -215,6 +216,148 @@ def test_redact_headers_masks_sensitive_fields() -> None:
     assert redacted["Authorization"] == "[redacted]"
     assert redacted["e-auth-token"] == "[redacted]"
     assert redacted["X-Test"] == "value"
+
+
+def test_evse_timeseries_unavailable_helper_branches() -> None:
+    class BadStr:
+        def __str__(self) -> str:
+            raise ValueError("boom")
+
+    assert (
+        api.is_evse_timeseries_unavailable_error(
+            "Service unavailable", 503, "https://x/service/timeseries/evse/timeseries/daily_energy"
+        )
+        is True
+    )
+    assert api.is_evse_timeseries_unavailable_error(
+        "EVSE timeseries unavailable",
+        None,
+        None,
+    )
+    assert api.is_evse_timeseries_unavailable_error(
+        "daily_energy service unavailable",
+        None,
+        None,
+    )
+    assert api.is_evse_timeseries_unavailable_error(
+        "lifetime_energy service unavailable",
+        None,
+        None,
+    )
+    assert api.is_evse_timeseries_unavailable_error(BadStr(), None, BadStr()) is False
+
+
+def test_evse_timeseries_normalizer_helpers(monkeypatch) -> None:
+    class BadSerial:
+        def __str__(self) -> str:
+            raise ValueError("bad-serial")
+
+    class BadUnit:
+        def __str__(self) -> str:
+            raise ValueError("bad-unit")
+
+    class BadFloat(float):
+        def __float__(self):
+            raise ValueError("bad-float")
+
+    client = _make_client()
+
+    assert client._normalize_evse_timeseries_serial(BadSerial()) is None
+    now_dt = datetime.datetime(2026, 3, 11, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    assert client._parse_evse_timeseries_date_key(now_dt) == "2026-03-11"
+    assert client._parse_evse_timeseries_date_key(now_dt.date()) == "2026-03-11"
+    assert client._parse_evse_timeseries_date_key(1_700_000_000_000) == "2023-11-14"
+    assert client._parse_evse_timeseries_date_key(BadFloat(1.0)) is None
+    assert client._parse_evse_timeseries_date_key([]) is None
+    assert client._parse_evse_timeseries_date_key("") is None
+    assert client._parse_evse_timeseries_date_key("2026-03-11 not-iso") == "2026-03-11"
+    assert client._parse_evse_timeseries_date_key("2026/03/11 broken") is None
+    assert client._parse_evse_timeseries_date_key("bad") is None
+
+    assert client._coerce_evse_timeseries_energy("bad") is None
+    assert client._coerce_evse_timeseries_energy("1000", unit_hint=BadUnit()) == pytest.approx(1000.0)
+    assert client._coerce_evse_timeseries_energy("1000", unit_hint="Wh") == pytest.approx(1.0)
+    assert client._normalize_evse_timeseries_metadata([]) == {}
+
+
+def test_evse_timeseries_payload_normalizer_branches(monkeypatch) -> None:
+    client = _make_client()
+
+    mapping_days, current_value = client._daily_values_from_mapping(
+        {"skip": "value", "2026-03-11": "bad", "energy_wh": 500}
+    )
+    assert mapping_days == {}
+    assert current_value == pytest.approx(0.5)
+
+    original_parser = client._parse_evse_timeseries_date_key
+    monkeypatch.setattr(
+        api.EnphaseEVClient,
+        "_parse_evse_timeseries_date_key",
+        staticmethod(lambda value: "bad-date" if value == "force-bad" else original_parser(value)),
+    )
+    values, current = client._daily_values_from_sequence(
+        [
+            {"energy_kwh": "bad"},
+            {"energy_kwh": 1.25},
+            "bad",
+            2.5,
+        ],
+        start_date_value="force-bad",
+    )
+    assert values == {}
+    assert current == pytest.approx(2.5)
+
+    values, current = client._daily_values_from_sequence(
+        [1.0, 2.0],
+        start_date_value="2026-03-10",
+    )
+    assert values["2026-03-10"] == pytest.approx(1.0)
+    assert values["2026-03-11"] == pytest.approx(2.0)
+    assert current is None
+
+    daily_entry = client._normalize_evse_daily_entry(
+        "SERIAL-1",
+        {"serial": "SERIAL-2", "data": {"2026-03-11": 3.0}},
+    )
+    assert daily_entry["serial"] == "SERIAL-2"
+    assert daily_entry["energy_kwh"] == pytest.approx(3.0)
+    assert client._normalize_evse_daily_entry("SERIAL-1", [4.0])["current_value_kwh"] == pytest.approx(4.0)
+    assert client._normalize_evse_daily_entry("SERIAL-1", "bad") is None
+
+    lifetime_entry = client._normalize_evse_lifetime_entry(
+        "SERIAL-1",
+        {"serial_number": "SERIAL-2", "values": [1.5]},
+    )
+    assert lifetime_entry["serial"] == "SERIAL-2"
+    assert lifetime_entry["energy_kwh"] == pytest.approx(1.5)
+    assert client._normalize_evse_lifetime_entry("SERIAL-1", 9.5)["energy_kwh"] == pytest.approx(9.5)
+    assert client._normalize_evse_lifetime_entry("SERIAL-1", {"data": {}}) is None
+
+    payload = client._normalize_evse_timeseries_payload(
+        {
+            "data": {
+                "results": [
+                    "skip",
+                    {"energy_kwh": 1.0},
+                    {"serial": "SERIAL-3", "energy_kwh": 5.0},
+                ]
+            }
+        },
+        daily=False,
+    )
+    assert payload["SERIAL-3"]["serial"] == "SERIAL-3"
+    assert payload["SERIAL-3"]["energy_kwh"] == pytest.approx(5.0)
+
+    class BadKey:
+        def __str__(self) -> str:
+            raise ValueError("bad-key")
+
+    payload = client._normalize_evse_timeseries_payload(
+        {BadKey(): {"energy_kwh": 1.0}, "SERIAL-4": {}},
+        daily=False,
+    )
+    assert payload == {}
+    assert client._normalize_evse_timeseries_payload("bad", daily=False) is None
 
 
 def test_invalid_payload_error_defaults_summary_when_blank() -> None:
@@ -2078,6 +2221,101 @@ async def test_lifetime_energy_normalization() -> None:
     assert payload["heatpump"] == [None, 4.2, None]
     assert payload["water_heater"] == [0.0, 15.0]
     assert payload["interval_minutes"] == 15.0
+
+
+@pytest.mark.asyncio
+async def test_evse_timeseries_daily_energy_normalization() -> None:
+    client = _make_client()
+    client.update_credentials(eauth=_make_token({"user_id": "user-123"}))
+    client._json = AsyncMock(
+        return_value={
+            "data": {
+                TEST_EVSE_SERIAL: {
+                    "days": [
+                        {"date": "2026-03-10", "energy_wh": 1200},
+                        {"date": "2026-03-11", "energy_kwh": "2.5"},
+                    ],
+                    "intervalMinutes": "1440",
+                    "lastReportDate": "2026-03-11T10:00:00+00:00",
+                },
+                "EVSE-2": {
+                    "2026-03-11": "3.1",
+                },
+            }
+        }
+    )
+
+    payload = await client.evse_timeseries_daily_energy()
+
+    assert payload[TEST_EVSE_SERIAL]["day_values_kwh"] == {
+        "2026-03-10": pytest.approx(1.2),
+        "2026-03-11": pytest.approx(2.5),
+    }
+    assert payload[TEST_EVSE_SERIAL]["energy_kwh"] == pytest.approx(2.5)
+    assert payload[TEST_EVSE_SERIAL]["interval_minutes"] == pytest.approx(1440.0)
+    assert payload["EVSE-2"]["energy_kwh"] == pytest.approx(3.1)
+    args, kwargs = client._json.await_args
+    assert args[0] == "GET"
+    assert "/service/timeseries/evse/timeseries/daily_energy" in args[1]
+    assert "siteId=SITE" in args[1]
+    assert kwargs["headers"]["username"] == "user-123"
+
+
+@pytest.mark.asyncio
+async def test_evse_timeseries_lifetime_energy_normalization() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        return_value={
+            "data": [
+                {
+                    "serial": TEST_EVSE_SERIAL,
+                    "lifetime_energy_wh": 45600,
+                    "interval": "60",
+                    "last_report_date": 1_700_000_000,
+                },
+                {
+                    "serial_number": "EVSE-2",
+                    "values": [{"value_kwh": "12.4"}],
+                },
+            ]
+        }
+    )
+
+    payload = await client.evse_timeseries_lifetime_energy()
+
+    assert payload[TEST_EVSE_SERIAL]["energy_kwh"] == pytest.approx(45.6)
+    assert payload[TEST_EVSE_SERIAL]["interval_minutes"] == pytest.approx(60.0)
+    assert payload["EVSE-2"]["energy_kwh"] == pytest.approx(12.4)
+
+
+@pytest.mark.asyncio
+async def test_evse_timeseries_wraps_unavailable() -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=_make_cre(503, "service unavailable"))
+
+    with pytest.raises(api.EVSETimeseriesUnavailable):
+        await client.evse_timeseries_daily_energy()
+
+    with pytest.raises(api.EVSETimeseriesUnavailable):
+        await client.evse_timeseries_lifetime_energy()
+
+
+@pytest.mark.asyncio
+async def test_evse_timeseries_methods_handle_username_and_reraise() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value=None)
+
+    assert await client.evse_timeseries_lifetime_energy(username="user-1") is None
+    args, _kwargs = client._json.await_args
+    assert "username=user-1" in args[1]
+
+    client._json = AsyncMock(side_effect=_make_cre(400, "bad request"))
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.evse_timeseries_daily_energy()
+
+    client._json = AsyncMock(side_effect=_make_cre(400, "bad request"))
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.evse_timeseries_lifetime_energy()
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -173,6 +173,15 @@ def test_coordinator_public_diagnostics_helpers(coordinator_factory) -> None:
         "meta": {"serverTimeStamp": "2026-03-08T09:40:02.917+00:00"},
         "error": {},
     }
+    coord.evse_timeseries = SimpleNamespace(
+        diagnostics=lambda: {
+            "cache_ttl_seconds": 900.0,
+            "daily_cache_days": ["2026-03-11"],
+            "daily_cache_age_seconds": {"2026-03-11": 5.0},
+            "lifetime_cache_age_seconds": 10.0,
+            "lifetime_serial_count": 1,
+        }
+    )
     coord.data[SERIAL_ONE]["charge_mode_supported_source"] = "feature_flag"
     coord.data["BROKEN"] = []
     coord._inverter_summary_counts = {"total": 1}  # noqa: SLF001
@@ -205,6 +214,13 @@ def test_coordinator_public_diagnostics_helpers(coordinator_factory) -> None:
         "interval_minutes": 15,
         "in_progress": 1,
     }
+    assert coord.evse_timeseries_diagnostics() == {
+        "cache_ttl_seconds": 900.0,
+        "daily_cache_days": ["2026-03-11"],
+        "daily_cache_age_seconds": {"2026-03-11": 5.0},
+        "lifetime_cache_age_seconds": 10.0,
+        "lifetime_serial_count": 1,
+    }
     assert coord.scheduler_backoff_active() is True
     assert coord.scheduler_diagnostics()["backoff_ends_utc"] == backoff_end.isoformat()
     assert coord.battery_diagnostics_payloads()["profile_payload"] == {
@@ -226,6 +242,13 @@ def test_coordinator_public_diagnostics_helpers(coordinator_factory) -> None:
             "sources": {"charge_mode_supported": "feature_flag"},
         }
     ]
+    assert coord.evse_diagnostics_payloads()["timeseries"] == {
+        "cache_ttl_seconds": 900.0,
+        "daily_cache_days": ["2026-03-11"],
+        "daily_cache_age_seconds": {"2026-03-11": 5.0},
+        "lifetime_cache_age_seconds": 10.0,
+        "lifetime_serial_count": 1,
+    }
     assert coord.inverter_diagnostics_payloads()["summary_counts"] == {"total": 1}
     assert coord.inverter_diagnostics_payloads()["panel_info"] == {
         "pv_module_manufacturer": "Acme"
@@ -252,6 +275,19 @@ def test_coordinator_public_diagnostics_helpers(coordinator_factory) -> None:
     }
     assert system_dashboard["hierarchy_summary"]["counts_by_type"]["envoy"] == 1
     assert system_dashboard["type_summaries"]["envoy"]["modem"]["rssi"] == -70
+
+
+def test_evse_timeseries_diagnostics_handles_missing_manager(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.evse_timeseries = None
+
+    assert coord.evse_timeseries_diagnostics() == {
+        "cache_ttl_seconds": None,
+        "daily_cache_days": [],
+        "daily_cache_age_seconds": {},
+        "lifetime_cache_age_seconds": None,
+        "lifetime_serial_count": 0,
+    }
 
 
 @pytest.mark.asyncio
@@ -1145,6 +1181,11 @@ def _prepare_minimal_success_update(coord, sn: str) -> None:
         async_fetch=AsyncMock(return_value=[]),
         invalidate=lambda: None,
     )
+    coord.evse_timeseries = SimpleNamespace(
+        async_refresh=AsyncMock(),
+        merge_charger_payloads=MagicMock(),
+        diagnostics=lambda: {},
+    )
     coord.session_history = _make_minimal_history()
     coord.energy._async_refresh_site_energy = AsyncMock()
     coord._sync_site_energy_issue = MagicMock()
@@ -1160,6 +1201,53 @@ def _prepare_minimal_success_update(coord, sn: str) -> None:
     coord._async_refresh_grid_control_check = AsyncMock()
     coord._async_refresh_devices_inventory = AsyncMock()
     coord._async_refresh_hems_devices = AsyncMock()
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_merges_evse_timeseries(
+    coordinator_factory, monkeypatch
+):
+    sn = "EV-TS"
+    coord = coordinator_factory(serials=[sn])
+    _prepare_minimal_success_update(coord, sn)
+    day_local = datetime(2026, 3, 11, 9, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(coord_mod.dt_util, "now", lambda: day_local)
+    original_merge = coord.evse_timeseries.merge_charger_payloads
+
+    def _merge(payloads, *, day_local):
+        payloads[sn]["evse_daily_energy_kwh"] = 4.5
+        payloads[sn]["evse_lifetime_energy_kwh"] = 120.0
+        payloads[sn]["evse_timeseries_source"] = "evse_timeseries"
+        original_merge(payloads, day_local=day_local)
+
+    coord.evse_timeseries.merge_charger_payloads = MagicMock(side_effect=_merge)
+
+    result = await coord._async_update_data()
+
+    coord.evse_timeseries.async_refresh.assert_awaited_once()
+    coord.evse_timeseries.merge_charger_payloads.assert_called_once()
+    assert result[sn]["evse_daily_energy_kwh"] == pytest.approx(4.5)
+    assert result[sn]["evse_lifetime_energy_kwh"] == pytest.approx(120.0)
+    assert result[sn]["evse_timeseries_source"] == "evse_timeseries"
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_ignores_evse_timeseries_exception(
+    coordinator_factory, monkeypatch
+):
+    sn = "EV-TS-ERR"
+    coord = coordinator_factory(serials=[sn])
+    _prepare_minimal_success_update(coord, sn)
+    monkeypatch.setattr(
+        coord_mod.dt_util,
+        "now",
+        lambda: datetime(2026, 3, 11, 9, 0, 0, tzinfo=timezone.utc),
+    )
+    coord.evse_timeseries.async_refresh = AsyncMock(side_effect=RuntimeError("boom"))
+
+    result = await coord._async_update_data()
+
+    assert sn in result
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_evse_timeseries.py
+++ b/tests/components/enphase_ev/test_evse_timeseries.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.enphase_ev import evse_timeseries as ts_mod
+from custom_components.enphase_ev.api import EVSETimeseriesUnavailable
+from custom_components.enphase_ev.evse_timeseries import EVSETimeseriesManager
+
+
+@pytest.mark.asyncio
+async def test_evse_timeseries_manager_refresh_and_merge(hass) -> None:
+    client = SimpleNamespace(
+        evse_timeseries_daily_energy=AsyncMock(
+            return_value={
+                "EV-1": {
+                    "energy_kwh": 2.5,
+                    "interval_minutes": 1440.0,
+                    "last_report_date": "2026-03-11T10:00:00+00:00",
+                }
+            }
+        ),
+        evse_timeseries_lifetime_energy=AsyncMock(
+            return_value={
+                "EV-1": {
+                    "energy_kwh": 12.75,
+                    "last_report_date": "2026-03-11T11:00:00+00:00",
+                }
+            }
+        ),
+    )
+    manager = EVSETimeseriesManager(hass, lambda: client)
+    day_local = datetime(2026, 3, 11, 12, 0, 0, tzinfo=timezone.utc)
+
+    await manager.async_refresh(day_local=day_local)
+
+    payloads = {"EV-1": {"sn": "EV-1"}}
+    manager.merge_charger_payloads(payloads, day_local=day_local)
+
+    assert payloads["EV-1"]["evse_daily_energy_kwh"] == pytest.approx(2.5)
+    assert payloads["EV-1"]["evse_lifetime_energy_kwh"] == pytest.approx(12.75)
+    assert payloads["EV-1"]["evse_timeseries_interval_minutes"] == pytest.approx(1440.0)
+    assert payloads["EV-1"]["evse_timeseries_last_reported_at"] == "2026-03-11T11:00:00+00:00"
+    assert payloads["EV-1"]["evse_timeseries_source"] == "evse_timeseries"
+    diagnostics = manager.diagnostics()
+    assert diagnostics["available"] is True
+    assert diagnostics["daily_cache_days"] == ["2026-03-11"]
+    assert diagnostics["lifetime_serial_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_evse_timeseries_manager_retains_cache_on_unavailable(hass) -> None:
+    client = SimpleNamespace(
+        evse_timeseries_daily_energy=AsyncMock(
+            return_value={"EV-1": {"energy_kwh": 1.5}}
+        ),
+        evse_timeseries_lifetime_energy=AsyncMock(
+            return_value={"EV-1": {"energy_kwh": 10.0}}
+        ),
+    )
+    manager = EVSETimeseriesManager(hass, lambda: client)
+    day_local = datetime(2026, 3, 11, 12, 0, 0, tzinfo=timezone.utc)
+
+    await manager.async_refresh(day_local=day_local)
+
+    client.evse_timeseries_daily_energy = AsyncMock(
+        side_effect=EVSETimeseriesUnavailable("daily down")
+    )
+    client.evse_timeseries_lifetime_energy = AsyncMock(
+        side_effect=EVSETimeseriesUnavailable("lifetime down")
+    )
+
+    await manager.async_refresh(day_local=day_local, force=True)
+
+    payloads = {"EV-1": {"sn": "EV-1"}}
+    manager.merge_charger_payloads(payloads, day_local=day_local)
+
+    assert payloads["EV-1"]["evse_daily_energy_kwh"] == pytest.approx(1.5)
+    assert payloads["EV-1"]["evse_lifetime_energy_kwh"] == pytest.approx(10.0)
+    diagnostics = manager.diagnostics()
+    assert diagnostics["available"] is False
+    assert diagnostics["failures"] == 2
+    assert diagnostics["last_error"] == "daily down"
+    assert diagnostics["daily"]["last_error"] == "daily down"
+    assert diagnostics["lifetime"]["last_error"] == "lifetime down"
+
+
+@pytest.mark.asyncio
+async def test_evse_timeseries_manager_helper_branches(hass, monkeypatch) -> None:
+    client = SimpleNamespace(
+        evse_timeseries_daily_energy=AsyncMock(return_value={"EV-1": {"energy_kwh": 1.0}}),
+        evse_timeseries_lifetime_energy=AsyncMock(return_value={"EV-1": {"energy_kwh": 2.0}}),
+    )
+    manager = EVSETimeseriesManager(hass, lambda: client)
+
+    manager._daily_cache["2026-03-11"] = ("bad", {})  # type: ignore[assignment]
+    manager._lifetime_cache = ("bad", {})  # type: ignore[assignment]
+    assert manager.daily_cache_age == {}
+    assert manager.lifetime_cache_age is None
+    assert manager._lifetime_cache_fresh() is False  # noqa: SLF001
+    assert manager._daily_cache_fresh("2026-03-11") is False  # noqa: SLF001
+
+    utcnow_calls = iter([datetime(2026, 3, 11, tzinfo=timezone.utc), RuntimeError("boom")])
+
+    def _fake_utcnow():
+        value = next(utcnow_calls)
+        if isinstance(value, Exception):
+            raise value
+        return value
+
+    monkeypatch.setattr(ts_mod.dt_util, "utcnow", _fake_utcnow)
+    manager._note_service_unavailable("daily", "down")  # noqa: SLF001
+    assert manager.service_backoff_ends_utc is None
+
+    day_local = datetime(2026, 3, 11, 12, 0, 0, tzinfo=timezone.utc)
+    manager._endpoint_state["daily"]["backoff_until"] = 999999999999.0  # noqa: SLF001
+    manager._endpoint_state["lifetime"]["backoff_until"] = 999999999999.0  # noqa: SLF001
+    await manager.async_refresh(day_local=day_local)
+    client.evse_timeseries_daily_energy.assert_not_awaited()
+    client.evse_timeseries_lifetime_energy.assert_not_awaited()
+
+    manager._endpoint_state["daily"]["backoff_until"] = None  # noqa: SLF001
+    manager._endpoint_state["lifetime"]["backoff_until"] = None  # noqa: SLF001
+    manager._daily_cache = {"2026-03-11": (0.0, {"EV-1": {"energy_kwh": 1.0}})}
+    manager._lifetime_cache = (0.0, {"EV-1": {"energy_kwh": 2.0, "interval_minutes": 60}})
+    monkeypatch.setattr(ts_mod.time, "monotonic", lambda: 10.0)
+    monkeypatch.setattr(ts_mod.dt_util, "now", lambda: day_local)
+    monkeypatch.setattr(ts_mod.dt_util, "as_local", lambda value: value)
+    await manager.async_refresh(day_local=None)
+    await manager.async_refresh(day_local=day_local)
+    assert client.evse_timeseries_daily_energy.await_count == 0
+    assert client.evse_timeseries_lifetime_energy.await_count == 0
+
+    payloads = {"EV-1": {"sn": "EV-1"}}
+    manager.merge_charger_payloads(payloads, day_local=day_local)
+    assert payloads["EV-1"]["evse_timeseries_interval_minutes"] == 60
+
+
+@pytest.mark.asyncio
+async def test_evse_timeseries_endpoint_backoff_is_independent(hass) -> None:
+    client = SimpleNamespace(
+        evse_timeseries_daily_energy=AsyncMock(
+            side_effect=EVSETimeseriesUnavailable("daily down")
+        ),
+        evse_timeseries_lifetime_energy=AsyncMock(
+            return_value={"EV-1": {"energy_kwh": 4.0}}
+        ),
+    )
+    manager = EVSETimeseriesManager(hass, lambda: client)
+    day_local = datetime(2026, 3, 11, 12, 0, 0, tzinfo=timezone.utc)
+
+    await manager.async_refresh(day_local=day_local, force=True)
+
+    assert manager.daily_available is False
+    assert manager.lifetime_available is True
+    assert manager.service_available is True

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -1805,6 +1805,71 @@ def test_lifetime_energy_accepts_resets(monkeypatch):
     assert sensor.native_value == pytest.approx(0.9)
 
 
+def test_lifetime_energy_falls_back_to_evse_timeseries():
+    from custom_components.enphase_ev.sensor import EnphaseLifetimeEnergySensor
+
+    sn = RANDOM_SERIAL
+    coord = _mk_coord_with(
+        sn,
+        {
+            "sn": sn,
+            "name": "Garage EV",
+            "lifetime_kwh": None,
+            "evse_lifetime_energy_kwh": 45.6,
+        },
+    )
+
+    sensor = EnphaseLifetimeEnergySensor(coord, sn)
+
+    assert sensor.native_value == pytest.approx(45.6)
+
+
+def test_lifetime_energy_ignores_bad_evse_timeseries_fallback():
+    from custom_components.enphase_ev.sensor import EnphaseLifetimeEnergySensor
+
+    class BadFloat:
+        def __float__(self):
+            raise ValueError("boom")
+
+    sn = RANDOM_SERIAL
+    coord = _mk_coord_with(
+        sn,
+        {
+            "sn": sn,
+            "name": "Garage EV",
+            "lifetime_kwh": None,
+            "evse_lifetime_energy_kwh": BadFloat(),
+        },
+    )
+
+    sensor = EnphaseLifetimeEnergySensor(coord, sn)
+
+    assert sensor.native_value is None
+
+
+def test_last_session_sensor_ignores_evse_daily_fallback():
+    from custom_components.enphase_ev.sensor import EnphaseEnergyTodaySensor
+
+    sn = RANDOM_SERIAL
+    coord = _mk_coord_with(
+        sn,
+        {
+            "sn": sn,
+            "name": "Garage EV",
+            "evse_daily_energy_kwh": 7.0,
+            "charging": False,
+            "energy_today_sessions": [],
+            "session_kwh": None,
+            "session_start": None,
+            "session_end": None,
+        },
+    )
+
+    sensor = EnphaseEnergyTodaySensor(coord, sn)
+
+    assert sensor.native_value is None
+
+
 def test_status_sensor_exposes_attributes(monkeypatch):
     from custom_components.enphase_ev.sensor import EnphaseStatusSensor
     from homeassistant.util import dt as dt_util


### PR DESCRIPTION
## Summary
- add EVSE daily and lifetime timeseries client support plus a dedicated fallback manager for charger energy data
- merge EVSE timeseries fallback data into coordinator diagnostics and charger payloads without changing Last Session semantics
- add regression coverage for API normalization, independent endpoint backoff, coordinator merge behavior, and charger lifetime fallback handling

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/evse_timeseries.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
