### PR TITLE
Harden auth and HEMS refresh diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,30 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v2.2.2 - 2026-03-13
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Added a cloud current power consumption sensor for site-level live load visibility. (#348)
+- Added EVSE timeseries energy fallback paths to preserve charger energy reporting when primary realtime/session sources are incomplete. (#347)
+
+### 🐛 Bug fixes
+- Fixed BatteryConfig writes and schedule CRUD flows for EMEA sites, including region-specific auth/header handling. (#340)
+- Fixed fast-poll interval fallback handling so charger polling stays aligned with configured intervals. (#350)
+- Treated optional system-dashboard and unsupported HEMS endpoints as soft failures instead of allowing them to cascade into misleading payload/auth errors. (#346)
+- Hardened system-dashboard diagnostics parsing and fallback handling for Enphase dashboard routes that return unexpected HTML or partial data. (#352)
+- Improved auth failure diagnostics by logging the exact request that received a `401` and the stored-credential reauth retry outcome.
+
+### 🔧 Improvements
+- Reused recent HEMS inventory payloads when refreshes temporarily fail and surfaced HEMS freshness/staleness details on Heat Pump entities and diagnostics.
+- Expanded regression coverage for BatteryConfig EMEA writes, EVSE timeseries fallback behavior, fast-poll fallback handling, optional dashboard/HEMS failures, auth retry logging, and hardened dashboard parsing.
+
+### 🔄 Other changes
+- Documented the integration activation checklist and cleaned up API spec notes. (#349)
+- Documented the filtered site-device inventory endpoint and refreshed related API docs. (#353)
+
 ## v2.2.1 - 2026-03-11
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -216,6 +216,35 @@ def _system_dashboard_query_type(type_key: object) -> str | None:
     return _SYSTEM_DASHBOARD_DETAIL_QUERY_MAP.get(normalized)
 
 
+def _request_label(method: object, url: object) -> str:
+    """Return a compact request label for debug logging."""
+
+    try:
+        method_text = str(method).strip().upper()
+    except Exception:  # noqa: BLE001 - defensive casting
+        method_text = "REQUEST"
+
+    path = ""
+    try:
+        url_obj = url if isinstance(url, URL) else URL(str(url))
+    except Exception:  # noqa: BLE001 - fallback to raw text
+        try:
+            raw = str(url).strip()
+        except Exception:  # noqa: BLE001
+            raw = ""
+        if raw:
+            return f"{method_text} {raw}"
+        return method_text
+
+    if url_obj.path:
+        path = url_obj.path
+    if url_obj.query_string:
+        path = f"{path}?{url_obj.query_string}" if path else f"?{url_obj.query_string}"
+    if path:
+        return f"{method_text} {path}"
+    return method_text
+
+
 def _serialize_cookie_jar(
     jar: aiohttp.CookieJar, urls: Iterable[str | URL]
 ) -> tuple[str, dict[str, str]]:
@@ -1221,6 +1250,7 @@ class EnphaseEVClient:
         self._eauth = eauth or None
         self._hems_site_supported: bool | None = None
         self._reauth_cb: Callable[[], Awaitable[bool]] | None = reauth_callback
+        self._last_unauthorized_request: str | None = None
         self._h = {
             "Accept": "application/json, text/plain, */*",
             "X-Requested-With": "XMLHttpRequest",
@@ -1234,6 +1264,12 @@ class EnphaseEVClient:
         """Register coroutine used to refresh credentials on 401."""
 
         self._reauth_cb = callback
+
+    @property
+    def last_unauthorized_request(self) -> str | None:
+        """Return the most recent request that received a 401 response."""
+
+        return self._last_unauthorized_request
 
     def update_credentials(
         self,
@@ -1623,6 +1659,7 @@ class EnphaseEVClient:
         """
         extra_headers = kwargs.pop("headers", None)
         attempt = 0
+        request_label = _request_label(method, url)
         while True:
             base_headers = dict(self._h)
             if callable(extra_headers):
@@ -1637,11 +1674,29 @@ class EnphaseEVClient:
                     method, url, headers=base_headers, **kwargs
                 ) as r:
                     if r.status == 401:
+                        self._last_unauthorized_request = request_label
                         if self._reauth_cb and attempt == 0:
+                            _LOGGER.debug(
+                                "Received 401 for %s; attempting stored-credential refresh",
+                                request_label,
+                            )
                             attempt += 1
                             reauth_ok = await self._reauth_cb()
                             if reauth_ok:
+                                _LOGGER.debug(
+                                    "Stored-credential refresh succeeded for %s; retrying request",
+                                    request_label,
+                                )
                                 continue
+                            _LOGGER.debug(
+                                "Stored-credential refresh failed for %s",
+                                request_label,
+                            )
+                        else:
+                            _LOGGER.debug(
+                                "Received 401 for %s with no stored-credential refresh available",
+                                request_label,
+                            )
                         raise Unauthorized()
                     if r.status in (204, 205):
                         return {}

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -255,6 +255,9 @@ class HeatPumpSgReadyActiveBinarySensor(CoordinatorEntity, BinarySensorEntity):
             "active_member_count": self._active_member_count(),
             "status_summary": snapshot.get("status_summary"),
             "latest_reported_utc": snapshot.get("latest_reported_utc"),
+            "hems_data_stale": snapshot.get("hems_data_stale"),
+            "hems_last_success_utc": snapshot.get("hems_last_success_utc"),
+            "hems_last_success_age_s": snapshot.get("hems_last_success_age_s"),
             **details,
         }
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -120,6 +120,7 @@ BATTERY_SETTINGS_CACHE_TTL = 300.0
 BATTERY_BACKUP_HISTORY_CACHE_TTL = 300.0
 BATTERY_BACKUP_HISTORY_FAILURE_CACHE_TTL = 60.0
 DEVICES_INVENTORY_CACHE_TTL = 300.0
+HEMS_DEVICES_STALE_AFTER_S = 900.0
 HEATPUMP_POWER_CACHE_TTL = 300.0
 HEATPUMP_POWER_FAILURE_BACKOFF_S = 900.0
 SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES: tuple[str, ...] = (
@@ -378,6 +379,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._system_dashboard_type_summaries: dict[str, dict[str, object]] = {}
         self._hems_devices_cache_until: float | None = None
         self._hems_devices_payload: dict[str, object] | None = None
+        self._hems_devices_last_success_mono: float | None = None
+        self._hems_devices_last_success_utc: datetime | None = None
+        self._hems_devices_using_stale = False
         self._devices_inventory_ready: bool = False
         self._current_power_consumption_w: float | None = None
         self._current_power_consumption_sample_utc: datetime | None = None
@@ -1543,23 +1547,63 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 return
         if not force and getattr(self.client, "hems_site_supported", None) is False:
             self._hems_devices_payload = None
+            self._hems_devices_using_stale = False
             self._merge_heatpump_type_bucket()
             self._hems_devices_cache_until = now + DEVICES_INVENTORY_CACHE_TTL
             return
         fetcher = getattr(self.client, "hems_devices", None)
         if not callable(fetcher):
             return
+        previous_payload = getattr(self, "_hems_devices_payload", None)
+
+        def _previous_payload_reusable() -> bool:
+            if previous_payload is None:
+                return False
+            last_success = getattr(self, "_hems_devices_last_success_mono", None)
+            if not isinstance(last_success, (int, float)):
+                return False
+            age = now - float(last_success)
+            if age < 0:
+                return True
+            return age < HEMS_DEVICES_STALE_AFTER_S
+
         try:
-            payload = await fetcher(refresh_data=False)
+            payload = await fetcher(refresh_data=force)
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(
                 "HEMS device inventory fetch failed for site %s: %s", self.site_id, err
             )
-            self._hems_devices_payload = None
-            self._merge_heatpump_type_bucket()
+            if getattr(self.client, "hems_site_supported", None) is False:
+                self._hems_devices_payload = None
+                self._hems_devices_using_stale = False
+                self._merge_heatpump_type_bucket()
+                self._hems_devices_cache_until = now + DEVICES_INVENTORY_CACHE_TTL
+            elif _previous_payload_reusable():
+                self._hems_devices_payload = previous_payload
+                self._hems_devices_using_stale = True
+                self._merge_heatpump_type_bucket()
+                self._hems_devices_cache_until = now + DEVICES_INVENTORY_CACHE_TTL
+            elif previous_payload is not None:
+                self._hems_devices_payload = None
+                self._hems_devices_using_stale = False
+                self._merge_heatpump_type_bucket()
+                self._hems_devices_cache_until = now + DEVICES_INVENTORY_CACHE_TTL
             return
         if payload is None:
+            if getattr(self.client, "hems_site_supported", None) is False:
+                self._hems_devices_payload = None
+                self._hems_devices_using_stale = False
+                self._merge_heatpump_type_bucket()
+                self._hems_devices_cache_until = now + DEVICES_INVENTORY_CACHE_TTL
+                return
+            if _previous_payload_reusable():
+                self._hems_devices_payload = previous_payload
+                self._hems_devices_using_stale = True
+                self._merge_heatpump_type_bucket()
+                self._hems_devices_cache_until = now + DEVICES_INVENTORY_CACHE_TTL
+                return
             self._hems_devices_payload = None
+            self._hems_devices_using_stale = False
             self._merge_heatpump_type_bucket()
             self._hems_devices_cache_until = now + DEVICES_INVENTORY_CACHE_TTL
             return
@@ -1568,6 +1612,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._hems_devices_payload = redacted_payload
         else:
             self._hems_devices_payload = {"value": redacted_payload}
+        self._hems_devices_last_success_mono = now
+        self._hems_devices_last_success_utc = dt_util.utcnow()
+        self._hems_devices_using_stale = False
         self._merge_heatpump_type_bucket()
         self._hems_devices_cache_until = now + DEVICES_INVENTORY_CACHE_TTL
 
@@ -4352,6 +4399,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             ),
             "dry_contact_settings_data_stale": self.dry_contact_settings_supported
             is None,
+            "hems_devices_data_stale": bool(
+                getattr(self, "_hems_devices_using_stale", False)
+            ),
         }
         grid_last_success = getattr(self, "_grid_control_check_last_success_mono", None)
         if isinstance(grid_last_success, (int, float)):
@@ -4365,6 +4415,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             age = time.monotonic() - float(dry_contacts_last_success)
             if age >= 0:
                 metrics["dry_contact_settings_last_success_age_s"] = round(age, 1)
+        hems_last_success = getattr(self, "_hems_devices_last_success_mono", None)
+        if isinstance(hems_last_success, (int, float)):
+            age = time.monotonic() - float(hems_last_success)
+            if age >= 0:
+                metrics["hems_devices_last_success_age_s"] = round(age, 1)
+        metrics["hems_devices_last_success_utc"] = _iso(
+            getattr(self, "_hems_devices_last_success_utc", None)
+        )
         session_manager = getattr(self, "session_history", None)
         if session_manager is not None:
             metrics["session_history_available"] = getattr(

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.2.1"
+  "version": "2.2.2"
 }

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import math
 import re
+import time
 
 from homeassistant.components.sensor import (
     RestoreSensor,
@@ -3782,6 +3783,16 @@ def _heatpump_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
     if not isinstance(status_summary, str) or not status_summary.strip():
         status_summary = EnphaseCoordinator._format_inverter_status_summary(status_counts)
 
+    hems_last_success_utc = getattr(coord, "_hems_devices_last_success_utc", None)
+    if not isinstance(hems_last_success_utc, datetime):
+        hems_last_success_utc = None
+    hems_last_success_mono = getattr(coord, "_hems_devices_last_success_mono", None)
+    hems_last_success_age_s: float | None = None
+    if isinstance(hems_last_success_mono, (int, float)):
+        age = time.monotonic() - float(hems_last_success_mono)
+        if age >= 0:
+            hems_last_success_age_s = round(age, 1)
+
     return {
         "total_devices": total_devices,
         "members": safe_members,
@@ -3797,6 +3808,13 @@ def _heatpump_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
         "latest_reported_device": latest_reported_device,
         "without_last_report_count": without_last_report_count,
         "overall_status_text": overall_status_text,
+        "hems_data_stale": bool(getattr(coord, "_hems_devices_using_stale", False)),
+        "hems_last_success_utc": (
+            hems_last_success_utc.isoformat()
+            if hems_last_success_utc is not None
+            else None
+        ),
+        "hems_last_success_age_s": hems_last_success_age_s,
     }
 
 
@@ -3848,6 +3866,9 @@ def _heatpump_type_snapshot(
             latest_reported.isoformat() if latest_reported is not None else None
         ),
         "latest_reported_device": latest_device,
+        "hems_data_stale": snapshot.get("hems_data_stale"),
+        "hems_last_success_utc": snapshot.get("hems_last_success_utc"),
+        "hems_last_success_age_s": snapshot.get("hems_last_success_age_s"),
     }
 
 
@@ -5802,6 +5823,9 @@ class EnphaseHeatPumpStatusSensor(_SiteBaseEntity):
             "firmware_summary": snapshot.get("firmware_summary"),
             "latest_reported_utc": snapshot.get("latest_reported_utc"),
             "latest_reported_device": snapshot.get("latest_reported_device"),
+            "hems_data_stale": snapshot.get("hems_data_stale"),
+            "hems_last_success_utc": snapshot.get("hems_last_success_utc"),
+            "hems_last_success_age_s": snapshot.get("hems_last_success_age_s"),
             "members": safe_members,
         }
 
@@ -5860,6 +5884,9 @@ class _EnphaseHeatPumpDeviceTypeSensor(_SiteBaseEntity):
             "status_summary": snapshot.get("status_summary"),
             "latest_reported_utc": snapshot.get("latest_reported_utc"),
             "latest_reported_device": snapshot.get("latest_reported_device"),
+            "hems_data_stale": snapshot.get("hems_data_stale"),
+            "hems_last_success_utc": snapshot.get("hems_last_success_utc"),
+            "hems_last_success_age_s": snapshot.get("hems_last_success_age_s"),
             "members": safe_members,
             "member_attributes": flattened_members,
             **sg_ready_details,
@@ -5925,6 +5952,9 @@ class EnphaseHeatPumpLastReportedSensor(_SiteBaseEntity):
             "without_last_report_count": snapshot.get("without_last_report_count"),
             "total_devices": snapshot.get("total_devices"),
             "status_summary": snapshot.get("status_summary"),
+            "hems_data_stale": snapshot.get("hems_data_stale"),
+            "hems_last_success_utc": snapshot.get("hems_last_success_utc"),
+            "hems_last_success_age_s": snapshot.get("hems_last_success_age_s"),
         }
 
 

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import datetime
 import json
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -211,6 +212,53 @@ def test_system_dashboard_query_type_helper_branches() -> None:
     assert api._system_dashboard_query_type("System Controller") is None
     assert api._system_dashboard_query_type("meter") == "meters"
     assert api._system_dashboard_query_type("encharge") == "encharges"
+
+
+def test_request_label_formats_path_and_query() -> None:
+    assert api._request_label("get", "https://example.test/path?foo=1") == "GET /path?foo=1"
+
+
+def test_request_label_handles_bad_method_and_raw_url_fallback(monkeypatch) -> None:
+    class _BadMethod:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        api,
+        "URL",
+        lambda _value: (_ for _ in ()).throw(ValueError("bad url")),
+    )
+
+    assert api._request_label(_BadMethod(), "not a url") == "REQUEST not a url"
+
+
+def test_request_label_handles_url_and_raw_text_failures(monkeypatch) -> None:
+    class _BadUrl:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        api,
+        "URL",
+        lambda _value: (_ for _ in ()).throw(ValueError("bad url")),
+    )
+
+    assert api._request_label("post", _BadUrl()) == "POST"
+
+
+def test_request_label_returns_method_when_url_has_no_path(monkeypatch) -> None:
+    class _UrlNoPath:
+        def __init__(self, _value) -> None:
+            self.path = ""
+            self.query_string = ""
+
+    monkeypatch.setattr(
+        api,
+        "URL",
+        _UrlNoPath,
+    )
+
+    assert api._request_label("patch", "https://example.test") == "PATCH"
 
 
 def test_bearer_extraction_prefers_cookie() -> None:
@@ -460,6 +508,29 @@ async def test_json_reauth_retry(monkeypatch) -> None:
     assert payload == {"ok": True}
     assert len(attempts) == 1
     assert len(session.calls) == 2
+    assert client.last_unauthorized_request == "GET /"
+
+
+@pytest.mark.asyncio
+async def test_json_reauth_retry_logs_request_label(caplog) -> None:
+    session = _FakeSession(
+        [
+            _FakeResponse(status=401, json_body={}),
+            _FakeResponse(status=200, json_body={"ok": True}),
+        ]
+    )
+    client = api.EnphaseEVClient(session, "SITE", None, None)
+
+    async def _reauth() -> bool:
+        return True
+
+    client.set_reauth_callback(_reauth)
+    with caplog.at_level(logging.DEBUG):
+        payload = await client._json("GET", "https://example.test/path?foo=1")
+
+    assert payload == {"ok": True}
+    assert "Received 401 for GET /path?foo=1; attempting stored-credential refresh" in caplog.text
+    assert "Stored-credential refresh succeeded for GET /path?foo=1; retrying request" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -595,6 +666,19 @@ async def test_json_reauth_failure_falls_back() -> None:
     client.set_reauth_callback(_reauth)
     with pytest.raises(api.Unauthorized):
         await client._json("GET", "https://example.test")
+    assert client.last_unauthorized_request == "GET /"
+
+
+@pytest.mark.asyncio
+async def test_json_unauthorized_without_reauth_logs_request_label(caplog) -> None:
+    session = _FakeSession([_FakeResponse(status=401, json_body={})])
+    client = api.EnphaseEVClient(session, "SITE", None, None)
+
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(api.Unauthorized):
+            await client._json("POST", "https://example.test/service/status")
+
+    assert "Received 401 for POST /service/status with no stored-credential refresh available" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+import time
 from types import SimpleNamespace
 from typing import Callable
 from unittest.mock import MagicMock
@@ -530,6 +531,9 @@ def test_heatpump_sg_ready_active_binary_sensor_metadata(
         ["heatpump"],
     )
     monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
+    coord._hems_devices_last_success_utc = datetime(2026, 3, 3, 7, 31, tzinfo=timezone.utc)  # noqa: SLF001
+    coord._hems_devices_last_success_mono = time.monotonic() - 30  # noqa: SLF001
+    coord._hems_devices_using_stale = True  # noqa: SLF001
 
     sensor = HeatPumpSgReadyActiveBinarySensor(coord)
     assert sensor.translation_key == "heat_pump_sg_ready_active"
@@ -546,6 +550,9 @@ def test_heatpump_sg_ready_active_binary_sensor_metadata(
         "Recommended means the SG Ready contact is closed."
     )
     assert attrs["latest_reported_utc"] == "2026-03-03T07:30:00+00:00"
+    assert attrs["hems_data_stale"] is True
+    assert attrs["hems_last_success_utc"] == "2026-03-03T07:31:00+00:00"
+    assert attrs["hems_last_success_age_s"] is not None
 
     info = sensor.device_info
     assert info["name"] == "Heat Pump"

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -32,6 +32,7 @@ from custom_components.enphase_ev.const import (
 from custom_components.enphase_ev.coordinator import (
     BATTERY_BACKUP_HISTORY_FAILURE_CACHE_TTL,
     FAST_TOGGLE_POLL_HOLD_S,
+    HEMS_DEVICES_STALE_AFTER_S,
     ServiceValidationError,
 )
 from custom_components.enphase_ev.voltage import resolve_nominal_voltage_for_hass
@@ -706,11 +707,97 @@ async def test_hems_devices_refresh_cache_and_exception_paths(
     assert coord._hems_devices_payload == {  # noqa: SLF001
         "data": {"hems-devices": {"heat-pump": []}}
     }
+    coord.client.hems_devices.assert_awaited_with(refresh_data=True)
+
+    coord._hems_devices_cache_until = None  # noqa: SLF001
+    coord.client._hems_site_supported = True  # noqa: SLF001
+    coord.client.hems_devices = AsyncMock(return_value=None)
+    await coord._async_refresh_hems_devices()
+    assert coord._hems_devices_payload == {  # noqa: SLF001
+        "data": {"hems-devices": {"heat-pump": []}}
+    }
+    assert coord._hems_devices_cache_until is not None  # noqa: SLF001
+    assert coord._hems_devices_using_stale is True  # noqa: SLF001
 
     coord._hems_devices_cache_until = None  # noqa: SLF001
     coord.client.hems_devices = AsyncMock(side_effect=RuntimeError("boom"))
     await coord._async_refresh_hems_devices(force=True)
+    assert coord._hems_devices_payload == {  # noqa: SLF001
+        "data": {"hems-devices": {"heat-pump": []}}
+    }
+    assert coord._hems_devices_using_stale is True  # noqa: SLF001
+
+    coord._hems_devices_cache_until = None  # noqa: SLF001
+    coord._hems_devices_last_success_mono = (  # noqa: SLF001
+        time.monotonic() - HEMS_DEVICES_STALE_AFTER_S - 1
+    )
+    coord.client._hems_site_supported = True  # noqa: SLF001
+    coord.client.hems_devices = AsyncMock(return_value=None)
+    await coord._async_refresh_hems_devices()
     assert coord._hems_devices_payload is None  # noqa: SLF001
+    assert coord._hems_devices_using_stale is False  # noqa: SLF001
+    assert coord._hems_devices_cache_until is not None  # noqa: SLF001
+
+    coord.client._hems_site_supported = False  # noqa: SLF001
+    coord._hems_devices_cache_until = None  # noqa: SLF001
+    coord.client.hems_devices = AsyncMock(return_value=None)
+    await coord._async_refresh_hems_devices()
+    assert coord._hems_devices_payload is None  # noqa: SLF001
+    assert coord._hems_devices_cache_until is not None  # noqa: SLF001
+
+    coord.client._hems_site_supported = False  # noqa: SLF001
+    coord._hems_devices_cache_until = None  # noqa: SLF001
+    coord._hems_devices_payload = {"data": {"hems-devices": {"heat-pump": []}}}  # noqa: SLF001
+    coord.client.hems_devices = AsyncMock(side_effect=RuntimeError("boom"))
+    await coord._async_refresh_hems_devices(force=True)
+    assert coord._hems_devices_payload is None  # noqa: SLF001
+    assert coord._hems_devices_using_stale is False  # noqa: SLF001
+    assert coord._hems_devices_cache_until is not None  # noqa: SLF001
+
+    coord.client._hems_site_supported = False  # noqa: SLF001
+    coord._hems_devices_cache_until = None  # noqa: SLF001
+    coord._hems_devices_payload = {"data": {"hems-devices": {"heat-pump": []}}}  # noqa: SLF001
+    coord.client.hems_devices = AsyncMock(return_value=None)
+    await coord._async_refresh_hems_devices()
+    assert coord._hems_devices_payload is None  # noqa: SLF001
+    assert coord._hems_devices_using_stale is False  # noqa: SLF001
+    assert coord._hems_devices_cache_until is not None  # noqa: SLF001
+
+    coord.client._hems_site_supported = None  # noqa: SLF001
+    coord._hems_devices_cache_until = None  # noqa: SLF001
+    coord._hems_devices_payload = {"data": {"hems-devices": {"heat-pump": []}}}  # noqa: SLF001
+    coord._hems_devices_last_success_mono = "bad"  # noqa: SLF001
+    coord.client.hems_devices = AsyncMock(return_value=None)
+    await coord._async_refresh_hems_devices()
+    assert coord._hems_devices_payload is None  # noqa: SLF001
+
+    coord._hems_devices_cache_until = None  # noqa: SLF001
+    coord._hems_devices_payload = {"data": {"hems-devices": {"heat-pump": []}}}  # noqa: SLF001
+    coord._hems_devices_last_success_mono = "bad"  # noqa: SLF001
+    coord.client.hems_devices = AsyncMock(side_effect=RuntimeError("boom"))
+    await coord._async_refresh_hems_devices(force=True)
+    assert coord._hems_devices_payload is None  # noqa: SLF001
+    assert coord._hems_devices_using_stale is False  # noqa: SLF001
+    assert coord._hems_devices_cache_until is not None  # noqa: SLF001
+
+    coord._hems_devices_cache_until = None  # noqa: SLF001
+    coord._hems_devices_payload = {"data": {"hems-devices": {"heat-pump": []}}}  # noqa: SLF001
+    coord._hems_devices_last_success_mono = time.monotonic() + 30  # noqa: SLF001
+    coord.client.hems_devices = AsyncMock(return_value=None)
+    await coord._async_refresh_hems_devices()
+    assert coord._hems_devices_payload == {  # noqa: SLF001
+        "data": {"hems-devices": {"heat-pump": []}}
+    }
+    assert coord._hems_devices_using_stale is True  # noqa: SLF001
+
+    coord.client._hems_site_supported = False  # noqa: SLF001
+    coord._hems_devices_cache_until = None  # noqa: SLF001
+    coord._hems_devices_payload = {"data": {"hems-devices": {"heat-pump": []}}}  # noqa: SLF001
+    coord.client.hems_devices = AsyncMock(return_value=None)
+    await coord._async_refresh_hems_devices(force=True)
+    assert coord._hems_devices_payload is None  # noqa: SLF001
+    assert coord._hems_devices_using_stale is False  # noqa: SLF001
+    assert coord._hems_devices_cache_until is not None  # noqa: SLF001
 
 
 def test_type_bucket_includes_extra_summary_fields(hass, monkeypatch) -> None:
@@ -3501,6 +3588,9 @@ def test_collect_site_metrics_and_placeholders(hass, monkeypatch):
     coord._last_error = "unauthorized"
     coord._phase_timings = {"status_s": 0.5}
     coord._session_history_cache_ttl = 300
+    coord._hems_devices_using_stale = True
+    coord._hems_devices_last_success_mono = time.monotonic() - 12
+    coord._hems_devices_last_success_utc = now
 
     metrics = coord.collect_site_metrics()
     assert metrics["site_id"] == coord.site_id
@@ -3508,12 +3598,24 @@ def test_collect_site_metrics_and_placeholders(hass, monkeypatch):
     assert metrics["last_success"] == now.isoformat()
     assert metrics["backoff_active"] is True
     assert metrics["phase_timings"] == {"status_s": 0.5}
+    assert metrics["hems_devices_data_stale"] is True
+    assert metrics["hems_devices_last_success_utc"] == now.isoformat()
+    assert metrics["hems_devices_last_success_age_s"] >= 0
 
     placeholders = coord._issue_translation_placeholders(metrics)
     assert placeholders["site_id"] == coord.site_id
     assert placeholders["site_name"] == "Garage Site"
     assert placeholders["last_error"] == "unauthorized"
     assert placeholders["last_status"] == "503"
+
+
+def test_collect_site_metrics_skips_negative_hems_age(hass, monkeypatch):
+    coord = _make_coordinator(hass, monkeypatch)
+    coord._hems_devices_last_success_mono = time.monotonic() + 5  # noqa: SLF001
+
+    metrics = coord.collect_site_metrics()
+
+    assert "hems_devices_last_success_age_s" not in metrics
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import time
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -1594,6 +1595,9 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
     coord._heatpump_power_device_uid = "HP-1"  # noqa: SLF001
     coord._heatpump_power_source = "hems_power_timeseries:HP-1"  # noqa: SLF001
     coord._heatpump_power_last_error = None  # noqa: SLF001
+    coord._hems_devices_last_success_utc = datetime(2026, 2, 27, 9, 16, tzinfo=timezone.utc)  # noqa: SLF001
+    coord._hems_devices_last_success_mono = time.monotonic() - 12  # noqa: SLF001
+    coord._hems_devices_using_stale = True  # noqa: SLF001
 
     status_sensor = EnphaseHeatPumpStatusSensor(coord)
     assert status_sensor.native_value == "Normal"
@@ -1601,6 +1605,9 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
     assert status_attrs["total_devices"] == 3
     assert status_attrs["status_counts"]["warning"] == 1
     assert status_attrs["device_type_counts"]["HEAT_PUMP"] == 1
+    assert status_attrs["hems_data_stale"] is True
+    assert status_attrs["hems_last_success_utc"] == "2026-02-27T09:16:00+00:00"
+    assert status_attrs["hems_last_success_age_s"] is not None
 
     sg_sensor = EnphaseHeatPumpSgReadyGatewaySensor(coord)
     assert sg_sensor.native_value == "Recommended"
@@ -1615,6 +1622,8 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
     assert sg_attrs["status_explanation"] == (
         "Recommended means the SG Ready contact is closed."
     )
+    assert sg_attrs["hems_data_stale"] is True
+    assert sg_attrs["hems_last_success_utc"] == "2026-02-27T09:16:00+00:00"
 
     meter_sensor = EnphaseHeatPumpEnergyMeterSensor(coord)
     assert meter_sensor.native_value == "Warning"
@@ -1632,6 +1641,7 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
         ]
         == "HP-EM-1"
     )
+    assert last_reported_sensor.extra_state_attributes["hems_data_stale"] is True
 
     power_sensor = EnphaseHeatPumpPowerSensor(coord)
     assert power_sensor.available is True


### PR DESCRIPTION
## Summary
- harden auth retry diagnostics by logging the exact request that received a 401 and the reauth retry outcome
- reuse recent HEMS inventory payloads during temporary refresh failures and expose HEMS freshness/staleness details on Heat Pump entities
- bump the integration version to 2.2.2 and add changelog entries covering changes since v2.2.1

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/binary_sensor.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/sensor.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
