### PR TITLE
Improve integration topology performance paths

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -418,6 +418,102 @@ def _sync_registry_devices(
     _sync_charger_devices(entry, coord, dev_reg, site_id, type_devices)
 
 
+def _registry_type_metadata_signature(coord) -> tuple[tuple[object, ...], ...]:
+    iter_type_keys = getattr(coord, "iter_type_keys", None)
+    type_identifier_fn = getattr(coord, "type_identifier", None)
+    type_label_fn = getattr(coord, "type_label", None)
+    type_device_name_fn = getattr(coord, "type_device_name", None)
+    type_device_model_fn = getattr(coord, "type_device_model", None)
+    type_device_hw_version_fn = getattr(coord, "type_device_hw_version", None)
+    type_device_serial_number_fn = getattr(coord, "type_device_serial_number", None)
+    type_device_model_id_fn = getattr(coord, "type_device_model_id", None)
+    type_device_sw_version_fn = getattr(coord, "type_device_sw_version", None)
+
+    type_keys = list(iter_type_keys()) if callable(iter_type_keys) else []
+    signature: list[tuple[object, ...]] = []
+    for type_key in type_keys:
+        if is_dry_contact_type_key(type_key):
+            continue
+        normalized = normalize_type_key(type_key) or _clean_optional_text(type_key) or ""
+        ident = type_identifier_fn(type_key) if callable(type_identifier_fn) else None
+        signature.append(
+            (
+                normalized,
+                ident,
+                _clean_optional_text(
+                    type_label_fn(type_key) if callable(type_label_fn) else None
+                ),
+                _clean_optional_text(
+                    type_device_name_fn(type_key)
+                    if callable(type_device_name_fn)
+                    else None
+                ),
+                _clean_optional_text(
+                    type_device_model_fn(type_key)
+                    if callable(type_device_model_fn)
+                    else None
+                ),
+                _clean_optional_text(
+                    type_device_hw_version_fn(type_key)
+                    if callable(type_device_hw_version_fn)
+                    else None
+                ),
+                _clean_optional_text(
+                    type_device_serial_number_fn(type_key)
+                    if callable(type_device_serial_number_fn)
+                    else None
+                ),
+                _clean_optional_text(
+                    type_device_model_id_fn(type_key)
+                    if callable(type_device_model_id_fn)
+                    else None
+                ),
+                _clean_optional_text(
+                    type_device_sw_version_fn(type_key)
+                    if callable(type_device_sw_version_fn)
+                    else None
+                ),
+            )
+        )
+    return tuple(signature)
+
+
+def _registry_charger_metadata_signature(coord) -> tuple[tuple[object, ...], ...]:
+    iter_serials = getattr(coord, "iter_serials", None)
+    serials = list(iter_serials()) if callable(iter_serials) else []
+    data_source = coord.data if isinstance(getattr(coord, "data", None), dict) else {}
+    signature: list[tuple[object, ...]] = []
+    for sn in serials:
+        payload = data_source.get(sn) or {}
+        display_name = _normalize_evse_display_name(payload.get("display_name"))
+        fallback_name = _normalize_evse_display_name(payload.get("name"))
+        device_name = display_name or fallback_name or f"Charger {sn}"
+        model_name_raw = payload.get("model_name")
+        model_display = _compose_charger_model_display(
+            display_name,
+            model_name_raw,
+            device_name,
+        )
+        signature.append(
+            (
+                str(sn),
+                device_name,
+                _clean_optional_text(model_display),
+                _clean_optional_text(payload.get("model_id")),
+                _clean_optional_text(payload.get("hw_version")),
+                _clean_optional_text(payload.get("sw_version")),
+            )
+        )
+    return tuple(signature)
+
+
+def _registry_metadata_signature(coord) -> tuple[tuple[object, ...], ...]:
+    return (
+        ("types", *_registry_type_metadata_signature(coord)),
+        ("chargers", *_registry_charger_metadata_signature(coord)),
+    )
+
+
 def _iter_entity_registry_entries(ent_reg) -> list[object]:
     entities = getattr(ent_reg, "entities", None)
     if entities is None:
@@ -940,22 +1036,29 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     dev_reg = dr.async_get(hass)
     _sync_registry_devices(entry, coord, dev_reg, site_id)
     _complete_startup_migrations_if_ready(hass, entry, coord, dev_reg, site_id)
+    last_registry_signature = _registry_metadata_signature(coord)
 
-    add_listener = getattr(coord, "async_add_listener", None)
-    if callable(add_listener):
+    def _sync_registry_on_update() -> None:
+        nonlocal last_registry_signature
 
-        def _sync_registry_on_update() -> None:
-            try:
+        try:
+            current_signature = _registry_metadata_signature(coord)
+            if current_signature != last_registry_signature:
                 _sync_registry_devices(entry, coord, dev_reg, site_id)
-                _complete_startup_migrations_if_ready(
-                    hass, entry, coord, dev_reg, site_id
-                )
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug(
-                    "Skipping registry sync for site %s after update: %s", site_id, err
-                )
+                last_registry_signature = current_signature
+            _complete_startup_migrations_if_ready(hass, entry, coord, dev_reg, site_id)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Skipping registry sync for site %s after update: %s", site_id, err
+            )
 
-        entry.async_on_unload(add_listener(_sync_registry_on_update))
+    add_topology_listener = getattr(coord, "async_add_topology_listener", None)
+    if callable(add_topology_listener):
+        entry.async_on_unload(add_topology_listener(_sync_registry_on_update))
+
+    add_state_listener = getattr(coord, "async_add_listener", None)
+    if callable(add_state_listener):
+        entry.async_on_unload(add_state_listener(_sync_registry_on_update))
 
     def _schedule_background_task(coro, name: str) -> None:
         entry_create_background = getattr(entry, "async_create_background_task", None)

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -84,8 +84,11 @@ async def async_setup_entry(
             async_add_entities(entities, update_before_add=False)
             known_serials.update(serials)
 
-    unsubscribe = coord.async_add_listener(_async_sync_chargers)
-    entry.async_on_unload(unsubscribe)
+    add_listener = getattr(coord, "async_add_topology_listener", None)
+    if not callable(add_listener):
+        add_listener = getattr(coord, "async_add_listener", None)
+    if callable(add_listener):
+        entry.async_on_unload(add_listener(_async_sync_chargers))
     _async_sync_chargers()
 
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import logging
 import random
+import re
 import time
 from dataclasses import dataclass
 from datetime import datetime, time as dt_time, timedelta
@@ -146,6 +147,18 @@ BATTERY_PROFILE_WRITE_DEBOUNCE_S = 2.0
 BATTERY_SETTINGS_WRITE_DEBOUNCE_S = 2.0
 DISCOVERY_SNAPSHOT_STORE_VERSION = 1
 DISCOVERY_SNAPSHOT_SAVE_DELAY_S = 1.0
+
+
+@dataclass(frozen=True)
+class CoordinatorTopologySnapshot:
+    charger_serials: tuple[str, ...]
+    battery_serials: tuple[str, ...]
+    inverter_serials: tuple[str, ...]
+    active_type_keys: tuple[str, ...]
+    gateway_iq_router_keys: tuple[str, ...]
+    inventory_ready: bool
+
+
 BATTERY_PROFILE_LABELS = {
     "self-consumption": "Self-Consumption",
     "cost_savings": "Savings",
@@ -317,6 +330,30 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._warmup_last_error: str | None = None
         self._restored_site_energy_channels: set[str] = set()
         self._restored_gateway_iq_energy_router_records: list[dict[str, object]] = []
+        self._topology_listeners: list[Callable[[], None]] = []
+        self._topology_snapshot_cache = CoordinatorTopologySnapshot(
+            charger_serials=(),
+            battery_serials=(),
+            inverter_serials=(),
+            active_type_keys=(),
+            gateway_iq_router_keys=(),
+            inventory_ready=False,
+        )
+        self._gateway_inventory_summary_cache: dict[str, object] = {}
+        self._gateway_inventory_summary_source: tuple[object, ...] | None = None
+        self._microinverter_inventory_summary_cache: dict[str, object] = {}
+        self._microinverter_inventory_summary_source: tuple[object, ...] | None = None
+        self._heatpump_inventory_summary_cache: dict[str, object] = {}
+        self._heatpump_inventory_summary_source: tuple[object, ...] | None = None
+        self._heatpump_type_summaries_cache: dict[str, dict[str, object]] = {}
+        self._heatpump_type_summaries_source: tuple[object, ...] | None = None
+        self._gateway_iq_energy_router_records_cache: list[dict[str, object]] = []
+        self._gateway_iq_energy_router_records_source: tuple[object, ...] | None = None
+        self._gateway_iq_energy_router_records_by_key_cache: dict[
+            str, dict[str, object]
+        ] = {}
+        self._topology_refresh_suppressed = 0
+        self._topology_refresh_pending = False
         self._site_energy_discovery_ready = False
         self._hems_inventory_ready = False
         self._refresh_lock = asyncio.Lock()
@@ -1001,6 +1038,175 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             session_manager.clear()
         self._session_history_cache_shim.clear()
         self._prune_runtime_caches(active_serials=(), keep_day_keys=())
+        self._topology_listeners.clear()
+
+    @callback
+    def async_add_topology_listener(
+        self, update_callback: Callable[[], None]
+    ) -> Callable[[], None]:
+        """Listen for topology-only changes."""
+        self._topology_listeners.append(update_callback)
+
+        @callback
+        def _remove_listener() -> None:
+            if update_callback in self._topology_listeners:
+                self._topology_listeners.remove(update_callback)
+
+        return _remove_listener
+
+    def topology_snapshot(self) -> CoordinatorTopologySnapshot:
+        """Return the latest cached topology snapshot."""
+        return self._topology_snapshot_cache
+
+    def gateway_inventory_summary(self) -> dict[str, object]:
+        source = self._gateway_inventory_summary_marker()
+        summary = getattr(self, "_gateway_inventory_summary_cache", {}) or {}
+        if not summary or source != self._gateway_inventory_summary_source:
+            summary = self._build_gateway_inventory_summary()
+            self._gateway_inventory_summary_cache = summary
+            self._gateway_inventory_summary_source = source
+        return dict(summary)
+
+    def microinverter_inventory_summary(self) -> dict[str, object]:
+        source = self._microinverter_inventory_summary_marker()
+        summary = getattr(self, "_microinverter_inventory_summary_cache", {}) or {}
+        if not summary or source != self._microinverter_inventory_summary_source:
+            summary = self._build_microinverter_inventory_summary()
+            self._microinverter_inventory_summary_cache = summary
+            self._microinverter_inventory_summary_source = source
+        return dict(summary)
+
+    def heatpump_inventory_summary(self) -> dict[str, object]:
+        source = self._heatpump_inventory_summary_marker()
+        summary = getattr(self, "_heatpump_inventory_summary_cache", {}) or {}
+        if not summary or source != self._heatpump_inventory_summary_source:
+            summary = self._build_heatpump_inventory_summary()
+            self._heatpump_inventory_summary_cache = summary
+            self._heatpump_inventory_summary_source = source
+        return dict(summary)
+
+    def heatpump_type_summary(self, device_type: str) -> dict[str, object]:
+        try:
+            normalized = str(device_type).strip().upper()
+        except Exception:  # noqa: BLE001
+            normalized = ""
+        source = self._heatpump_inventory_summary_marker()
+        summaries = getattr(self, "_heatpump_type_summaries_cache", {}) or {}
+        if source != self._heatpump_type_summaries_source or (
+            normalized and normalized not in summaries
+        ):
+            summaries = self._build_heatpump_type_summaries()
+            self._heatpump_type_summaries_cache = summaries
+            self._heatpump_type_summaries_source = source
+        summary = summaries.get(normalized, {})
+        return dict(summary) if isinstance(summary, dict) else {}
+
+    def gateway_iq_energy_router_summary_records(self) -> list[dict[str, object]]:
+        source = self._gateway_iq_energy_router_records_marker()
+        records = getattr(self, "_gateway_iq_energy_router_records_cache", [])
+        if not records or source != self._gateway_iq_energy_router_records_source:
+            records = self._gateway_iq_energy_router_summary_records(
+                self.gateway_iq_energy_router_records()
+            )
+            self._gateway_iq_energy_router_records_cache = records
+            self._gateway_iq_energy_router_records_source = source
+            self._gateway_iq_energy_router_records_by_key_cache = {
+                record["key"]: record
+                for record in records
+                if isinstance(record, dict) and isinstance(record.get("key"), str)
+            }
+        return [dict(record) for record in records if isinstance(record, dict)]
+
+    @staticmethod
+    def _router_record_key(record: object) -> str | None:
+        if not isinstance(record, dict):
+            return None
+        key = record.get("key")
+        if key is None:
+            return None
+        try:
+            key_text = str(key).strip()
+        except Exception:  # noqa: BLE001
+            return None
+        return key_text or None
+
+    def gateway_iq_energy_router_record(
+        self, router_key: object
+    ) -> dict[str, object] | None:
+        try:
+            key = str(router_key).strip()
+        except Exception:  # noqa: BLE001
+            return None
+        if not key:
+            return None
+        self.gateway_iq_energy_router_summary_records()
+        record = getattr(
+            self, "_gateway_iq_energy_router_records_by_key_cache", {}
+        ).get(key)
+        return dict(record) if isinstance(record, dict) else None
+
+    def _current_topology_snapshot(self) -> CoordinatorTopologySnapshot:
+        router_records = self.gateway_iq_energy_router_summary_records()
+        router_keys = tuple(
+            key
+            for key in (self._router_record_key(record) for record in router_records)
+            if key
+        )
+        return CoordinatorTopologySnapshot(
+            charger_serials=tuple(self.iter_serials()),
+            battery_serials=tuple(self.iter_battery_serials()),
+            inverter_serials=tuple(self.iter_inverter_serials()),
+            active_type_keys=tuple(self.iter_type_keys()),
+            gateway_iq_router_keys=router_keys,
+            inventory_ready=bool(
+                getattr(self, "_devices_inventory_ready", False)
+                or getattr(self, "_hems_inventory_ready", False)
+            ),
+        )
+
+    @callback
+    def _notify_topology_listeners(self) -> None:
+        for listener in list(self._topology_listeners):
+            try:
+                listener()
+            except Exception:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Topology listener failed for site %s", self.site_id, exc_info=True
+                )
+
+    @callback
+    def _refresh_cached_topology(self) -> bool:
+        if self._topology_refresh_suppressed > 0:
+            self._topology_refresh_pending = True
+            return False
+        try:
+            self._rebuild_inventory_summary_caches()
+            snapshot = self._current_topology_snapshot()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Skipping topology cache rebuild for site %s: %s",
+                self.site_id,
+                err,
+            )
+            return False
+        if snapshot == self._topology_snapshot_cache:
+            return False
+        self._topology_snapshot_cache = snapshot
+        self._notify_topology_listeners()
+        return True
+
+    @callback
+    def _begin_topology_refresh_batch(self) -> None:
+        self._topology_refresh_suppressed += 1
+
+    @callback
+    def _end_topology_refresh_batch(self) -> bool:
+        if self._topology_refresh_suppressed > 0:
+            self._topology_refresh_suppressed -= 1
+        if self._topology_refresh_suppressed > 0 or not self._topology_refresh_pending:
+            return False
+        self._topology_refresh_pending = False
+        return self._refresh_cached_topology()
 
     @staticmethod
     def _snapshot_compatible_value(value: object) -> object:
@@ -1260,6 +1466,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._restored_gateway_iq_energy_router_records = [
                 dict(item) for item in restored_router_records if isinstance(item, dict)
             ]
+        self._refresh_cached_topology()
 
     async def async_restore_discovery_state(self) -> None:
         if self._discovery_snapshot_loaded:
@@ -1321,6 +1528,123 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         current = self.data if isinstance(self.data, dict) else {}
         self.async_set_updated_data(dict(current))
 
