### PR TITLE
Fix async session stub in API client tests

### DIFF
--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -73,6 +73,18 @@ class _FakeSession:
         return resp
 
 
+class _DefaultSession:
+    """Session stub that safely absorbs unexpected request calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, str, dict]] = []
+        self.cookie_jar = SimpleNamespace(filter_cookies=lambda _url: {})
+
+    def request(self, method: str, url: str, **kwargs):
+        self.calls.append((method, url, kwargs))
+        return _FakeResponse(status=200, json_body={}, text_body="")
+
+
 class _BadCookie:
     def split(self, *_args, **_kwargs):
         raise RuntimeError("cannot split")
@@ -81,7 +93,7 @@ class _BadCookie:
 def _make_client(
     session: _FakeSession | MagicMock | None = None,
 ) -> api.EnphaseEVClient:
-    session = session or MagicMock()
+    session = session or _DefaultSession()
     return api.EnphaseEVClient(session, "SITE", "EAUTH", "COOKIE")
 
 


### PR DESCRIPTION
## Summary
- replace the default API client test session `MagicMock` with a lightweight synchronous stub that safely supports unexpected XSRF acquisition calls
- avoid Python 3.13 unawaited coroutine warnings in BatteryConfig-related tests without changing production code paths
- preserve 100% coverage for `custom_components/enphase_ev/api.py`

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/api.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
