### PR TITLE
Fix service status timeline range

### DIFF
--- a/scripts/service_status.py
+++ b/scripts/service_status.py
@@ -698,17 +698,37 @@ def _incident_mermaid_duration(incident: dict[str, Any]) -> int:
     return max(duration, MIN_VISIBLE_INCIDENT_MINUTES)
 
 
+def _timeline_window(
+    *,
+    checked_at: str | None,
+) -> tuple[str, str]:
+    end_dt = _parse_iso_utc(checked_at)
+    if end_dt is None:
+        end_dt = datetime.now(timezone.utc)
+    start_dt = end_dt - timedelta(days=DEFAULT_HISTORY_DAYS)
+    if start_dt >= end_dt:
+        start_dt = end_dt - timedelta(hours=1)
+
+    return (
+        start_dt.strftime("%Y-%m-%dT%H:%M:%S"),
+        end_dt.strftime("%Y-%m-%dT%H:%M:%S"),
+    )
+
+
 def _render_mermaid_timeline(
     incidents: list[dict[str, Any]],
     *,
     checked_at: str | None,
 ) -> str:
+    timeline_start, timeline_end = _timeline_window(checked_at=checked_at)
     lines = [
         "```mermaid",
         "gantt",
         "    title Enphase Service Status Incident Timeline (Last 30 Days)",
         "    dateFormat  YYYY-MM-DDTHH:mm:ss",
         "    axisFormat  %b %d",
+        f"    Window start :vert, window-start, {timeline_start}, 0ms",
+        f"    Window end :vert, window-end, {timeline_end}, 0ms",
     ]
 
     grouped = {

--- a/tests/scripts/test_service_status.py
+++ b/tests/scripts/test_service_status.py
@@ -237,6 +237,25 @@ def test_render_mermaid_timeline_uses_colon_safe_labels(service_status_module) -
     assert "Degraded 1 (2026-03-12 16:50 UTC)" not in content
 
 
+def test_render_mermaid_timeline_anchors_to_30_day_window(
+    service_status_module,
+) -> None:
+    content = service_status_module._render_mermaid_timeline(
+        [
+            {
+                "status": "Degraded",
+                "started_at": "2026-03-12T16:50:43Z",
+                "duration_minutes": 60,
+            }
+        ],
+        checked_at="2026-03-18T23:23:31Z",
+    )
+
+    assert "Window start :vert, window-start, 2026-02-16T23:23:31, 0ms" in content
+    assert "Window end :vert, window-end, 2026-03-18T23:23:31, 0ms" in content
+    assert "section Window" not in content
+
+
 def test_write_outputs_generates_status_history_and_wiki(
     service_status_module, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary
- anchor the service-status gantt chart to `checked_at - 30 days` so the rendered range matches the chart title
- use Mermaid `vert` markers instead of synthetic task rows so range bounds do not appear as incidents
- add regression coverage for the 30-day window behavior

## Testing
- `pytest tests/scripts/test_service_status.py -q`