+    async def _async_run_refresh_call(
+        self,
+        timing_key: str,
+        log_label: str,
+        callback_factory: Callable[[], object],
+    ) -> tuple[str, float | None]:
+        started = time.monotonic()
+        try:
+            result = callback_factory()
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Skipping %s refresh for site %s: %s",
+                log_label,
+                self.site_id,
+                err,
+            )
+        return timing_key, round(time.monotonic() - started, 3)
+
+    async def _async_run_refresh_calls(
+        self,
+        phase_timings: dict[str, float],
+        *,
+        calls: tuple[tuple[str, str, Callable[[], object]], ...],
+        stage_key: str | None = None,
+        defer_topology: bool = False,
+    ) -> None:
+        if defer_topology:
+            self._begin_topology_refresh_batch()
+
+        group_started = time.monotonic()
+        try:
+            results = await asyncio.gather(
+                *(
+                    self._async_run_refresh_call(
+                        timing_key, log_label, callback_factory
+                    )
+                    for timing_key, log_label, callback_factory in calls
+                )
+            )
+        finally:
+            if defer_topology:
+                self._end_topology_refresh_batch()
+
+        for timing_key, duration in results:
+            if duration is not None:
+                phase_timings[timing_key] = duration
+        if stage_key is not None:
+            phase_timings[f"{stage_key}_s"] = round(time.monotonic() - group_started, 3)
+
+    async def _async_run_ordered_refresh_calls(
+        self,
+        phase_timings: dict[str, float],
+        *,
+        calls: tuple[tuple[str, str, Callable[[], object]], ...],
+        stage_key: str | None = None,
+        defer_topology: bool = False,
+    ) -> None:
+        if defer_topology:
+            self._begin_topology_refresh_batch()
+
+        group_started = time.monotonic()
+        try:
+            for timing_key, log_label, callback_factory in calls:
+                key, duration = await self._async_run_refresh_call(
+                    timing_key,
+                    log_label,
+                    callback_factory,
+                )
+                if duration is not None:
+                    phase_timings[key] = duration
+        finally:
+            if defer_topology:
+                self._end_topology_refresh_batch()
+
+        if stage_key is not None:
+            phase_timings[f"{stage_key}_s"] = round(time.monotonic() - group_started, 3)
+
+    async def _async_run_staged_refresh_calls(
+        self,
+        phase_timings: dict[str, float],
+        *,
+        parallel_calls: tuple[tuple[str, str, Callable[[], object]], ...] = (),
+        ordered_calls: tuple[tuple[str, str, Callable[[], object]], ...] = (),
+        stage_key: str | None = None,
+        defer_topology: bool = False,
+    ) -> None:
+        if not parallel_calls and not ordered_calls:
+            if stage_key is not None:
+                phase_timings[f"{stage_key}_s"] = 0.0
+            return
+
+        if defer_topology:
+            self._begin_topology_refresh_batch()
+
+        group_started = time.monotonic()
+        try:
+            if parallel_calls:
+                await self._async_run_refresh_calls(
+                    phase_timings,
+                    calls=parallel_calls,
+                )
+            if ordered_calls:
+                await self._async_run_ordered_refresh_calls(
+                    phase_timings,
+                    calls=ordered_calls,
+                )
+        finally:
+            if defer_topology:
+                self._end_topology_refresh_batch()
+
+        if stage_key is not None:
+            phase_timings[f"{stage_key}_s"] = round(time.monotonic() - group_started, 3)
+
     async def async_ensure_system_dashboard_diagnostics(self) -> None:
         if (
             self._system_dashboard_type_summaries
@@ -1333,65 +1657,145 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         warmup_timings: dict[str, float] = {}
         self._warmup_in_progress = True
         self._warmup_last_error = None
-        stages: tuple[tuple[str, tuple[str, ...]], ...] = (
-            (
-                "discovery",
-                (
-                    "_async_refresh_battery_site_settings",
-                    "_async_refresh_devices_inventory",
-                    "_async_refresh_hems_devices",
-                    "_async_refresh_battery_status",
-                    "_async_refresh_inverters",
-                ),
-            ),
-            (
-                "state",
-                (
-                    "_async_refresh_battery_backup_history",
-                    "_async_refresh_battery_settings",
-                    "_async_refresh_battery_schedules",
-                    "_async_refresh_storm_guard_profile",
-                    "_async_refresh_storm_alert",
-                    "_async_refresh_grid_control_check",
-                    "_async_refresh_dry_contact_settings",
-                    "_async_refresh_evse_feature_flags",
-                    "_async_refresh_current_power_consumption",
-                    "_async_refresh_heatpump_power",
-                ),
-            ),
-            (
-                "energy",
-                (
-                    "_async_refresh_site_energy_for_warmup",
-                    "_async_refresh_evse_timeseries_for_warmup",
-                    "_async_refresh_session_state_for_warmup",
-                    "_async_refresh_secondary_evse_state_for_warmup",
-                ),
-            ),
+        warmup_data = (
+            {sn: dict(payload) for sn, payload in self.data.items()}
+            if isinstance(self.data, dict)
+            else {}
         )
         try:
-            for stage_name, method_names in stages:
-                stage_start = time.monotonic()
-                for method_name in method_names:
-                    method = getattr(self, method_name, None)
-                    if not callable(method):
-                        continue
-                    try:
-                        await method()
-                    except asyncio.CancelledError:
-                        raise
-                    except Exception as err:  # noqa: BLE001
-                        _LOGGER.debug(
-                            "Startup warmup %s step %s failed for site %s: %s",
-                            stage_name,
-                            method_name,
-                            self.site_id,
-                            err,
-                        )
-                warmup_timings[f"{stage_name}_s"] = round(
-                    time.monotonic() - stage_start, 3
+            await self._async_run_staged_refresh_calls(
+                warmup_timings,
+                stage_key="discovery",
+                defer_topology=True,
+                parallel_calls=(
+                    (
+                        "battery_site_settings_s",
+                        "battery site settings",
+                        lambda: self._async_refresh_battery_site_settings(),
+                    ),
+                ),
+                ordered_calls=(
+                    (
+                        "battery_status_s",
+                        "battery status",
+                        lambda: self._async_refresh_battery_status(),
+                    ),
+                    (
+                        "devices_inventory_s",
+                        "device inventory",
+                        lambda: self._async_refresh_devices_inventory(),
+                    ),
+                    (
+                        "hems_devices_s",
+                        "HEMS inventory",
+                        lambda: self._async_refresh_hems_devices(),
+                    ),
+                    (
+                        "inverters_s",
+                        "inverters",
+                        lambda: self._async_refresh_inverters(),
+                    ),
+                ),
+            )
+            await self._async_run_refresh_calls(
+                warmup_timings,
+                stage_key="state",
+                calls=(
+                    (
+                        "battery_backup_history_s",
+                        "battery backup history",
+                        lambda: self._async_refresh_battery_backup_history(),
+                    ),
+                    (
+                        "battery_settings_s",
+                        "battery settings",
+                        lambda: self._async_refresh_battery_settings(),
+                    ),
+                    (
+                        "battery_schedules_s",
+                        "battery schedules",
+                        lambda: self._async_refresh_battery_schedules(),
+                    ),
+                    (
+                        "storm_guard_s",
+                        "storm guard",
+                        lambda: self._async_refresh_storm_guard_profile(),
+                    ),
+                    (
+                        "storm_alert_s",
+                        "storm alert",
+                        lambda: self._async_refresh_storm_alert(),
+                    ),
+                    (
+                        "grid_control_check_s",
+                        "grid control",
+                        lambda: self._async_refresh_grid_control_check(),
+                    ),
+                    (
+                        "dry_contact_settings_s",
+                        "dry contact settings",
+                        lambda: self._async_refresh_dry_contact_settings(),
+                    ),
+                    (
+                        "evse_feature_flags_s",
+                        "EVSE feature flags",
+                        lambda: self._async_refresh_evse_feature_flags(),
+                    ),
+                    (
+                        "current_power_s",
+                        "current power consumption",
+                        lambda: self._async_refresh_current_power_consumption(),
+                    ),
+                ),
+            )
+            heatpump_started = time.monotonic()
+            try:
+                await self._async_refresh_heatpump_power()
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Skipping heat pump power refresh for site %s during warmup: %s",
+                    self.site_id,
+                    err,
                 )
-                self._publish_internal_state_update()
+            warmup_timings["heatpump_power_s"] = round(
+                time.monotonic() - heatpump_started, 3
+            )
+            await self._async_run_refresh_calls(
+                warmup_timings,
+                stage_key="energy",
+                calls=(
+                    (
+                        "site_energy_s",
+                        "site energy",
+                        lambda: self._async_refresh_site_energy_for_warmup(),
+                    ),
+                    (
+                        "evse_timeseries_s",
+                        "EVSE timeseries",
+                        lambda: self._async_refresh_evse_timeseries_for_warmup(
+                            working_data=warmup_data
+                        ),
+                    ),
+                    (
+                        "sessions_s",
+                        "session state",
+                        lambda: self._async_refresh_session_state_for_warmup(
+                            working_data=warmup_data
+                        ),
+                    ),
+                    (
+                        "secondary_evse_state_s",
+                        "secondary EVSE state",
+                        lambda: self._async_refresh_secondary_evse_state_for_warmup(
+                            working_data=warmup_data
+                        ),
+                    ),
+                ),
+            )
+            if warmup_data:
+                self.async_set_updated_data(warmup_data)
         except asyncio.CancelledError:
             raise
         except Exception as err:  # noqa: BLE001
@@ -1425,43 +1829,65 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._sync_site_energy_discovery_state()
         self._sync_site_energy_issue()
 
-    async def _async_refresh_evse_timeseries_for_warmup(self) -> None:
+    async def _async_refresh_evse_timeseries_for_warmup(
+        self,
+        *,
+        working_data: dict[str, dict[str, object]] | None = None,
+    ) -> None:
         try:
             day_local = dt_util.as_local(dt_util.now())
         except Exception:
             day_local = datetime.now(tz=_tz.utc)
         await self.evse_timeseries.async_refresh(day_local=day_local)
-        if isinstance(self.data, dict) and self.data:
-            updated = {sn: dict(payload) for sn, payload in self.data.items()}
-            self.evse_timeseries.merge_charger_payloads(updated, day_local=day_local)
-            self.async_set_updated_data(updated)
+        target = working_data
+        if target is None and isinstance(self.data, dict) and self.data:
+            target = {sn: dict(payload) for sn, payload in self.data.items()}
+        if target:
+            self.evse_timeseries.merge_charger_payloads(target, day_local=day_local)
+            if working_data is None:
+                self.async_set_updated_data(target)
 
-    async def _async_refresh_session_state_for_warmup(self) -> None:
-        if not isinstance(self.data, dict) or not self.data:
+    async def _async_refresh_session_state_for_warmup(
+        self,
+        *,
+        working_data: dict[str, dict[str, object]] | None = None,
+    ) -> None:
+        target = working_data if working_data is not None else self.data
+        if not isinstance(target, dict) or not target:
             return
         try:
             day_ref = dt_util.as_local(dt_util.now())
         except Exception:
             day_ref = datetime.now(tz=_tz.utc)
         updates = await self._async_enrich_sessions(
-            self.data.keys(),
+            target.keys(),
             day_ref,
             in_background=False,
         )
         if not updates:
             return
-        merged = {sn: dict(payload) for sn, payload in self.data.items()}
+        merged = (
+            target
+            if working_data is not None
+            else {sn: dict(payload) for sn, payload in target.items()}
+        )
         for sn, sessions in updates.items():
             payload = merged.get(sn)
             if payload is None:
                 continue
             payload["energy_today_sessions"] = sessions
             payload["energy_today_sessions_kwh"] = self._sum_session_energy(sessions)
-        self.async_set_updated_data(merged)
+        if working_data is None:
+            self.async_set_updated_data(merged)
         self._sync_session_history_issue()
 
-    async def _async_refresh_secondary_evse_state_for_warmup(self) -> None:
-        if not isinstance(self.data, dict) or not self.data:
+    async def _async_refresh_secondary_evse_state_for_warmup(
+        self,
+        *,
+        working_data: dict[str, dict[str, object]] | None = None,
+    ) -> None:
+        target = working_data if working_data is not None else self.data
+        if not isinstance(target, dict) or not target:
             return
         serials = [sn for sn in self.iter_serials() if sn]
         if not serials:
@@ -1469,7 +1895,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         charge_modes = await self._async_resolve_charge_modes(serials)
         green_settings = await self._async_resolve_green_battery_settings(serials)
         auth_settings = await self._async_resolve_auth_settings(serials)
-        merged = {sn: dict(payload) for sn, payload in self.data.items()}
+        merged = (
+            target
+            if working_data is not None
+            else {sn: dict(payload) for sn, payload in target.items()}
+        )
         for sn in serials:
             payload = merged.get(sn)
             if payload is None:
@@ -1499,7 +1929,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                         if value is not None
                     ]
                     payload["auth_required"] = any(values) if values else None
-        self.async_set_updated_data(merged)
+        if working_data is None:
+            self.async_set_updated_data(merged)
 
     def _parse_devices_inventory_payload(
         self, payload: object
@@ -1947,9 +2378,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 device_type_counts[device_type] = (
                     device_type_counts.get(device_type, 0) + 1
                 )
-                status_text = self._type_member_text(
-                    member, "statusText", "status_text", "status"
-                )
+                status_text = self._heatpump_status_text(member)
                 normalized_status = self._normalize_inverter_status(status_text)
                 status_counts[normalized_status] = (
                     int(status_counts.get(normalized_status, 0)) + 1
@@ -2033,6 +2462,651 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._set_type_device_buckets(buckets, ordered)
         if not ready_before:
             self._devices_inventory_ready = False
+        self._refresh_cached_topology()
+
+    @staticmethod
+    def _summary_text(value: object) -> str | None:
+        if value is None:
+            return None
+        try:
+            text = str(value).strip()
+        except Exception:  # noqa: BLE001
+            return None
+        return text or None
+
+    @classmethod
+    def _summary_identity(cls, value: object) -> str | None:
+        text = cls._summary_text(value)
+        if not text:
+            return None
+        normalized = re.sub(r"[^a-z0-9]+", "_", text.lower()).strip("_")
+        return normalized or None
+
+    def _summary_type_bucket_source(self, type_key: object) -> dict[str, object] | None:
+        normalized = normalize_type_key(type_key)
+        if not normalized:
+            return None
+        buckets = getattr(self, "_type_device_buckets", None)
+        if not isinstance(buckets, dict):
+            return None
+        bucket = buckets.get(normalized)
+        return bucket if isinstance(bucket, dict) else None
+
+    def _gateway_inventory_summary_marker(self) -> tuple[object, ...]:
+        dashboard_payloads = getattr(
+            self, "_system_dashboard_devices_details_raw", None
+        )
+        dashboard_envoy = (
+            dashboard_payloads.get("envoy")
+            if isinstance(dashboard_payloads, dict)
+            else None
+        )
+        return (
+            id(self._summary_type_bucket_source("envoy")),
+            id(dashboard_envoy),
+        )
+
+    def _microinverter_inventory_summary_marker(self) -> tuple[object, ...]:
+        return (id(self._summary_type_bucket_source("microinverter")),)
+
+    def _heatpump_inventory_summary_marker(self) -> tuple[object, ...]:
+        return (
+            id(self._summary_type_bucket_source("heatpump")),
+            id(getattr(self, "_hems_devices_payload", None)),
+            bool(getattr(self, "_hems_devices_using_stale", False)),
+            getattr(self, "_hems_devices_last_success_utc", None),
+            getattr(self, "_hems_devices_last_success_mono", None),
+        )
+
+    def _gateway_iq_energy_router_records_marker(self) -> tuple[object, ...]:
+        return (
+            id(getattr(self, "_hems_devices_payload", None)),
+            id(getattr(self, "_devices_inventory_payload", None)),
+            id(getattr(self, "_restored_gateway_iq_energy_router_records", None)),
+        )
+
+    @staticmethod
+    def _heatpump_status_text(member: dict[str, object] | None) -> str | None:
+        if not isinstance(member, dict):
+            return None
+        status_text = (
+            member.get("statusText")
+            if member.get("statusText") is not None
+            else member.get("status_text")
+        )
+        text = EnphaseCoordinator._summary_text(status_text)
+        if text:
+            return text
+        raw = EnphaseCoordinator._summary_text(member.get("status"))
+        if not raw:
+            return None
+        return raw.replace("_", " ").replace("-", " ").title()
+
+    @classmethod
+    def _gateway_iq_energy_router_summary_records(
+        cls, members: list[dict[str, object]]
+    ) -> list[dict[str, object]]:
+        records: list[dict[str, object]] = []
+        key_counts: dict[str, int] = {}
+        for member in members:
+            index = len(records) + 1
+            base_key = None
+            for key in ("device-uid", "device_uid", "uid"):
+                base_key = cls._summary_identity(member.get(key))
+                if base_key:
+                    break
+            if base_key is None:
+                name_identity = cls._summary_identity(member.get("name"))
+                base_key = (
+                    f"name_{name_identity}" if name_identity else f"index_{index}"
+                )
+            key_counts[base_key] = key_counts.get(base_key, 0) + 1
+            key = base_key
+            if key_counts[base_key] > 1:
+                key = f"{base_key}_{key_counts[base_key]}"
+            records.append(
+                {
+                    "key": key,
+                    "index": index,
+                    "name": cls._summary_text(member.get("name"))
+                    or f"IQ Energy Router_{index}",
+                    "member": dict(member),
+                }
+            )
+        return records
+
+    def _build_gateway_inventory_summary(self) -> dict[str, object]:
+        bucket = self.type_bucket("envoy") or {}
+        members_raw = bucket.get("devices")
+        members = (
+            [item for item in members_raw if isinstance(item, dict)]
+            if isinstance(members_raw, list)
+            else []
+        )
+        dashboard_envoy = self.system_dashboard_envoy_detail()
+        if not members and isinstance(dashboard_envoy, dict):
+            members = [dict(dashboard_envoy)]
+        try:
+            total_devices = int(bucket.get("count", len(members)) or 0)
+        except Exception:
+            total_devices = len(members)
+        total_devices = max(total_devices, len(members))
+        status_counts: dict[str, int] = {
+            "normal": 0,
+            "warning": 0,
+            "error": 0,
+            "not_reporting": 0,
+            "unknown": 0,
+        }
+        model_counts: dict[str, int] = {}
+        firmware_counts: dict[str, int] = {}
+        property_keys: set[str] = set()
+        connected_devices = 0
+        disconnected_devices = 0
+        latest_reported: datetime | None = None
+        latest_reported_device: dict[str, object] | None = None
+        without_last_report_count = 0
+
+        for member in members:
+            property_keys.update(str(key) for key in member.keys())
+            status_source = None
+            for key in ("statusText", "status_text", "status"):
+                if member.get(key) is not None:
+                    status_source = member.get(key)
+                    break
+            status = self._normalize_inverter_status(status_source)
+            status_counts[status] = status_counts.get(status, 0) + 1
+
+            connected = member.get("connected")
+            if isinstance(connected, str):
+                normalized_connected = connected.strip().lower()
+                if normalized_connected in {"true", "1", "yes", "y"}:
+                    connected = True
+                elif normalized_connected in {"false", "0", "no", "n"}:
+                    connected = False
+                else:
+                    connected = None
+            elif isinstance(connected, (int, float)):
+                connected = connected != 0
+            elif not isinstance(connected, bool):
+                connected = None
+            if connected is None:
+                if status == "normal":
+                    connected = True
+                elif status == "not_reporting":
+                    connected = False
+            if connected is True:
+                connected_devices += 1
+            elif connected is False:
+                disconnected_devices += 1
+
+            model_name = self._type_member_text(
+                member, "model", "model_name", "part_number", "device_type"
+            )
+            if model_name:
+                model_counts[model_name] = model_counts.get(model_name, 0) + 1
+            firmware_version = self._type_member_text(
+                member, "firmware_version", "sw_version", "software_version"
+            )
+            if firmware_version:
+                firmware_counts[firmware_version] = (
+                    firmware_counts.get(firmware_version, 0) + 1
+                )
+
+            parsed_last_report = None
+            for key in (
+                "last_report",
+                "last_reported",
+                "last_reported_at",
+                "last-report",
+            ):
+                parsed_last_report = self._parse_inverter_last_report(member.get(key))
+                if parsed_last_report is not None:
+                    break
+            if parsed_last_report is None:
+                without_last_report_count += 1
+                continue
+            if latest_reported is None or parsed_last_report > latest_reported:
+                latest_reported = parsed_last_report
+                latest_reported_device = {
+                    "name": self._summary_text(member.get("name")),
+                    "serial_number": self._summary_text(member.get("serial_number")),
+                    "status": self._summary_text(status_source),
+                }
+
+        unknown_connection_devices = max(
+            0, total_devices - connected_devices - disconnected_devices
+        )
+        status_summary = (
+            f"Normal {status_counts.get('normal', 0)} | "
+            f"Warning {status_counts.get('warning', 0)} | "
+            f"Error {status_counts.get('error', 0)} | "
+            f"Not Reporting {status_counts.get('not_reporting', 0)} | "
+            f"Unknown {status_counts.get('unknown', 0)}"
+            if total_devices > 0
+            else None
+        )
+        if latest_reported is None and isinstance(dashboard_envoy, dict):
+            fallback_last = None
+            for key in ("last_report", "last_interval_end_date"):
+                fallback_last = self._parse_inverter_last_report(
+                    dashboard_envoy.get(key)
+                )
+                if fallback_last is not None:
+                    break
+            if fallback_last is not None:
+                latest_reported = fallback_last
+                latest_reported_device = {
+                    "name": self._summary_text(dashboard_envoy.get("name"))
+                    or "IQ Gateway",
+                    "serial_number": self._summary_text(
+                        dashboard_envoy.get("serial_number")
+                    ),
+                    "status": self._summary_text(
+                        dashboard_envoy.get("statusText")
+                        if dashboard_envoy.get("statusText") is not None
+                        else dashboard_envoy.get("status")
+                    ),
+                }
+        return {
+            "total_devices": total_devices,
+            "connected_devices": connected_devices,
+            "disconnected_devices": disconnected_devices,
+            "unknown_connection_devices": unknown_connection_devices,
+            "without_last_report_count": without_last_report_count,
+            "status_counts": status_counts,
+            "status_summary": status_summary,
+            "model_counts": model_counts,
+            "model_summary": self._format_inverter_model_summary(model_counts),
+            "firmware_counts": firmware_counts,
+            "firmware_summary": self._format_inverter_model_summary(firmware_counts),
+            "latest_reported": latest_reported,
+            "latest_reported_utc": (
+                latest_reported.isoformat() if latest_reported is not None else None
+            ),
+            "latest_reported_device": latest_reported_device,
+            "property_keys": sorted(property_keys),
+        }
+
+    def _build_microinverter_inventory_summary(self) -> dict[str, object]:
+        bucket = self.type_bucket("microinverter") or {}
+        members = bucket.get("devices")
+        safe_members = (
+            [dict(item) for item in members if isinstance(item, dict)]
+            if isinstance(members, list)
+            else []
+        )
+        status_counts_raw = bucket.get("status_counts")
+        status_counts: dict[str, int] = {}
+        has_status_counts = isinstance(status_counts_raw, dict)
+        if isinstance(status_counts_raw, dict):
+            for key in (
+                "total",
+                "normal",
+                "warning",
+                "error",
+                "not_reporting",
+                "unknown",
+            ):
+                try:
+                    status_counts[key] = int(status_counts_raw.get(key, 0) or 0)
+                except Exception:
+                    status_counts[key] = 0
+        try:
+            total_inverters = int(bucket.get("count", len(safe_members)) or 0)
+        except Exception:
+            total_inverters = len(safe_members)
+        if status_counts.get("total", 0) > 0:
+            total_inverters = max(total_inverters, int(status_counts.get("total", 0)))
+        not_reporting = max(0, int(status_counts.get("not_reporting", 0)))
+        unknown = max(0, int(status_counts.get("unknown", 0)))
+        if not has_status_counts:
+            unknown = total_inverters
+        elif (
+            total_inverters > 0
+            and int(status_counts.get("total", 0) or 0) <= 0
+            and max(
+                0,
+                int(status_counts.get("normal", 0) or 0)
+                + int(status_counts.get("warning", 0) or 0)
+                + int(status_counts.get("error", 0) or 0)
+                + not_reporting
+                + unknown,
+            )
+            == 0
+        ):
+            unknown = total_inverters
+        known_status_total = not_reporting + unknown
+        if known_status_total > total_inverters:
+            unknown = max(0, unknown - (known_status_total - total_inverters))
+        reporting = max(0, total_inverters - not_reporting - unknown)
+        latest_reported = self._parse_inverter_last_report(
+            bucket.get("latest_reported_utc")
+            if bucket.get("latest_reported_utc") is not None
+            else bucket.get("latest_reported")
+        )
+        latest_reported_device = (
+            dict(bucket.get("latest_reported_device"))
+            if isinstance(bucket.get("latest_reported_device"), dict)
+            else None
+        )
+        if latest_reported is None:
+            for member in safe_members:
+                parsed_last = self._parse_inverter_last_report(
+                    member.get("last_report")
+                )
+                if parsed_last is None:
+                    continue
+                if latest_reported is None or parsed_last > latest_reported:
+                    latest_reported = parsed_last
+                    latest_reported_device = {
+                        "serial_number": self._summary_text(
+                            member.get("serial_number")
+                        ),
+                        "name": self._summary_text(member.get("name")),
+                        "status": self._summary_text(
+                            member.get("statusText")
+                            if member.get("statusText") is not None
+                            else member.get("status")
+                        ),
+                    }
+        snapshot: dict[str, object] = {
+            "total_inverters": total_inverters,
+            "reporting_inverters": reporting,
+            "not_reporting_inverters": not_reporting,
+            "unknown_inverters": unknown,
+            "status_counts": status_counts,
+            "status_summary": bucket.get("status_summary"),
+            "model_summary": bucket.get("model_summary"),
+            "firmware_summary": bucket.get("firmware_summary"),
+            "array_summary": bucket.get("array_summary"),
+            "panel_info": (
+                dict(bucket.get("panel_info"))
+                if isinstance(bucket.get("panel_info"), dict)
+                else None
+            ),
+            "status_type_counts": (
+                dict(bucket.get("status_type_counts"))
+                if isinstance(bucket.get("status_type_counts"), dict)
+                else None
+            ),
+            "latest_reported": latest_reported,
+            "latest_reported_utc": (
+                latest_reported.isoformat() if latest_reported is not None else None
+            ),
+            "latest_reported_device": latest_reported_device,
+            "production_start_date": bucket.get("production_start_date"),
+            "production_end_date": bucket.get("production_end_date"),
+        }
+        connectivity_state = bucket.get("connectivity_state")
+        if not isinstance(connectivity_state, str) or not connectivity_state.strip():
+            connectivity_state = "degraded"
+            if total_inverters <= 0:
+                connectivity_state = None
+            elif reporting >= total_inverters:
+                connectivity_state = "online"
+            elif reporting == 0 and not_reporting > 0:
+                connectivity_state = "offline"
+            elif reporting > 0 and reporting < total_inverters:
+                connectivity_state = "degraded"
+            elif unknown >= total_inverters:
+                connectivity_state = "unknown"
+        snapshot["connectivity_state"] = connectivity_state
+        return snapshot
+
+    def _build_heatpump_inventory_summary(self) -> dict[str, object]:
+        bucket = self.type_bucket("heatpump") or {}
+        members = bucket.get("devices")
+        safe_members = (
+            [dict(item) for item in members if isinstance(item, dict)]
+            if isinstance(members, list)
+            else []
+        )
+        status_counts_raw = bucket.get("status_counts")
+        status_counts: dict[str, int] | None = None
+        if isinstance(status_counts_raw, dict):
+            parsed_counts = {
+                "total": 0,
+                "normal": 0,
+                "warning": 0,
+                "error": 0,
+                "not_reporting": 0,
+                "unknown": 0,
+            }
+            try:
+                for key in parsed_counts:
+                    parsed_counts[key] = int(status_counts_raw.get(key, 0) or 0)
+                status_counts = parsed_counts
+            except Exception:
+                status_counts = None
+        if status_counts is None:
+            status_counts = {
+                "total": len(safe_members),
+                "normal": 0,
+                "warning": 0,
+                "error": 0,
+                "not_reporting": 0,
+                "unknown": 0,
+            }
+            for member in safe_members:
+                status_key = self._normalize_inverter_status(
+                    self._heatpump_status_text(member)
+                )
+                status_counts[status_key] = int(status_counts.get(status_key, 0)) + 1
+        try:
+            total_devices = int(bucket.get("count", len(safe_members)) or 0)
+        except Exception:
+            total_devices = len(safe_members)
+        total_devices = max(total_devices, len(safe_members))
+        status_counts["total"] = max(
+            int(status_counts.get("total", 0) or 0), total_devices
+        )
+        latest_reported = self._parse_inverter_last_report(
+            bucket.get("latest_reported_utc")
+            if bucket.get("latest_reported_utc") is not None
+            else bucket.get("latest_reported")
+        )
+        latest_reported_device = (
+            dict(bucket.get("latest_reported_device"))
+            if isinstance(bucket.get("latest_reported_device"), dict)
+            else None
+        )
+        without_last_report_count = 0
+        if latest_reported is None:
+            for member in safe_members:
+                member_last = None
+                for key in (
+                    "last_report",
+                    "last_reported",
+                    "last_reported_at",
+                    "last-report",
+                ):
+                    member_last = self._parse_inverter_last_report(member.get(key))
+                    if member_last is not None:
+                        break
+                if member_last is None:
+                    without_last_report_count += 1
+                    continue
+                if latest_reported is None or member_last > latest_reported:
+                    latest_reported = member_last
+                    latest_reported_device = {
+                        "device_type": self._heatpump_member_device_type(member),
+                        "name": self._summary_text(member.get("name")),
+                        "device_uid": self._type_member_text(
+                            member, "device_uid", "device-uid", "uid"
+                        ),
+                        "status": self._heatpump_status_text(member),
+                    }
+        overall_status_text = self._summary_text(bucket.get("overall_status_text"))
+        if not overall_status_text:
+            for member in safe_members:
+                if self._heatpump_member_device_type(member) != "HEAT_PUMP":
+                    continue
+                overall_status_text = self._heatpump_status_text(member)
+                if overall_status_text:
+                    break
+        if not overall_status_text:
+            overall_status_text = self._heatpump_worst_status_text(status_counts)
+        device_type_counts: dict[str, int] = {}
+        if isinstance(bucket.get("device_type_counts"), dict):
+            for key, value in bucket.get("device_type_counts", {}).items():
+                if key is None:
+                    continue
+                try:
+                    count = int(value)
+                except Exception:
+                    continue
+                if count > 0:
+                    device_type_counts[str(key)] = count
+        else:
+            for member in safe_members:
+                device_type = self._heatpump_member_device_type(member) or "UNKNOWN"
+                device_type_counts[device_type] = (
+                    device_type_counts.get(device_type, 0) + 1
+                )
+        status_summary = bucket.get("status_summary")
+        if not isinstance(status_summary, str) or not status_summary.strip():
+            status_summary = self._format_inverter_status_summary(status_counts)
+        hems_last_success_utc = getattr(self, "_hems_devices_last_success_utc", None)
+        if not isinstance(hems_last_success_utc, datetime):
+            hems_last_success_utc = None
+        hems_last_success_mono = getattr(self, "_hems_devices_last_success_mono", None)
+        hems_last_success_age_s: float | None = None
+        if isinstance(hems_last_success_mono, (int, float)):
+            age = time.monotonic() - float(hems_last_success_mono)
+            if age >= 0:
+                hems_last_success_age_s = round(age, 1)
+        return {
+            "total_devices": total_devices,
+            "members": safe_members,
+            "status_counts": status_counts,
+            "status_summary": status_summary,
+            "device_type_counts": device_type_counts,
+            "model_summary": bucket.get("model_summary"),
+            "firmware_summary": bucket.get("firmware_summary"),
+            "latest_reported": latest_reported,
+            "latest_reported_utc": (
+                latest_reported.isoformat() if latest_reported is not None else None
+            ),
+            "latest_reported_device": latest_reported_device,
+            "without_last_report_count": without_last_report_count,
+            "overall_status_text": overall_status_text,
+            "hems_data_stale": bool(getattr(self, "_hems_devices_using_stale", False)),
+            "hems_last_success_utc": (
+                hems_last_success_utc.isoformat()
+                if hems_last_success_utc is not None
+                else None
+            ),
+            "hems_last_success_age_s": hems_last_success_age_s,
+        }
+
+    def _build_heatpump_type_summaries(self) -> dict[str, dict[str, object]]:
+        snapshot = self._build_heatpump_inventory_summary()
+        members = [
+            member for member in snapshot.get("members", []) if isinstance(member, dict)
+        ]
+        summaries: dict[str, dict[str, object]] = {}
+        for device_type in sorted(
+            {
+                self._heatpump_member_device_type(member)
+                for member in members
+                if self._heatpump_member_device_type(member)
+            }
+        ):
+            type_members = [
+                member
+                for member in members
+                if self._heatpump_member_device_type(member) == device_type
+            ]
+            counts = {
+                "total": len(type_members),
+                "normal": 0,
+                "warning": 0,
+                "error": 0,
+                "not_reporting": 0,
+                "unknown": 0,
+            }
+            latest_reported: datetime | None = None
+            latest_device: dict[str, object] | None = None
+            status_texts: list[str] = []
+            for member in type_members:
+                status_text = self._heatpump_status_text(member)
+                if status_text:
+                    status_texts.append(status_text)
+                status_key = self._normalize_inverter_status(status_text)
+                counts[status_key] = int(counts.get(status_key, 0)) + 1
+                parsed_last = None
+                for key in (
+                    "last_report",
+                    "last_reported",
+                    "last_reported_at",
+                    "last-report",
+                ):
+                    parsed_last = self._parse_inverter_last_report(member.get(key))
+                    if parsed_last is not None:
+                        break
+                if parsed_last is not None and (
+                    latest_reported is None or parsed_last > latest_reported
+                ):
+                    latest_reported = parsed_last
+                    latest_device = {
+                        "name": self._summary_text(member.get("name")),
+                        "device_uid": self._type_member_text(
+                            member, "device_uid", "device-uid", "uid"
+                        ),
+                        "status": status_text,
+                    }
+            unique_statuses = list(dict.fromkeys(status_texts))
+            if len(unique_statuses) == 1:
+                native_status = unique_statuses[0]
+            else:
+                native_status = self._heatpump_worst_status_text(counts)
+            summaries[device_type] = {
+                "device_type": device_type,
+                "members": type_members,
+                "member_count": len(type_members),
+                "status_counts": counts,
+                "status_summary": self._format_inverter_status_summary(counts),
+                "native_status": native_status,
+                "latest_reported": latest_reported,
+                "latest_reported_utc": (
+                    latest_reported.isoformat() if latest_reported is not None else None
+                ),
+                "latest_reported_device": latest_device,
+                "hems_data_stale": snapshot.get("hems_data_stale"),
+                "hems_last_success_utc": snapshot.get("hems_last_success_utc"),
+                "hems_last_success_age_s": snapshot.get("hems_last_success_age_s"),
+            }
+        return summaries
+
+    @callback
+    def _rebuild_inventory_summary_caches(self) -> None:
+        gateway_source = self._gateway_inventory_summary_marker()
+        micro_source = self._microinverter_inventory_summary_marker()
+        heatpump_source = self._heatpump_inventory_summary_marker()
+        router_source = self._gateway_iq_energy_router_records_marker()
+        gateway_summary = self._build_gateway_inventory_summary()
+        micro_summary = self._build_microinverter_inventory_summary()
+        heatpump_summary = self._build_heatpump_inventory_summary()
+        heatpump_type_summaries = self._build_heatpump_type_summaries()
+        router_records = self._gateway_iq_energy_router_summary_records(
+            self.gateway_iq_energy_router_records()
+        )
+        self._gateway_inventory_summary_cache = gateway_summary
+        self._gateway_inventory_summary_source = gateway_source
+        self._microinverter_inventory_summary_cache = micro_summary
+        self._microinverter_inventory_summary_source = micro_source
+        self._heatpump_inventory_summary_cache = heatpump_summary
+        self._heatpump_inventory_summary_source = heatpump_source
+        self._heatpump_type_summaries_cache = heatpump_type_summaries
+        self._heatpump_type_summaries_source = heatpump_source
+        self._gateway_iq_energy_router_records_cache = router_records
+        self._gateway_iq_energy_router_records_source = router_source
+        self._gateway_iq_energy_router_records_by_key_cache = {
+            record["key"]: record
+            for record in router_records
+            if isinstance(record, dict) and isinstance(record.get("key"), str)
+        }
 
     async def _async_refresh_devices_inventory(self, *, force: bool = False) -> None:
         now = time.monotonic()
@@ -5414,59 +6488,87 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 time.monotonic() - site_energy_start, 3
             )
             if not first_refresh:
-                try:
-                    await self._async_refresh_battery_site_settings()
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Skipping battery site settings refresh: %s", err)
-                try:
-                    await self._async_refresh_battery_status()
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Skipping battery status refresh: %s", err)
-                try:
-                    await self._async_refresh_battery_backup_history()
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Skipping battery backup history refresh: %s", err)
-                try:
-                    await self._async_refresh_battery_settings()
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Skipping battery settings refresh: %s", err)
-                try:
-                    await self._async_refresh_battery_schedules()
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Skipping battery schedules refresh: %s", err)
-                try:
-                    await self._async_refresh_storm_guard_profile()
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Skipping storm guard refresh: %s", err)
-                try:
-                    await self._async_refresh_storm_alert()
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Skipping storm alert refresh: %s", err)
-                try:
-                    await self._async_refresh_grid_control_check()
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Skipping grid control refresh: %s", err)
-                try:
-                    await self._async_refresh_devices_inventory()
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Skipping device inventory refresh: %s", err)
-                try:
-                    await self._async_refresh_dry_contact_settings()
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Skipping dry contact settings refresh: %s", err)
-                try:
-                    await self._async_refresh_hems_devices()
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Skipping HEMS inventory refresh: %s", err)
-                try:
-                    await self._async_refresh_inverters()
-                except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Skipping inverter refresh: %s", err)
-                await self._async_refresh_current_power_consumption()
+                await self._async_run_staged_refresh_calls(
+                    phase_timings,
+                    defer_topology=True,
+                    parallel_calls=(
+                        (
+                            "battery_site_settings_s",
+                            "battery site settings",
+                            lambda: self._async_refresh_battery_site_settings(),
+                        ),
+                        (
+                            "battery_backup_history_s",
+                            "battery backup history",
+                            lambda: self._async_refresh_battery_backup_history(),
+                        ),
+                        (
+                            "battery_settings_s",
+                            "battery settings",
+                            lambda: self._async_refresh_battery_settings(),
+                        ),
+                        (
+                            "battery_schedules_s",
+                            "battery schedules",
+                            lambda: self._async_refresh_battery_schedules(),
+                        ),
+                        (
+                            "storm_guard_s",
+                            "storm guard",
+                            lambda: self._async_refresh_storm_guard_profile(),
+                        ),
+                        (
+                            "storm_alert_s",
+                            "storm alert",
+                            lambda: self._async_refresh_storm_alert(),
+                        ),
+                        (
+                            "grid_control_check_s",
+                            "grid control",
+                            lambda: self._async_refresh_grid_control_check(),
+                        ),
+                        (
+                            "dry_contact_settings_s",
+                            "dry contact settings",
+                            lambda: self._async_refresh_dry_contact_settings(),
+                        ),
+                        (
+                            "current_power_s",
+                            "current power consumption",
+                            lambda: self._async_refresh_current_power_consumption(),
+                        ),
+                    ),
+                    ordered_calls=(
+                        (
+                            "battery_status_s",
+                            "battery status",
+                            lambda: self._async_refresh_battery_status(),
+                        ),
+                        (
+                            "devices_inventory_s",
+                            "device inventory",
+                            lambda: self._async_refresh_devices_inventory(),
+                        ),
+                        (
+                            "hems_devices_s",
+                            "HEMS inventory",
+                            lambda: self._async_refresh_hems_devices(),
+                        ),
+                        (
+                            "inverters_s",
+                            "inverters",
+                            lambda: self._async_refresh_inverters(),
+                        ),
+                    ),
+                )
+                heatpump_started = time.monotonic()
                 try:
                     await self._async_refresh_heatpump_power()
                 except Exception as err:  # noqa: BLE001
                     _LOGGER.debug("Skipping heat pump power refresh: %s", err)
+                phase_timings["heatpump_power_s"] = round(
+                    time.monotonic() - heatpump_started, 3
+                )
             self._prune_runtime_caches(active_serials=(), keep_day_keys=())
             self._sync_battery_profile_pending_issue()
             self.last_success_utc = dt_util.utcnow()
@@ -5475,6 +6577,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._phase_timings = phase_timings.copy()
             if first_refresh:
                 self._bootstrap_phase_timings = phase_timings.copy()
+            self._refresh_cached_topology()
             self._schedule_discovery_snapshot_save()
             return {}
 
@@ -5777,95 +6880,73 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self.last_success_utc = dt_util.utcnow()
 
         if not first_refresh:
-            battery_site_settings_start = time.monotonic()
-            try:
-                await self._async_refresh_battery_site_settings()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Skipping battery site settings refresh: %s", err)
-            phase_timings["battery_site_settings_s"] = round(
-                time.monotonic() - battery_site_settings_start, 3
-            )
-            battery_status_start = time.monotonic()
-            try:
-                await self._async_refresh_battery_status()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Skipping battery status refresh: %s", err)
-            phase_timings["battery_status_s"] = round(
-                time.monotonic() - battery_status_start, 3
-            )
-            battery_backup_history_start = time.monotonic()
-            try:
-                await self._async_refresh_battery_backup_history()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Skipping battery backup history refresh: %s", err)
-            phase_timings["battery_backup_history_s"] = round(
-                time.monotonic() - battery_backup_history_start, 3
-            )
-            battery_settings_start = time.monotonic()
-            try:
-                await self._async_refresh_battery_settings()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Skipping battery settings refresh: %s", err)
-            phase_timings["battery_settings_s"] = round(
-                time.monotonic() - battery_settings_start, 3
-            )
-
-            battery_schedules_start = time.monotonic()
-            try:
-                await self._async_refresh_battery_schedules()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Skipping battery schedules refresh: %s", err)
-            phase_timings["battery_schedules_s"] = round(
-                time.monotonic() - battery_schedules_start, 3
-            )
-
-            storm_guard_start = time.monotonic()
-            try:
-                await self._async_refresh_storm_guard_profile()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Skipping storm guard refresh: %s", err)
-            phase_timings["storm_guard_s"] = round(
-                time.monotonic() - storm_guard_start, 3
-            )
-            storm_alert_start = time.monotonic()
-            try:
-                await self._async_refresh_storm_alert()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Skipping storm alert refresh: %s", err)
-            phase_timings["storm_alert_s"] = round(
-                time.monotonic() - storm_alert_start, 3
-            )
-            grid_control_check_start = time.monotonic()
-            try:
-                await self._async_refresh_grid_control_check()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Skipping grid control refresh: %s", err)
-            phase_timings["grid_control_check_s"] = round(
-                time.monotonic() - grid_control_check_start, 3
-            )
-            inventory_start = time.monotonic()
-            try:
-                await self._async_refresh_devices_inventory()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Skipping device inventory refresh: %s", err)
-            phase_timings["devices_inventory_s"] = round(
-                time.monotonic() - inventory_start, 3
-            )
-            dry_contact_settings_start = time.monotonic()
-            try:
-                await self._async_refresh_dry_contact_settings()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Skipping dry contact settings refresh: %s", err)
-            phase_timings["dry_contact_settings_s"] = round(
-                time.monotonic() - dry_contact_settings_start, 3
-            )
-            hems_inventory_start = time.monotonic()
-            try:
-                await self._async_refresh_hems_devices()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug("Skipping HEMS inventory refresh: %s", err)
-            phase_timings["hems_devices_s"] = round(
-                time.monotonic() - hems_inventory_start, 3
+            await self._async_run_staged_refresh_calls(
+                phase_timings,
+                defer_topology=True,
+                parallel_calls=(
+                    (
+                        "battery_site_settings_s",
+                        "battery site settings",
+                        lambda: self._async_refresh_battery_site_settings(),
+                    ),
+                    (
+                        "battery_backup_history_s",
+                        "battery backup history",
+                        lambda: self._async_refresh_battery_backup_history(),
+                    ),
+                    (
+                        "battery_settings_s",
+                        "battery settings",
+                        lambda: self._async_refresh_battery_settings(),
+                    ),
+                    (
+                        "battery_schedules_s",
+                        "battery schedules",
+                        lambda: self._async_refresh_battery_schedules(),
+                    ),
+                    (
+                        "storm_guard_s",
+                        "storm guard",
+                        lambda: self._async_refresh_storm_guard_profile(),
+                    ),
+                    (
+                        "storm_alert_s",
+                        "storm alert",
+                        lambda: self._async_refresh_storm_alert(),
+                    ),
+                    (
+                        "grid_control_check_s",
+                        "grid control",
+                        lambda: self._async_refresh_grid_control_check(),
+                    ),
+                    (
+                        "dry_contact_settings_s",
+                        "dry contact settings",
+                        lambda: self._async_refresh_dry_contact_settings(),
+                    ),
+                    (
+                        "current_power_s",
+                        "current power consumption",
+                        lambda: self._async_refresh_current_power_consumption(),
+                    ),
+                ),
+                ordered_calls=(
+                    (
+                        "battery_status_s",
+                        "battery status",
+                        lambda: self._async_refresh_battery_status(),
+                    ),
+                    (
+                        "devices_inventory_s",
+                        "device inventory",
+                        lambda: self._async_refresh_devices_inventory(),
+                    ),
+                    (
+                        "hems_devices_s",
+                        "HEMS inventory",
+                        lambda: self._async_refresh_hems_devices(),
+                    ),
+                ),
             )
 
         prev_data = self.data if isinstance(self.data, dict) else {}
@@ -6723,37 +7804,38 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._sync_session_history_issue()
 
         if not first_refresh:
-            evse_timeseries_start = time.monotonic()
+            await self._async_run_refresh_calls(
+                phase_timings,
+                defer_topology=True,
+                calls=(
+                    (
+                        "evse_timeseries_s",
+                        "EVSE timeseries",
+                        lambda: self.evse_timeseries.async_refresh(
+                            day_local=day_local_default
+                        ),
+                    ),
+                    (
+                        "site_energy_s",
+                        "site energy",
+                        lambda: self.energy._async_refresh_site_energy(),
+                    ),
+                    (
+                        "inverters_s",
+                        "inverters",
+                        lambda: self._async_refresh_inverters(),
+                    ),
+                ),
+            )
             try:
-                await self.evse_timeseries.async_refresh(day_local=day_local_default)
                 self.evse_timeseries.merge_charger_payloads(
                     out, day_local=day_local_default
                 )
-            except Exception:  # noqa: BLE001
+            except Exception:
                 pass
-            phase_timings["evse_timeseries_s"] = round(
-                time.monotonic() - evse_timeseries_start, 3
-            )
-
-            site_energy_start = time.monotonic()
-            await self.energy._async_refresh_site_energy()
             self._sync_site_energy_discovery_state()
             self._sync_site_energy_issue()
             self._sync_battery_profile_pending_issue()
-            phase_timings["site_energy_s"] = round(
-                time.monotonic() - site_energy_start, 3
-            )
-            inverter_start = time.monotonic()
-            try:
-                await self._async_refresh_inverters()
-            except Exception:  # noqa: BLE001
-                pass
-            phase_timings["inverters_s"] = round(time.monotonic() - inverter_start, 3)
-            current_power_start = time.monotonic()
-            await self._async_refresh_current_power_consumption()
-            phase_timings["current_power_s"] = round(
-                time.monotonic() - current_power_start, 3
-            )
             heatpump_power_start = time.monotonic()
             try:
                 await self._async_refresh_heatpump_power()
@@ -6783,6 +7865,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._phase_timings = phase_timings
         if first_refresh:
             self._bootstrap_phase_timings = phase_timings.copy()
+        self._refresh_cached_topology()
         self._schedule_discovery_snapshot_save()
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
@@ -9310,6 +10393,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._battery_aggregate_charge_pct = None
             self._battery_aggregate_status = None
             self._battery_aggregate_status_details = {}
+            self._refresh_cached_topology()
             return
 
         storages = payload.get("storages")
@@ -9466,6 +10550,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 payload.get("excluded_count")
             ),
         }
+        self._refresh_cached_topology()
 
     @staticmethod
     def _normalize_storm_guard_state(value) -> str | None:

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -83,8 +83,11 @@ async def async_setup_entry(
         async_add_entities(entities, update_before_add=False)
         known_serials.update(serials)
 
-    unsubscribe = coord.async_add_listener(_async_sync_chargers)
-    entry.async_on_unload(unsubscribe)
+    add_listener = getattr(coord, "async_add_topology_listener", None)
+    if not callable(add_listener):
+        add_listener = getattr(coord, "async_add_listener", None)
+    if callable(add_listener):
+        entry.async_on_unload(add_listener(_async_sync_chargers))
     _async_sync_chargers()
 
 

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -101,12 +101,17 @@ async def async_setup_entry(
     ent_reg = er.async_get(hass)
     known_site_entity_keys: set[str] = set()
     known_serials: set[str] = set()
+    known_storm_guard_serials: set[str] = set()
     known_battery_serials: set[str] = set()
     known_inverter_serials: set[str] = set()
     known_type_keys: set[str] = set()
     known_gateway_iq_router_keys: set[str] = set()
     battery_registry_pruned = False
     inverter_registry_pruned = False
+    last_type_key_set: set[str] | None = None
+    last_battery_serial_set: set[str] | None = None
+    last_charger_serial_set: set[str] | None = None
+    last_inverter_serial_set: set[str] | None = None
 
     def _site_sensor_unique_id(key: str) -> str:
         return f"{DOMAIN}_site_{coord.site_id}_{key}"
@@ -604,11 +609,7 @@ async def async_setup_entry(
 
     @callback
     def _async_sync_chargers() -> None:
-        _async_sync_site_entities()
-        _async_sync_batteries()
         serials = [sn for sn in coord.iter_serials() if sn and sn not in known_serials]
-        if not serials:
-            return
         per_serial_entities = []
         site_has_battery = _site_has_battery(coord)
         for sn in serials:
@@ -624,16 +625,28 @@ async def async_setup_entry(
             per_serial_entities.append(EnphaseLifetimeEnergySensor(coord, sn))
             if site_has_battery:
                 per_serial_entities.append(EnphaseStormGuardStateSensor(coord, sn))
+                known_storm_guard_serials.add(sn)
             # The following sensors were removed due to unreliable values in most deployments:
             # Connector Reason, Schedule Type/Start/End, Session Miles, Session Plug timestamps
+        if site_has_battery:
+            storm_guard_serials = [
+                sn
+                for sn in coord.iter_serials()
+                if sn and sn not in known_storm_guard_serials
+            ]
+            if storm_guard_serials:
+                per_serial_entities.extend(
+                    EnphaseStormGuardStateSensor(coord, sn) for sn in storm_guard_serials
+                )
+                known_storm_guard_serials.update(storm_guard_serials)
         if per_serial_entities:
             async_add_entities(per_serial_entities, update_before_add=False)
+        if serials:
             known_serials.update(serials)
 
     @callback
     def _async_sync_batteries() -> None:
         nonlocal battery_registry_pruned
-        _async_sync_type_inventory()
         site_has_battery = _site_has_battery(coord)
         if not site_has_battery or not _type_available(coord, "encharge"):
             current_serials: list[str] = []
@@ -705,7 +718,6 @@ async def async_setup_entry(
     @callback
     def _async_sync_inverters() -> None:
         nonlocal inverter_registry_pruned
-        _async_sync_type_inventory()
         current_serials = [
             sn for sn in getattr(coord, "iter_inverter_serials", lambda: [])() if sn
         ]
@@ -755,21 +767,52 @@ async def async_setup_entry(
             async_add_entities(entities, update_before_add=False)
             known_inverter_serials.update(serials)
 
-    unsubscribe = coord.async_add_listener(_async_sync_chargers)
-    entry.async_on_unload(unsubscribe)
-    unsubscribe_type = coord.async_add_listener(_async_sync_type_inventory)
-    entry.async_on_unload(unsubscribe_type)
-    unsubscribe_batteries = coord.async_add_listener(_async_sync_batteries)
-    entry.async_on_unload(unsubscribe_batteries)
-    unsubscribe_inverters = coord.async_add_listener(_async_sync_inverters)
-    entry.async_on_unload(unsubscribe_inverters)
+    @callback
+    def _async_sync_topology() -> None:
+        nonlocal last_type_key_set
+        nonlocal last_battery_serial_set
+        nonlocal last_charger_serial_set
+        nonlocal last_inverter_serial_set
+
+        current_type_keys = {
+            key
+            for key in getattr(coord, "iter_type_keys", lambda: [])()
+            if key
+        }
+        current_battery_serials = {
+            sn
+            for sn in getattr(coord, "iter_battery_serials", lambda: [])()
+            if sn
+        }
+        current_charger_serials = {sn for sn in coord.iter_serials() if sn}
+        current_inverter_serials = {
+            sn
+            for sn in getattr(coord, "iter_inverter_serials", lambda: [])()
+            if sn
+        }
+
+        _async_sync_site_entities()
+        _async_sync_type_inventory()
+        last_type_key_set = current_type_keys
+        if current_battery_serials != last_battery_serial_set:
+            _async_sync_batteries()
+            _async_sync_chargers()
+            last_battery_serial_set = current_battery_serials
+        if current_charger_serials != last_charger_serial_set:
+            _async_sync_chargers()
+            last_charger_serial_set = current_charger_serials
+        if current_inverter_serials != last_inverter_serial_set:
+            _async_sync_inverters()
+            last_inverter_serial_set = current_inverter_serials
+
+    add_topology_listener = getattr(coord, "async_add_topology_listener", None)
+    if not callable(add_topology_listener):
+        add_topology_listener = getattr(coord, "async_add_listener", None)
+    if callable(add_topology_listener):
+        entry.async_on_unload(add_topology_listener(_async_sync_topology))
     _async_prune_historical_charger_sensor_entities()
     _async_prune_removed_site_entities()
-    _async_sync_site_entities()
-    _async_sync_type_inventory()
-    _async_sync_batteries()
-    _async_sync_chargers()
-    _async_sync_inverters()
+    _async_sync_topology()
 
 
 class _BaseEVSensor(EnphaseBaseEntity, SensorEntity):
@@ -3335,6 +3378,14 @@ def _gateway_format_counts(counts: dict[str, int]) -> str | None:
 
 
 def _gateway_inventory_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
+    summary_getter = getattr(coord, "gateway_inventory_summary", None)
+    if callable(summary_getter):
+        try:
+            snapshot = summary_getter()
+        except Exception:  # noqa: BLE001
+            snapshot = None
+        if isinstance(snapshot, dict):
+            return snapshot
     bucket = coord.type_bucket("envoy") or {}
     members_raw = bucket.get("devices")
     members = (
@@ -3512,6 +3563,14 @@ def _microinverter_connectivity_state(snapshot: dict[str, object]) -> str | None
 
 
 def _microinverter_inventory_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
+    summary_getter = getattr(coord, "microinverter_inventory_summary", None)
+    if callable(summary_getter):
+        try:
+            snapshot = summary_getter()
+        except Exception:  # noqa: BLE001
+            snapshot = None
+        if isinstance(snapshot, dict):
+            return snapshot
     bucket = coord.type_bucket("microinverter") or {}
     members = bucket.get("devices")
     if isinstance(members, list):
@@ -3692,6 +3751,14 @@ def _heatpump_member_last_reported(member: dict[str, object] | None) -> datetime
 
 
 def _heatpump_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
+    summary_getter = getattr(coord, "heatpump_inventory_summary", None)
+    if callable(summary_getter):
+        try:
+            snapshot = summary_getter()
+        except Exception:  # noqa: BLE001
+            snapshot = None
+        if isinstance(snapshot, dict):
+            return snapshot
     bucket = coord.type_bucket("heatpump") or {}
     members = bucket.get("devices")
     safe_members = (
@@ -3828,6 +3895,14 @@ def _heatpump_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
 def _heatpump_type_snapshot(
     coord: EnphaseCoordinator, *, device_type: str
 ) -> dict[str, object]:
+    summary_getter = getattr(coord, "heatpump_type_summary", None)
+    if callable(summary_getter):
+        try:
+            snapshot = summary_getter(device_type)
+        except Exception:  # noqa: BLE001
+            snapshot = None
+        if isinstance(snapshot, dict):
+            return snapshot
     snapshot = _heatpump_snapshot(coord)
     members = [
         member
@@ -4071,6 +4146,14 @@ def _gateway_iq_energy_router_member_key(
 def _gateway_iq_energy_router_records(
     coord: EnphaseCoordinator,
 ) -> list[dict[str, object]]:
+    records_getter = getattr(coord, "gateway_iq_energy_router_summary_records", None)
+    if callable(records_getter):
+        try:
+            records = records_getter()
+        except Exception:  # noqa: BLE001
+            records = None
+        if isinstance(records, list):
+            return [dict(record) for record in records if isinstance(record, dict)]
     router_members: list[dict[str, object]] = []
     restored_records = getattr(coord, "gateway_iq_energy_router_records", None)
     if callable(restored_records):
@@ -4160,6 +4243,14 @@ def _gateway_iq_energy_router_record(
     key = _gateway_clean_text(router_key)
     if not key:
         return None
+    record_getter = getattr(coord, "gateway_iq_energy_router_record", None)
+    if callable(record_getter):
+        try:
+            record = record_getter(key)
+        except Exception:  # noqa: BLE001
+            record = None
+        if isinstance(record, dict):
+            return record
     for record in _gateway_iq_energy_router_records(coord):
         if _gateway_clean_text(record.get("key")) == key:
             return record

--- a/custom_components/enphase_ev/time.py
+++ b/custom_components/enphase_ev/time.py
@@ -120,8 +120,11 @@ async def async_setup_entry(
         )
         site_entities_added = True
 
-    unsubscribe = coord.async_add_listener(_async_sync_site_entities)
-    entry.async_on_unload(unsubscribe)
+    add_listener = getattr(coord, "async_add_topology_listener", None)
+    if not callable(add_listener):
+        add_listener = getattr(coord, "async_add_listener", None)
+    if callable(add_listener):
+        entry.async_on_unload(add_listener(_async_sync_site_entities))
     _async_sync_site_entities()
 
 

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -118,7 +118,9 @@ async def async_setup_entry(
         known_serials.update(serials)
 
     _async_sync_charger_updates()
-    add_listener = getattr(coord, "async_add_listener", None)
+    add_listener = getattr(coord, "async_add_topology_listener", None)
+    if not callable(add_listener):
+        add_listener = getattr(coord, "async_add_listener", None)
     if callable(add_listener):
         unsubscribe = add_listener(_async_sync_charger_updates)
         entry.async_on_unload(unsubscribe)

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -56,7 +56,7 @@ async def test_async_setup_entry_syncs_binary_sensors(
         callbacks.append(callback)
         return _stub_listener()
 
-    monkeypatch.setattr(coord, "async_add_listener", _capture_listener)
+    monkeypatch.setattr(coord, "async_add_topology_listener", _capture_listener)
 
     added = []
 
@@ -101,6 +101,26 @@ async def test_async_setup_entry_syncs_binary_sensors(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_falls_back_to_generic_listener_for_binary_sensors(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    callbacks: list[Callable[[], None]] = []
+
+    monkeypatch.setattr(coord, "async_add_topology_listener", None, raising=False)
+    monkeypatch.setattr(
+        coord,
+        "async_add_listener",
+        lambda callback: callbacks.append(callback) or _stub_listener(),
+    )
+
+    await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
+
+    assert callbacks
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_keeps_site_sensor_without_gateway_type(
     hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:
@@ -130,7 +150,7 @@ async def test_async_setup_entry_keeps_site_sensor_without_gateway_type(
     )
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
-    monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
+    monkeypatch.setattr(coord, "async_add_topology_listener", lambda callback: _stub_listener())
     added = []
 
     def _collect(entities, update_before_add=False):
@@ -164,7 +184,7 @@ async def test_async_setup_entry_keeps_site_sensor_when_inventory_unknown(
     coord._devices_inventory_ready = False  # noqa: SLF001
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
-    monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
+    monkeypatch.setattr(coord, "async_add_topology_listener", lambda callback: _stub_listener())
     added = []
 
     def _collect(entities, update_before_add=False):
@@ -213,7 +233,7 @@ async def test_async_setup_entry_does_not_duplicate_site_sensor_when_gateway_typ
         callbacks.append(callback)
         return _stub_listener()
 
-    monkeypatch.setattr(coord, "async_add_listener", _capture_listener)
+    monkeypatch.setattr(coord, "async_add_topology_listener", _capture_listener)
     added = []
 
     def _collect(entities, update_before_add=False):
@@ -286,7 +306,7 @@ async def test_async_setup_entry_adds_heatpump_sg_ready_binary_sensor_when_type_
         callbacks.append(callback)
         return _stub_listener()
 
-    monkeypatch.setattr(coord, "async_add_listener", _capture_listener)
+    monkeypatch.setattr(coord, "async_add_topology_listener", _capture_listener)
     added = []
 
     def _collect(entities, update_before_add=False):
@@ -371,7 +391,7 @@ async def test_async_setup_entry_prunes_heatpump_sg_ready_binary_sensor_when_typ
         ),
         async_remove=MagicMock(),
     )
-    monkeypatch.setattr(coord, "async_add_listener", _capture_listener)
+    monkeypatch.setattr(coord, "async_add_topology_listener", _capture_listener)
     monkeypatch.setattr(
         "custom_components.enphase_ev.binary_sensor.er.async_get",
         lambda _hass: fake_registry,
@@ -427,7 +447,7 @@ def test_ev_bool_sensors_reflect_coordinator_state(
             }
         }
     )
-    monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
+    monkeypatch.setattr(coord, "async_add_topology_listener", lambda callback: _stub_listener())
 
     plugged = PluggedInBinarySensor(coord, RANDOM_SERIAL)
     assert plugged.is_on is False
@@ -451,7 +471,7 @@ def test_site_cloud_reachable_binary_sensor_metadata(
 ) -> None:
     """Exercise availability, attributes, and device info for the site sensor."""
     coord = coordinator_factory(serials=[], data={})
-    monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
+    monkeypatch.setattr(coord, "async_add_topology_listener", lambda callback: _stub_listener())
 
     sensor = SiteCloudReachableBinarySensor(coord)
     assert sensor.translation_key == "cloud_reachable"
@@ -530,7 +550,7 @@ def test_heatpump_sg_ready_active_binary_sensor_metadata(
         },
         ["heatpump"],
     )
-    monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
+    monkeypatch.setattr(coord, "async_add_topology_listener", lambda callback: _stub_listener())
     coord._hems_devices_last_success_utc = datetime(2026, 3, 3, 7, 31, tzinfo=timezone.utc)  # noqa: SLF001
     coord._hems_devices_last_success_mono = time.monotonic() - 30  # noqa: SLF001
     coord._hems_devices_using_stale = True  # noqa: SLF001
@@ -620,7 +640,7 @@ def test_heatpump_sg_ready_active_binary_sensor_uses_dedicated_hems_inventory(
         }
     }
     coord._merge_heatpump_type_bucket()  # noqa: SLF001
-    monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
+    monkeypatch.setattr(coord, "async_add_topology_listener", lambda callback: _stub_listener())
 
     sensor = HeatPumpSgReadyActiveBinarySensor(coord)
     assert sensor.available is True
@@ -657,7 +677,7 @@ def test_heatpump_sg_ready_active_binary_sensor_stays_on_for_mixed_member_status
         },
         ["heatpump"],
     )
-    monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
+    monkeypatch.setattr(coord, "async_add_topology_listener", lambda callback: _stub_listener())
 
     sensor = HeatPumpSgReadyActiveBinarySensor(coord)
     assert sensor.available is True
@@ -671,7 +691,7 @@ def test_heatpump_sg_ready_active_binary_sensor_helper_edge_cases(
     coordinator_factory, monkeypatch
 ) -> None:
     coord = coordinator_factory(serials=[], data={})
-    monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
+    monkeypatch.setattr(coord, "async_add_topology_listener", lambda callback: _stub_listener())
     sensor = HeatPumpSgReadyActiveBinarySensor(coord)
 
     coord._set_type_device_buckets(  # noqa: SLF001
@@ -738,7 +758,7 @@ def test_heatpump_sg_ready_active_binary_sensor_unavailable_without_type(
 ) -> None:
     coord = coordinator_factory(serials=[], data={})
     coord.has_type_for_entities = lambda _type_key: False  # type: ignore[assignment]
-    monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
+    monkeypatch.setattr(coord, "async_add_topology_listener", lambda callback: _stub_listener())
 
     sensor = HeatPumpSgReadyActiveBinarySensor(coord)
     assert sensor.available is False
@@ -748,7 +768,7 @@ def test_site_cloud_reachable_binary_sensor_fallback_paths(
     coordinator_factory, monkeypatch
 ) -> None:
     coord = coordinator_factory(serials=[], data={})
-    monkeypatch.setattr(coord, "async_add_listener", lambda callback: _stub_listener())
+    monkeypatch.setattr(coord, "async_add_topology_listener", lambda callback: _stub_listener())
     coord.has_type_for_entities = lambda _type_key: False  # type: ignore[assignment]
     coord.last_update_success = False
 

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -3029,6 +3029,178 @@ def test_inverter_start_date_returns_none_when_unknown(coordinator_factory) -> N
     assert coord._inverter_start_date() is None  # noqa: SLF001
 
 
+@pytest.mark.asyncio
+async def test_refresh_helper_wrappers_cover_stage_and_topology_paths(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    phase_timings: dict[str, float] = {}
+    begin = Mock()
+    end = Mock(return_value=False)
+    coord._begin_topology_refresh_batch = begin  # type: ignore[assignment]  # noqa: SLF001
+    coord._end_topology_refresh_batch = end  # type: ignore[assignment]  # noqa: SLF001
+
+    await coord._async_run_ordered_refresh_calls(  # noqa: SLF001
+        phase_timings,
+        stage_key="ordered",
+        defer_topology=True,
+        calls=(("first_s", "first", AsyncMock(return_value=None)),),
+    )
+
+    assert "first_s" in phase_timings
+    assert "ordered_s" in phase_timings
+    begin.assert_called_once()
+    end.assert_called_once()
+
+    phase_timings.clear()
+    begin.reset_mock()
+    end.reset_mock()
+
+    await coord._async_run_staged_refresh_calls(  # noqa: SLF001
+        phase_timings,
+        stage_key="empty",
+    )
+
+    assert phase_timings == {"empty_s": 0.0}
+    begin.assert_not_called()
+    end.assert_not_called()
+
+
+def test_summary_type_bucket_source_guards_invalid_inputs(coordinator_factory) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._type_device_buckets = "bad"  # type: ignore[assignment]  # noqa: SLF001
+    assert coord._summary_type_bucket_source("envoy") is None  # noqa: SLF001
+    assert coord._summary_type_bucket_source(None) is None  # noqa: SLF001
+
+
+def test_publish_internal_state_update_copies_current_data(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.async_set_updated_data = Mock()  # type: ignore[assignment]
+
+    coord._publish_internal_state_update()  # noqa: SLF001
+
+    coord.async_set_updated_data.assert_called_once_with(dict(coord.data))
+
+
+def test_end_topology_refresh_batch_flushes_pending_refresh(coordinator_factory) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._topology_refresh_suppressed = 1  # noqa: SLF001
+    coord._topology_refresh_pending = True  # noqa: SLF001
+    coord._refresh_cached_topology = Mock(return_value=True)  # type: ignore[assignment]  # noqa: SLF001
+
+    assert coord._end_topology_refresh_batch() is True  # noqa: SLF001
+    coord._refresh_cached_topology.assert_called_once()
+    assert coord._topology_refresh_pending is False  # noqa: SLF001
+
+
+def test_topology_listener_and_summary_helpers_cover_edge_paths(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    calls: list[str] = []
+
+    class BadStr:
+        def __str__(self) -> str:
+            raise ValueError("boom")
+
+    remove = coord.async_add_topology_listener(lambda: calls.append("ok"))
+    coord.async_add_topology_listener(lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    coord._notify_topology_listeners()  # noqa: SLF001
+    assert calls == ["ok"]
+
+    remove()
+    assert coord.topology_snapshot() == coord._topology_snapshot_cache  # noqa: SLF001
+    assert len(coord._topology_listeners) == 1  # noqa: SLF001
+
+    coord._build_heatpump_type_summaries = Mock(return_value={})  # type: ignore[assignment]  # noqa: SLF001
+    assert coord.heatpump_type_summary(BadStr()) == {}
+
+    original_router_marker = coord._gateway_iq_energy_router_records_marker
+    coord._gateway_iq_energy_router_records_marker = lambda: ("stable",)  # type: ignore[assignment]  # noqa: SLF001
+    coord._gateway_iq_energy_router_records_cache = [{"key": "router_1", "name": "Router"}]  # noqa: SLF001
+    coord._gateway_iq_energy_router_records_source = ("stable",)  # noqa: SLF001
+    coord._gateway_iq_energy_router_records_by_key_cache = {  # noqa: SLF001
+        "router_1": {"key": "router_1", "name": "Router"}
+    }
+
+    assert coord._router_record_key("bad") is None  # noqa: SLF001
+    assert coord._router_record_key({"key": None}) is None  # noqa: SLF001
+    assert coord._router_record_key({"key": BadStr()}) is None  # noqa: SLF001
+    assert coord.gateway_iq_energy_router_record(BadStr()) is None
+    assert coord.gateway_iq_energy_router_record(" ") is None
+    assert coord.gateway_iq_energy_router_record("router_1") == {
+        "key": "router_1",
+        "name": "Router",
+    }
+    coord._gateway_iq_energy_router_records_marker = original_router_marker  # type: ignore[assignment]  # noqa: SLF001
+
+    assert coord._summary_text(BadStr()) is None  # noqa: SLF001
+    assert coord._summary_identity("Router Main") == "router_main"  # noqa: SLF001
+    assert coord._gateway_iq_energy_router_records_marker() == (  # noqa: SLF001
+        id(getattr(coord, "_hems_devices_payload", None)),
+        id(getattr(coord, "_devices_inventory_payload", None)),
+        id(getattr(coord, "_restored_gateway_iq_energy_router_records", None)),
+    )
+    assert coord._heatpump_status_text(None) is None  # noqa: SLF001
+
+    records = coord._gateway_iq_energy_router_summary_records(  # noqa: SLF001
+        [
+            {"name": "Router Main"},
+            {"name": "Router Main"},
+            {},
+        ]
+    )
+    assert [record["key"] for record in records] == [
+        "name_router_main",
+        "name_router_main_2",
+        "index_3",
+    ]
+
+
+def test_gateway_and_microinverter_summary_builders_cover_string_and_fallback_paths(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord.type_bucket = lambda type_key: {  # type: ignore[assignment]
+        "envoy": {
+            "count": 3,
+            "devices": [
+                {
+                    "name": "Gateway A",
+                    "statusText": "online",
+                    "connected": "yes",
+                    "model": "IQ Gateway",
+                    "envoy_sw_version": "8.2.0",
+                    "last_report": "2026-02-15T10:00:00Z",
+                },
+                {
+                    "name": "Gateway B",
+                    "status": "offline",
+                    "connected": "no",
+                },
+                {
+                    "name": "Gateway C",
+                    "status": "mystery",
+                    "connected": "maybe",
+                },
+            ],
+        },
+        "microinverter": {
+            "count": 3,
+            "devices": [],
+            "status_counts": {"total": 3, "unknown": 1},
+        },
+    }.get(type_key, {})
+
+    gateway_snapshot = coord._build_gateway_inventory_summary()  # noqa: SLF001
+    assert gateway_snapshot["connected_devices"] == 1
+    assert gateway_snapshot["disconnected_devices"] == 1
+    assert gateway_snapshot["unknown_connection_devices"] == 1
+
+    micro_snapshot = coord._build_microinverter_inventory_summary()  # noqa: SLF001
+    assert micro_snapshot["connectivity_state"] == "degraded"
+
+
 def test_inverter_start_date_uses_existing_snapshot_start_date(
     coordinator_factory,
 ) -> None:
@@ -4663,7 +4835,7 @@ async def test_startup_warmup_runner_and_task_edge_paths(
     coordinator_factory, monkeypatch
 ) -> None:
     coord = coordinator_factory()
-    coord._publish_internal_state_update = Mock(side_effect=RuntimeError("publish"))  # type: ignore[assignment]  # noqa: SLF001
+    coord.async_set_updated_data = Mock(side_effect=RuntimeError("publish"))  # type: ignore[assignment]
     coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
     coord._async_refresh_battery_site_settings = None  # type: ignore[assignment]  # noqa: SLF001
 
@@ -4677,6 +4849,25 @@ async def test_startup_warmup_runner_and_task_edge_paths(
     coord = coordinator_factory()
     coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
     coord._async_refresh_battery_site_settings = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        side_effect=asyncio.CancelledError()
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await coord._async_startup_warmup_runner()  # noqa: SLF001
+    assert coord._warmup_in_progress is False  # noqa: SLF001
+    coord._schedule_discovery_snapshot_save.assert_called_once()  # type: ignore[attr-defined]
+
+    coord = coordinator_factory()
+    coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
+    coord._async_refresh_heatpump_power = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        side_effect=RuntimeError("heatpump")
+    )
+    await coord._async_startup_warmup_runner()  # noqa: SLF001
+    assert "heatpump_power_s" in coord._warmup_phase_timings  # noqa: SLF001
+    coord._schedule_discovery_snapshot_save.assert_called_once()  # type: ignore[attr-defined]
+
+    coord = coordinator_factory()
+    coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
+    coord._async_refresh_heatpump_power = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=asyncio.CancelledError()
     )
     with pytest.raises(asyncio.CancelledError):
@@ -6935,6 +7126,172 @@ async def test_update_data_normal_ignores_optional_refresh_failures(
     assert "inverters_s" in coord.phase_timings
     assert "heatpump_power_s" in coord.phase_timings
     coord._get_charge_mode.assert_awaited_once_with(RANDOM_SERIAL)
+
+
+@pytest.mark.asyncio
+async def test_update_data_normal_ignores_merge_charger_payload_failures(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._scheduler_available = False  # noqa: SLF001
+    coord._scheduler_backoff_active = lambda: False  # type: ignore[assignment]  # noqa: SLF001
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "chargeMode": "IMMEDIATE",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                    "charging": False,
+                }
+            ],
+            "ts": 1_700_000_000,
+        }
+    )
+    coord.energy._async_refresh_site_energy = AsyncMock(return_value=None)  # noqa: SLF001
+    coord.evse_timeseries.async_refresh = AsyncMock(return_value=None)  # noqa: SLF001
+    coord.evse_timeseries.merge_charger_payloads = Mock(side_effect=RuntimeError("boom"))  # noqa: SLF001
+    coord._async_refresh_battery_site_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_status = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_backup_history = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_schedules = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_guard_profile = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_alert = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_grid_control_check = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_devices_inventory = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_dry_contact_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_hems_devices = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_inverters = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_current_power_consumption = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_heatpump_power = AsyncMock()  # noqa: SLF001
+    coord._get_charge_mode = AsyncMock(return_value="IMMEDIATE")  # type: ignore[assignment]  # noqa: SLF001
+    coord._async_resolve_green_battery_settings = AsyncMock(return_value={})  # noqa: SLF001
+    coord._async_resolve_auth_settings = AsyncMock(return_value={})  # noqa: SLF001
+    coord._sync_battery_profile_pending_issue = MagicMock()  # noqa: SLF001
+
+    result = await coord._async_update_data()  # noqa: SLF001
+
+    assert RANDOM_SERIAL in result
+
+
+@pytest.mark.asyncio
+async def test_update_data_site_only_orders_topology_mutations_deterministically(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord.site_only = True
+    coord.serials = set()
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord.energy._async_refresh_site_energy = AsyncMock(return_value=None)  # noqa: SLF001
+
+    order: list[str] = []
+
+    async def _record(name: str) -> None:
+        order.append(name)
+
+    async def _record_battery_status() -> None:
+        await _record("battery_status")
+
+    async def _record_devices_inventory() -> None:
+        await _record("devices_inventory")
+
+    async def _record_hems_devices() -> None:
+        await _record("hems_devices")
+
+    async def _record_inverters() -> None:
+        await _record("inverters")
+
+    async def _record_heatpump_power() -> None:
+        await _record("heatpump_power")
+
+    coord._async_refresh_battery_site_settings = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_battery_backup_history = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_battery_settings = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_battery_schedules = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_storm_guard_profile = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_storm_alert = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_grid_control_check = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_dry_contact_settings = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_current_power_consumption = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_battery_status = AsyncMock(side_effect=_record_battery_status)  # noqa: SLF001
+    coord._async_refresh_devices_inventory = AsyncMock(  # noqa: SLF001
+        side_effect=_record_devices_inventory
+    )
+    coord._async_refresh_hems_devices = AsyncMock(side_effect=_record_hems_devices)  # noqa: SLF001
+    coord._async_refresh_inverters = AsyncMock(side_effect=_record_inverters)  # noqa: SLF001
+    coord._async_refresh_heatpump_power = AsyncMock(side_effect=_record_heatpump_power)  # noqa: SLF001
+
+    await coord._async_update_data()  # noqa: SLF001
+
+    assert order == [
+        "battery_status",
+        "devices_inventory",
+        "hems_devices",
+        "inverters",
+        "heatpump_power",
+    ]
+
+
+def test_inventory_summary_helpers_reuse_stable_cache_markers(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "type_label": "Gateway",
+                "count": 1,
+                "devices": [{"serial_number": "GW-1", "name": "Gateway"}],
+            },
+            "microinverter": {
+                "type_key": "microinverter",
+                "type_label": "Microinverters",
+                "count": 1,
+                "devices": [{"serial_number": "INV-1", "name": "Inverter"}],
+            },
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 1,
+                "devices": [{"serial_number": "HP-1", "name": "Heat Pump"}],
+            },
+        },
+        ["envoy", "microinverter", "heatpump"],
+    )
+    coord._system_dashboard_devices_details_raw = {  # noqa: SLF001
+        "envoy": {"envoy": {"status": "normal"}}
+    }
+    coord._hems_devices_payload = {"result": {"devices": []}}  # noqa: SLF001
+
+    gateway_builder = Mock(return_value={"gateway": 1})
+    micro_builder = Mock(return_value={"micro": 1})
+    heatpump_builder = Mock(return_value={"heatpump": 1})
+    heatpump_type_builder = Mock(return_value={"HEAT_PUMP": {"count": 1}})
+
+    monkeypatch.setattr(coord, "_build_gateway_inventory_summary", gateway_builder)
+    monkeypatch.setattr(coord, "_build_microinverter_inventory_summary", micro_builder)
+    monkeypatch.setattr(coord, "_build_heatpump_inventory_summary", heatpump_builder)
+    monkeypatch.setattr(coord, "_build_heatpump_type_summaries", heatpump_type_builder)
+
+    assert coord.gateway_inventory_summary() == {"gateway": 1}
+    assert coord.gateway_inventory_summary() == {"gateway": 1}
+    assert coord.microinverter_inventory_summary() == {"micro": 1}
+    assert coord.microinverter_inventory_summary() == {"micro": 1}
+    assert coord.heatpump_inventory_summary() == {"heatpump": 1}
+    assert coord.heatpump_inventory_summary() == {"heatpump": 1}
+    assert coord.heatpump_type_summary("heat_pump") == {"count": 1}
+    assert coord.heatpump_type_summary("heat_pump") == {"count": 1}
+
+    assert gateway_builder.call_count == 1
+    assert micro_builder.call_count == 1
+    assert heatpump_builder.call_count == 1
+    assert heatpump_type_builder.call_count == 1
 
 
 def test_battery_status_helper_edge_cases(coordinator_factory) -> None:

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -25,10 +25,14 @@ from custom_components.enphase_ev import (
     _migrate_legacy_gateway_type_devices,
     _normalize_selected_type_keys,
     _normalize_evse_model_name,
+    _registry_charger_metadata_signature,
+    _registry_metadata_signature,
+    _registry_type_metadata_signature,
     _remove_legacy_inventory_entities,
     _startup_migration_version,
     _sync_charger_devices,
     _sync_type_devices,
+    async_setup,
     async_setup_entry,
     async_unload_entry,
 )
@@ -54,6 +58,58 @@ def test_normalize_selected_type_keys_covers_string_and_fallback_paths() -> None
 def test_startup_migration_version_returns_zero_for_invalid_value(config_entry) -> None:
     entry = SimpleNamespace(data={"startup_migration_version": "bad"})
     assert _startup_migration_version(entry) == 0
+
+
+@pytest.mark.asyncio
+async def test_async_setup_registers_services(hass: HomeAssistant, monkeypatch) -> None:
+    setup_services = Mock()
+    monkeypatch.setattr("custom_components.enphase_ev.async_setup_services", setup_services)
+
+    assert await async_setup(hass, {})
+    setup_services.assert_called_once()
+
+
+def test_registry_metadata_signature_skips_dry_contact_and_handles_missing_helpers() -> None:
+    coord = SimpleNamespace(
+        data={RANDOM_SERIAL: {"name": "Garage Charger", "sw_version": "1.0.0"}},
+        iter_serials=lambda: [RANDOM_SERIAL],
+        iter_type_keys=lambda: ["dry_contact_1", "iqevse"],
+        type_identifier=lambda key: (DOMAIN, f"type:{key}"),
+        type_label=lambda key: f"Label {key}",
+        type_device_name=lambda key: f"Name {key}",
+    )
+
+    type_signature = _registry_type_metadata_signature(coord)
+    assert type_signature == (
+        (
+            "iqevse",
+            (DOMAIN, "type:iqevse"),
+            "Label iqevse",
+            "Name iqevse",
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+    )
+
+    charger_signature = _registry_charger_metadata_signature(coord)
+    assert charger_signature == (
+        (
+            RANDOM_SERIAL,
+            "Garage Charger",
+            "Garage Charger",
+            None,
+            None,
+            "1.0.0",
+        ),
+    )
+
+    assert _registry_metadata_signature(coord) == (
+        ("types", *type_signature),
+        ("chargers", *charger_signature),
+    )
 
 
 def test_complete_startup_migrations_if_ready_ignores_failing_readiness_check(
@@ -786,7 +842,8 @@ async def test_async_setup_entry_registry_sync_listener_handles_exceptions(
     hass: HomeAssistant, config_entry, monkeypatch
 ) -> None:
     site_id = config_entry.data[CONF_SITE_ID]
-    listeners: list = []
+    topology_listeners: list = []
+    state_listeners: list = []
 
     class DummyCoordinator:
         def __init__(self) -> None:
@@ -813,8 +870,12 @@ async def test_async_setup_entry_registry_sync_listener_handles_exceptions(
         def type_device_name(self, _type_key: str) -> str:
             return "EV Chargers (1)"
 
+        def async_add_topology_listener(self, callback):
+            topology_listeners.append(callback)
+            return lambda: None
+
         def async_add_listener(self, callback):
-            listeners.append(callback)
+            state_listeners.append(callback)
             return lambda: None
 
     dummy_coord = DummyCoordinator()
@@ -826,13 +887,15 @@ async def test_async_setup_entry_registry_sync_listener_handles_exceptions(
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
 
     assert await async_setup_entry(hass, config_entry)
-    assert listeners, "expected setup to register a coordinator listener"
+    assert topology_listeners, "expected setup to register a topology listener"
+    assert state_listeners, "expected setup to register a state listener"
 
     def _boom(*_args, **_kwargs):
         raise RuntimeError("boom")
 
     monkeypatch.setattr("custom_components.enphase_ev._sync_registry_devices", _boom)
-    listeners[0]()  # should swallow and log internal sync exceptions
+    dummy_coord.data[RANDOM_SERIAL]["sw_version"] = "1.2.3"
+    state_listeners[0]()  # should swallow and log internal sync exceptions
 
 
 @pytest.mark.asyncio
@@ -2778,7 +2841,8 @@ async def test_async_setup_entry_registry_sync_listener_only_resyncs_devices_on_
     hass: HomeAssistant, config_entry, monkeypatch
 ) -> None:
     site_id = config_entry.data[CONF_SITE_ID]
-    listeners: list = []
+    topology_listeners: list = []
+    state_listeners: list = []
 
     class DummyCoordinator:
         def __init__(self) -> None:
@@ -2809,8 +2873,12 @@ async def test_async_setup_entry_registry_sync_listener_only_resyncs_devices_on_
         def startup_migrations_ready(self) -> bool:
             return self._startup_ready
 
+        def async_add_topology_listener(self, callback):
+            topology_listeners.append(callback)
+            return lambda: None
+
         def async_add_listener(self, callback):
-            listeners.append(callback)
+            state_listeners.append(callback)
             return lambda: None
 
     dummy_coord = DummyCoordinator()
@@ -2835,15 +2903,24 @@ async def test_async_setup_entry_registry_sync_listener_only_resyncs_devices_on_
     )
 
     assert await async_setup_entry(hass, config_entry)
-    assert listeners, "expected setup to register a coordinator listener"
+    assert topology_listeners, "expected setup to register a topology listener"
+    assert state_listeners, "expected setup to register a state listener"
     assert migrate.call_count == 0
     assert migrate_cloud.call_count == 0
     assert "startup_migration_version" not in config_entry.data
+    assert sync_registry_devices.call_count == 1
 
     dummy_coord._startup_ready = True
-    listeners[0]()
+    topology_listeners[0]()
 
-    assert sync_registry_devices.call_count >= 2
+    assert sync_registry_devices.call_count == 1
     assert migrate.call_count == 1
     assert migrate_cloud.call_count == 1
     assert config_entry.data["startup_migration_version"] == 1
+
+    state_listeners[0]()
+    assert sync_registry_devices.call_count == 1
+
+    dummy_coord.data[RANDOM_SERIAL]["sw_version"] = "1.2.3"
+    state_listeners[0]()
+    assert sync_registry_devices.call_count == 2

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -61,6 +61,28 @@ async def test_charge_mode_select(hass, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_falls_back_to_generic_listener_for_selects(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.select import async_setup_entry
+
+    coord = coordinator_factory()
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    callbacks: list = []
+
+    monkeypatch.setattr(coord, "async_add_topology_listener", None, raising=False)
+    monkeypatch.setattr(
+        coord,
+        "async_add_listener",
+        lambda callback: callbacks.append(callback) or (lambda: None),
+    )
+
+    await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
+
+    assert callbacks
+
+
+@pytest.mark.asyncio
 async def test_charge_mode_select_scheduled_requires_enabled_schedule(
     hass, monkeypatch
 ) -> None:
@@ -289,7 +311,7 @@ async def test_select_platform_async_setup_entry_filters_known_serials(
 
         return _remove
 
-    coord.async_add_listener = capture_listener  # type: ignore[attr-defined]
+    coord.async_add_topology_listener = capture_listener  # type: ignore[attr-defined]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     await async_setup_entry(hass, config_entry, capture_add)
@@ -329,7 +351,7 @@ async def test_select_platform_skips_system_profile_without_battery(
         listeners.append(callback)
         return lambda: None
 
-    coord.async_add_listener = capture_listener  # type: ignore[attr-defined]
+    coord.async_add_topology_listener = capture_listener  # type: ignore[attr-defined]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     await async_setup_entry(hass, config_entry, capture_add)

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -35,7 +35,7 @@ def _mk_coord(sn: str, payload: dict[str, Any]) -> Any:
     def _default_listener(callback, context=None):
         return lambda: None
 
-    coord.async_add_listener = _default_listener  # type: ignore[assignment]
+    coord.async_add_topology_listener = _default_listener  # type: ignore[assignment]
     coord.last_success_utc = None
     coord.last_failure_utc = None
     coord.last_failure_status = None
@@ -69,7 +69,7 @@ async def test_async_setup_entry_registers_entities(
         callbacks.append(cb)
         return lambda: None
 
-    coord.async_add_listener = fake_add_listener  # type: ignore[assignment]
+    coord.async_add_topology_listener = fake_add_listener  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     added = []
@@ -84,14 +84,14 @@ async def test_async_setup_entry_registers_entities(
     assert any(ent.unique_id.endswith("_charger_authentication") for ent in added)
     assert len([ent for ent in added if hasattr(ent, "_sn")]) == 11
 
-    sync_chargers_cb = next(cb for cb in callbacks if cb.__name__ == "_async_sync_chargers")
-    sync_chargers_cb()
+    sync_topology_cb = next(cb for cb in callbacks if cb.__name__ == "_async_sync_topology")
+    sync_topology_cb()
     assert len([ent for ent in added if hasattr(ent, "_sn")]) == 11
 
     new_sn = "NEWSN123"
     coord.data[new_sn] = dict(coord.data[RANDOM_SERIAL], sn=new_sn)
     coord.serials.add(new_sn)
-    sync_chargers_cb()
+    sync_topology_cb()
     assert len({ent._sn for ent in added if hasattr(ent, "_sn")}) == 2
 
 
@@ -162,6 +162,52 @@ async def test_async_setup_entry_restored_topology_adds_dynamic_entities(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_backfills_storm_guard_sensor_when_battery_appears(
+    hass, config_entry, coordinator_factory
+) -> None:
+    from custom_components.enphase_ev.sensor import async_setup_entry
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._battery_has_encharge = False  # noqa: SLF001
+    callbacks: list[Any] = []
+
+    def fake_add_listener(cb):
+        callbacks.append(cb)
+        return lambda: None
+
+    coord.async_add_topology_listener = fake_add_listener  # type: ignore[assignment]
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    added: list[Any] = []
+
+    def _async_add_entities(entities, update_before_add=False) -> None:
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _async_add_entities)
+
+    assert not any(
+        entity.__class__.__name__ == "EnphaseStormGuardStateSensor" for entity in added
+    )
+
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_storage_data = {  # noqa: SLF001
+        "BAT-1": {"serial_number": "BAT-1", "name": "Battery 1"}
+    }
+    coord._battery_storage_order = ["BAT-1"]  # noqa: SLF001
+
+    sync_topology_cb = next(cb for cb in callbacks if cb.__name__ == "_async_sync_topology")
+    sync_topology_cb()
+
+    storm_guard_entities = [
+        entity
+        for entity in added
+        if entity.__class__.__name__ == "EnphaseStormGuardStateSensor"
+    ]
+    assert len(storm_guard_entities) == 1
+    assert storm_guard_entities[0]._sn == RANDOM_SERIAL
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_site_energy_known_error_falls_back_to_bucket_lengths(
     hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:
@@ -183,7 +229,7 @@ async def test_async_setup_entry_site_energy_known_error_falls_back_to_bucket_le
         callbacks.append(cb)
         return lambda: None
 
-    coord.async_add_listener = fake_add_listener  # type: ignore[assignment]
+    coord.async_add_topology_listener = fake_add_listener  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     created: list[Any] = []
@@ -281,7 +327,7 @@ async def test_async_setup_entry_prunes_historical_charger_sensor_entities(
     from custom_components.enphase_ev.sensor import async_setup_entry
 
     coord = coordinator_factory(serials=[RANDOM_SERIAL])
-    coord.async_add_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
+    coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     removed_ids: list[str] = []
@@ -549,7 +595,7 @@ async def test_async_setup_entry_removes_battery_entity_on_serial_drop(
         callbacks.append(cb)
         return lambda: None
 
-    coord.async_add_listener = fake_add_listener  # type: ignore[assignment]
+    coord.async_add_topology_listener = fake_add_listener  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
@@ -590,7 +636,7 @@ async def test_async_setup_entry_removes_stale_battery_entity_after_restart(
     coord = coordinator_factory(serials=[RANDOM_SERIAL])
     coord._battery_storage_data = {}  # noqa: SLF001
     coord._battery_storage_order = []  # noqa: SLF001
-    coord.async_add_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
+    coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     removed_ids: list[str] = []
@@ -629,7 +675,7 @@ async def test_async_setup_entry_keeps_battery_site_summary_entities_on_registry
     coord = coordinator_factory(serials=[RANDOM_SERIAL])
     coord._battery_storage_data = {}  # noqa: SLF001
     coord._battery_storage_order = []  # noqa: SLF001
-    coord.async_add_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
+    coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     removed_ids: list[str] = []
@@ -684,7 +730,7 @@ async def test_async_setup_entry_keeps_current_battery_entity(
         }
     }
     coord._battery_storage_order = ["BAT-KEEP"]  # noqa: SLF001
-    coord.async_add_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
+    coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     removed_ids: list[str] = []
@@ -729,7 +775,7 @@ async def test_async_setup_entry_prunes_legacy_battery_last_reported_entities_fo
         }
     }
     coord._battery_storage_order = ["BAT-KEEP"]  # noqa: SLF001
-    coord.async_add_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
+    coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     removed_ids: list[str] = []
@@ -789,7 +835,7 @@ async def test_async_setup_entry_ignores_empty_battery_serial_unique_id(
     coord = coordinator_factory(serials=[RANDOM_SERIAL])
     coord._battery_storage_data = {}  # noqa: SLF001
     coord._battery_storage_order = []  # noqa: SLF001
-    coord.async_add_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
+    coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     removed_ids: list[str] = []
@@ -892,7 +938,7 @@ async def test_async_setup_entry_removes_deleted_inverter_entity(
         callbacks.append(cb)
         return lambda: None
 
-    coord.async_add_listener = _add_listener  # type: ignore[assignment]
+    coord.async_add_topology_listener = _add_listener  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     removed_ids: list[str] = []
@@ -927,7 +973,7 @@ async def test_async_setup_entry_removes_deleted_inverter_entity(
 
     await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
     sync_inverters = next(
-        cb for cb in callbacks if cb.__name__ == "_async_sync_inverters"
+        cb for cb in callbacks if cb.__name__ == "_async_sync_topology"
     )
 
     coord._inverter_data = {}  # noqa: SLF001
@@ -947,7 +993,7 @@ async def test_async_setup_entry_removes_stale_inverter_entity_after_restart(
     coord = coordinator_factory(serials=[RANDOM_SERIAL])
     coord._inverter_data = {}  # noqa: SLF001
     coord._inverter_order = []  # noqa: SLF001
-    coord.async_add_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
+    coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     removed_ids: list[str] = []
@@ -986,7 +1032,7 @@ async def test_async_setup_entry_registry_cleanup_filters_irrelevant_entries(
     coord = coordinator_factory(serials=[RANDOM_SERIAL])
     coord._inverter_data = {}  # noqa: SLF001
     coord._inverter_order = []  # noqa: SLF001
-    coord.async_add_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
+    coord.async_add_topology_listener = lambda _cb: (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     removed_ids: list[str] = []
@@ -1567,6 +1613,43 @@ def test_microinverter_snapshot_clamps_unknown_overflow(
     assert snapshot["connectivity_state"] == "offline"
 
 
+def test_microinverter_snapshot_fallback_covers_summary_error_and_zero_status_paths() -> None:
+    coord = SimpleNamespace(
+        microinverter_inventory_summary=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        type_bucket=lambda _type_key: {
+            "count": 2,
+            "devices": [
+                {
+                    "serial_number": "INV-A",
+                    "name": "Inverter A",
+                    "status": "normal",
+                    "last_report": "2026-02-15T10:00:00Z",
+                }
+            ],
+            "status_counts": {
+                "total": 0,
+                "normal": 0,
+                "warning": 0,
+                "error": 0,
+                "not_reporting": 0,
+                "unknown": 0,
+            },
+            "panel_info": {"panels": 1},
+            "status_type_counts": {"ok": 1},
+            "connectivity_state": " ",
+        },
+    )
+
+    snapshot = sensor_mod._microinverter_inventory_snapshot(coord)
+    assert snapshot["total_inverters"] == 2
+    assert snapshot["unknown_inverters"] == 2
+    assert snapshot["latest_reported_device"]["serial_number"] == "INV-A"
+    assert snapshot["panel_info"] == {"panels": 1}
+    assert snapshot["status_type_counts"] == {"ok": 1}
+    assert snapshot["connectivity_state"] == "unknown"
+    assert sensor_mod._microinverter_connectivity_state({"total_inverters": 0}) is None
+
+
 def test_microinverter_reporting_count_attributes_fallbacks(
     coordinator_factory,
 ) -> None:
@@ -1941,6 +2024,151 @@ def test_heatpump_sensor_availability_edge_paths(
         "Site Heat Pump Consumption",
     )
     assert site_sensor.extra_state_attributes["heat_pump_power_w"] is None
+
+
+def test_heatpump_snapshot_fallback_covers_summary_error_and_type_snapshot_paths() -> None:
+    mono_now = time.monotonic()
+    coord = SimpleNamespace(
+        heatpump_inventory_summary=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        heatpump_type_summary=lambda _device_type: (_ for _ in ()).throw(
+            RuntimeError("boom")
+        ),
+        type_bucket=lambda _type_key: {
+            "count": "bad-count",
+            "devices": [
+                {
+                    "device-type": "HEAT_PUMP",
+                    "name": "Heat Pump",
+                    "status": "not_reporting",
+                    "last-report": "2026-02-15T10:00:00Z",
+                },
+                {
+                    "device_type": "ENERGY_METER",
+                    "name": "Meter 1",
+                    "status": "warning",
+                    "device_uid": "EM-1",
+                    "last_reported": "2026-02-15T10:05:00Z",
+                },
+                {
+                    "device_type": "ENERGY_METER",
+                    "name": "Meter 2",
+                    "status_text": "Normal",
+                    "device-uid": "EM-2",
+                    "last_reported_at": "2026-02-15T10:06:00Z",
+                },
+                {"device_type": "", "name": "Unknown Member"},
+                "bad-member",
+            ],
+            "status_counts": {"total": "bad"},
+            "overall_status_text": " ",
+            "device_type_counts": {
+                None: 1,
+                "ENERGY_METER": "2",
+                "SG_READY_GATEWAY": "bad",
+                "ZERO": 0,
+            },
+            "status_summary": " ",
+            "model_summary": "Model A x1",
+            "firmware_summary": "FW x1",
+        },
+        _hems_devices_last_success_utc=datetime(2026, 2, 15, 10, 7, tzinfo=timezone.utc),
+        _hems_devices_last_success_mono=mono_now - 1.6,
+        _hems_devices_using_stale=True,
+    )
+
+    snapshot = sensor_mod._heatpump_snapshot(coord)
+    assert snapshot["total_devices"] == 4
+    assert snapshot["without_last_report_count"] == 1
+    assert snapshot["latest_reported_device"] == {
+        "device_type": "ENERGY_METER",
+        "name": "Meter 2",
+        "device_uid": "EM-2",
+        "status": "Normal",
+    }
+    assert snapshot["overall_status_text"] == "Not Reporting"
+    assert snapshot["device_type_counts"] == {"ENERGY_METER": 2}
+    assert snapshot["status_counts"] == {
+        "total": 4,
+        "normal": 1,
+        "warning": 1,
+        "error": 0,
+        "not_reporting": 1,
+        "unknown": 1,
+    }
+    assert snapshot["status_summary"] == (
+        "Normal 1 | Warning 1 | Error 0 | Not Reporting 1 | Unknown 1"
+    )
+    assert snapshot["model_summary"] == "Model A x1"
+    assert snapshot["firmware_summary"] == "FW x1"
+    assert snapshot["hems_data_stale"] is True
+    assert snapshot["hems_last_success_utc"] == "2026-02-15T10:07:00+00:00"
+    assert isinstance(snapshot["hems_last_success_age_s"], float)
+
+    energy_meter_snapshot = sensor_mod._heatpump_type_snapshot(
+        coord, device_type="energy_meter"
+    )
+    assert energy_meter_snapshot["device_type"] == "ENERGY_METER"
+    assert energy_meter_snapshot["member_count"] == 2
+    assert energy_meter_snapshot["latest_reported_device"] == {
+        "name": "Meter 2",
+        "device_uid": "EM-2",
+        "status": "Normal",
+    }
+    assert energy_meter_snapshot["native_status"] == "Warning"
+    assert energy_meter_snapshot["status_summary"] == (
+        "Normal 1 | Warning 1 | Error 0 | Not Reporting 0"
+    )
+    assert energy_meter_snapshot["hems_data_stale"] is True
+
+    heat_pump_type_snapshot = sensor_mod._heatpump_type_snapshot(
+        coord, device_type="heat_pump"
+    )
+    assert heat_pump_type_snapshot["member_count"] == 1
+    assert heat_pump_type_snapshot["native_status"] == "Not Reporting"
+
+
+def test_heatpump_snapshot_fallback_covers_remaining_edge_paths() -> None:
+    coord = SimpleNamespace(
+        heatpump_inventory_summary=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        heatpump_type_summary=lambda _device_type: (_ for _ in ()).throw(
+            RuntimeError("boom")
+        ),
+        type_bucket=lambda _type_key: {
+            "count": 0,
+            "devices": [
+                {"device_type": "ENERGY_METER", "name": "Meter A", "status": "warning"},
+                {
+                    "device_type": "SG_READY_GATEWAY",
+                    "name": "Gateway",
+                    "status": "normal",
+                    "last_report": "2026-02-15T10:00:00Z",
+                },
+            ],
+            "status_counts": {
+                "total": 2,
+                "normal": 1,
+                "warning": 1,
+                "error": 0,
+                "not_reporting": 0,
+                "unknown": 0,
+            },
+        },
+        _hems_devices_last_success_utc="bad",
+        _hems_devices_last_success_mono=None,
+        _hems_devices_using_stale=False,
+    )
+
+    snapshot = sensor_mod._heatpump_snapshot(coord)
+    assert snapshot["total_devices"] == 2
+    assert snapshot["without_last_report_count"] == 1
+    assert snapshot["overall_status_text"] == "Warning"
+    assert snapshot["device_type_counts"] == {"ENERGY_METER": 1, "SG_READY_GATEWAY": 1}
+    assert snapshot["hems_last_success_utc"] is None
+
+    type_snapshot = sensor_mod._heatpump_type_snapshot(coord, device_type="energy_meter")
+    assert type_snapshot["member_count"] == 1
+    assert type_snapshot["latest_reported_device"] is None
+    assert type_snapshot["native_status"] == "Warning"
 
 
 def test_gateway_meter_sensors_expose_status_and_meter_attributes(
@@ -2327,6 +2555,64 @@ async def test_async_setup_entry_adds_gateway_iq_energy_router_entities(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_skips_duplicate_gateway_iq_energy_router_entities_on_repeat_topology(
+    hass, config_entry, coordinator_factory
+) -> None:
+    from custom_components.enphase_ev.sensor import (
+        EnphaseGatewayIQEnergyRouterSensor,
+        async_setup_entry,
+    )
+
+    coord = coordinator_factory(serials=[])
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._hems_devices_payload = {  # noqa: SLF001
+        "data": {
+            "hems-devices": {
+                "gateway": [
+                    {
+                        "name": "IQ Energy Router_1",
+                        "device-type": "IQ_ENERGY_ROUTER",
+                        "device-uid": "5956621_IQ_ENERGY_ROUTER_1",
+                        "statusText": "Normal",
+                    }
+                ]
+            }
+        }
+    }
+    callbacks: list[Any] = []
+
+    def _add_listener(callback):
+        callbacks.append(callback)
+        return lambda: None
+
+    coord.async_add_topology_listener = _add_listener  # type: ignore[assignment]
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    added: list[Any] = []
+
+    def _capture(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _capture)
+    router_entities = [
+        entity
+        for entity in added
+        if isinstance(entity, EnphaseGatewayIQEnergyRouterSensor)
+    ]
+    assert len(router_entities) == 1
+
+    sync_topology_cb = next(cb for cb in callbacks if cb.__name__ == "_async_sync_topology")
+    sync_topology_cb()
+
+    router_entities = [
+        entity
+        for entity in added
+        if isinstance(entity, EnphaseGatewayIQEnergyRouterSensor)
+    ]
+    assert len(router_entities) == 1
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_adds_gateway_iq_energy_router_entities_without_envoy_type(
     hass, config_entry, coordinator_factory
 ) -> None:
@@ -2436,7 +2722,7 @@ async def test_async_setup_entry_gateway_iq_energy_router_sync_handles_invalid_r
         callbacks.append(cb)
         return lambda: None
 
-    coord.async_add_listener = fake_add_listener  # type: ignore[assignment]
+    coord.async_add_topology_listener = fake_add_listener  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     router_records = [
@@ -3380,6 +3666,8 @@ def test_gateway_helpers_cover_edge_paths(coordinator_factory) -> None:
         "status": "normal",
         "last_report": "2026-03-09T05:45:00+00:00",
     }
+    coord._gateway_inventory_summary_cache = {}  # noqa: SLF001
+    coord._gateway_inventory_summary_source = None  # noqa: SLF001
     fallback_snapshot = sensor_mod._gateway_inventory_snapshot(coord)
     assert fallback_snapshot["total_devices"] == 1
     assert fallback_snapshot["connected_devices"] == 1
@@ -3578,6 +3866,175 @@ def test_gateway_helpers_cover_edge_paths(coordinator_factory) -> None:
     )
 
 
+def test_gateway_inventory_snapshot_fallback_covers_summary_error_and_dashboard_fallback() -> None:
+    coord = SimpleNamespace(
+        gateway_inventory_summary=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        type_bucket=lambda _type_key: {
+            "count": "bad-count",
+            "devices": [
+                {
+                    "name": "Gateway A",
+                    "serial_number": "GW-A",
+                    "statusText": "Normal",
+                    "model": "IQ Gateway",
+                    "sw_version": "8.2.0",
+                    "last_reported": "2026-02-15T10:00:00Z",
+                },
+                {
+                    "name": "Gateway B",
+                    "serial_number": "GW-B",
+                    "status": "offline",
+                    "connected": None,
+                    "model_name": "System Controller",
+                    "firmware": "1.0.0",
+                },
+                {
+                    "name": "Gateway C",
+                    "serial_number": "GW-C",
+                    "status": "warn",
+                    "connected": "maybe",
+                    "firmwareVersion": "2.0.0",
+                    "last-report": "2026-02-15T10:05:00Z",
+                },
+            ],
+        },
+        system_dashboard_envoy_detail=lambda: {
+            "name": "",
+            "serial_number": "GW-D",
+            "status": "normal",
+            "last_interval_end_date": "2026-02-15T10:10:00Z",
+        },
+    )
+
+    snapshot = sensor_mod._gateway_inventory_snapshot(coord)
+    assert snapshot["total_devices"] == 3
+    assert snapshot["connected_devices"] == 1
+    assert snapshot["disconnected_devices"] == 1
+    assert snapshot["unknown_connection_devices"] == 1
+    assert snapshot["without_last_report_count"] == 2
+    assert snapshot["status_counts"] == {
+        "normal": 1,
+        "warning": 1,
+        "error": 0,
+        "not_reporting": 1,
+        "unknown": 0,
+    }
+    assert snapshot["status_summary"] == (
+        "Normal 1 | Warning 1 | Error 0 | Not Reporting 1 | Unknown 0"
+    )
+    assert snapshot["model_summary"] == "IQ Gateway x1"
+    assert snapshot["firmware_summary"] == "8.2.0 x1"
+    assert snapshot["latest_reported_device"] == {
+        "name": "Gateway A",
+        "serial_number": "GW-A",
+        "status": "Normal",
+    }
+    assert "statusText" in snapshot["property_keys"]
+
+    dashboard_only_coord = SimpleNamespace(
+        gateway_inventory_summary=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        type_bucket=lambda _type_key: {"count": 0, "devices": []},
+        system_dashboard_envoy_detail=lambda: {
+            "name": "",
+            "serial_number": "GW-FALLBACK",
+            "statusText": "Normal",
+            "last_interval_end_date": "2026-02-15T10:20:00Z",
+        },
+    )
+    fallback_snapshot = sensor_mod._gateway_inventory_snapshot(dashboard_only_coord)
+    assert fallback_snapshot["total_devices"] == 1
+    assert fallback_snapshot["latest_reported_device"] == {
+        "name": "IQ Gateway",
+        "serial_number": "GW-FALLBACK",
+        "status": "Normal",
+    }
+    assert fallback_snapshot["latest_reported_utc"] == "2026-02-15T10:20:00+00:00"
+
+
+def test_gateway_inventory_snapshot_zero_devices_returns_empty_status_summary() -> None:
+    coord = SimpleNamespace(
+        gateway_inventory_summary=lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        type_bucket=lambda _type_key: {"count": 0, "devices": []},
+        system_dashboard_envoy_detail=lambda: None,
+    )
+
+    snapshot = sensor_mod._gateway_inventory_snapshot(coord)
+    assert snapshot["total_devices"] == 0
+    assert snapshot["status_summary"] is None
+    assert snapshot["latest_reported_device"] is None
+
+
+def test_microinverter_snapshot_fallback_covers_bad_counts_and_missing_status_counts() -> None:
+    class BadInt:
+        def __int__(self) -> int:
+            raise ValueError("bad")
+
+    coord = SimpleNamespace(
+        microinverter_inventory_summary=lambda: (_ for _ in ()).throw(
+            RuntimeError("boom")
+        ),
+        type_bucket=lambda _type_key: {
+            "count": BadInt(),
+            "devices": [
+                {"serial_number": "INV-A"},
+                {
+                    "serial_number": "INV-B",
+                    "name": "Inverter B",
+                    "status": "warning",
+                    "last_report": "2026-02-15T11:00:00Z",
+                },
+            ],
+            "status_counts": {
+                "total": 1,
+                "normal": BadInt(),
+                "warning": 0,
+                "error": 0,
+                "not_reporting": 1,
+                "unknown": 2,
+            },
+            "latest_reported_device": "bad",
+            "connectivity_state": " ",
+        },
+    )
+
+    snapshot = sensor_mod._microinverter_inventory_snapshot(coord)
+    assert snapshot["total_inverters"] == 2
+    assert snapshot["not_reporting_inverters"] == 1
+    assert snapshot["unknown_inverters"] == 1
+    assert snapshot["latest_reported_device"] == {
+        "serial_number": "INV-B",
+        "name": "Inverter B",
+        "status": "warning",
+    }
+    assert snapshot["connectivity_state"] == "offline"
+
+    missing_status_counts_coord = SimpleNamespace(
+        microinverter_inventory_summary=lambda: (_ for _ in ()).throw(
+            RuntimeError("boom")
+        ),
+        type_bucket=lambda _type_key: {
+            "count": 2,
+            "devices": [],
+            "status_counts": "bad",
+            "connectivity_state": " ",
+        },
+    )
+    snapshot2 = sensor_mod._microinverter_inventory_snapshot(missing_status_counts_coord)
+    assert snapshot2["unknown_inverters"] == 2
+    assert snapshot2["connectivity_state"] == "unknown"
+    assert (
+        sensor_mod._microinverter_connectivity_state(
+            {
+                "total_inverters": 3,
+                "reporting_inverters": 1,
+                "not_reporting_inverters": 0,
+                "unknown_inverters": 0,
+            }
+        )
+        == "degraded"
+    )
+
+
 def test_gateway_diagnostic_sensor_availability_paths(coordinator_factory) -> None:
     from custom_components.enphase_ev.sensor import (
         EnphaseGatewayConnectivityStatusSensor,
@@ -3648,7 +4105,7 @@ async def test_async_setup_entry_adds_site_energy_entities(
         callbacks.append(cb)
         return lambda: None
 
-    coord.async_add_listener = fake_add_listener  # type: ignore[assignment]
+    coord.async_add_topology_listener = fake_add_listener  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     added: list = []
@@ -3708,7 +4165,7 @@ async def test_async_setup_entry_adds_optional_site_energy_entities_when_support
         callbacks.append(cb)
         return lambda: None
 
-    coord.async_add_listener = fake_add_listener  # type: ignore[assignment]
+    coord.async_add_topology_listener = fake_add_listener  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     created: list = []
@@ -3748,7 +4205,7 @@ async def test_async_setup_entry_skips_water_heater_site_energy_without_device_c
         callbacks.append(cb)
         return lambda: None
 
-    coord.async_add_listener = fake_add_listener  # type: ignore[assignment]
+    coord.async_add_topology_listener = fake_add_listener  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     created: list = []
@@ -3796,7 +4253,7 @@ async def test_async_setup_entry_keeps_water_heater_site_energy_when_flow_exists
         callbacks.append(cb)
         return lambda: None
 
-    coord.async_add_listener = fake_add_listener  # type: ignore[assignment]
+    coord.async_add_topology_listener = fake_add_listener  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     created: list = []
@@ -4577,12 +5034,12 @@ async def test_async_setup_entry_removes_known_dry_contact_type_inventory_entity
         lambda key: original(key) if flag["enabled"] else False,
     )
     callbacks: list[Any] = []
-    coord.async_add_listener = lambda cb: callbacks.append(cb) or (lambda: None)  # type: ignore[assignment]
+    coord.async_add_topology_listener = lambda cb: callbacks.append(cb) or (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
 
-    sync_type_cb = next(cb for cb in callbacks if cb.__name__ == "_async_sync_type_inventory")
+    sync_type_cb = next(cb for cb in callbacks if cb.__name__ == "_async_sync_topology")
     flag["enabled"] = True
     sync_type_cb()
 
@@ -4632,12 +5089,12 @@ async def test_async_setup_entry_known_dry_contact_removal_handles_missing_entit
         lambda key: original(key) if flag["enabled"] else False,
     )
     callbacks: list[Any] = []
-    coord.async_add_listener = lambda cb: callbacks.append(cb) or (lambda: None)  # type: ignore[assignment]
+    coord.async_add_topology_listener = lambda cb: callbacks.append(cb) or (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
 
-    sync_type_cb = next(cb for cb in callbacks if cb.__name__ == "_async_sync_type_inventory")
+    sync_type_cb = next(cb for cb in callbacks if cb.__name__ == "_async_sync_topology")
     flag["enabled"] = True
     sync_type_cb()
 
@@ -4687,12 +5144,12 @@ async def test_async_setup_entry_known_dry_contact_removal_handles_noncallable_l
         lambda key: original(key) if flag["enabled"] else False,
     )
     callbacks: list[Any] = []
-    coord.async_add_listener = lambda cb: callbacks.append(cb) or (lambda: None)  # type: ignore[assignment]
+    coord.async_add_topology_listener = lambda cb: callbacks.append(cb) or (lambda: None)  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
 
-    sync_type_cb = next(cb for cb in callbacks if cb.__name__ == "_async_sync_type_inventory")
+    sync_type_cb = next(cb for cb in callbacks if cb.__name__ == "_async_sync_topology")
     flag["enabled"] = True
     sync_type_cb()
 

--- a/tests/components/enphase_ev/test_time_module.py
+++ b/tests/components/enphase_ev/test_time_module.py
@@ -104,6 +104,26 @@ async def test_async_setup_entry_adds_site_time_entities(
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_falls_back_to_generic_listener_for_time_entities(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    callbacks: list = []
+
+    monkeypatch.setattr(coord, "async_add_topology_listener", None, raising=False)
+    monkeypatch.setattr(
+        coord,
+        "async_add_listener",
+        lambda callback: callbacks.append(callback) or (lambda: None),
+    )
+
+    await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
+
+    assert callbacks
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_migrates_charge_from_grid_time_entity_ids(
     hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:
@@ -337,7 +357,7 @@ async def test_async_setup_entry_does_not_duplicate_site_time_entities_on_listen
         callbacks.append(callback)
         return lambda: None
 
-    coord.async_add_listener = _capture_listener  # type: ignore[assignment]
+    coord.async_add_topology_listener = _capture_listener  # type: ignore[assignment]
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     added = []


### PR DESCRIPTION
## Summary
- refactor coordinator topology handling, dynamic entity reconciliation, and registry synchronization so topology work runs only on topology changes instead of every update
- cache gateway, microinverter, and heat pump inventory summaries, keep safe refresh work concurrent, and preserve deterministic ordering for topology-mutating refreshes
- broaden the regression suite to cover the new listener wiring, fallback branches, and inventory snapshot edge paths with 100% coverage on touched modules

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/binary_sensor.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/select.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/time.py,custom_components/enphase_ev/update.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
