### PR TITLE
Fix fast poll interval fallback

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -308,6 +308,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 )
             )
         interval = slow or config.get(CONF_SCAN_INTERVAL, DEFAULT_SCAN_INTERVAL)
+        self._configured_slow_poll_interval = max(1, int(interval))
         self.last_set_amps: dict[str, int] = {}
         self._amp_restart_tasks: dict[str, asyncio.Task] = {}
         self.last_success_utc = None
@@ -5968,10 +5969,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             fast = DEFAULT_FAST_POLL_INTERVAL
             fast_configured = False
         fast = max(1, fast)
-        slow_default = (
-            self.update_interval.total_seconds()
-            if self.update_interval
-            else DEFAULT_SLOW_POLL_INTERVAL
+        slow_default = getattr(
+            self,
+            "_configured_slow_poll_interval",
+            DEFAULT_SCAN_INTERVAL,
         )
         slow_opt = None
         if self.config_entry is not None:

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -4979,6 +4979,76 @@ async def test_streaming_prefers_fast(hass, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_streaming_reverts_to_configured_scan_interval(hass, monkeypatch):
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+        OPT_FAST_POLL_INTERVAL,
+        OPT_FAST_WHILE_STREAMING,
+    )
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    cfg = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 15,
+    }
+    options = {
+        OPT_FAST_POLL_INTERVAL: 6,
+        OPT_FAST_WHILE_STREAMING: True,
+    }
+
+    class DummyEntry:
+        def __init__(self, options):
+            self.options = options
+
+        def async_on_unload(self, cb):
+            return None
+
+    entry = DummyEntry(options)
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    coord = EnphaseCoordinator(hass, cfg, config_entry=entry)
+
+    class StubClient:
+        def __init__(self, payload):
+            self._payload = payload
+
+        async def status(self):
+            return self._payload
+
+    payload_idle = {
+        "evChargerData": [
+            {
+                "sn": RANDOM_SERIAL,
+                "name": "Garage EV",
+                "charging": False,
+                "pluggedIn": True,
+            }
+        ]
+    }
+    coord.client = StubClient(payload_idle)
+
+    coord._streaming = True
+    coord._streaming_until = time.monotonic() + 60
+    await coord._async_update_data()
+    assert int(coord.update_interval.total_seconds()) == 6
+
+    coord._streaming = False
+    coord._streaming_until = None
+    await coord._async_update_data()
+    assert int(coord.update_interval.total_seconds()) == 15
+
+
+@pytest.mark.asyncio
 async def test_session_history_enrichment(hass, monkeypatch):
     from custom_components.enphase_ev.const import (
         CONF_COOKIE,


### PR DESCRIPTION
## Summary
- Fix dynamic polling so fast mode reverts to the configured slow scan interval instead of reusing the temporary fast interval as the fallback.
- Add a regression test that proves streaming-driven fast polling returns to the configured scan interval after the fast condition ends.
- Coverage: `custom_components/enphase_ev/coordinator.py` remains at 100%.

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
