### PR TITLE
Add cloud current power consumption sensor

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -59,6 +59,7 @@ _CLOUD_ENTITY_UNIQUE_ID_SUFFIXES_BY_DOMAIN: dict[str, tuple[str, ...]] = {
     "sensor": (
         "last_update",
         "latency_ms",
+        "current_power_consumption",
         "last_error_code",
         "backoff_ends",
         *_SITE_ENERGY_ENTITY_UNIQUE_ID_SUFFIXES,

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2347,6 +2347,69 @@ class EnphaseEVClient:
             raise
         return self._normalize_lifetime_energy_payload(data)
 
+    @classmethod
+    def _normalize_latest_power_payload(cls, payload: object) -> dict[str, object] | None:
+        """Normalize app-api latest power payloads into a common shape."""
+
+        data = payload
+        if isinstance(data, dict) and isinstance(data.get("data"), dict):
+            data = data.get("data")
+        if not isinstance(data, dict):
+            return None
+
+        latest = data.get("latest_power")
+        if not isinstance(latest, dict):
+            latest = data
+
+        value = cls._coerce_non_boolean_number(latest.get("value"))
+        if value is None:
+            return None
+
+        normalized: dict[str, object] = {"value": value}
+
+        units = latest.get("units")
+        if units is not None:
+            try:
+                units_text = str(units).strip()
+            except Exception:  # noqa: BLE001
+                units_text = ""
+            if units_text:
+                normalized["units"] = units_text
+
+        precision = cls._coerce_non_boolean_number(latest.get("precision"))
+        if precision is not None:
+            try:
+                precision_int = int(precision)
+            except Exception:  # noqa: BLE001
+                precision_int = None
+            if precision_int is not None:
+                normalized["precision"] = precision_int
+
+        sample_time = latest.get("time")
+        if sample_time is not None:
+            sample_time_val = cls._coerce_non_boolean_number(sample_time)
+            if sample_time_val is not None:
+                if sample_time_val > 10**12:
+                    sample_time_val /= 1000.0
+                try:
+                    sample_time_int = int(sample_time_val)
+                except Exception:  # noqa: BLE001
+                    sample_time_int = None
+                if sample_time_int is not None:
+                    normalized["time"] = sample_time_int
+
+        return normalized
+
+    async def latest_power(self) -> dict[str, object] | None:
+        """Return the latest site power sample for the configured site.
+
+        GET /app-api/<site_id>/get_latest_power
+        """
+
+        url = f"{BASE_URL}/app-api/{self._site}/get_latest_power"
+        data = await self._json("GET", url)
+        return self._normalize_latest_power_payload(data)
+
     @staticmethod
     def _normalize_evse_timeseries_serial(value: object) -> str | None:
         if value is None:
@@ -2800,6 +2863,14 @@ class EnphaseEVClient:
             except Exception:  # noqa: BLE001
                 return None
         return None
+
+    @classmethod
+    def _coerce_non_boolean_number(cls, value: object) -> float | None:
+        """Normalize numeric values while rejecting JSON booleans."""
+
+        if isinstance(value, bool):
+            return None
+        return cls._coerce_lifetime_energy_value(value)
 
     @classmethod
     def _normalize_lifetime_energy_payload(cls, payload: object) -> dict | None:

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -60,7 +60,7 @@ async def async_setup_entry(
     def _async_sync_chargers() -> None:
         nonlocal site_entity_added, heatpump_sg_ready_entity_added
         inventory_ready = bool(getattr(coord, "_devices_inventory_ready", False))
-        if not site_entity_added and _type_available(coord, "envoy"):
+        if not site_entity_added:
             async_add_entities([SiteCloudReachableBinarySensor(coord)], update_before_add=False)
             site_entity_added = True
         heatpump_available = _type_available(coord, "heatpump")
@@ -153,8 +153,6 @@ class SiteCloudReachableBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def available(self) -> bool:
-        if not _type_available(self._coord, "envoy"):
-            return False
         if self._coord.last_success_utc is not None:
             return True
         return super().available

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -368,6 +368,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._hems_devices_cache_until: float | None = None
         self._hems_devices_payload: dict[str, object] | None = None
         self._devices_inventory_ready: bool = False
+        self._current_power_consumption_w: float | None = None
+        self._current_power_consumption_sample_utc: datetime | None = None
+        self._current_power_consumption_reported_units: str | None = None
+        self._current_power_consumption_reported_precision: int | None = None
+        self._current_power_consumption_source: str | None = None
         self._heatpump_power_w: float | None = None
         self._heatpump_power_sample_utc: datetime | None = None
         self._heatpump_power_start_utc: datetime | None = None
@@ -3135,6 +3140,78 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         elif sample_index is not None:
             self._heatpump_power_sample_utc = dt_util.utcnow()
 
+    def _clear_current_power_consumption(self) -> None:
+        self._current_power_consumption_w = None
+        self._current_power_consumption_sample_utc = None
+        self._current_power_consumption_reported_units = None
+        self._current_power_consumption_reported_precision = None
+        self._current_power_consumption_source = None
+
+    async def _async_refresh_current_power_consumption(self) -> None:
+        fetcher = getattr(self.client, "latest_power", None)
+        if not callable(fetcher):
+            self._clear_current_power_consumption()
+            return
+
+        try:
+            payload = await fetcher()
+        except Exception as err:  # noqa: BLE001
+            self._clear_current_power_consumption()
+            _LOGGER.debug(
+                "Skipping current power consumption refresh for site %s: %s",
+                self.site_id,
+                err,
+            )
+            return
+
+        if not isinstance(payload, dict):
+            self._clear_current_power_consumption()
+            return
+
+        value = payload.get("value")
+        try:
+            numeric = float(value)
+        except Exception:  # noqa: BLE001
+            self._clear_current_power_consumption()
+            return
+        if numeric != numeric or numeric in (float("inf"), float("-inf")):
+            self._clear_current_power_consumption()
+            return
+
+        sampled_at = None
+        sample_time = payload.get("time")
+        if sample_time is not None:
+            try:
+                sample_seconds = float(sample_time)
+                if sample_seconds > 10**12:
+                    sample_seconds /= 1000.0
+                sampled_at = datetime.fromtimestamp(sample_seconds, tz=_tz.utc)
+            except Exception:  # noqa: BLE001
+                sampled_at = None
+
+        units = payload.get("units")
+        if units is not None:
+            try:
+                units = str(units).strip()
+            except Exception:  # noqa: BLE001
+                units = None
+            if not units:
+                units = None
+
+        precision_raw = payload.get("precision")
+        precision = None
+        if precision_raw is not None:
+            try:
+                precision = int(precision_raw)
+            except Exception:  # noqa: BLE001
+                precision = None
+
+        self._current_power_consumption_w = numeric
+        self._current_power_consumption_sample_utc = sampled_at
+        self._current_power_consumption_reported_units = units
+        self._current_power_consumption_reported_precision = precision
+        self._current_power_consumption_source = "app-api:get_latest_power"
+
     def iter_type_keys(self) -> list[str]:
         type_order = getattr(self, "_type_device_order", None)
         if isinstance(type_order, list):
@@ -4404,6 +4481,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 await self._async_refresh_inverters()
             except Exception as err:  # noqa: BLE001
                 _LOGGER.debug("Skipping inverter refresh: %s", err)
+            await self._async_refresh_current_power_consumption()
             try:
                 await self._async_refresh_heatpump_power()
             except Exception as err:  # noqa: BLE001
@@ -5688,6 +5766,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         except Exception:  # noqa: BLE001
             pass
         phase_timings["inverters_s"] = round(time.monotonic() - inverter_start, 3)
+        current_power_start = time.monotonic()
+        await self._async_refresh_current_power_consumption()
+        phase_timings["current_power_s"] = round(
+            time.monotonic() - current_power_start, 3
+        )
         heatpump_power_start = time.monotonic()
         try:
             await self._async_refresh_heatpump_power()
@@ -7387,6 +7470,58 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     @property
     def heatpump_power_last_error(self) -> str | None:
         value = getattr(self, "_heatpump_power_last_error", None)
+        if value is None:
+            return None
+        try:
+            text = str(value).strip()
+        except Exception:
+            return None
+        return text or None
+
+    @property
+    def current_power_consumption_w(self) -> float | None:
+        value = getattr(self, "_current_power_consumption_w", None)
+        if value is None:
+            return None
+        try:
+            numeric = float(value)
+        except Exception:
+            return None
+        if numeric != numeric or numeric in (float("inf"), float("-inf")):
+            return None
+        return numeric
+
+    @property
+    def current_power_consumption_sample_utc(self) -> datetime | None:
+        value = getattr(self, "_current_power_consumption_sample_utc", None)
+        if isinstance(value, datetime):
+            return value
+        return None
+
+    @property
+    def current_power_consumption_reported_units(self) -> str | None:
+        value = getattr(self, "_current_power_consumption_reported_units", None)
+        if value is None:
+            return None
+        try:
+            text = str(value).strip()
+        except Exception:
+            return None
+        return text or None
+
+    @property
+    def current_power_consumption_reported_precision(self) -> int | None:
+        value = getattr(self, "_current_power_consumption_reported_precision", None)
+        if value is None:
+            return None
+        try:
+            return int(value)
+        except Exception:
+            return None
+
+    @property
+    def current_power_consumption_source(self) -> str | None:
+        value = getattr(self, "_current_power_consumption_source", None)
         if value is None:
             return None
         try:

--- a/custom_components/enphase_ev/icons.json
+++ b/custom_components/enphase_ev/icons.json
@@ -157,6 +157,15 @@
           "backoff_ends_utc": { "default": "mdi:clock-alert-outline" }
         }
       },
+      "current_power_consumption": {
+        "default": "mdi:flash",
+        "state_attributes": {
+          "sampled_at_utc": { "default": "mdi:clock-outline" },
+          "source": { "default": "mdi:source-branch" },
+          "reported_units": { "default": "mdi:ruler" },
+          "reported_precision": { "default": "mdi:decimal" }
+        }
+      },
       "cloud_error_code": {
         "default": "mdi:numeric",
         "state_attributes": {

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -388,15 +388,16 @@ async def async_setup_entry(
             except (TypeError, ValueError):
                 return bool(bucket_length)
 
+        _add_site_entity("site_last_update", EnphaseSiteLastUpdateSensor(coord))
+        _add_site_entity("site_cloud_latency", EnphaseCloudLatencySensor(coord))
+        _add_site_entity(
+            "current_power_consumption",
+            EnphaseCurrentPowerConsumptionSensor(coord),
+        )
+        _add_site_entity("site_last_error_code", EnphaseSiteLastErrorCodeSensor(coord))
+        _add_site_entity("site_backoff_ends", EnphaseSiteBackoffEndsSensor(coord))
+
         if gateway_available:
-            _add_site_entity("site_last_update", EnphaseSiteLastUpdateSensor(coord))
-            _add_site_entity("site_cloud_latency", EnphaseCloudLatencySensor(coord))
-            _add_site_entity(
-                "site_last_error_code", EnphaseSiteLastErrorCodeSensor(coord)
-            )
-            _add_site_entity(
-                "site_backoff_ends", EnphaseSiteBackoffEndsSensor(coord)
-            )
             _add_site_entity(
                 "system_controller_inventory",
                 EnphaseSystemControllerInventorySensor(coord),
@@ -4384,7 +4385,11 @@ class _SiteBaseEntity(CoordinatorEntity, SensorEntity):
     )
 
     def __init__(
-        self, coord: EnphaseCoordinator, key: str, _name: str, type_key: str = "envoy"
+        self,
+        coord: EnphaseCoordinator,
+        key: str,
+        _name: str,
+        type_key: str | None = "envoy",
     ):
         super().__init__(coord)
         self._coord = coord
@@ -4394,7 +4399,7 @@ class _SiteBaseEntity(CoordinatorEntity, SensorEntity):
 
     @property
     def available(self) -> bool:
-        if not _type_available(self._coord, self._type_key):
+        if self._type_key is not None and not _type_available(self._coord, self._type_key):
             return False
         if self._coord.last_success_utc is not None:
             return True
@@ -4441,6 +4446,8 @@ class _SiteBaseEntity(CoordinatorEntity, SensorEntity):
 
     @property
     def device_info(self):
+        if self._type_key is None:
+            return _cloud_device_info(self._coord.site_id)
         type_device_info = getattr(self._coord, "type_device_info", None)
         info = (
             type_device_info(self._type_key) if callable(type_device_info) else None
@@ -4631,7 +4638,7 @@ class EnphaseSiteLastUpdateSensor(_SiteBaseEntity):
     _attr_entity_registry_enabled_default = False
 
     def __init__(self, coord: EnphaseCoordinator):
-        super().__init__(coord, "last_update", "Last Successful Update")
+        super().__init__(coord, "last_update", "Last Successful Update", type_key=None)
 
     @property
     def native_value(self):
@@ -4654,7 +4661,7 @@ class EnphaseCloudLatencySensor(_SiteBaseEntity):
     _attr_entity_registry_enabled_default = False
 
     def __init__(self, coord: EnphaseCoordinator):
-        super().__init__(coord, "latency_ms", "Cloud Latency")
+        super().__init__(coord, "latency_ms", "Cloud Latency", type_key=None)
 
     @property
     def native_value(self):
@@ -4673,12 +4680,67 @@ class EnphaseCloudLatencySensor(_SiteBaseEntity):
         return _cloud_device_info(self._coord.site_id)
 
 
+class EnphaseCurrentPowerConsumptionSensor(_SiteBaseEntity):
+    _attr_translation_key = "current_power_consumption"
+    _attr_device_class = SensorDeviceClass.POWER
+    _attr_native_unit_of_measurement = UnitOfPower.WATT
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_entity_registry_enabled_default = True
+
+    def __init__(self, coord: EnphaseCoordinator):
+        super().__init__(
+            coord,
+            "current_power_consumption",
+            "Current Power Consumption",
+            type_key=None,
+        )
+
+    @property
+    def available(self) -> bool:
+        if not super().available:
+            return False
+        return self._coord.current_power_consumption_w is not None
+
+    @property
+    def native_value(self):
+        value = self._coord.current_power_consumption_w
+        if value is None:
+            return None
+        rounded = round(value, 3)
+        if float(rounded).is_integer():
+            return int(rounded)
+        return rounded
+
+    @property
+    def extra_state_attributes(self):
+        return {
+            "sampled_at_utc": (
+                self._coord.current_power_consumption_sample_utc.isoformat()
+                if self._coord.current_power_consumption_sample_utc is not None
+                else None
+            ),
+            "source": self._coord.current_power_consumption_source,
+            "reported_units": self._coord.current_power_consumption_reported_units,
+            "reported_precision": (
+                self._coord.current_power_consumption_reported_precision
+            ),
+        }
+
+    @property
+    def device_info(self):
+        type_device_info = getattr(self._coord, "type_device_info", None)
+        info = type_device_info("cloud") if callable(type_device_info) else None
+        if info is not None:
+            return info
+        return _cloud_device_info(self._coord.site_id)
+
+
 class EnphaseSiteLastErrorCodeSensor(_SiteBaseEntity):
     _attr_translation_key = "cloud_error_code"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
 
     def __init__(self, coord: EnphaseCoordinator):
-        super().__init__(coord, "last_error_code", "Cloud Error Code")
+        super().__init__(coord, "last_error_code", "Cloud Error Code", type_key=None)
 
     @property
     def native_value(self):
@@ -4724,7 +4786,7 @@ class EnphaseSiteBackoffEndsSensor(_SiteBaseEntity):
     _attr_device_class = SensorDeviceClass.TIMESTAMP
 
     def __init__(self, coord: EnphaseCoordinator):
-        super().__init__(coord, "backoff_ends", "Cloud Backoff Ends")
+        super().__init__(coord, "backoff_ends", "Cloud Backoff Ends", type_key=None)
         self._expiry_cancel: CALLBACK_TYPE | None = None
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -402,6 +402,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "reported_units": {
+            "name": "Reported Units"
+          },
+          "reported_precision": {
+            "name": "Reported Precision"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Cloud Error Code",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Текуща консумация на мощност",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
+          },
+          "source": {
+            "name": "Източник"
+          },
+          "reported_units": {
+            "name": "Отчетени единици"
+          },
+          "reported_precision": {
+            "name": "Отчетена точност"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Код на грешка в облака",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Aktuální příkon",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
+          },
+          "source": {
+            "name": "Zdroj"
+          },
+          "reported_units": {
+            "name": "Nahlášené jednotky"
+          },
+          "reported_precision": {
+            "name": "Nahlášená přesnost"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Kód chyby cloudu",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Aktuelt effektforbrug",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "reported_units": {
+            "name": "Rapporterede enheder"
+          },
+          "reported_precision": {
+            "name": "Rapporteret præcision"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Cloud-fejlkode",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Aktueller Stromverbrauch",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
+          },
+          "source": {
+            "name": "Quelle"
+          },
+          "reported_units": {
+            "name": "Gemeldete Einheiten"
+          },
+          "reported_precision": {
+            "name": "Gemeldete Genauigkeit"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Cloud-Fehlercode",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Τρέχουσα κατανάλωση ισχύος",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
+          },
+          "source": {
+            "name": "Πηγή"
+          },
+          "reported_units": {
+            "name": "Αναφερόμενες μονάδες"
+          },
+          "reported_precision": {
+            "name": "Αναφερόμενη ακρίβεια"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Κωδικός σφάλματος cloud",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "reported_units": {
+            "name": "Reported Units"
+          },
+          "reported_precision": {
+            "name": "Reported Precision"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Cloud Error Code",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "reported_units": {
+            "name": "Reported Units"
+          },
+          "reported_precision": {
+            "name": "Reported Precision"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Cloud Error Code",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "reported_units": {
+            "name": "Reported Units"
+          },
+          "reported_precision": {
+            "name": "Reported Precision"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Cloud Error Code",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "reported_units": {
+            "name": "Reported Units"
+          },
+          "reported_precision": {
+            "name": "Reported Precision"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Cloud Error Code",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "reported_units": {
+            "name": "Reported Units"
+          },
+          "reported_precision": {
+            "name": "Reported Precision"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Cloud Error Code",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Current Power Consumption",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "reported_units": {
+            "name": "Reported Units"
+          },
+          "reported_precision": {
+            "name": "Reported Precision"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Cloud Error Code",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Consumo de potencia actual",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
+          },
+          "source": {
+            "name": "Origen"
+          },
+          "reported_units": {
+            "name": "Unidades informadas"
+          },
+          "reported_precision": {
+            "name": "Precisión informada"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Código de error en la nube",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Praegune võimsustarve",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
+          },
+          "source": {
+            "name": "Allikas"
+          },
+          "reported_units": {
+            "name": "Teatatud ühikud"
+          },
+          "reported_precision": {
+            "name": "Teatatud täpsus"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Pilve veakood",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Nykyinen tehonkulutus",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
+          },
+          "source": {
+            "name": "Lähde"
+          },
+          "reported_units": {
+            "name": "Ilmoitetut yksiköt"
+          },
+          "reported_precision": {
+            "name": "Ilmoitettu tarkkuus"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Pilvivirhekoodi",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Consommation électrique actuelle",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "reported_units": {
+            "name": "Unités signalées"
+          },
+          "reported_precision": {
+            "name": "Précision signalée"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Code d'erreur cloud",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Aktuális teljesítményfogyasztás",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
+          },
+          "source": {
+            "name": "Forrás"
+          },
+          "reported_units": {
+            "name": "Jelentett mértékegységek"
+          },
+          "reported_precision": {
+            "name": "Jelentett pontosság"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Cloud hibakód",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Consumo di potenza attuale",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
+          },
+          "source": {
+            "name": "Origine"
+          },
+          "reported_units": {
+            "name": "Unità riportate"
+          },
+          "reported_precision": {
+            "name": "Precisione riportata"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Codice errore cloud",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Dabartinis galios suvartojimas",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
+          },
+          "source": {
+            "name": "Šaltinis"
+          },
+          "reported_units": {
+            "name": "Pateikti vienetai"
+          },
+          "reported_precision": {
+            "name": "Pateiktas tikslumas"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Debesies klaidos kodas",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Pašreizējais jaudas patēriņš",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
+          },
+          "source": {
+            "name": "Avots"
+          },
+          "reported_units": {
+            "name": "Norādītās vienības"
+          },
+          "reported_precision": {
+            "name": "Norādītā precizitāte"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Mākoņa kļūdas kods",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Nåværende strømforbruk",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "reported_units": {
+            "name": "Rapporterte enheter"
+          },
+          "reported_precision": {
+            "name": "Rapportert presisjon"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Sky-feilkode",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Huidig stroomverbruik",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
+          },
+          "source": {
+            "name": "Bron"
+          },
+          "reported_units": {
+            "name": "Gerapporteerde eenheden"
+          },
+          "reported_precision": {
+            "name": "Gerapporteerde precisie"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Cloud-foutcode",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Bieżący pobór mocy",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
+          },
+          "source": {
+            "name": "Źródło"
+          },
+          "reported_units": {
+            "name": "Raportowane jednostki"
+          },
+          "reported_precision": {
+            "name": "Raportowana precyzja"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Kod błędu chmury",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Consumo de potência atual",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
+          },
+          "source": {
+            "name": "Origem"
+          },
+          "reported_units": {
+            "name": "Unidades informadas"
+          },
+          "reported_precision": {
+            "name": "Precisão informada"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Código de erro da nuvem",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Consum instantaneu de putere",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
+          },
+          "source": {
+            "name": "Sursă"
+          },
+          "reported_units": {
+            "name": "Unități raportate"
+          },
+          "reported_precision": {
+            "name": "Precizie raportată"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Cod de eroare cloud",
         "state_attributes": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -356,6 +356,23 @@
           }
         }
       },
+      "current_power_consumption": {
+        "name": "Aktuell effektförbrukning",
+        "state_attributes": {
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
+          },
+          "source": {
+            "name": "Källa"
+          },
+          "reported_units": {
+            "name": "Rapporterade enheter"
+          },
+          "reported_precision": {
+            "name": "Rapporterad precision"
+          }
+        }
+      },
       "cloud_error_code": {
         "name": "Molnfelkod",
         "state_attributes": {

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -46,7 +46,7 @@ For integration work and troubleshooting, process endpoints in this order:
 1. Authenticate and establish session headers (`6.1`-`6.5`).
 2. Discover sites (`1.1`).
 3. Load site capabilities and inventory (`2.9`, `2.13`-`2.17`, `5.2`).
-4. Load runtime telemetry (`2.1`, `2.2`, `2.7`, `2.8`, `2.10`, `2.11`, `2.14`-`2.16`, `2.18`-`2.21`).
+4. Load runtime telemetry (`2.1`, `2.2`, `2.7`, `2.8`, `2.9.2`, `2.10`, `2.11`, `2.14`-`2.16`, `2.18`-`2.21`).
 5. Apply site-level controls (`2.12.1`-`2.12.5`, `5.4`-`5.6`).
 6. Apply EV charger controls and scheduling (`3.1`-`3.3`, `4.1`-`4.5`).
 7. Validate failures, retries, and cloud backoff behavior (`8`, `9`).
@@ -86,6 +86,7 @@ For integration work and troubleshooting, process endpoints in this order:
 | EV feature flags | `GET` | `/service/evse_management/api/v1/config/feature-flags?site_id=<site_id>[&country=<country>]` | `e-auth-token` + cookies | Yes |
 | Site inventory | `GET` | `/app-api/<site_id>/devices.json` | `e-auth-token` + cookies | Yes |
 | Site live-stream flags | `GET` | `/app-api/<site_id>/show_livestream` | `e-auth-token` + cookies | No (documented from web UI) |
+| Site latest power | `GET` | `/app-api/<site_id>/get_latest_power` | `e-auth-token` + cookies | Yes |
 | System dashboard summary | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/summary` | `e-auth-token` + cookies | No (documented from web UI) |
 | System dashboard status | `GET` | `/service/system_dashboard/api_internal/dashboard/sites/<site_id>/status` | `e-auth-token` + cookies | No (documented from web UI) |
 | System dashboard device tree | `GET` | `/service/system_dashboard/api_internal/dashboard/sites/<site_id>/devices-tree` | `e-auth-token` + cookies | No (documented from web UI) |
@@ -764,7 +765,36 @@ Example response (anonymized):
 }
 ```
 
-### 2.9.2 System Dashboard Summary Flags
+### 2.9.2 Latest Site Power
+```
+GET /app-api/<site_id>/get_latest_power
+```
+Returns the latest observed site power sample used by the Enlighten site UI for near-real-time site consumption.
+
+Example response (anonymized capture):
+```json
+{
+  "latest_power": {
+    "value": 752,
+    "units": "W",
+    "precision": 0,
+    "time": 1773207600
+  }
+}
+```
+
+Observed fields:
+- `value`: current site consumption in watts.
+- `units`: reported unit string, observed as `W`.
+- `precision`: precision hint used by the UI when formatting the sample.
+- `time`: Unix timestamp in seconds for the sampled value.
+
+Notes:
+- Requires the standard authenticated Enlighten session headers (`e-auth-token` plus cookies).
+- The payload is nested under `latest_power`; treat a missing or non-numeric `value` as no sample rather than coercing to `0`.
+- Observed timestamps are epoch seconds rather than milliseconds.
+
+### 2.9.3 System Dashboard Summary Flags
 ```
 GET /service/system_dashboard/api_internal/cs/sites/<site_id>/summary
 ```
@@ -791,7 +821,7 @@ Observed structure:
 - This payload is small but important for feature gating; `is_hems` matched the site also exposing IQ Energy Router / heat-pump endpoints.
 - `currency_*`, `geo`, and `country_code` are region-dependent and suitable for diagnostics only.
 
-### 2.9.3 System Dashboard Status Overview
+### 2.9.4 System Dashboard Status Overview
 ```
 GET /service/system_dashboard/api_internal/dashboard/sites/<site_id>/status
 ```
@@ -830,7 +860,7 @@ Observed structure:
 - `battery_mode`, `storm_guard`, and `backup_type` are localized display strings, not stable enums.
 - `storage_setpoint` was negative in the captured battery site; semantics are still unclear, so preserve raw values.
 
-### 2.9.4 System Dashboard Device Tree
+### 2.9.5 System Dashboard Device Tree
 ```
 GET /service/system_dashboard/api_internal/dashboard/sites/<site_id>/devices-tree
 ```
@@ -882,7 +912,7 @@ Observed structure:
 - Observed `type` values included `Site`, `Envoy`, `CellularModem`, `Enpower`, `EnpowerE3ControlBoard`, `EnpowerStartupPcba`, `PcuDevice`, and `EimDevice`.
 - `status`/`sub_status` are human-readable strings and may vary by locale.
 
-### 2.9.5 Standing Alarms
+### 2.9.6 Standing Alarms
 ```
 GET /service/system_dashboard/api_internal/dashboard/sites/<site_id>/alarms?range=today&filter_columns=<...>&type=table&page=<page>&per_page=<n>
 ```
@@ -920,7 +950,7 @@ Observed structure:
 - `serial_num` may contain a true serial number or aggregate text such as `"2 Devices"`.
 - `force_clearable` and `disable_force_clear` appear to drive whether the UI offers manual clear actions.
 
-### 2.9.6 System Dashboard Device Details by Type
+### 2.9.7 System Dashboard Device Details by Type
 ```
 GET /service/system_dashboard/api_internal/dashboard/sites/<site_id>/devices_details?type=envoys
 GET /service/system_dashboard/api_internal/dashboard/sites/<site_id>/devices_details?type=encharges

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -2224,6 +2224,90 @@ async def test_lifetime_energy_normalization() -> None:
 
 
 @pytest.mark.asyncio
+async def test_latest_power_normalization() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        return_value={
+            "latest_power": {
+                "value": 752,
+                "units": "W",
+                "precision": 0,
+                "time": 1_773_207_600,
+            }
+        }
+    )
+
+    payload = await client.latest_power()
+
+    assert payload == {
+        "value": 752.0,
+        "units": "W",
+        "precision": 0,
+        "time": 1_773_207_600,
+    }
+    client._json.assert_awaited_once_with(
+        "GET",
+        f"{api.BASE_URL}/app-api/SITE/get_latest_power",
+    )
+
+
+def test_normalize_latest_power_payload_rejects_invalid_shapes() -> None:
+    client = _make_client()
+
+    assert client._normalize_latest_power_payload("bad") is None  # noqa: SLF001
+    assert client._normalize_latest_power_payload({}) is None  # noqa: SLF001
+    assert client._normalize_latest_power_payload(  # noqa: SLF001
+        {"latest_power": {"units": "W"}}
+    ) is None
+    assert client._normalize_latest_power_payload(  # noqa: SLF001
+        {"latest_power": {"value": "bad"}}
+    ) is None
+    assert client._normalize_latest_power_payload(  # noqa: SLF001
+        {"latest_power": {"value": False}}
+    ) is None
+    assert client._normalize_latest_power_payload(  # noqa: SLF001
+        {"latest_power": {"value": 752, "precision": True, "time": False}}
+    ) == {"value": 752.0}
+
+    assert client._normalize_latest_power_payload(  # noqa: SLF001
+        {
+            "data": {
+                "latest_power": {
+                    "value": "600.5",
+                    "units": "W",
+                    "precision": "1",
+                    "time": "1773207600000",
+                }
+            }
+        }
+    ) == {
+        "value": 600.5,
+        "units": "W",
+        "precision": 1,
+        "time": 1_773_207_600,
+    }
+
+
+def test_normalize_latest_power_payload_handles_unstringable_units_and_nan_metadata() -> None:
+    client = _make_client()
+
+    class BadString:
+        def __str__(self) -> str:
+            raise ValueError("boom")
+
+    assert client._normalize_latest_power_payload(  # noqa: SLF001
+        {
+            "latest_power": {
+                "value": 752,
+                "units": BadString(),
+                "precision": "nan",
+                "time": "nan",
+            }
+        }
+    ) == {"value": 752.0}
+
+
+@pytest.mark.asyncio
 async def test_evse_timeseries_daily_energy_normalization() -> None:
     client = _make_client()
     client.update_credentials(eauth=_make_token({"user_id": "user-123"}))

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -100,7 +100,7 @@ async def test_async_setup_entry_syncs_binary_sensors(
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_skips_site_sensor_without_gateway_type(
+async def test_async_setup_entry_keeps_site_sensor_without_gateway_type(
     hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:
     coord = coordinator_factory(
@@ -137,7 +137,7 @@ async def test_async_setup_entry_skips_site_sensor_without_gateway_type(
 
     await async_setup_entry(hass, config_entry, _collect)
 
-    assert not any(isinstance(ent, SiteCloudReachableBinarySensor) for ent in added)
+    assert any(isinstance(ent, SiteCloudReachableBinarySensor) for ent in added)
     assert len([ent for ent in added if hasattr(ent, "_sn")]) == 3
 
 
@@ -177,7 +177,7 @@ async def test_async_setup_entry_keeps_site_sensor_when_inventory_unknown(
 
 
 @pytest.mark.asyncio
-async def test_async_setup_entry_adds_site_sensor_when_gateway_type_appears_later(
+async def test_async_setup_entry_does_not_duplicate_site_sensor_when_gateway_type_appears_later(
     hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:
     coord = coordinator_factory(
@@ -219,7 +219,7 @@ async def test_async_setup_entry_adds_site_sensor_when_gateway_type_appears_late
         added.extend(entities)
 
     await async_setup_entry(hass, config_entry, _collect)
-    assert not any(isinstance(ent, SiteCloudReachableBinarySensor) for ent in added)
+    assert len([ent for ent in added if isinstance(ent, SiteCloudReachableBinarySensor)]) == 1
 
     coord._set_type_device_buckets(  # noqa: SLF001
         {
@@ -743,11 +743,15 @@ def test_site_cloud_reachable_binary_sensor_fallback_paths(
     coord = coordinator_factory(serials=[], data={})
     monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
     coord.has_type_for_entities = lambda _type_key: False  # type: ignore[assignment]
+    coord.last_update_success = False
 
     sensor = SiteCloudReachableBinarySensor(coord)
     assert sensor.available is False
 
-    coord.has_type_for_entities = lambda _type_key: True  # type: ignore[assignment]
+    coord.last_update_success = True
+    coord.last_success_utc = datetime.now(timezone.utc)
+    assert sensor.available is True
+
     coord.last_success_utc = None
     assert sensor.is_on is False
 

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1573,6 +1573,131 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(coordinator_fac
     assert coord.heatpump_power_source is None
 
 
+@pytest.mark.asyncio
+async def test_refresh_current_power_consumption_tracks_latest_sample(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord.client.latest_power = AsyncMock(
+        return_value={
+            "value": 752.0,
+            "units": "W",
+            "precision": 0,
+            "time": 1_773_207_600,
+        }
+    )
+
+    await coord._async_refresh_current_power_consumption()  # noqa: SLF001
+
+    assert coord.current_power_consumption_w == pytest.approx(752.0)
+    assert coord.current_power_consumption_reported_units == "W"
+    assert coord.current_power_consumption_reported_precision == 0
+    assert coord.current_power_consumption_source == "app-api:get_latest_power"
+    assert coord.current_power_consumption_sample_utc == datetime(
+        2026, 3, 11, 5, 40, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_current_power_consumption_clears_invalid_or_failed_payload(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._current_power_consumption_w = 123.0  # noqa: SLF001
+    coord._current_power_consumption_sample_utc = datetime.now(timezone.utc)  # noqa: SLF001
+    coord._current_power_consumption_reported_units = "W"  # noqa: SLF001
+    coord._current_power_consumption_reported_precision = 1  # noqa: SLF001
+    coord._current_power_consumption_source = "stale"  # noqa: SLF001
+
+    coord.client.latest_power = AsyncMock(return_value=None)
+    await coord._async_refresh_current_power_consumption()  # noqa: SLF001
+    assert coord.current_power_consumption_w is None
+    assert coord.current_power_consumption_source is None
+
+    coord._current_power_consumption_w = 456.0  # noqa: SLF001
+    coord.client.latest_power = AsyncMock(side_effect=RuntimeError("boom"))
+    await coord._async_refresh_current_power_consumption()  # noqa: SLF001
+    assert coord.current_power_consumption_w is None
+    assert coord.current_power_consumption_sample_utc is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_current_power_consumption_handles_edge_payload_shapes(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+
+    coord.client.latest_power = AsyncMock(return_value={"value": object()})
+    await coord._async_refresh_current_power_consumption()  # noqa: SLF001
+    assert coord.current_power_consumption_w is None
+
+    coord.client.latest_power = AsyncMock(return_value={"value": float("nan")})
+    await coord._async_refresh_current_power_consumption()  # noqa: SLF001
+    assert coord.current_power_consumption_w is None
+
+    class BadString:
+        def __str__(self) -> str:
+            raise ValueError("boom")
+
+    coord.client.latest_power = AsyncMock(
+        return_value={
+            "value": 752.0,
+            "units": BadString(),
+            "precision": "bad",
+            "time": "1773207600000",
+        }
+    )
+    await coord._async_refresh_current_power_consumption()  # noqa: SLF001
+    assert coord.current_power_consumption_w == pytest.approx(752.0)
+    assert coord.current_power_consumption_sample_utc == datetime(
+        2026, 3, 11, 5, 40, tzinfo=timezone.utc
+    )
+    assert coord.current_power_consumption_reported_units is None
+    assert coord.current_power_consumption_reported_precision is None
+
+    coord.client.latest_power = AsyncMock(
+        return_value={
+            "value": 753.0,
+            "units": "   ",
+            "precision": object(),
+            "time": "nan",
+        }
+    )
+    await coord._async_refresh_current_power_consumption()  # noqa: SLF001
+    assert coord.current_power_consumption_w == pytest.approx(753.0)
+    assert coord.current_power_consumption_sample_utc is None
+    assert coord.current_power_consumption_reported_units is None
+    assert coord.current_power_consumption_reported_precision is None
+
+
+def test_current_power_consumption_property_guards(coordinator_factory) -> None:
+    coord = coordinator_factory(serials=[])
+
+    coord._current_power_consumption_w = object()  # noqa: SLF001
+    assert coord.current_power_consumption_w is None
+
+    coord._current_power_consumption_w = float("inf")  # noqa: SLF001
+    assert coord.current_power_consumption_w is None
+
+    coord._current_power_consumption_reported_units = None  # noqa: SLF001
+    assert coord.current_power_consumption_reported_units is None
+
+    class BadString:
+        def __str__(self) -> str:
+            raise ValueError("boom")
+
+    coord._current_power_consumption_reported_units = BadString()  # noqa: SLF001
+    assert coord.current_power_consumption_reported_units is None
+
+    coord._current_power_consumption_reported_precision = None  # noqa: SLF001
+    assert coord.current_power_consumption_reported_precision is None
+    coord._current_power_consumption_reported_precision = object()  # noqa: SLF001
+    assert coord.current_power_consumption_reported_precision is None
+
+    coord._current_power_consumption_source = BadString()  # noqa: SLF001
+    assert coord.current_power_consumption_source is None
+
+
 def test_heatpump_primary_helpers_and_metadata_fallbacks(coordinator_factory) -> None:
     coord = coordinator_factory(serials=[])
     assert coord._heatpump_primary_member() is None  # noqa: SLF001

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -2028,6 +2028,13 @@ async def test_migrate_cloud_entities_to_cloud_device_rehomes_known_entities(
         device_id=gateway.id,
         config_entry=config_entry,
     )
+    cloud_current_power = ent_reg.async_get_or_create(
+        domain="sensor",
+        platform=DOMAIN,
+        unique_id=f"{DOMAIN}_site_{site_id}_current_power_consumption",
+        device_id=gateway.id,
+        config_entry=config_entry,
+    )
     cloud_error = ent_reg.async_get_or_create(
         domain="sensor",
         platform=DOMAIN,
@@ -2077,6 +2084,7 @@ async def test_migrate_cloud_entities_to_cloud_device_rehomes_known_entities(
     for entity_id in (
         cloud_last_update.entity_id,
         cloud_latency.entity_id,
+        cloud_current_power.entity_id,
         cloud_error.entity_id,
         cloud_backoff.entity_id,
         cloud_reachable.entity_id,

--- a/tests/components/enphase_ev/test_latency_and_connectivity.py
+++ b/tests/components/enphase_ev/test_latency_and_connectivity.py
@@ -35,6 +35,68 @@ def test_cloud_latency_sensor_value():
     assert s.native_value == 123
 
 
+def test_current_power_consumption_sensor_value_and_attributes():
+    from custom_components.enphase_ev.sensor import EnphaseCurrentPowerConsumptionSensor
+
+    coord = _make_site_coord()
+    coord.last_success_utc = datetime(2026, 3, 11, 5, 41, tzinfo=timezone.utc)
+    coord._current_power_consumption_w = 752.0
+    coord._current_power_consumption_sample_utc = datetime(
+        2026, 3, 11, 5, 40, tzinfo=timezone.utc
+    )
+    coord._current_power_consumption_reported_units = "W"
+    coord._current_power_consumption_reported_precision = 0
+    coord._current_power_consumption_source = "app-api:get_latest_power"
+
+    sensor = EnphaseCurrentPowerConsumptionSensor(coord)
+    assert sensor.available is True
+    assert sensor.native_value == 752
+    assert sensor.extra_state_attributes == {
+        "sampled_at_utc": "2026-03-11T05:40:00+00:00",
+        "source": "app-api:get_latest_power",
+        "reported_units": "W",
+        "reported_precision": 0,
+    }
+
+
+def test_cloud_site_sensors_are_not_gated_by_envoy_type():
+    from custom_components.enphase_ev.binary_sensor import SiteCloudReachableBinarySensor
+    from custom_components.enphase_ev.sensor import (
+        _SiteBaseEntity,
+        EnphaseCloudLatencySensor,
+        EnphaseCurrentPowerConsumptionSensor,
+        EnphaseSiteLastUpdateSensor,
+    )
+
+    coord = _make_site_coord()
+    coord.has_type_for_entities = lambda _type_key: False
+    coord.last_success_utc = datetime(2026, 3, 11, 5, 41, tzinfo=timezone.utc)
+    coord.latency_ms = 123
+    coord._current_power_consumption_w = 752.0
+
+    assert EnphaseSiteLastUpdateSensor(coord).available is True
+    assert EnphaseCloudLatencySensor(coord).available is True
+    assert EnphaseCurrentPowerConsumptionSensor(coord).available is True
+    assert SiteCloudReachableBinarySensor(coord).available is True
+    assert _SiteBaseEntity(coord, "cloud_base", "Cloud Base", type_key=None).device_info[
+        "identifiers"
+    ] == {("enphase_ev", f"type:{coord.site_id}:cloud")}
+
+
+def test_current_power_consumption_sensor_edge_paths():
+    from custom_components.enphase_ev.sensor import EnphaseCurrentPowerConsumptionSensor
+
+    coord = _make_site_coord()
+    coord.last_update_success = False
+    sensor = EnphaseCurrentPowerConsumptionSensor(coord)
+    assert sensor.available is False
+    assert sensor.native_value is None
+
+    coord.last_success_utc = datetime(2026, 3, 11, 5, 41, tzinfo=timezone.utc)
+    coord._current_power_consumption_w = 752.1254
+    assert sensor.native_value == pytest.approx(752.125)
+
+
 def test_site_cloud_reachable_binary_sensor_states():
     from custom_components.enphase_ev.binary_sensor import (
         SiteCloudReachableBinarySensor,
@@ -250,6 +312,7 @@ def test_site_backoff_sensor_rounds_up_remaining_seconds(monkeypatch):
 
 def test_cloud_site_sensors_device_info_prefers_coordinator_info():
     from custom_components.enphase_ev.sensor import (
+        EnphaseCurrentPowerConsumptionSensor,
         EnphaseCloudLatencySensor,
         EnphaseSiteBackoffEndsSensor,
         EnphaseSiteLastErrorCodeSensor,
@@ -262,6 +325,7 @@ def test_cloud_site_sensors_device_info_prefers_coordinator_info():
 
     assert EnphaseSiteLastUpdateSensor(coord).device_info is provided
     assert EnphaseCloudLatencySensor(coord).device_info is provided
+    assert EnphaseCurrentPowerConsumptionSensor(coord).device_info is provided
     assert EnphaseSiteLastErrorCodeSensor(coord).device_info is provided
     assert EnphaseSiteBackoffEndsSensor(coord).device_info is provided
 

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -3612,6 +3612,7 @@ async def test_async_setup_entry_keeps_gateway_site_entities_when_inventory_unkn
 ) -> None:
     from custom_components.enphase_ev.sensor import (
         EnphaseCloudLatencySensor,
+        EnphaseCurrentPowerConsumptionSensor,
         EnphaseGatewayConsumptionMeterSensor,
         EnphaseMicroinverterConnectivityStatusSensor,
         EnphaseMicroinverterLastReportedSensor,
@@ -3637,6 +3638,7 @@ async def test_async_setup_entry_keeps_gateway_site_entities_when_inventory_unkn
 
     assert any(isinstance(ent, EnphaseSiteLastUpdateSensor) for ent in added)
     assert any(isinstance(ent, EnphaseCloudLatencySensor) for ent in added)
+    assert any(isinstance(ent, EnphaseCurrentPowerConsumptionSensor) for ent in added)
     assert any(isinstance(ent, EnphaseSystemControllerInventorySensor) for ent in added)
     assert any(isinstance(ent, EnphaseGatewayProductionMeterSensor) for ent in added)
     assert any(isinstance(ent, EnphaseGatewayConsumptionMeterSensor) for ent in added)
@@ -3645,6 +3647,47 @@ async def test_async_setup_entry_keeps_gateway_site_entities_when_inventory_unkn
     )
     assert any(isinstance(ent, EnphaseMicroinverterReportingCountSensor) for ent in added)
     assert any(isinstance(ent, EnphaseMicroinverterLastReportedSensor) for ent in added)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_adds_cloud_site_entities_without_envoy_type(
+    hass, config_entry, coordinator_factory
+) -> None:
+    from custom_components.enphase_ev.sensor import (
+        EnphaseCloudLatencySensor,
+        EnphaseCurrentPowerConsumptionSensor,
+        EnphaseSiteBackoffEndsSensor,
+        EnphaseSiteLastErrorCodeSensor,
+        EnphaseSiteLastUpdateSensor,
+        async_setup_entry,
+    )
+
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "iqevse": {
+                "type_key": "iqevse",
+                "type_label": "EV Chargers",
+                "count": 1,
+                "devices": [{"serial_number": "EV1", "name": "Garage EV"}],
+            }
+        },
+        ["iqevse"],
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    added: list[Any] = []
+
+    def _capture(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _capture)
+
+    assert any(isinstance(ent, EnphaseSiteLastUpdateSensor) for ent in added)
+    assert any(isinstance(ent, EnphaseCloudLatencySensor) for ent in added)
+    assert any(isinstance(ent, EnphaseCurrentPowerConsumptionSensor) for ent in added)
+    assert any(isinstance(ent, EnphaseSiteLastErrorCodeSensor) for ent in added)
+    assert any(isinstance(ent, EnphaseSiteBackoffEndsSensor) for ent in added)
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -340,6 +340,28 @@ def test_gateway_status_string_localized_for_non_english_locales() -> None:
             )
 
 
+def test_cloud_current_power_string_localized_for_non_english_locales() -> None:
+    """Ensure current cloud power label is translated for non-English locales."""
+
+    translations_dir = (
+        pathlib.Path(__file__).resolve().parents[3]
+        / "custom_components"
+        / "enphase_ev"
+        / "translations"
+    )
+    path = "entity.sensor.current_power_consumption.name"
+    en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
+    for locale in translations_dir.glob("*.json"):
+        name = locale.name
+        data = json.loads(locale.read_text(encoding="utf-8"))
+        value = _at_path(data, path)
+        assert value.strip(), f"{name} missing value for {path}"
+        if name != "en.json" and not name.startswith("en-"):
+            assert value != _at_path(en_data, path), (
+                f"{name} should localize {path} (still matches English)"
+            )
+
+
 def test_update_entity_strings_localized_for_non_english_locales() -> None:
     """Ensure firmware update entity labels are translated for non-English locales."""
 

--- a/tests/components/enphase_ev/test_type_device_entity_fallbacks.py
+++ b/tests/components/enphase_ev/test_type_device_entity_fallbacks.py
@@ -31,7 +31,7 @@ from custom_components.enphase_ev.switch import (
 from custom_components.enphase_ev.time import ChargeFromGridStartTimeEntity
 
 
-def test_site_binary_sensor_has_type_false_is_unavailable() -> None:
+def test_site_binary_sensor_not_gated_by_envoy_type() -> None:
     coord = SimpleNamespace(
         site_id="12345",
         has_type=lambda _key: False,
@@ -46,7 +46,7 @@ def test_site_binary_sensor_has_type_false_is_unavailable() -> None:
         update_interval=None,
     )
     entity = SiteCloudReachableBinarySensor(coord)
-    assert entity.available is False
+    assert entity.available is True
 
 
 def test_site_binary_sensor_device_info_falls_back_without_type_info() -> None:
@@ -288,7 +288,7 @@ def test_grid_control_status_device_info_prefers_enpower_then_envoy() -> None:
     assert sensor.device_info is envoy_info
 
 
-def test_site_sensor_type_gate_and_last_success_attrs() -> None:
+def test_cloud_site_sensor_last_success_attrs_not_type_gated() -> None:
     coord = SimpleNamespace(
         site_id="site-gate",
         last_update_success=True,
@@ -306,7 +306,6 @@ def test_site_sensor_type_gate_and_last_success_attrs() -> None:
         latency_ms=None,
     )
     sensor = EnphaseSiteLastUpdateSensor(coord)
-    assert sensor.available is False
-    coord.has_type = lambda _key: True
+    assert sensor.available is True
     attrs = sensor.extra_state_attributes
     assert "last_success_utc" in attrs


### PR DESCRIPTION
## Summary
- add a cloud-backed Current Power Consumption sensor using `GET /app-api/<site_id>/get_latest_power`
- document the `get_latest_power` endpoint and sync the new entity strings, icons, and translations
- remove envoy gating from cloud site entities and add regression coverage for malformed latest-power payloads

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_latency_and_connectivity.py tests/components/enphase_ev/test_binary_sensor_module.py tests/components/enphase_ev/test_sensor_additional_coverage.py tests/components/enphase_ev/test_type_device_entity_fallbacks.py -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/api.py,custom_components/enphase_ev/binary_sensor.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/sensor.py --fail-under=100"
