### PR TITLE
Infer missing heat pump interval metadata

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -5421,7 +5421,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         now_utc = dt_util.utcnow()
         if now_utc.tzinfo is None:
             now_utc = now_utc.replace(tzinfo=_tz.utc)
-        interval_minutes = EnphaseCoordinator._coerce_optional_int(
+        interval_minutes = EnphaseCoordinator._coerce_optional_float(
             payload.get("interval_minutes")
         )
         if interval_minutes is None:
@@ -5823,7 +5823,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
         start_utc = self._parse_inverter_last_report(payload.get("start_date"))
         self._heatpump_power_start_utc = start_utc
-        interval_minutes = self._coerce_optional_int(payload.get("interval_minutes"))
+        interval_minutes = self._coerce_optional_float(payload.get("interval_minutes"))
         if interval_minutes is None:
             values = payload.get("heat_pump_consumption")
             if isinstance(values, list):

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2299,6 +2299,26 @@ def test_heatpump_latest_power_sample_infers_missing_interval(
     ) == (620, 610.0)
 
 
+def test_heatpump_latest_power_sample_uses_float_interval_metadata(
+    coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = coordinator_factory(serials=[])
+    fixed_now = datetime(2026, 3, 18, 11, 24, tzinfo=timezone.utc)
+    monkeypatch.setattr(coord_mod.dt_util, "utcnow", lambda: fixed_now)
+    values = [0.0] * 672
+    values[620] = 610.0
+
+    assert coord._heatpump_latest_power_sample(  # noqa: SLF001
+        {
+            "heat_pump_consumption": values,
+            "start_date": "2026-03-12T00:00:00Z",
+            "interval_minutes": 15.0,
+        }
+    ) == (620, 610.0)
+
+
 def test_infer_heatpump_interval_minutes_uses_fallback_when_series_is_in_past(
     coordinator_factory,
 ) -> None:
@@ -2803,6 +2823,46 @@ async def test_refresh_heatpump_power_infers_missing_interval_metadata(
             "device_uid": "HP-1",
             "heat_pump_consumption": values,
             "start_date": "2026-03-12T00:00:00Z",
+        }
+    )
+
+    await coord._async_refresh_heatpump_power(force=True)  # noqa: SLF001
+
+    assert coord.heatpump_power_w == pytest.approx(610.0)
+    assert coord.heatpump_power_device_uid == "HP-1"
+    assert coord.heatpump_power_source == "hems_power_timeseries:HP-1"
+    assert coord.heatpump_power_sample_utc == datetime(
+        2026, 3, 18, 11, 0, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_heatpump_power_uses_float_interval_metadata(
+    coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    fixed_now = datetime(2026, 3, 18, 11, 24, tzinfo=timezone.utc)
+    monkeypatch.setattr(coord_mod.dt_util, "utcnow", lambda: fixed_now)
+    values = [0.0] * 672
+    values[620] = 610.0
+    coord.client.hems_power_timeseries = AsyncMock(
+        return_value={
+            "device_uid": "HP-1",
+            "heat_pump_consumption": values,
+            "start_date": "2026-03-12T00:00:00Z",
+            "interval_minutes": 15.0,
         }
     )
 


### PR DESCRIPTION
## Summary
- infer a common HEMS heat-pump bucket interval when `interval_minutes` is missing from `hems_power_timeseries`
- use the inferred interval both for selecting the latest valid power sample and for deriving `sampled_at_utc`
- add regression coverage for missing-interval sample selection and full coordinator refresh behavior

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_coordinator_behavior.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_behavior.py -k 'heatpump_power or infers_missing_interval'"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_behavior.py"`
