### PR TITLE
Refine AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,7 @@
 ## Project Structure & Module Organization
 - Integration code lives in `custom_components/enphase_ev/`; the main coordination and API logic is concentrated in `coordinator.py`, `api.py`, `sensor.py`, `config_flow.py`, and the platform modules (`button.py`, `number.py`, `select.py`, `switch.py`, `update.py`).
 - Tests live in `tests/components/enphase_ev/`; keep new coverage close to the behavior being changed and reuse `conftest.py`, `random_ids.py`, fixture JSON, and snapshot files where possible.
-- User-facing strings are sourced from `custom_components/enphase_ev/strings.json` and mirrored in `custom_components/enphase_ev/translations/*.json`.
+- User-facing strings are maintained in `custom_components/enphase_ev/strings.json` and mirrored in `custom_components/enphase_ev/translations/*.json`.
 - Contributor documentation is in `README.md`, `CONTRIBUTING.md`, and `CHANGELOG.md`; API research and reference material are under `docs/api/`; maintenance scripts are under `scripts/`; the pinned Docker dev environment is under `devtools/docker/`.
 
 ## Build, Test, and Development Commands
@@ -19,28 +19,29 @@
   - `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"`
 - Keep changed Python modules at 100% targeted coverage:
   - `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m coverage erase && python -m coverage run -m pytest tests/components/enphase_ev -q && python -m coverage report -m --include=<comma-separated-paths> --fail-under=100"`
-- Use the actual on-disk pytest path in this checkout: `tests/components/enphase_ev/`.
+- When running pytest in Docker, target the on-disk test directory in this checkout: `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"`.
 
 ## Coding Style & Naming Conventions
 - Follow Home Assistant integration patterns and keep dependencies limited to the standard library or Home Assistant unless there is a strong reason otherwise.
 - Target Home Assistant `2024.12.0+` behavior and Python `3.13` syntax/runtime expectations.
+- Keep external I/O async and avoid blocking the event loop; use executor jobs only for genuinely blocking work.
 - Keep code Black-formatted, Ruff-clean, and consistent with lazy logging and clear type hints.
+- Keep `try` blocks narrow and raise the most specific Home Assistant exception available.
+- For transient setup failures, raise `ConfigEntryNotReady` from `async_setup_entry`; use `ConfigEntryAuthFailed` for expired or invalid credentials so Home Assistant can start reauth.
 - Name entities, services, and fixtures with explicit Enphase domain context.
-- For BatteryConfig/system-profile work, preserve canonical profile keys: `self-consumption`, `cost_savings`, and `backup_only`.
-- Preserve unknown regional BatteryConfig profile values as passthrough values.
-- Keep `showStormGuard` out of system-profile option logic; Storm Guard controls are separate.
 
 ## Testing Guidelines
 - Maintain 100% coverage for every touched file; cover new branches and guard paths, not just happy paths.
 - Pair source changes with matching tests in `tests/components/enphase_ev/`, including coordinator coverage when behavior is driven through refresh/update flows.
 - Reuse existing helper fixtures and deterministic IDs when mocking API payloads.
-- BatteryConfig profile/control changes must cover site-settings parsing, unknown profile passthrough, pending/apply/cancel lifecycle, and write lock/debounce behavior.
-- Diagnostics changes must verify redaction and any expected payload snapshots.
+- Prefer tests of Home Assistant integration behavior over tests of mock internals; assert outbound API calls directly for service actions.
+- For diagnostics changes, test that sensitive fields remain redacted and that the diagnostics output matches the expected payload.
 - Translation or repair-issue changes should include regression coverage when applicable, including `tests/components/enphase_ev/test_service_translations.py`.
 
 ## Translations, Docs, and Changelog
 - Any user-facing string change must update `custom_components/enphase_ev/strings.json` and every locale file under `custom_components/enphase_ev/translations/`.
 - Do not leave new non-English locale entries in English.
+- If translation or manifest changes need `hassfest` validation, follow `CONTRIBUTING.md` for the local workflow; CI also runs hassfest for this repository.
 - Update `README.md` or `docs/` when supported features, setup, or behavior change.
 - Update `CHANGELOG.md` for user-facing changes.
 
@@ -49,4 +50,4 @@
 - Repository contributor docs use branch names like `feature/...`, `bugfix/...`, or `docs/...`.
 - Before opening or updating a PR, run the relevant quality gates above and fill out `.github/pull_request_template.md`.
 - Include exact commands run in the PR testing section and call out coverage for touched modules.
-- Include screenshots or diagnostics when changing UI-visible strings, repairs, or diagnostics output.
+- Include diagnostics when changing repairs or diagnostics output.


### PR DESCRIPTION
## Summary
- tighten `AGENTS.md` around Docker-based test commands and Home Assistant-specific guidance
- remove overly specific BatteryConfig rules and clarify diagnostics/PR guidance
- keep `strings.json` as a maintained translation source alongside locale files

## Type of change
- [ ] Bugfix
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing
- [ ] `ruff check .`
- [ ] `black custom_components/enphase_ev`
- [ ] `pytest -q tests_enphase_ev`
- [ ] `python scripts/validate_quality_scale.py`
- [ ] `python -m script.hassfest`
- [ ] `pre-commit run --all-files`
- [x] Other (describe below)
  - Not run; docs-only change to `AGENTS.md`

## Checklist
- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Additional context
- This PR only updates contributor guidance in `AGENTS.md`.