### PR TITLE
Fix battery entity gating when regional inventory omits batteries

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -5456,7 +5456,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             return False
         if not getattr(self, "_devices_inventory_ready", False):
             return True
-        return self.has_type(normalized)
+        if self.has_type(normalized):
+            return True
+        # BatteryConfig site settings are a separate capability source from
+        # devices.json and are the authoritative battery-family signal on some
+        # regional deployments where the inventory bucket is missing or delayed.
+        if normalized == "encharge":
+            return getattr(self, "_battery_has_encharge", None) is True
+        return False
 
     def type_bucket(self, type_key: object) -> dict[str, object] | None:
         normalized = normalize_type_key(type_key)

--- a/tests/components/enphase_ev/test_region_type_fallbacks.py
+++ b/tests/components/enphase_ev/test_region_type_fallbacks.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.enphase_ev.number import (
+    BatteryReserveNumber,
+    async_setup_entry as async_setup_number_entry,
+)
+from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
+from custom_components.enphase_ev.sensor import EnphaseBatteryModeSensor
+from tests.components.enphase_ev.random_ids import RANDOM_SERIAL, RANDOM_SITE_ID
+
+
+def _inventory_without_battery(serial: str) -> dict[str, dict[str, object]]:
+    return {
+        "envoy": {
+            "type_key": "envoy",
+            "type_label": "Gateway",
+            "count": 1,
+            "devices": [
+                {"serial_number": f"GW-{RANDOM_SITE_ID}", "name": "IQ Gateway"}
+            ],
+        },
+        "iqevse": {
+            "type_key": "iqevse",
+            "type_label": "EV Chargers",
+            "count": 1,
+            "devices": [{"serial_number": serial, "name": "Garage EV"}],
+        },
+    }
+
+
+def test_has_type_for_entities_uses_battery_site_settings_fallback(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[], data={})
+    coord._set_type_device_buckets(  # noqa: SLF001
+        _inventory_without_battery(RANDOM_SERIAL),
+        ["envoy", "iqevse"],
+    )
+    coord._battery_has_encharge = True  # noqa: SLF001
+
+    assert coord.has_type("encharge") is False
+    assert coord.has_type_for_entities("encharge") is True
+
+
+def test_battery_mode_sensor_available_when_inventory_omits_encharge(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[], data={})
+    coord._set_type_device_buckets(  # noqa: SLF001
+        _inventory_without_battery(RANDOM_SERIAL),
+        ["envoy", "iqevse"],
+    )
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_grid_mode = "ImportExport"  # noqa: SLF001
+    coord.last_success_utc = dt_util.utcnow()
+
+    sensor = EnphaseBatteryModeSensor(coord)
+
+    assert sensor.available is True
+    assert sensor.native_value == "Import and Export"
+
+
+@pytest.mark.asyncio
+async def test_number_setup_adds_battery_entities_when_site_settings_confirm_battery(
+    hass,
+    config_entry,
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        _inventory_without_battery(RANDOM_SERIAL),
+        ["envoy", "iqevse"],
+    )
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord.async_add_listener = MagicMock(return_value=lambda: None)
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    added = []
+
+    def _capture(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_number_entry(hass, config_entry, _capture)
+
+    assert any(isinstance(entity, BatteryReserveNumber) for entity in added)


### PR DESCRIPTION
## Summary
- use BatteryConfig site settings as a fallback for battery entity gating when regional `devices.json` inventory omits the `encharge` bucket
- add regression coverage for battery entity availability and setup when battery site settings are present but inventory does not expose battery devices

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
