### PR TITLE
Fix stable heat pump power selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Fixed lifetime-derived site power sensors so they no longer expose stale or nonsensical startup wattage when only incomplete lifetime-energy history is available.
+- Fixed heat-pump power selection so stable HEMS inventories continue ranking alternate device payloads when the previously selected source reports zero or empty samples, avoiding stale low-power picks on delayed backend updates.
 
 ### 🔧 Improvements
 - Removed stale deprecated split grid-power entities during sensor sync and localized the new `Current Grid Power` label across all supported locales.

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -5760,21 +5760,6 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             if not isinstance(current_payload, dict):
                 continue
             current_sample = self._heatpump_latest_power_sample(current_payload)
-            if not compare_all:
-                if payload is None:
-                    payload = current_payload
-                    requested_uid = candidate_uid
-                if current_sample is None:
-                    continue
-                payload = current_payload
-                requested_uid = candidate_uid
-                sample = current_sample
-                selected_key = self._heatpump_power_selection_key(
-                    current_payload,
-                    requested_uid=candidate_uid,
-                    sample=current_sample,
-                )
-                break
             current_key = self._heatpump_power_selection_key(
                 current_payload,
                 requested_uid=candidate_uid,

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -3290,9 +3290,219 @@ async def test_refresh_heatpump_power_reuses_selected_uid_when_inventory_stable(
         call.kwargs.get("device_uid")
         for call in coord.client.hems_power_timeseries.await_args_list
     ]
-    assert requested_uids == ["HP-METER"]
+    assert requested_uids == ["HP-METER", "HP-CTRL", None]
     assert coord.heatpump_power_w == pytest.approx(600.0)
     assert coord.heatpump_power_device_uid == "HP-METER"
+
+
+@pytest.mark.asyncio
+async def test_refresh_heatpump_power_stable_inventory_switches_from_zero_sample(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 2,
+                "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-CTRL",
+                        "statusText": "Normal",
+                    },
+                    {
+                        "device_type": "ENERGY_METER",
+                        "device_uid": "HP-METER",
+                        "statusText": "Normal",
+                    },
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._heatpump_power_selection_marker = (
+        coord._heatpump_power_inventory_marker()
+    )  # noqa: SLF001
+    coord._heatpump_power_device_uid = "HP-CTRL"  # noqa: SLF001
+
+    coord.client.hems_power_timeseries = AsyncMock(
+        side_effect=[
+            {"device_uid": "HP-CTRL", "heat_pump_consumption": [0.0]},
+            {"device_uid": "HP-METER", "heat_pump_consumption": [540.0]},
+            {"heat_pump_consumption": [525.0]},
+        ]
+    )
+
+    await coord._async_refresh_heatpump_power(force=True)  # noqa: SLF001
+
+    requested_uids = [
+        call.kwargs.get("device_uid")
+        for call in coord.client.hems_power_timeseries.await_args_list
+    ]
+    assert requested_uids == ["HP-CTRL", "HP-METER", None]
+    assert coord.heatpump_power_w == pytest.approx(540.0)
+    assert coord.heatpump_power_device_uid == "HP-METER"
+    assert coord.heatpump_power_source == "hems_power_timeseries:HP-METER"
+
+
+@pytest.mark.asyncio
+async def test_refresh_heatpump_power_stable_inventory_switches_from_empty_sample(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 2,
+                "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-CTRL",
+                        "statusText": "Normal",
+                    },
+                    {
+                        "device_type": "ENERGY_METER",
+                        "device_uid": "HP-METER",
+                        "statusText": "Normal",
+                    },
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._heatpump_power_selection_marker = (
+        coord._heatpump_power_inventory_marker()
+    )  # noqa: SLF001
+    coord._heatpump_power_device_uid = "HP-CTRL"  # noqa: SLF001
+
+    coord.client.hems_power_timeseries = AsyncMock(
+        side_effect=[
+            {"device_uid": "HP-CTRL", "heat_pump_consumption": [None]},
+            {"device_uid": "HP-METER", "heat_pump_consumption": [575.0]},
+            {"heat_pump_consumption": [525.0]},
+        ]
+    )
+
+    await coord._async_refresh_heatpump_power(force=True)  # noqa: SLF001
+
+    requested_uids = [
+        call.kwargs.get("device_uid")
+        for call in coord.client.hems_power_timeseries.await_args_list
+    ]
+    assert requested_uids == ["HP-CTRL", "HP-METER", None]
+    assert coord.heatpump_power_w == pytest.approx(575.0)
+    assert coord.heatpump_power_device_uid == "HP-METER"
+    assert coord.heatpump_power_source == "hems_power_timeseries:HP-METER"
+
+
+@pytest.mark.asyncio
+async def test_refresh_heatpump_power_stable_inventory_keeps_best_later_uid(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 3,
+                "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-CTRL",
+                        "statusText": "Normal",
+                    },
+                    {
+                        "device_type": "ENERGY_METER",
+                        "device_uid": "HP-METER",
+                        "statusText": "Normal",
+                    },
+                    {
+                        "device_type": "SG_READY_GATEWAY",
+                        "device_uid": "HP-SG",
+                        "statusText": "Normal",
+                    },
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._heatpump_power_selection_marker = (
+        coord._heatpump_power_inventory_marker()
+    )  # noqa: SLF001
+    coord._heatpump_power_device_uid = "HP-CTRL"  # noqa: SLF001
+
+    coord.client.hems_power_timeseries = AsyncMock(
+        side_effect=[
+            {"device_uid": "HP-CTRL", "heat_pump_consumption": [0.0]},
+            {"device_uid": "HP-METER", "heat_pump_consumption": [120.0]},
+            {"device_uid": "HP-SG", "heat_pump_consumption": [245.0]},
+            {"heat_pump_consumption": [100.0]},
+        ]
+    )
+
+    await coord._async_refresh_heatpump_power(force=True)  # noqa: SLF001
+
+    requested_uids = [
+        call.kwargs.get("device_uid")
+        for call in coord.client.hems_power_timeseries.await_args_list
+    ]
+    assert requested_uids == ["HP-CTRL", "HP-METER", "HP-SG", None]
+    assert coord.heatpump_power_w == pytest.approx(245.0)
+    assert coord.heatpump_power_device_uid == "HP-SG"
+    assert coord.heatpump_power_source == "hems_power_timeseries:HP-SG"
+
+
+@pytest.mark.asyncio
+async def test_refresh_heatpump_power_stable_inventory_keeps_best_unfiltered_payload(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 2,
+                "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-CTRL",
+                        "statusText": "Normal",
+                    },
+                    {
+                        "device_type": "ENERGY_METER",
+                        "device_uid": "HP-METER",
+                        "statusText": "Normal",
+                    },
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._heatpump_power_selection_marker = (
+        coord._heatpump_power_inventory_marker()
+    )  # noqa: SLF001
+    coord._heatpump_power_device_uid = "HP-CTRL"  # noqa: SLF001
+
+    coord.client.hems_power_timeseries = AsyncMock(
+        side_effect=[
+            {"device_uid": "HP-CTRL", "heat_pump_consumption": [0.0]},
+            {"device_uid": "HP-METER", "heat_pump_consumption": [140.0]},
+            {"heat_pump_consumption": [360.0]},
+        ]
+    )
+
+    await coord._async_refresh_heatpump_power(force=True)  # noqa: SLF001
+
+    requested_uids = [
+        call.kwargs.get("device_uid")
+        for call in coord.client.hems_power_timeseries.await_args_list
+    ]
+    assert requested_uids == ["HP-CTRL", "HP-METER", None]
+    assert coord.heatpump_power_w == pytest.approx(360.0)
+    assert coord.heatpump_power_device_uid is None
+    assert coord.heatpump_power_source == "hems_power_timeseries"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- keep stable heat-pump HEMS power selection ranking all candidate payloads instead of stopping at the first positive sample
- add regression coverage for reused heat-pump device UIDs that return zero or empty samples, later heat-pump members that should outrank earlier candidates, and unfiltered payload fallback ranking
- document the fix in the v2.3.5 changelog

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_coordinator_behavior.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
