### PR TITLE
Harden system dashboard diagnostics

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -183,8 +183,24 @@ class ChargerInfo:
     name: str | None = None
 
 
+_SYSTEM_DASHBOARD_DETAIL_QUERY_MAP: dict[str, str] = {
+    "envoy": "envoys",
+    "envoys": "envoys",
+    "meter": "meters",
+    "meters": "meters",
+    "enpower": "enpowers",
+    "enpowers": "enpowers",
+    "encharge": "encharges",
+    "encharges": "encharges",
+    "modem": "modems",
+    "modems": "modems",
+    "microinverter": "inverters",
+    "inverters": "inverters",
+}
+
+
 def _system_dashboard_query_type(type_key: object) -> str | None:
-    """Normalize a dashboard query type without canonical alias remapping."""
+    """Normalize a dashboard query type to the observed endpoint value."""
 
     if type_key is None:
         return None
@@ -195,7 +211,9 @@ def _system_dashboard_query_type(type_key: object) -> str | None:
     if not text:
         return None
     normalized = "".join(ch if ch.isalnum() else "_" for ch in text).strip("_")
-    return normalized or None
+    if not normalized:
+        return None
+    return _SYSTEM_DASHBOARD_DETAIL_QUERY_MAP.get(normalized)
 
 
 def _serialize_cookie_jar(
@@ -1344,6 +1362,37 @@ class EnphaseEVClient:
         headers = dict(self._h)
         headers.update(self._control_headers())
         return headers
+
+    @staticmethod
+    def _system_dashboard_is_optional_error(err: Exception) -> bool:
+        """Return True when a dashboard route should fall back or soft-fail."""
+
+        if isinstance(err, Unauthorized):
+            return True
+        if isinstance(err, InvalidPayloadError):
+            return _is_optional_non_json_payload(err)
+        if isinstance(err, aiohttp.ClientResponseError):
+            return err.status in (401, 403, 404)
+        return False
+
+    async def _system_dashboard_get(
+        self,
+        modern_url: str,
+        legacy_url: str,
+    ) -> dict | None:
+        """Fetch a system dashboard payload from the modern route with fallback."""
+
+        headers = self._system_dashboard_headers()
+        for url in (modern_url, legacy_url):
+            try:
+                data = await self._json("GET", url, headers=headers)
+            except Exception as err:  # noqa: BLE001
+                if self._system_dashboard_is_optional_error(err):
+                    continue
+                raise
+            return data if isinstance(data, dict) else None
+
+        return None
 
     def _hems_headers(self) -> dict[str, str]:
         """Return headers for HEMS read endpoints."""
@@ -3500,82 +3549,38 @@ class EnphaseEVClient:
     async def devices_tree(self) -> dict | None:
         """Return the system dashboard device hierarchy when available.
 
-        GET /pv/systems/<site_id>/system_dashboard/devices-tree
+        GET /service/system_dashboard/api_internal/dashboard/sites/<site_id>/devices-tree
+        Fallback: GET /pv/systems/<site_id>/system_dashboard/devices-tree
         """
 
-        url = f"{BASE_URL}/pv/systems/{self._site}/system_dashboard/devices-tree"
-        try:
-            data = await self._json("GET", url, headers=self._system_dashboard_headers())
-        except Unauthorized:
-            _LOGGER.debug(
-                "System dashboard devices-tree endpoint unavailable for site %s (unauthorized)",
-                self._site,
-            )
-            return None
-        except InvalidPayloadError as err:
-            if _is_optional_non_json_payload(err):
-                _LOGGER.debug(
-                    "System dashboard devices-tree endpoint unavailable for site %s (%s)",
-                    self._site,
-                    err.summary,
-                )
-                return None
-            raise
-        except aiohttp.ClientResponseError as err:
-            if err.status in (401, 403, 404):
-                _LOGGER.debug(
-                    "System dashboard devices-tree endpoint unavailable for site %s (status=%s)",
-                    self._site,
-                    err.status,
-                )
-                return None
-            raise
-        return data if isinstance(data, dict) else None
+        modern_url = (
+            f"{BASE_URL}/service/system_dashboard/api_internal/dashboard/sites/"
+            f"{self._site}/devices-tree"
+        )
+        legacy_url = f"{BASE_URL}/pv/systems/{self._site}/system_dashboard/devices-tree"
+        return await self._system_dashboard_get(modern_url, legacy_url)
 
     async def devices_details(self, type_key: str) -> dict | None:
         """Return system dashboard per-type device details when available.
 
-        GET /pv/systems/<site_id>/system_dashboard/devices_details?type=<type_key>
+        GET /service/system_dashboard/api_internal/dashboard/sites/<site_id>/devices_details?type=<observed_type>
+        Fallback: GET /pv/systems/<site_id>/system_dashboard/devices_details?type=<observed_type>
         """
 
         normalized = _system_dashboard_query_type(type_key)
         if not normalized:
             return None
-        url = str(
+        modern_url = str(
+            URL(
+                f"{BASE_URL}/service/system_dashboard/api_internal/dashboard/sites/{self._site}/devices_details"
+            ).update_query({"type": normalized})
+        )
+        legacy_url = str(
             URL(
                 f"{BASE_URL}/pv/systems/{self._site}/system_dashboard/devices_details"
             ).update_query({"type": normalized})
         )
-        try:
-            data = await self._json("GET", url, headers=self._system_dashboard_headers())
-        except Unauthorized:
-            _LOGGER.debug(
-                "System dashboard devices_details endpoint unavailable for site %s type %s (unauthorized)",
-                self._site,
-                normalized,
-            )
-            return None
-        except InvalidPayloadError as err:
-            if _is_optional_non_json_payload(err):
-                _LOGGER.debug(
-                    "System dashboard devices_details endpoint unavailable for site %s type %s (%s)",
-                    self._site,
-                    normalized,
-                    err.summary,
-                )
-                return None
-            raise
-        except aiohttp.ClientResponseError as err:
-            if err.status in (401, 403, 404):
-                _LOGGER.debug(
-                    "System dashboard devices_details endpoint unavailable for site %s type %s (status=%s)",
-                    self._site,
-                    normalized,
-                    err.status,
-                )
-                return None
-            raise
-        return data if isinstance(data, dict) else None
+        return await self._system_dashboard_get(modern_url, legacy_url)
 
     async def hems_devices(self, *, refresh_data: bool = False) -> dict | None:
         """Return dedicated HEMS device inventory when available.

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -123,11 +123,21 @@ DEVICES_INVENTORY_CACHE_TTL = 300.0
 HEATPUMP_POWER_CACHE_TTL = 300.0
 HEATPUMP_POWER_FAILURE_BACKOFF_S = 900.0
 SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES: tuple[str, ...] = (
-    "envoy",
-    "meter",
-    "enpower",
-    "encharge",
+    "envoys",
+    "meters",
+    "enpowers",
+    "encharges",
+    "modems",
+    "inverters",
 )
+SYSTEM_DASHBOARD_TYPE_KEY_MAP: dict[str, str] = {
+    "envoys": "envoy",
+    "meters": "envoy",
+    "enpowers": "envoy",
+    "encharges": "encharge",
+    "inverters": "microinverter",
+    "modems": "modem",
+}
 SAVINGS_OPERATION_MODE_SUBTYPE = "prioritize-energy"
 BATTERY_PROFILE_PENDING_TIMEOUT_S = 900.0
 BATTERY_PROFILE_WRITE_DEBOUNCE_S = 2.0
@@ -1758,7 +1768,125 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @classmethod
     def _system_dashboard_type_key(cls, raw_type: object) -> str | None:
+        text = cls._coerce_optional_text(raw_type)
+        if text:
+            token = "".join(ch if ch.isalnum() else "_" for ch in text.lower()).strip(
+                "_"
+            )
+            if token in SYSTEM_DASHBOARD_TYPE_KEY_MAP:
+                return SYSTEM_DASHBOARD_TYPE_KEY_MAP[token]
         return normalize_type_key(raw_type)
+
+    @classmethod
+    def _system_dashboard_detail_records(
+        cls,
+        payloads: dict[str, object],
+        *source_types: str,
+    ) -> list[dict[str, object]]:
+        records: list[dict[str, object]] = []
+        seen: set[tuple[str | None, str | None, str | None]] = set()
+        for source_type in source_types:
+            payload = payloads.get(source_type)
+            if not isinstance(payload, dict):
+                continue
+            items = payload.get(source_type)
+            if isinstance(items, list):
+                source_items = items
+            elif isinstance(items, dict):
+                nested_items = (
+                    items.get("devices")
+                    if isinstance(items.get("devices"), list)
+                    else (
+                        items.get("members")
+                        if isinstance(items.get("members"), list)
+                        else (
+                            items.get("items")
+                            if isinstance(items.get("items"), list)
+                            else None
+                        )
+                    )
+                )
+                source_items = (
+                    nested_items if isinstance(nested_items, list) else [items]
+                )
+            else:
+                nested_items = (
+                    payload.get("devices")
+                    if isinstance(payload.get("devices"), list)
+                    else (
+                        payload.get("members")
+                        if isinstance(payload.get("members"), list)
+                        else (
+                            payload.get("items")
+                            if isinstance(payload.get("items"), list)
+                            else None
+                        )
+                    )
+                )
+                source_items = (
+                    nested_items if isinstance(nested_items, list) else [payload]
+                )
+            for item in source_items:
+                if not isinstance(item, dict):
+                    continue
+                record = dict(item)
+                dedupe_key = (
+                    cls._coerce_optional_text(record.get("serial_number")),
+                    cls._coerce_optional_text(record.get("device_uid")),
+                    cls._coerce_optional_text(record.get("id")),
+                )
+                if dedupe_key in seen:
+                    continue
+                seen.add(dedupe_key)
+                records.append(record)
+        return records
+
+    @classmethod
+    def _system_dashboard_meter_kind(cls, payload: dict[str, object]) -> str | None:
+        for value in (
+            payload.get("meter_type"),
+            payload.get("config_type"),
+            payload.get("channel_type"),
+            payload.get("name"),
+        ):
+            text = cls._coerce_optional_text(value)
+            if not text:
+                continue
+            normalized = "".join(ch if ch.isalnum() else "_" for ch in text.lower())
+            if "production" in normalized or normalized in ("prod", "pv", "solar"):
+                return "production"
+            if "consumption" in normalized or normalized in (
+                "cons",
+                "load",
+                "site_load",
+            ):
+                return "consumption"
+        return None
+
+    @classmethod
+    def _system_dashboard_battery_detail_subset(
+        cls,
+        payload: dict[str, object] | None,
+    ) -> dict[str, object]:
+        if not isinstance(payload, dict):
+            return {}
+        allowed = (
+            "phase",
+            "operation_mode",
+            "app_version",
+            "sw_version",
+            "rssi_subghz",
+            "rssi_24ghz",
+            "rssi_dbm",
+            "led_status",
+            "alarm_id",
+        )
+        out: dict[str, object] = {}
+        for key in allowed:
+            value = payload.get(key)
+            if value is not None:
+                out[key] = value
+        return out
 
     @classmethod
     def _dashboard_node_entry(
@@ -1818,6 +1946,18 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 "nodes",
                 "result",
                 "data",
+                "envoy",
+                "envoys",
+                "meter",
+                "meters",
+                "enpower",
+                "enpowers",
+                "encharge",
+                "encharges",
+                "modem",
+                "modems",
+                "inverter",
+                "inverters",
             ) and isinstance(value, (dict, list)):
                 out.append((value, next_type))
         return out
@@ -1979,51 +2119,47 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     ) -> list[dict[str, object]]:
         meters: list[dict[str, object]] = []
         seen: set[tuple[str | None, str | None]] = set()
-        for payload in payloads.values():
-            for mapping in cls._iter_dashboard_mappings(payload):
-                raw_type = cls._dashboard_raw_type(mapping)
-                if cls._system_dashboard_type_key(raw_type) != "envoy":
-                    continue
-                meter_type = cls._coerce_optional_text(mapping.get("meter_type"))
-                name = cls._coerce_optional_text(mapping.get("name"))
-                if not meter_type and not cls._dashboard_key_matches(raw_type, "meter"):
-                    continue
-                dedupe_key = (name, meter_type)
-                if dedupe_key in seen:
-                    continue
-                seen.add(dedupe_key)
-                config_payload = cls._dashboard_first_mapping(
-                    mapping,
-                    "config",
-                    "configuration",
-                    "meter_config",
-                    "meter_configuration",
+        for record in cls._system_dashboard_detail_records(payloads, "meters", "meter"):
+            name = cls._coerce_optional_text(record.get("name"))
+            meter_kind = cls._system_dashboard_meter_kind(record)
+            meter_type = (
+                cls._coerce_optional_text(record.get("meter_type")) or meter_kind
+            )
+            dedupe_key = (name, meter_type)
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            meter_summary = {
+                "name": name,
+                "meter_type": meter_type,
+                "status": cls._dashboard_field(record, "status", "status_text"),
+                "meter_state": cls._coerce_optional_text(record.get("meter_state")),
+                "config_type": cls._coerce_optional_text(record.get("config_type")),
+            }
+            config_payload = cls._dashboard_first_mapping(
+                record,
+                "configuration",
+                "meter_config",
+                "meter_configuration",
+            )
+            if isinstance(config_payload, dict):
+                config = cls._dashboard_field_map(
+                    config_payload,
+                    {
+                        "phase": ("phase", "phase_mode", "phase_configuration"),
+                        "wiring": ("wiring", "wiring_type"),
+                        "mode": ("mode", "config_mode", "meter_mode"),
+                        "role": ("role", "measurement", "measurement_type"),
+                        "enabled": ("enabled", "is_enabled"),
+                    },
                 )
-                meter_summary = {
-                    "name": name,
-                    "meter_type": meter_type or cls._coerce_optional_text(raw_type),
-                    "status": cls._dashboard_field(mapping, "status", "status_text"),
-                }
-                if isinstance(config_payload, dict):
-                    config = cls._dashboard_field_map(
-                        config_payload,
-                        {
-                            "phase": ("phase", "phase_mode", "phase_configuration"),
-                            "wiring": ("wiring", "wiring_type"),
-                            "mode": ("mode", "config_mode", "meter_mode"),
-                            "role": ("role", "measurement", "measurement_type"),
-                            "enabled": ("enabled", "is_enabled"),
-                        },
-                    )
-                    if config:
-                        meter_summary["config"] = config
-                cleaned = {
-                    key: value
-                    for key, value in meter_summary.items()
-                    if value is not None
-                }
-                if cleaned:
-                    meters.append(cleaned)
+                if config:
+                    meter_summary["config"] = config
+            cleaned = {
+                key: value for key, value in meter_summary.items() if value is not None
+            }
+            if cleaned:
+                meters.append(cleaned)
         meters.sort(
             key=lambda item: (
                 str(item.get("name") or ""),
@@ -2039,22 +2175,38 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         index: dict[str, dict[str, object]],
         alias_index: dict[str, str] | None = None,
     ) -> dict[str, object]:
-        modem_source = cls._dashboard_first_mapping(
-            payloads, "modem", "cellular", "sim"
+        modem_records = cls._system_dashboard_detail_records(
+            payloads, "modems", "modem"
         )
+        modem_source = (
+            modem_records[0]
+            if modem_records
+            else cls._dashboard_first_mapping(payloads, "modem", "cellular", "sim")
+        )
+        envoy_records = cls._system_dashboard_detail_records(
+            payloads, "envoys", "envoy"
+        )
+        envoy_source = envoy_records[0] if envoy_records else payloads
         network_source = cls._dashboard_first_mapping(
-            payloads,
+            envoy_source,
             "network",
             "network_config",
             "gateway_network",
             "gateway_config",
         )
-        tunnel_source = cls._dashboard_first_mapping(payloads, "tunnel", "vpn")
-        controller_source = cls._dashboard_first_mapping(
-            payloads,
-            "controller",
-            "system_controller",
-            "enpower",
+        tunnel_source = cls._dashboard_first_mapping(envoy_source, "tunnel", "vpn")
+        controller_records = cls._system_dashboard_detail_records(
+            payloads, "enpowers", "enpower"
+        )
+        controller_source = (
+            controller_records[0]
+            if controller_records
+            else cls._dashboard_first_mapping(
+                payloads,
+                "controller",
+                "system_controller",
+                "enpower",
+            )
         )
         summary = {
             "modem": cls._dashboard_field_map(
@@ -2071,12 +2223,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                         "sim_plan_expiry",
                         "plan_expiry",
                         "plan_expiry_date",
+                        "plan_end",
                         "sim_expiry",
                     ),
                 },
             ),
             "network": cls._dashboard_field_map(
-                network_source or payloads,
+                network_source or envoy_source,
                 {
                     "status": ("status", "state", "link_state"),
                     "mode": ("mode", "network_mode", "config_mode"),
@@ -2123,27 +2276,31 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         index: dict[str, dict[str, object]],
         alias_index: dict[str, str] | None = None,
     ) -> dict[str, object]:
+        records = cls._system_dashboard_detail_records(
+            payloads, "encharges", "encharge"
+        )
+        first_record = records[0] if records else payloads
         connectivity_source = cls._dashboard_first_mapping(
-            payloads,
+            first_record,
             "connectivity",
             "network",
             "wireless",
         )
         software_source = cls._dashboard_first_mapping(
-            payloads,
+            first_record,
             "software",
             "app",
             "application",
         )
         operation_source = cls._dashboard_first_mapping(
-            payloads,
+            first_record,
             "operation_mode",
             "operation",
             "mode",
         )
         summary = {
             "connectivity": cls._dashboard_field_map(
-                connectivity_source or payloads,
+                connectivity_source or first_record,
                 {
                     "signal": (
                         "signal",
@@ -2152,23 +2309,49 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                         "sig_str",
                     ),
                     "rssi": ("rssi",),
+                    "rssi_subghz": ("rssi_subghz",),
+                    "rssi_24ghz": ("rssi_24ghz",),
+                    "rssi_dbm": ("rssi_dbm",),
                     "status": ("status", "state"),
                 },
             ),
             "software": cls._dashboard_field_map(
-                software_source or payloads,
+                software_source or first_record,
                 {
                     "app_version": ("app_version", "appVersion", "version"),
                     "firmware": ("firmware", "fw_version", "sw_version"),
+                    "sw_version": ("sw_version",),
                 },
             ),
             "operation_mode": cls._dashboard_field_map(
-                operation_source or payloads,
+                operation_source or first_record,
                 {
                     "mode": ("operation_mode", "operationMode", "mode"),
                     "state": ("status", "state"),
                 },
             ),
+            "batteries": [
+                cls._system_dashboard_battery_detail_subset(record)
+                | {
+                    key: value
+                    for key, value in {
+                        "name": cls._coerce_optional_text(record.get("name")),
+                        "serial_number": cls._coerce_optional_text(
+                            record.get("serial_number")
+                        ),
+                        "status": cls._coerce_optional_text(record.get("status")),
+                        "status_text": cls._coerce_optional_text(
+                            record.get("statusText")
+                        ),
+                        "soc": cls._coerce_optional_text(record.get("soc")),
+                    }.items()
+                    if value is not None
+                }
+                for record in records
+                if cls._system_dashboard_battery_detail_subset(record)
+                or cls._coerce_optional_text(record.get("serial_number"))
+                or cls._coerce_optional_text(record.get("name"))
+            ],
             "hierarchy": cls._system_dashboard_type_hierarchy(
                 "encharge", index, alias_index
             ),
@@ -2176,6 +2359,61 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return {
             key: value for key, value in summary.items() if value not in ({}, [], None)
         }
+
+    @classmethod
+    def _system_dashboard_microinverter_summary(
+        cls,
+        payloads: dict[str, object],
+        index: dict[str, dict[str, object]],
+        alias_index: dict[str, str] | None = None,
+    ) -> dict[str, object]:
+        summary_payload = (
+            cls._dashboard_first_mapping(payloads, "inverters", "inverter") or {}
+        )
+        if not isinstance(summary_payload, dict):
+            return {}
+        nested_payload = summary_payload.get("inverters")
+        if isinstance(nested_payload, dict):
+            summary_payload = nested_payload
+        total = cls._coerce_optional_int(summary_payload.get("total"))
+        not_reporting = cls._coerce_optional_int(summary_payload.get("not_reporting"))
+        plc_comm = cls._coerce_optional_int(summary_payload.get("plc_comm"))
+        items = summary_payload.get("items")
+        if isinstance(items, list):
+            model_counts = {
+                cls._coerce_optional_text(item.get("name"))
+                or f"item_{index}": (cls._coerce_optional_int(item.get("count")) or 0)
+                for index, item in enumerate(items, start=1)
+                if isinstance(item, dict)
+            }
+        else:
+            model_counts = {}
+        reporting = None
+        if total is not None:
+            reporting = max(0, total - int(not_reporting or 0))
+        connectivity = None
+        if total is not None:
+            if int(total) <= 0:
+                connectivity = None
+            elif int(not_reporting or 0) <= 0:
+                connectivity = "online"
+            elif int(not_reporting or 0) >= int(total):
+                connectivity = "offline"
+            else:
+                connectivity = "degraded"
+        summary = {
+            "total_inverters": total,
+            "reporting_inverters": reporting,
+            "not_reporting_inverters": not_reporting,
+            "plc_comm_inverters": plc_comm,
+            "model_counts": model_counts or None,
+            "model_summary": cls._format_inverter_model_summary(model_counts),
+            "connectivity": connectivity,
+            "hierarchy": cls._system_dashboard_type_hierarchy(
+                "microinverter", index, alias_index
+            ),
+        }
+        return {key: value for key, value in summary.items() if value is not None}
 
     def _build_system_dashboard_summaries(
         self,
@@ -2203,8 +2441,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             hierarchy_aliases,
         )
         type_summaries: dict[str, dict[str, object]] = {}
+        envoy_payloads: dict[str, object] = {}
+        for key in ("envoy", "modem"):
+            payloads = details_payloads.get(key, {})
+            if isinstance(payloads, dict):
+                envoy_payloads.update(payloads)
         if envoy_summary := self._system_dashboard_envoy_summary(
-            details_payloads.get("envoy", {}),
+            envoy_payloads,
             hierarchy_index,
             hierarchy_aliases,
         ):
@@ -2215,6 +2458,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             hierarchy_aliases,
         ):
             type_summaries["encharge"] = encharge_summary
+        if microinverter_summary := self._system_dashboard_microinverter_summary(
+            details_payloads.get("microinverter", {}),
+            hierarchy_index,
+            hierarchy_aliases,
+        ):
+            type_summaries["microinverter"] = microinverter_summary
         return type_summaries, hierarchy_summary, hierarchy_index
 
     async def _async_refresh_system_dashboard(self, *, force: bool = False) -> None:
@@ -4361,6 +4610,109 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             "production_payload": getattr(self, "_inverter_production_payload", None),
             "bucket_snapshot": bucket_snapshot,
         }
+
+    def _system_dashboard_raw_payloads(
+        self, canonical_type: str
+    ) -> dict[str, dict[str, object]]:
+        payloads = getattr(self, "_system_dashboard_devices_details_raw", None)
+        if not isinstance(payloads, dict):
+            return {}
+        raw = payloads.get(canonical_type)
+        if not isinstance(raw, dict):
+            return {}
+        return {
+            str(source_type): dict(payload)
+            for source_type, payload in raw.items()
+            if isinstance(payload, dict)
+        }
+
+    def system_dashboard_envoy_detail(self) -> dict[str, object] | None:
+        """Return the primary dashboard gateway detail record when available."""
+
+        records = self._system_dashboard_detail_records(
+            self._system_dashboard_raw_payloads("envoy"),
+            "envoys",
+            "envoy",
+        )
+        if not records:
+            return None
+        record = records[0]
+        out: dict[str, object] = {}
+        for key in (
+            "status",
+            "statusText",
+            "connected",
+            "last_report",
+            "last_interval_end_date",
+            "envoy_sw_version",
+            "ap_mode",
+            "sku_id",
+        ):
+            value = record.get(key)
+            if value is not None:
+                out[key] = value
+        return out or None
+
+    def system_dashboard_meter_detail(
+        self, meter_kind: str
+    ) -> dict[str, object] | None:
+        """Return a sanitized dashboard meter record for the requested kind."""
+
+        for record in self._system_dashboard_detail_records(
+            self._system_dashboard_raw_payloads("envoy"),
+            "meters",
+            "meter",
+        ):
+            if self._system_dashboard_meter_kind(record) != meter_kind:
+                continue
+            out: dict[str, object] = {}
+            for key in (
+                "name",
+                "serial_number",
+                "channel_type",
+                "status",
+                "statusText",
+                "last_report",
+                "meter_state",
+                "config_type",
+                "meter_type",
+            ):
+                value = record.get(key)
+                if value is not None:
+                    out[key] = value
+            return out or None
+        return None
+
+    def system_dashboard_battery_detail(self, serial: str) -> dict[str, object] | None:
+        """Return sanitized dashboard battery detail fields for a battery."""
+
+        snapshots = getattr(self, "_battery_storage_data", None)
+        snapshot = snapshots.get(serial) if isinstance(snapshots, dict) else None
+        candidates: set[str] = set()
+        for value in (
+            serial,
+            snapshot.get("serial_number") if isinstance(snapshot, dict) else None,
+            snapshot.get("identity") if isinstance(snapshot, dict) else None,
+            snapshot.get("battery_id") if isinstance(snapshot, dict) else None,
+            snapshot.get("id") if isinstance(snapshot, dict) else None,
+        ):
+            text = self._coerce_optional_text(value)
+            if text:
+                candidates.add(text)
+        if not candidates:
+            return None
+        for record in self._system_dashboard_detail_records(
+            self._system_dashboard_raw_payloads("encharge"),
+            "encharges",
+            "encharge",
+        ):
+            record_serial = self._coerce_optional_text(record.get("serial_number"))
+            record_id = self._coerce_optional_text(record.get("id"))
+            if record_serial not in candidates and record_id not in candidates:
+                continue
+            detail = self._system_dashboard_battery_detail_subset(record)
+            return detail or None
+        return None
 
     def system_dashboard_diagnostics(self) -> dict[str, object]:
         """Return cached system dashboard diagnostics payloads and summaries."""
@@ -6785,6 +7137,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             "userid",
             "user_id",
             "username",
+            "device_link",
+            "interface_ip",
+            "ip_addr",
+            "gateway_ip_addr",
+            "default_route",
+            "mac_addr",
         }
         if isinstance(value, dict):
             out: dict[str, object] = {}
@@ -7862,7 +8220,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         payload = snapshots.get(key)
         if not isinstance(payload, dict):
             return None
-        return dict(payload)
+        out = dict(payload)
+        detail = self.system_dashboard_battery_detail(key)
+        if isinstance(detail, dict):
+            for detail_key, detail_value in detail.items():
+                if detail_value is None:
+                    continue
+                out[detail_key] = detail_value
+        return out
 
     def get_desired_charging(self, sn: str) -> bool | None:
         """Return the user-requested charging state when known."""

--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -74,6 +74,12 @@ DIAGNOSTIC_IDENTIFIER_KEYS = [
     "tunnel-host",
     "tunnel_endpoint",
     "tunnel-endpoint",
+    "device_link",
+    "interface_ip",
+    "ip_addr",
+    "gateway_ip_addr",
+    "default_route",
+    "mac_addr",
 ]
 
 DIAGNOSTICS_REDACT_KEYS = [*TO_REDACT, *DIAGNOSTIC_IDENTIFIER_KEYS]

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -3334,6 +3334,10 @@ def _gateway_inventory_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
         if isinstance(members_raw, list)
         else []
     )
+    detail_getter = getattr(coord, "system_dashboard_envoy_detail", None)
+    dashboard_envoy = detail_getter() if callable(detail_getter) else None
+    if not members and isinstance(dashboard_envoy, dict):
+        members = [dict(dashboard_envoy)]
     try:
         total_devices = int(bucket.get("count", len(members)))
     except Exception:  # noqa: BLE001
@@ -3422,6 +3426,25 @@ def _gateway_inventory_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
     )
     if total_devices <= 0:
         status_summary = None
+    if latest_reported is None and isinstance(dashboard_envoy, dict):
+        fallback_last = None
+        for key in ("last_report", "last_interval_end_date"):
+            fallback_last = _gateway_parse_timestamp(dashboard_envoy.get(key))
+            if fallback_last is not None:
+                break
+        if fallback_last is not None:
+            latest_reported = fallback_last
+            latest_reported_device = {
+                "name": _gateway_clean_text(dashboard_envoy.get("name")) or "IQ Gateway",
+                "serial_number": _gateway_clean_text(
+                    dashboard_envoy.get("serial_number")
+                ),
+                "status": _gateway_clean_text(
+                    dashboard_envoy.get("statusText")
+                    if dashboard_envoy.get("statusText") is not None
+                    else dashboard_envoy.get("status")
+                ),
+            }
 
     return {
         "total_devices": total_devices,
@@ -4122,8 +4145,12 @@ def _gateway_meter_member(
 ) -> dict[str, object] | None:
     bucket = coord.type_bucket("envoy") or {}
     members = bucket.get("devices")
+    dashboard_detail = None
+    detail_getter = getattr(coord, "system_dashboard_meter_detail", None)
+    if callable(detail_getter):
+        dashboard_detail = detail_getter(meter_kind)
     if not isinstance(members, list):
-        return None
+        return dict(dashboard_detail) if isinstance(dashboard_detail, dict) else None
     for member in members:
         if not isinstance(member, dict):
             continue
@@ -4135,8 +4162,19 @@ def _gateway_meter_member(
             elif "consumption" in name.lower():
                 kind = "consumption"
         if kind == meter_kind:
-            return dict(member)
-    return None
+            merged = dict(member)
+            if isinstance(dashboard_detail, dict):
+                for key, value in dashboard_detail.items():
+                    if value is None:
+                        continue
+                    if merged.get(key) in (None, "") or key in (
+                        "meter_state",
+                        "config_type",
+                        "meter_type",
+                    ):
+                        merged[key] = value
+            return merged
+    return dict(dashboard_detail) if isinstance(dashboard_detail, dict) else None
 
 
 def _gateway_meter_status_text(member: dict[str, object] | None) -> str | None:
@@ -5245,6 +5283,7 @@ class _EnphaseGatewayMeterSensor(_SiteBaseEntity):
         attrs: dict[str, object] = {
             "meter_name": _gateway_clean_text(member.get("name")),
             "meter_type": self._meter_kind,
+            "dashboard_meter_type": _gateway_clean_text(member.get("meter_type")),
             "channel_type": _gateway_clean_text(member.get("channel_type")),
             "serial_number": _gateway_clean_text(member.get("serial_number")),
             "connected": _gateway_optional_bool(member.get("connected")),
@@ -5255,6 +5294,8 @@ class _EnphaseGatewayMeterSensor(_SiteBaseEntity):
             "last_reported_utc": (
                 last_reported.isoformat() if last_reported is not None else None
             ),
+            "meter_state": _gateway_clean_text(member.get("meter_state")),
+            "config_type": _gateway_clean_text(member.get("config_type")),
             "ip_address": _gateway_clean_text(
                 member.get("ip")
                 if member.get("ip") is not None
@@ -5272,6 +5313,9 @@ class _EnphaseGatewayMeterSensor(_SiteBaseEntity):
                     "connected",
                     "status_text",
                     "status_raw",
+                    "meter_type",
+                    "meter_state",
+                    "config_type",
                     "last_report",
                     "last_reported",
                     "last_reported_at",

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -1042,6 +1042,9 @@ GET /service/system_dashboard/api_internal/dashboard/sites/<site_id>/devices_det
 ```
 Returns per-family detail cards for the system dashboard device modal.
 
+Observed query parameter:
+- `type` selects the device family. Observed values: `envoys`, `encharges`, `enpowers`, `meters`, `modems`, `inverters`.
+
 Example response for `type=envoys` (anonymized):
 ```json
 {
@@ -1073,10 +1076,148 @@ Example response for `type=envoys` (anonymized):
 }
 ```
 
+Example response for `type=encharges` (anonymized):
+```json
+{
+  "encharges": [
+    {
+      "id": 300001,
+      "name": "IQ Battery 5P",
+      "serial_number": "BAT0000000001",
+      "device_link": "https://enlighten.example/systems/<site_id>/ac_batteries/300001",
+      "sku_id": "B05-T02-ROW00-1-2",
+      "channel_type": "IQ Battery",
+      "phase": "L1(A)",
+      "status": "normal",
+      "statusText": "Normal",
+      "last_report": "2026/03/09 16:38:49 +1100 (AEDT)",
+      "sw_version": "546-00002-01-v01",
+      "total": 2,
+      "not_reporting": 0,
+      "rssi_subghz": 0,
+      "rssi_24ghz": 5,
+      "rssi_dbm": 0,
+      "soc": "98%",
+      "operation_mode": "Multi-mode On Grid, Discharging",
+      "led_status": 13,
+      "app_version": "3.0.8557_rel/31.44",
+      "alarm_id": null
+    }
+  ]
+}
+```
+
+Example response for `type=enpowers` (anonymized):
+```json
+{
+  "enpowers": [
+    {
+      "id": 310001,
+      "name": "IQ System Controller",
+      "serial_number": "CTRL000000001",
+      "device_link": "https://enlighten.example/systems/<site_id>/ac_batteries/310001",
+      "sku_id": "SC100G-M230ROW",
+      "channel_type": "IQ System Controller",
+      "status": "normal",
+      "statusText": "Normal",
+      "last_report": "2026/03/09 16:42:43 +1100 (AEDT)",
+      "sw_version": "546-00003-01-v01",
+      "rssi_subghz": 0,
+      "rssi_24ghz": 5,
+      "rssi_dbm": 0,
+      "operation_mode": "Grid Connected - IQ Batteries Connected",
+      "app_version": "2.7.7054_rel/31.44",
+      "earth": "TN-C-S"
+    }
+  ]
+}
+```
+
+Example response for `type=meters` (anonymized):
+```json
+{
+  "meters": [
+    {
+      "id": 320001,
+      "name": "IQ Gateway",
+      "serial_number": "GW0000000000EIM1",
+      "device_link": "https://enlighten.example/systems/<site_id>/meters/320001",
+      "sku_id": null,
+      "channel_type": "Production Meter",
+      "status": "normal",
+      "statusText": "Normal",
+      "last_report": "2026/03/09 16:40:00 +1100 (AEDT)",
+      "meter_state": "Enabled",
+      "config_type": "Production",
+      "meter_type": "Production"
+    },
+    {
+      "id": 320002,
+      "name": "IQ Gateway",
+      "serial_number": "GW0000000000EIM2",
+      "device_link": "https://enlighten.example/systems/<site_id>/meters/320002",
+      "sku_id": null,
+      "channel_type": "Consumption Meter",
+      "status": "normal",
+      "statusText": "Normal",
+      "last_report": "2026/03/09 16:40:00 +1100 (AEDT)",
+      "meter_state": "Enabled",
+      "config_type": "Net (Load with Solar)",
+      "meter_type": "Consumption"
+    }
+  ]
+}
+```
+
+Example response for `type=modems` (anonymized):
+```json
+{
+  "modems": [
+    {
+      "id": 330001,
+      "serial_number": "89010000000000000000",
+      "device_status": "Normal",
+      "status": "activated",
+      "statusText": "Activated",
+      "last_report": "2026/03/09 16:44:25 +1100 (AEDT)",
+      "sw_version": "EG25GLGDR07A03M1G_01.200.01.200",
+      "signal": 4,
+      "rssi": 18,
+      "bit_error_rate": "99 (Unknown)",
+      "plan_end": "2030/09/17",
+      "part_number_with_sku": "865-02038-r03 (CELLMODEM-07-INT-05-CM)",
+      "device_link": "https://enlighten.example/systems/<site_id>/devices?status=active#cellular_modems"
+    }
+  ]
+}
+```
+
+Example response for `type=inverters` (anonymized):
+```json
+{
+  "inverters": {
+    "total": 16,
+    "not_reporting": 0,
+    "plc_comm": 5,
+    "items": [
+      {
+        "name": "IQ7A Microinverters",
+        "count": 16
+      }
+    ],
+    "device_link": "https://enlighten.example/systems/<site_id>/devices?status=active"
+  }
+}
+```
+
 Observed structure:
 - The top-level key matches the requested `type`.
-- `envoys`, `encharges`, `enpowers`, `meters`, and `modems` returned arrays; `inverters` returned a summary object with `total`, `not_reporting`, `plc_comm`, `items[]`, and `device_link`.
+- `envoys`, `encharges`, `enpowers`, `meters`, and `modems` return arrays of device cards.
+- `inverters` returns a summary object with `total`, `not_reporting`, `plc_comm`, `items[]`, and `device_link` rather than per-device rows.
 - Fields are family-specific and often localized (`statusText`, `channel_type`, meter labels, modem plan text).
+- `encharges` and `enpowers` both expose RF/link-health fields (`rssi_subghz`, `rssi_24ghz`, `rssi_dbm`) plus family-specific operating-state strings.
+- `meters` expose configuration labels (`config_type`, `meter_type`) rather than firmware/network details.
+- `modems` expose provisioning state (`status`, `plan_end`, `part_number_with_sku`) instead of the gateway-style network payload.
 - These endpoints expose sensitive infrastructure details such as IP addresses, MAC-derived identifiers, and direct dashboard links; redact aggressively before sharing traces.
 
 ### 2.10 Homeowner Events History

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -208,7 +208,9 @@ def test_system_dashboard_query_type_helper_branches() -> None:
     assert api._system_dashboard_query_type(None) is None
     assert api._system_dashboard_query_type(_BadText()) is None
     assert api._system_dashboard_query_type(" - ") is None
-    assert api._system_dashboard_query_type("System Controller") == "system_controller"
+    assert api._system_dashboard_query_type("System Controller") is None
+    assert api._system_dashboard_query_type("meter") == "meters"
+    assert api._system_dashboard_query_type("encharge") == "encharges"
 
 
 def test_bearer_extraction_prefers_cookie() -> None:
@@ -734,7 +736,7 @@ async def test_devices_tree_uses_system_dashboard_endpoint_and_headers() -> None
     assert result == {"devices": []}
     client._json.assert_awaited_once_with(
         "GET",
-        f"{api.BASE_URL}/pv/systems/SITE/system_dashboard/devices-tree",
+        f"{api.BASE_URL}/service/system_dashboard/api_internal/dashboard/sites/SITE/devices-tree",
         headers=client._system_dashboard_headers(),
     )
 
@@ -751,21 +753,37 @@ async def test_devices_tree_returns_none_when_payload_not_dict() -> None:
 @pytest.mark.parametrize("error", [api.Unauthorized(), _make_cre(403), _make_cre(404)])
 async def test_devices_tree_optional_errors_return_none(error) -> None:
     client = _make_client()
-    client._json = AsyncMock(side_effect=error)
+    client._json = AsyncMock(side_effect=[error, error])
 
     assert await client.devices_tree() is None
+
+
+@pytest.mark.asyncio
+async def test_devices_tree_falls_back_to_legacy_route() -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=[_make_cre(404), {"devices": []}])
+
+    result = await client.devices_tree()
+
+    assert result == {"devices": []}
+    assert client._json.await_args_list[0].args[1] == (
+        f"{api.BASE_URL}/service/system_dashboard/api_internal/dashboard/sites/SITE/devices-tree"
+    )
+    assert client._json.await_args_list[1].args[1] == (
+        f"{api.BASE_URL}/pv/systems/SITE/system_dashboard/devices-tree"
+    )
 
 
 @pytest.mark.asyncio
 async def test_devices_tree_non_json_payload_returns_none(monkeypatch) -> None:
     client = _make_client()
     err = api.InvalidPayloadError(
-        "Invalid JSON response (status=200, content_type=text/html, endpoint=/pv/systems/SITE/system_dashboard/devices-tree, decode_error=ContentTypeError)",
+        "Invalid JSON response (status=200, content_type=text/html, endpoint=/service/system_dashboard/api_internal/dashboard/sites/SITE/devices-tree, decode_error=ContentTypeError)",
         status=200,
         content_type="text/html",
-        endpoint="/pv/systems/SITE/system_dashboard/devices-tree",
+        endpoint="/service/system_dashboard/api_internal/dashboard/sites/SITE/devices-tree",
     )
-    monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
+    monkeypatch.setattr(client, "_json", AsyncMock(side_effect=[err, err]))
 
     assert await client.devices_tree() is None
 
@@ -774,10 +792,10 @@ async def test_devices_tree_non_json_payload_returns_none(monkeypatch) -> None:
 async def test_devices_tree_json_invalid_payload_reraises(monkeypatch) -> None:
     client = _make_client()
     err = api.InvalidPayloadError(
-        "Invalid JSON response (status=200, content_type=application/json, endpoint=/pv/systems/SITE/system_dashboard/devices-tree, decode_error=ValueError)",
+        "Invalid JSON response (status=200, content_type=application/json, endpoint=/service/system_dashboard/api_internal/dashboard/sites/SITE/devices-tree, decode_error=ValueError)",
         status=200,
         content_type="application/json",
-        endpoint="/pv/systems/SITE/system_dashboard/devices-tree",
+        endpoint="/service/system_dashboard/api_internal/dashboard/sites/SITE/devices-tree",
     )
     monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
 
@@ -804,7 +822,7 @@ async def test_devices_details_uses_system_dashboard_endpoint_and_headers() -> N
     assert result == {"details": []}
     client._json.assert_awaited_once_with(
         "GET",
-        f"{api.BASE_URL}/pv/systems/SITE/system_dashboard/devices_details?type=meter",
+        f"{api.BASE_URL}/service/system_dashboard/api_internal/dashboard/sites/SITE/devices_details?type=meters",
         headers=client._system_dashboard_headers(),
     )
 
@@ -815,6 +833,7 @@ async def test_devices_details_returns_none_when_type_invalid_or_payload_bad() -
     client._json = AsyncMock(return_value=["bad"])
 
     assert await client.devices_details("") is None
+    assert await client.devices_details("unsupported") is None
     assert await client.devices_details("encharge") is None
 
 
@@ -822,21 +841,37 @@ async def test_devices_details_returns_none_when_type_invalid_or_payload_bad() -
 @pytest.mark.parametrize("error", [api.Unauthorized(), _make_cre(401), _make_cre(404)])
 async def test_devices_details_optional_errors_return_none(error) -> None:
     client = _make_client()
-    client._json = AsyncMock(side_effect=error)
+    client._json = AsyncMock(side_effect=[error, error])
 
     assert await client.devices_details("envoy") is None
+
+
+@pytest.mark.asyncio
+async def test_devices_details_falls_back_to_legacy_route_and_query_mapping() -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=[_make_cre(404), {"details": []}])
+
+    result = await client.devices_details("microinverter")
+
+    assert result == {"details": []}
+    assert client._json.await_args_list[0].args[1] == (
+        f"{api.BASE_URL}/service/system_dashboard/api_internal/dashboard/sites/SITE/devices_details?type=inverters"
+    )
+    assert client._json.await_args_list[1].args[1] == (
+        f"{api.BASE_URL}/pv/systems/SITE/system_dashboard/devices_details?type=inverters"
+    )
 
 
 @pytest.mark.asyncio
 async def test_devices_details_non_json_payload_returns_none(monkeypatch) -> None:
     client = _make_client()
     err = api.InvalidPayloadError(
-        "Invalid JSON response (status=200, content_type=text/html, endpoint=/pv/systems/SITE/system_dashboard/devices_details, decode_error=ContentTypeError)",
+        "Invalid JSON response (status=200, content_type=text/html, endpoint=/service/system_dashboard/api_internal/dashboard/sites/SITE/devices_details, decode_error=ContentTypeError)",
         status=200,
         content_type="text/html",
-        endpoint="/pv/systems/SITE/system_dashboard/devices_details",
+        endpoint="/service/system_dashboard/api_internal/dashboard/sites/SITE/devices_details",
     )
-    monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
+    monkeypatch.setattr(client, "_json", AsyncMock(side_effect=[err, err]))
 
     assert await client.devices_details("envoy") is None
 
@@ -845,10 +880,10 @@ async def test_devices_details_non_json_payload_returns_none(monkeypatch) -> Non
 async def test_devices_details_json_invalid_payload_reraises(monkeypatch) -> None:
     client = _make_client()
     err = api.InvalidPayloadError(
-        "Invalid JSON response (status=200, content_type=application/json, endpoint=/pv/systems/SITE/system_dashboard/devices_details, decode_error=ValueError)",
+        "Invalid JSON response (status=200, content_type=application/json, endpoint=/service/system_dashboard/api_internal/dashboard/sites/SITE/devices_details, decode_error=ValueError)",
         status=200,
         content_type="application/json",
-        endpoint="/pv/systems/SITE/system_dashboard/devices_details",
+        endpoint="/service/system_dashboard/api_internal/dashboard/sites/SITE/devices_details",
     )
     monkeypatch.setattr(client, "_json", AsyncMock(side_effect=err))
 

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -325,43 +325,76 @@ async def test_refresh_system_dashboard_diagnostics_populates_summary(
     )
     coord.client.devices_details = AsyncMock(
         side_effect=lambda type_key: {
-            "envoy": {
-                "device_uid": "GW-1",
-                "modem": {
-                    "signal_strength": "strong",
-                    "rssi": -72,
-                    "plan_expiry_date": "2026-08-01",
-                },
-                "network": {"status": "online", "network_mode": "dhcp"},
-                "tunnel": {"status": "connected", "healthy": True},
+            "envoys": {
+                "envoys": [
+                    {
+                        "device_uid": "GW-1",
+                        "type": "envoy",
+                        "name": "Gateway",
+                        "status": "normal",
+                        "last_report": "2026-03-09T05:45:00+00:00",
+                        "network": {"status": "online", "network_mode": "dhcp"},
+                        "tunnel": {"status": "connected", "healthy": True},
+                    }
+                ]
             },
-            "meter": {
-                "devices": [
+            "meters": {
+                "meters": [
                     {
                         "device_uid": "MTR-1",
                         "type": "meter",
                         "name": "Consumption Meter",
                         "meter_type": "consumption",
+                        "config_type": "Net",
+                        "meter_state": "Enabled",
                         "configuration": {"phase": "three_phase", "enabled": True},
                     }
                 ]
             },
-            "enpower": {
-                "device_uid": "CTRL-1",
-                "type": "enpower",
-                "earth_type": "TN-C-S",
-                "status": "normal",
+            "enpowers": {
+                "enpowers": [
+                    {
+                        "device_uid": "CTRL-1",
+                        "type": "enpower",
+                        "earth_type": "TN-C-S",
+                        "status": "normal",
+                    }
+                ]
             },
-            "encharge": {
-                "devices": [
+            "encharges": {
+                "encharges": [
                     {
                         "device_uid": "BAT-1",
                         "type": "encharge",
-                        "connectivity": {"rssi": -61, "status": "online"},
-                        "software": {"app_version": "1.2.3"},
-                        "operation_mode": {"mode": "backup"},
+                        "serial_number": "BAT-1",
+                        "rssi_dbm": -61,
+                        "app_version": "1.2.3",
+                        "operation_mode": "backup",
                     }
                 ]
+            },
+            "modems": {
+                "modems": [
+                    {
+                        "id": "MODEM-1",
+                        "signal": 4,
+                        "rssi": -72,
+                        "plan_end": "2026-08-01",
+                    }
+                ]
+            },
+            "inverters": {
+                "inverters": {
+                    "total": 16,
+                    "not_reporting": 1,
+                    "plc_comm": 5,
+                    "items": [
+                        {
+                            "name": "IQ7A Microinverters",
+                            "count": 16,
+                        }
+                    ],
+                }
             },
         }.get(type_key)
     )
@@ -369,18 +402,20 @@ async def test_refresh_system_dashboard_diagnostics_populates_summary(
     await coord._async_refresh_system_dashboard()  # noqa: SLF001
 
     diagnostics = coord.system_dashboard_diagnostics()
-    assert diagnostics["devices_details_payloads"]["envoy"]["meter"]["devices"][0][
+    assert diagnostics["devices_details_payloads"]["envoy"]["meters"]["meters"][0][
         "meter_type"
     ] == "consumption"
     assert diagnostics["hierarchy_summary"]["counts_by_type"] == {
         "encharge": 1,
         "envoy": 3,
+        "modem": 1,
     }
     envoy = diagnostics["type_summaries"]["envoy"]
     assert envoy["modem"]["rssi"] == -72
     assert envoy["modem"]["sim_plan_expiry"] == "2026-08-01"
     assert envoy["controller"]["earth_type"] == "TN-C-S"
     assert envoy["meters"][0]["config"]["phase"] == "three_phase"
+    assert envoy["meters"][0]["meter_state"] == "Enabled"
     assert envoy["hierarchy"]["count"] == 3
     assert next(
         rel["child_count"]
@@ -388,9 +423,15 @@ async def test_refresh_system_dashboard_diagnostics_populates_summary(
         if rel["device_uid"] == "GW-1"
     ) == 3
     battery = diagnostics["type_summaries"]["encharge"]
-    assert battery["connectivity"]["rssi"] == -61
+    assert battery["connectivity"]["rssi_dbm"] == -61
     assert battery["software"]["app_version"] == "1.2.3"
     assert battery["operation_mode"]["mode"] == "backup"
+    assert battery["batteries"][0]["serial_number"] == "BAT-1"
+    micro = diagnostics["type_summaries"]["microinverter"]
+    assert micro["total_inverters"] == 16
+    assert micro["not_reporting_inverters"] == 1
+    assert micro["plc_comm_inverters"] == 5
+    assert micro["model_summary"] == "IQ7A Microinverters x16"
 
 
 @pytest.mark.asyncio
@@ -439,6 +480,14 @@ def test_system_dashboard_helper_branches(coordinator_factory, monkeypatch) -> N
     assert coord._dashboard_simple_value(_BadText()) is None  # noqa: SLF001
     assert coord._dashboard_parent_id({"parentId": "PARENT"}) == "PARENT"  # noqa: SLF001
     assert coord._system_dashboard_type_key("meter") == "envoy"  # noqa: SLF001
+    assert coord._system_dashboard_type_key("envoys") == "envoy"  # noqa: SLF001
+    assert coord._system_dashboard_type_key("encharges") == "encharge"  # noqa: SLF001
+    assert coord._system_dashboard_type_key("inverters") == "microinverter"  # noqa: SLF001
+    assert list(  # noqa: SLF001
+        coord._iter_dashboard_mappings(
+            [{"status": "ok"}, {"nested": {"mode": "dhcp"}}]
+        )
+    ) == [{"status": "ok"}, {"nested": {"mode": "dhcp"}}, {"mode": "dhcp"}]
     assert coord._index_dashboard_nodes("bad") == {}  # noqa: SLF001
     assert coord._dashboard_node_entry(  # noqa: SLF001
         {"id": "node-1", "serial": "SER-1", "display_name": "Gateway"},
@@ -449,6 +498,16 @@ def test_system_dashboard_helper_branches(coordinator_factory, monkeypatch) -> N
         "name": "Gateway",
         "serial_number": "SER-1",
     }
+    assert coord._system_dashboard_detail_records(  # noqa: SLF001
+        {
+            "envoys": {
+                "envoys": {"devices": [{"id": "dup"}, {"id": "dup"}, "bad"]},
+            }
+        },
+        "envoys",
+    ) == [{"id": "dup"}]
+    assert coord._system_dashboard_meter_kind({"meter_type": " "}) is None  # noqa: SLF001
+    assert coord._system_dashboard_battery_detail_subset(None) == {}  # noqa: SLF001
     meters = coord._system_dashboard_meter_summaries(  # noqa: SLF001
         {
             "meter": {
@@ -460,6 +519,38 @@ def test_system_dashboard_helper_branches(coordinator_factory, monkeypatch) -> N
         }
     )
     assert meters == [{"name": "M1", "meter_type": "consumption"}]
+    assert coord._system_dashboard_meter_summaries(  # noqa: SLF001
+        {
+            "meters": {
+                "meters": [
+                    {"id": "1", "name": "M1", "meter_type": "consumption"},
+                    {"id": "2", "name": "M1", "meter_type": "consumption"},
+                ]
+            }
+        }
+    ) == [{"name": "M1", "meter_type": "consumption"}]
+    assert "connectivity" not in coord._system_dashboard_microinverter_summary(  # noqa: SLF001
+        {"inverters": {"total": 0, "not_reporting": 0}},
+        {},
+        None,
+    )
+    assert coord._system_dashboard_microinverter_summary(  # noqa: SLF001
+        {"inverters": {"total": 2, "not_reporting": 0}},
+        {},
+        None,
+    )["connectivity"] == "online"
+    assert coord._system_dashboard_microinverter_summary(  # noqa: SLF001
+        {"inverters": {"total": 2, "not_reporting": 2}},
+        {},
+        None,
+    )["connectivity"] == "offline"
+    with monkeypatch.context() as nested_patch:
+        nested_patch.setattr(
+            type(coord),
+            "_dashboard_first_mapping",
+            classmethod(lambda cls, payload, *keys: "bad"),
+        )
+        assert coord._system_dashboard_microinverter_summary({}, {}, None) == {}  # noqa: SLF001
 
     original_node_entry = type(coord)._dashboard_node_entry
 
@@ -485,6 +576,78 @@ def test_system_dashboard_helper_branches(coordinator_factory, monkeypatch) -> N
         },
         {"id-1": "serial-1"},
     )["relationships"][0]["parent_uid"] == "serial-1"
+
+
+def test_system_dashboard_detail_accessors_cover_edges(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+
+    coord._system_dashboard_devices_details_raw = []  # noqa: SLF001
+    assert coord._system_dashboard_raw_payloads("envoy") == {}  # noqa: SLF001
+
+    coord._system_dashboard_devices_details_raw = {  # noqa: SLF001
+        "envoy": {
+            "envoys": {
+                "envoys": [
+                    {
+                        "status": "normal",
+                        "last_report": "2026-03-09T05:45:00+00:00",
+                    }
+                ]
+            },
+            "meters": {
+                "meters": [
+                    {
+                        "name": "Consumption Meter",
+                        "channel_type": "Consumption Meter",
+                        "meter_state": "Enabled",
+                    }
+                ]
+            },
+        },
+        "encharge": {
+            "encharges": {
+                "encharges": [
+                    {"serial_number": "BAT-2", "phase": "L2"},
+                ]
+            }
+        },
+    }
+    assert coord.system_dashboard_envoy_detail() == {
+        "status": "normal",
+        "last_report": "2026-03-09T05:45:00+00:00",
+    }
+    assert coord.system_dashboard_meter_detail("consumption") == {
+        "name": "Consumption Meter",
+        "channel_type": "Consumption Meter",
+        "meter_state": "Enabled",
+    }
+
+    coord._battery_storage_data = {"BAT-1": {"serial_number": "BAT-1"}}  # noqa: SLF001
+    assert coord.system_dashboard_battery_detail("BAT-1") is None
+
+    with monkeypatch.context() as nested_patch:
+        nested_patch.setattr(
+            type(coord),
+            "_coerce_optional_text",
+            classmethod(lambda cls, value: None),
+        )
+        assert coord.system_dashboard_battery_detail("BAT-1") is None
+
+    coord._battery_storage_data = {  # noqa: SLF001
+        "BAT-1": {"serial_number": "BAT-1", "status": "normal"}
+    }
+    monkeypatch.setattr(
+        coord,
+        "system_dashboard_battery_detail",
+        lambda _serial: {"phase": None, "rssi_dbm": -61},
+    )
+    assert coord.battery_storage("BAT-1") == {
+        "serial_number": "BAT-1",
+        "status": "normal",
+        "rssi_dbm": -61,
+    }
 
 
 @pytest.mark.asyncio
@@ -516,6 +679,13 @@ async def test_refresh_system_dashboard_diagnostics_cache_and_invalid_type_branc
     await coord._async_refresh_system_dashboard(force=True)  # noqa: SLF001
 
     assert coord.system_dashboard_diagnostics()["devices_details_payloads"] == {}
+
+    monkeypatch.setattr(coord_mod, "SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES", ("envoys",))
+    coord.client.devices_details = AsyncMock(return_value={})
+
+    await coord._async_refresh_system_dashboard(force=True)  # noqa: SLF001
+
+    assert "envoy" in coord.system_dashboard_diagnostics()["devices_details_payloads"]
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -914,6 +914,10 @@ async def test_battery_payload_snapshots_are_saved_and_redacted(
     assert coord._battery_profile_payload["token"] == "[redacted]"  # noqa: SLF001
     nested = {
         "userId": "123",
+        "device_link": "https://enlighten.example/systems/3381244/envoys/200001",
+        "connection_details": {
+            "interface_ip": {"ethernet": "192.0.2.10"},
+        },
         "nested": {
             "Authorization": "Bearer abc",
             "X-XSRF-Token": "xsrf",
@@ -921,6 +925,12 @@ async def test_battery_payload_snapshots_are_saved_and_redacted(
             "items": [
                 {"cookie": "a=b"},
                 {"username": "user@example.com"},
+                {
+                    "default_route": "192.168.1.1 (Ethernet)",
+                    "mac_addr": "00:11:22:33:44:55",
+                    "ip_addr": "192.0.2.10",
+                    "gateway_ip_addr": "192.0.2.1",
+                },
                 {"safe": "ok"},
             ],
         },
@@ -930,9 +940,15 @@ async def test_battery_payload_snapshots_are_saved_and_redacted(
     assert redacted_nested["nested"]["Authorization"] == "[redacted]"
     assert redacted_nested["nested"]["X-XSRF-Token"] == "[redacted]"
     assert redacted_nested["nested"]["refresh-token"] == "[redacted]"
+    assert redacted_nested["device_link"] == "[redacted]"
+    assert redacted_nested["connection_details"]["interface_ip"] == "[redacted]"
     assert redacted_nested["nested"]["items"][0]["cookie"] == "[redacted]"
     assert redacted_nested["nested"]["items"][1]["username"] == "[redacted]"
-    assert redacted_nested["nested"]["items"][2]["safe"] == "ok"
+    assert redacted_nested["nested"]["items"][2]["default_route"] == "[redacted]"
+    assert redacted_nested["nested"]["items"][2]["mac_addr"] == "[redacted]"
+    assert redacted_nested["nested"]["items"][2]["ip_addr"] == "[redacted]"
+    assert redacted_nested["nested"]["items"][2]["gateway_ip_addr"] == "[redacted]"
+    assert redacted_nested["nested"]["items"][3]["safe"] == "ok"
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -218,12 +218,28 @@ class DummyCoordinator(SimpleNamespace):
         self._system_dashboard_devices_details_payloads = {
             "envoy": {
                 "envoy": {
+                    "device_link": "https://enlighten.example/systems/3381244/envoys/200001",
                     "modem": {
                         "rssi": -72,
                         "signal_strength": "strong",
                         "plan_expiry_date": "2026-08-01",
                         "imei": "359111111111111",
                     },
+                    "connection_details": {
+                        "interface_ip": {
+                            "ethernet": "192.0.2.10",
+                        }
+                    },
+                    "network_configuration": [
+                        {
+                            "details": {
+                                "mac_addr": "00:11:22:33:44:55",
+                                "ip_addr": "192.0.2.10",
+                                "gateway_ip_addr": "192.0.2.1",
+                            }
+                        }
+                    ],
+                    "default_route": "192.0.2.1 (Ethernet)",
                     "network": {"status": "online", "mode": "dhcp"},
                     "tunnel": {"status": "connected"},
                 },
@@ -300,6 +316,12 @@ class DummyCoordinator(SimpleNamespace):
                         {"device_uid": "BAT-1", "parent_uid": "GW-1"}
                     ],
                 },
+            },
+            "microinverter": {
+                "total_inverters": 16,
+                "not_reporting_inverters": 1,
+                "plc_comm_inverters": 5,
+                "model_summary": "IQ7A Microinverters x16",
             },
         }
         self._evse_site_feature_flags = {
@@ -527,12 +549,36 @@ async def test_config_entry_diagnostics_includes_coordinator(hass, config_entry)
     assert diag["coordinator"]["system_dashboard"]["devices_details_payloads"]["envoy"][
         "envoy"
     ]["modem"]["imei"] == "**REDACTED**"
+    assert diag["coordinator"]["system_dashboard"]["devices_details_payloads"]["envoy"][
+        "envoy"
+    ]["device_link"] == "**REDACTED**"
+    assert diag["coordinator"]["system_dashboard"]["devices_details_payloads"]["envoy"][
+        "envoy"
+    ]["connection_details"]["interface_ip"] == "**REDACTED**"
+    assert diag["coordinator"]["system_dashboard"]["devices_details_payloads"]["envoy"][
+        "envoy"
+    ]["network_configuration"][0]["details"]["mac_addr"] == "**REDACTED**"
+    assert diag["coordinator"]["system_dashboard"]["devices_details_payloads"]["envoy"][
+        "envoy"
+    ]["network_configuration"][0]["details"]["ip_addr"] == "**REDACTED**"
+    assert diag["coordinator"]["system_dashboard"]["devices_details_payloads"]["envoy"][
+        "envoy"
+    ]["network_configuration"][0]["details"]["gateway_ip_addr"] == "**REDACTED**"
+    assert diag["coordinator"]["system_dashboard"]["devices_details_payloads"]["envoy"][
+        "envoy"
+    ]["default_route"] == "**REDACTED**"
     assert diag["coordinator"]["system_dashboard"]["hierarchy_summary"]["relationships"][
         1
     ]["parent_uid"] == "**REDACTED**"
     assert diag["coordinator"]["system_dashboard"]["type_summaries"]["envoy"]["modem"][
         "sim_plan_expiry"
     ] == "2026-08-01"
+    assert (
+        diag["coordinator"]["system_dashboard"]["type_summaries"]["microinverter"][
+            "plc_comm_inverters"
+        ]
+        == 5
+    )
     assert diag["coordinator"]["schedule_sync"] == {"enabled": True}
     assert diag["coordinator"]["scheduler"]["backoff_ends_utc"] == "2025-01-01T00:00:00+00:00"
 

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -1866,6 +1866,29 @@ def test_gateway_meter_sensors_expose_status_and_meter_attributes(
         },
         ["envoy"],
     )
+    coord._system_dashboard_devices_details_raw = {  # noqa: SLF001
+        "envoy": {
+            "meters": {
+                "meters": [
+                    {
+                        "name": "Production Meter",
+                        "serial_number": "MTR-P",
+                        "meter_type": "Production",
+                        "meter_state": "Enabled",
+                        "config_type": "Production",
+                    },
+                    {
+                        "name": "Consumption Meter",
+                        "serial_number": "MTR-C",
+                        "meter_type": "Consumption",
+                        "meter_state": "Enabled",
+                        "config_type": "Net (Load with Solar)",
+                        "last_report": "2026-02-15T11:00:00Z",
+                    },
+                ]
+            }
+        }
+    }
 
     production = EnphaseGatewayProductionMeterSensor(coord)
     assert production.native_value == "Normal"
@@ -1873,9 +1896,12 @@ def test_gateway_meter_sensors_expose_status_and_meter_attributes(
     p_attrs = production.extra_state_attributes
     assert p_attrs["meter_name"] == "Production Meter"
     assert p_attrs["meter_type"] == "production"
+    assert p_attrs["dashboard_meter_type"] == "Production"
     assert p_attrs["channel_type"] == "production_meter"
     assert p_attrs["connected"] is True
     assert p_attrs["envoy_sw_version"] == "8.3.1"
+    assert p_attrs["meter_state"] == "Enabled"
+    assert p_attrs["config_type"] == "Production"
     assert p_attrs["meter_attributes"]["serial_number"] == "MTR-P"
     assert p_attrs["last_reported_utc"] is not None
 
@@ -1885,8 +1911,12 @@ def test_gateway_meter_sensors_expose_status_and_meter_attributes(
     c_attrs = consumption.extra_state_attributes
     assert c_attrs["meter_name"] == "Consumption Meter"
     assert c_attrs["meter_type"] == "consumption"
+    assert c_attrs["dashboard_meter_type"] == "Consumption"
     assert c_attrs["channel_type"] == "consumption_meter"
     assert c_attrs["connected"] is False
+    assert c_attrs["meter_state"] == "Enabled"
+    assert c_attrs["config_type"] == "Net (Load with Solar)"
+    assert c_attrs["last_reported_utc"] == "2026-02-15T11:00:00+00:00"
     assert c_attrs["meter_attributes"]["serial_number"] == "MTR-C"
     assert "meter_attributes" in consumption._unrecorded_attributes  # noqa: SLF001
     assert "last_reported_utc" in consumption._unrecorded_attributes  # noqa: SLF001
@@ -1928,6 +1958,107 @@ def test_gateway_meter_sensor_name_fallback_and_missing_member(coordinator_facto
 
     coord.last_update_success = False
     assert production.available is False
+
+
+def test_gateway_last_reported_sensor_uses_dashboard_fallback(coordinator_factory) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseGatewayLastReportedSensor
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "type_label": "Gateway",
+                "count": 1,
+                "devices": [
+                    {
+                        "name": "IQ Gateway",
+                        "serial_number": "GW-1",
+                        "statusText": "Normal",
+                    }
+                ],
+            }
+        },
+        ["envoy"],
+    )
+    coord._system_dashboard_devices_details_raw = {  # noqa: SLF001
+        "envoy": {
+            "envoys": {
+                "envoys": [
+                    {
+                        "name": "IQ Gateway",
+                        "serial_number": "GW-1",
+                        "statusText": "Normal",
+                        "last_report": "2026-02-15T12:00:00Z",
+                    }
+                ]
+            }
+        }
+    }
+
+    sensor = EnphaseGatewayLastReportedSensor(coord)
+    assert sensor.available is True
+    assert sensor.native_value == datetime(2026, 2, 15, 12, 0, tzinfo=timezone.utc)
+
+
+def test_battery_storage_sensors_include_dashboard_detail_fields(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import (
+        EnphaseBatteryStorageChargeSensor,
+        EnphaseBatteryStorageStatusSensor,
+    )
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._battery_storage_data = {  # noqa: SLF001
+        "BAT-1": {
+            "identity": "BAT-1",
+            "name": "IQ Battery 5P",
+            "serial_number": "BAT-1",
+            "current_charge_pct": 48.0,
+            "status": "normal",
+            "status_text": "Normal",
+            "status_normalized": "normal",
+        }
+    }
+    coord._battery_storage_order = ["BAT-1"]  # noqa: SLF001
+    coord._system_dashboard_devices_details_raw = {  # noqa: SLF001
+        "encharge": {
+            "encharges": {
+                "encharges": [
+                    {
+                        "serial_number": "BAT-1",
+                        "phase": "L1(A)",
+                        "operation_mode": "Multi-mode On Grid, Charging",
+                        "app_version": "3.0.8557_rel/31.44",
+                        "sw_version": "546-00002-01-v01",
+                        "rssi_subghz": 1,
+                        "rssi_24ghz": 5,
+                        "rssi_dbm": -61,
+                        "led_status": 12,
+                        "alarm_id": None,
+                        "current_charge_pct": 99.0,
+                        "status": "warning",
+                    }
+                ]
+            }
+        }
+    }
+
+    charge = EnphaseBatteryStorageChargeSensor(coord, "BAT-1")
+    status = EnphaseBatteryStorageStatusSensor(coord, "BAT-1")
+
+    assert charge.native_value == 48.0
+    assert status.native_value == "Normal"
+    attrs = charge.extra_state_attributes
+    assert attrs["phase"] == "L1(A)"
+    assert attrs["operation_mode"] == "Multi-mode On Grid, Charging"
+    assert attrs["app_version"] == "3.0.8557_rel/31.44"
+    assert attrs["sw_version"] == "546-00002-01-v01"
+    assert attrs["rssi_subghz"] == 1
+    assert attrs["rssi_24ghz"] == 5
+    assert attrs["rssi_dbm"] == -61
+    assert attrs["led_status"] == 12
 
 
 def test_gateway_iq_energy_router_sensor_state_and_attributes(
@@ -3093,6 +3224,27 @@ def test_gateway_helpers_cover_edge_paths(coordinator_factory) -> None:
     assert sensor_mod._gateway_meter_member(coord, "production") is None
     coord.type_bucket = lambda _key: {"devices": ["bad"]}  # type: ignore[assignment]
     assert sensor_mod._gateway_meter_member(coord, "production") is None
+    coord.type_bucket = lambda _key: {"count": 0, "devices": []}  # type: ignore[assignment]
+    coord.system_dashboard_envoy_detail = lambda: {  # type: ignore[attr-defined]
+        "status": "normal",
+        "last_report": "2026-03-09T05:45:00+00:00",
+    }
+    fallback_snapshot = sensor_mod._gateway_inventory_snapshot(coord)
+    assert fallback_snapshot["total_devices"] == 1
+    assert fallback_snapshot["connected_devices"] == 1
+    assert fallback_snapshot["latest_reported_utc"] == "2026-03-09T05:45:00+00:00"
+    coord.type_bucket = lambda _key: {  # type: ignore[assignment]
+        "devices": [{"channel_type": "production_meter", "name": "Production Meter"}]
+    }
+    coord.system_dashboard_meter_detail = lambda _kind: {  # type: ignore[attr-defined]
+        "meter_state": None,
+        "config_type": "Production",
+    }
+    assert sensor_mod._gateway_meter_member(coord, "production") == {
+        "channel_type": "production_meter",
+        "name": "Production Meter",
+        "config_type": "Production",
+    }
     coord.type_bucket = lambda _key: {"devices": "bad"}  # type: ignore[assignment]
     assert sensor_mod._gateway_system_controller_member(coord) is None
     coord.type_bucket = lambda _key: {"devices": ["bad"]}  # type: ignore[assignment]


### PR DESCRIPTION
## Summary
- switch system dashboard reads to the observed modern routes with legacy fallback and plural query mapping
- enrich gateway, meter, battery, and diagnostics data from system dashboard details without changing entity ids
- redact newly captured dashboard deep links and network identifiers in diagnostics and add regression coverage

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/diagnostics.py,custom_components/enphase_ev/sensor.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
