### PR TITLE
Stabilize charge mode fallback state

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -158,6 +158,22 @@ BATTERY_PROFILE_WRITE_DEBOUNCE_S = 2.0
 BATTERY_SETTINGS_WRITE_DEBOUNCE_S = 2.0
 DISCOVERY_SNAPSHOT_STORE_VERSION = 1
 DISCOVERY_SNAPSHOT_SAVE_DELAY_S = 1.0
+CHARGE_MODE_CACHE_TTL = 300.0
+CHARGE_MODE_PREFERENCE_MAP: dict[str, str] = {
+    "MANUAL": "MANUAL_CHARGING",
+    "MANUAL_CHARGING": "MANUAL_CHARGING",
+    "SCHEDULED": "SCHEDULED_CHARGING",
+    "SCHEDULED_CHARGING": "SCHEDULED_CHARGING",
+    "GREEN": "GREEN_CHARGING",
+    "GREEN_CHARGING": "GREEN_CHARGING",
+}
+EFFECTIVE_CHARGE_MODE_VALUES: frozenset[str] = frozenset(
+    {
+        *CHARGE_MODE_PREFERENCE_MAP.values(),
+        "IDLE",
+        "IMMEDIATE",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -8240,24 +8256,25 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 else:
                     charging_now_flag = target_state
 
-            # Charge mode: use cached/parallel fetch; fall back to derived values
-            charge_mode_pref = charge_modes.get(sn)
-            charge_mode = charge_mode_pref
-            if not charge_mode:
-                charge_mode = (
-                    obj.get("chargeMode")
-                    or obj.get("chargingMode")
-                    or (obj.get("sch_d") or {}).get("mode")
-                )
-                if not charge_mode:
-                    if charging_now_flag:
-                        charge_mode = "IMMEDIATE"
-                    elif sch_info0.get("type") or sch.get("status"):
-                        charge_mode = str(
-                            sch_info0.get("type") or sch.get("status")
-                        ).upper()
-                    else:
-                        charge_mode = "IDLE"
+            # Keep preference state stable when scheduler lookups temporarily omit it.
+            charge_mode_pref = self._normalize_charge_mode_preference(
+                charge_modes.get(sn)
+            )
+            if charge_mode_pref is None:
+                charge_mode_pref = self._cached_charge_mode_preference(sn)
+
+            charge_mode = self._normalize_effective_charge_mode(
+                obj.get("chargeMode")
+                or obj.get("chargingMode")
+                or (obj.get("sch_d") or {}).get("mode")
+            )
+            if charge_mode is None:
+                if charge_mode_pref:
+                    charge_mode = charge_mode_pref
+                elif charging_now_flag:
+                    charge_mode = "IMMEDIATE"
+                else:
+                    charge_mode = "IDLE"
 
             green_setting = green_settings.get(sn)
             green_enabled: bool | None = None
@@ -9079,21 +9096,20 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         """Resolve charge modes concurrently for the provided serial numbers."""
         results: dict[str, str | None] = {}
         pending: dict[str, asyncio.Task[str | None]] = {}
-        now = time.monotonic()
         if self._scheduler_backoff_active():
             for sn in dict.fromkeys(serials):
                 if not sn:
                     continue
-                cached = self._charge_mode_cache.get(sn)
-                if cached and (now - cached[1] < 300):
-                    results[sn] = cached[0]
+                cached = self._cached_charge_mode_preference(sn)
+                if cached is not None:
+                    results[sn] = cached
             return results
         for sn in dict.fromkeys(serials):
             if not sn:
                 continue
-            cached = self._charge_mode_cache.get(sn)
-            if cached and (now - cached[1] < 300):
-                results[sn] = cached[0]
+            cached = self._cached_charge_mode_preference(sn)
+            if cached is not None:
+                results[sn] = cached
                 continue
             pending[sn] = asyncio.create_task(self._get_charge_mode(sn))
 
@@ -11062,12 +11078,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     async def _get_charge_mode(self, sn: str) -> str | None:
         """Return charge mode using a 300s cache to reduce API calls."""
+        cached = self._cached_charge_mode_preference(sn)
+        if cached is not None:
+            return cached
         now = time.monotonic()
-        cached = self._charge_mode_cache.get(sn)
-        if cached and (now - cached[1] < 300):
-            return cached[0]
         try:
-            mode = await self.client.charge_mode(sn)
+            mode = self._normalize_charge_mode_preference(
+                await self.client.charge_mode(sn)
+            )
         except SchedulerUnavailable as err:
             self._note_scheduler_unavailable(err)
             return None
@@ -11206,7 +11224,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     def set_charge_mode_cache(self, sn: str, mode: str) -> None:
         """Update cache when user changes mode via select."""
-        self._charge_mode_cache[str(sn)] = (str(mode), time.monotonic())
+        normalized = self._normalize_charge_mode_preference(mode)
+        if normalized is None:
+            return
+        self._charge_mode_cache[str(sn)] = (normalized, time.monotonic())
 
     def set_green_battery_cache(
         self, sn: str, enabled: bool, supported: bool = True
@@ -14189,18 +14210,59 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             data.get("charge_mode_pref"),
             data.get("charge_mode"),
         ]
-        cached = self._charge_mode_cache.get(sn_str)
-        if cached:
-            candidates.append(cached[0])
+        cached = self._cached_charge_mode_preference(sn_str)
+        if cached is not None:
+            candidates.append(cached)
         for raw in candidates:
-            if raw is None:
-                continue
-            try:
-                value = str(raw).strip()
-            except Exception:
-                continue
-            if value:
-                return value.upper()
+            value = self._normalize_charge_mode_preference(raw)
+            if value is not None:
+                return value
+        return None
+
+    def _cached_charge_mode_preference(
+        self, sn: str, *, now: float | None = None
+    ) -> str | None:
+        """Return a fresh cached scheduler preference for a charger."""
+
+        cache_entry = self._charge_mode_cache.get(str(sn))
+        if not cache_entry:
+            return None
+        if now is None:
+            now = time.monotonic()
+        if now - cache_entry[1] >= CHARGE_MODE_CACHE_TTL:
+            return None
+        return self._normalize_charge_mode_preference(cache_entry[0])
+
+    @staticmethod
+    def _normalize_charge_mode_preference(value: object) -> str | None:
+        """Normalize a scheduler preference into a supported charge mode."""
+
+        if value is None:
+            return None
+        try:
+            normalized = str(value).strip().upper()
+        except Exception:
+            return None
+        if not normalized:
+            return None
+        return CHARGE_MODE_PREFERENCE_MAP.get(normalized)
+
+    def _normalize_effective_charge_mode(self, value: object) -> str | None:
+        """Normalize a charger-reported effective mode."""
+
+        preferred = self._normalize_charge_mode_preference(value)
+        if preferred is not None:
+            return preferred
+        if value is None:
+            return None
+        try:
+            normalized = str(value).strip().upper()
+        except Exception:
+            return None
+        if not normalized:
+            return None
+        if normalized in EFFECTIVE_CHARGE_MODE_VALUES:
+            return normalized
         return None
 
     def _charge_mode_start_preferences(self, sn: str) -> ChargeModeStartPreferences:

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -194,12 +194,11 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
 
     @property
     def current_option(self) -> str | None:
-        d = self.data
-        # Prefer scheduler-reported charge mode when available
-        val = d.get("charge_mode_pref") or d.get("charge_mode")
+        resolve_pref = getattr(self._coord, "_resolve_charge_mode_pref", None)
+        val = resolve_pref(self._sn) if callable(resolve_pref) else None
         if not val:
             return None
-        return LABELS.get(str(val), str(val).title())
+        return LABELS.get(val)
 
     async def async_select_option(self, option: str) -> None:
         if not self._coord.scheduler_available:

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -983,11 +983,11 @@ async def test_async_resolve_charge_modes_backoff_uses_cache(
     coord = coordinator_factory()
     now = time.monotonic()
     coord._scheduler_backoff_until = now + 60  # noqa: SLF001
-    coord._charge_mode_cache[SERIAL_ONE] = ("CACHED", now)
+    coord._charge_mode_cache[SERIAL_ONE] = ("MANUAL_CHARGING", now)
 
     result = await coord._async_resolve_charge_modes(["", SERIAL_ONE])
 
-    assert result == {SERIAL_ONE: "CACHED"}
+    assert result == {SERIAL_ONE: "MANUAL_CHARGING"}
 
 
 def test_scheduler_note_default_reason_and_backoff_error(
@@ -1905,7 +1905,7 @@ async def test_async_update_data_success_enriches_payload(
         "ts": "2025-10-30T10:00:00Z[UTC]",
     }
     coord.client.status = AsyncMock(return_value=status_payload)
-    coord._async_resolve_charge_modes = AsyncMock(return_value={sn: "SMART"})
+    coord._async_resolve_charge_modes = AsyncMock(return_value={})
     coord.summary = SimpleNamespace(
         prepare_refresh=lambda **kwargs: True,
         async_fetch=AsyncMock(
@@ -1959,8 +1959,246 @@ async def test_async_update_data_success_enriches_payload(
     result = await coord._async_update_data()
     assert sn in result
     entry = result[sn]
-    assert entry["charge_mode"] == "SMART"
+    assert entry["charge_mode"] == "IDLE"
     assert entry["energy_today_sessions_kwh"] == 2.0
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_preserves_known_charge_preference_when_status_only_has_custom_schedule(
+    coordinator_factory,
+):
+    coord = coordinator_factory(
+        serials=["EV1"],
+        data={
+            "EV1": {
+                "sn": "EV1",
+                "name": "Garage EV",
+                "charge_mode_pref": "GREEN_CHARGING",
+                "charge_mode": "GREEN_CHARGING",
+            }
+        },
+    )
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._scheduler_available = False  # noqa: SLF001
+    coord._scheduler_backoff_active = lambda: False  # type: ignore[assignment]  # noqa: SLF001
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": "EV1",
+                    "name": "Garage EV",
+                    "connectors": [
+                        {
+                            "connectorStatusType": coord_mod.SUSPENDED_EVSE_STATUS,
+                            "connectorStatusReason": "INSUFFICIENT_SOLAR",
+                        }
+                    ],
+                    "sch_d": {"status": 1, "info": [{"type": "CUSTOM"}]},
+                    "session_d": {},
+                    "charging": False,
+                }
+            ],
+            "ts": 1_700_000_000,
+        }
+    )
+    coord.summary = SimpleNamespace(
+        prepare_refresh=lambda **kwargs: False,
+        async_fetch=AsyncMock(return_value=[]),
+        invalidate=lambda: None,
+    )
+    coord.evse_timeseries.async_refresh = AsyncMock(return_value=None)  # noqa: SLF001
+    coord.evse_timeseries.merge_charger_payloads = MagicMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord.energy._async_refresh_site_energy = AsyncMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord._async_refresh_battery_site_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_status = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_backup_history = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_schedules = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_guard_profile = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_alert = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_grid_control_check = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_devices_inventory = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_dry_contact_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_hems_devices = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_inverters = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_current_power_consumption = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_heatpump_power = AsyncMock()  # noqa: SLF001
+    coord._async_resolve_green_battery_settings = AsyncMock(
+        return_value={}
+    )  # noqa: SLF001
+    coord._async_resolve_auth_settings = AsyncMock(return_value={})  # noqa: SLF001
+    coord._get_charge_mode = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
+    coord._sync_battery_profile_pending_issue = MagicMock()  # noqa: SLF001
+
+    result = await coord._async_update_data()  # noqa: SLF001
+
+    assert result["EV1"]["charge_mode_pref"] is None
+    assert result["EV1"]["charge_mode"] == "IDLE"
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_uses_cached_charge_preference_when_status_only_has_custom_schedule(
+    coordinator_factory,
+):
+    coord = coordinator_factory(
+        serials=["EV1"],
+        data={
+            "EV1": {
+                "sn": "EV1",
+                "name": "Garage EV",
+                "charge_mode": "IDLE",
+            }
+        },
+    )
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._scheduler_available = False  # noqa: SLF001
+    coord._scheduler_backoff_active = lambda: False  # type: ignore[assignment]  # noqa: SLF001
+    coord._charge_mode_cache["EV1"] = (
+        "GREEN_CHARGING",
+        coord_mod.time.monotonic(),
+    )
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": "EV1",
+                    "name": "Garage EV",
+                    "connectors": [
+                        {
+                            "connectorStatusType": coord_mod.SUSPENDED_EVSE_STATUS,
+                            "connectorStatusReason": "INSUFFICIENT_SOLAR",
+                        }
+                    ],
+                    "sch_d": {"status": 1, "info": [{"type": "CUSTOM"}]},
+                    "session_d": {},
+                    "charging": False,
+                }
+            ],
+            "ts": 1_700_000_000,
+        }
+    )
+    coord.summary = SimpleNamespace(
+        prepare_refresh=lambda **kwargs: False,
+        async_fetch=AsyncMock(return_value=[]),
+        invalidate=lambda: None,
+    )
+    coord.evse_timeseries.async_refresh = AsyncMock(return_value=None)  # noqa: SLF001
+    coord.evse_timeseries.merge_charger_payloads = MagicMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord.energy._async_refresh_site_energy = AsyncMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord._async_refresh_battery_site_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_status = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_backup_history = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_schedules = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_guard_profile = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_alert = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_grid_control_check = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_devices_inventory = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_dry_contact_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_hems_devices = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_inverters = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_current_power_consumption = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_heatpump_power = AsyncMock()  # noqa: SLF001
+    coord._async_resolve_green_battery_settings = AsyncMock(
+        return_value={}
+    )  # noqa: SLF001
+    coord._async_resolve_auth_settings = AsyncMock(return_value={})  # noqa: SLF001
+    coord._get_charge_mode = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
+    coord._sync_battery_profile_pending_issue = MagicMock()  # noqa: SLF001
+
+    result = await coord._async_update_data()  # noqa: SLF001
+
+    assert result["EV1"]["charge_mode_pref"] == "GREEN_CHARGING"
+    assert result["EV1"]["charge_mode"] == "GREEN_CHARGING"
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_drops_expired_cached_charge_preference_when_status_only_has_custom_schedule(
+    coordinator_factory,
+):
+    coord = coordinator_factory(
+        serials=["EV1"],
+        data={
+            "EV1": {
+                "sn": "EV1",
+                "name": "Garage EV",
+                "charge_mode_pref": "GREEN_CHARGING",
+                "charge_mode": "IDLE",
+            }
+        },
+    )
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._scheduler_available = False  # noqa: SLF001
+    coord._scheduler_backoff_active = lambda: False  # type: ignore[assignment]  # noqa: SLF001
+    coord._charge_mode_cache["EV1"] = (
+        "GREEN_CHARGING",
+        coord_mod.time.monotonic() - coord_mod.CHARGE_MODE_CACHE_TTL - 1,
+    )
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": "EV1",
+                    "name": "Garage EV",
+                    "connectors": [
+                        {
+                            "connectorStatusType": coord_mod.SUSPENDED_EVSE_STATUS,
+                            "connectorStatusReason": "INSUFFICIENT_SOLAR",
+                        }
+                    ],
+                    "sch_d": {"status": 1, "info": [{"type": "CUSTOM"}]},
+                    "session_d": {},
+                    "charging": False,
+                }
+            ],
+            "ts": 1_700_000_000,
+        }
+    )
+    coord.summary = SimpleNamespace(
+        prepare_refresh=lambda **kwargs: False,
+        async_fetch=AsyncMock(return_value=[]),
+        invalidate=lambda: None,
+    )
+    coord.evse_timeseries.async_refresh = AsyncMock(return_value=None)  # noqa: SLF001
+    coord.evse_timeseries.merge_charger_payloads = MagicMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord.energy._async_refresh_site_energy = AsyncMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord._async_refresh_battery_site_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_status = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_backup_history = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_schedules = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_guard_profile = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_alert = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_grid_control_check = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_devices_inventory = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_dry_contact_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_hems_devices = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_inverters = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_current_power_consumption = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_heatpump_power = AsyncMock()  # noqa: SLF001
+    coord._async_resolve_green_battery_settings = AsyncMock(
+        return_value={}
+    )  # noqa: SLF001
+    coord._async_resolve_auth_settings = AsyncMock(return_value={})  # noqa: SLF001
+    coord._get_charge_mode = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
+    coord._sync_battery_profile_pending_issue = MagicMock()  # noqa: SLF001
+
+    result = await coord._async_update_data()  # noqa: SLF001
+
+    assert result["EV1"]["charge_mode_pref"] is None
+    assert result["EV1"]["charge_mode"] == "IDLE"
 
 
 @pytest.mark.asyncio
@@ -2042,17 +2280,19 @@ async def test_async_resolve_charge_modes_uses_cache_and_handles_errors(
     monkeypatch, coordinator_factory
 ):
     coord = coordinator_factory(serials=["EV1", "EV2"])
-    coord._charge_mode_cache = {"EV1": ("IMMEDIATE", coord_mod.time.monotonic())}
+    coord._charge_mode_cache = {
+        "EV1": ("SCHEDULED_CHARGING", coord_mod.time.monotonic())
+    }
 
     async def fake_get(sn: str):
         if sn == "EV2":
-            return "SMART"
+            return "GREEN_CHARGING"
         raise RuntimeError("boom")
 
     coord._get_charge_mode = AsyncMock(side_effect=fake_get)
     result = await coord._async_resolve_charge_modes(["EV1", "EV2", "EV3"])
-    assert result["EV1"] == "IMMEDIATE"
-    assert result["EV2"] == "SMART"
+    assert result["EV1"] == "SCHEDULED_CHARGING"
+    assert result["EV2"] == "GREEN_CHARGING"
     assert "EV3" not in result
 
 
@@ -2131,7 +2371,17 @@ def test_charge_mode_preference_helpers(coordinator_factory):
 
     coord.data[sn]["charge_mode_pref"] = None
     coord._charge_mode_cache[sn] = ("SMART", coord_mod.time.monotonic())
-    assert coord._resolve_charge_mode_pref(sn) == "SMART"
+    assert coord._resolve_charge_mode_pref(sn) is None
+
+    coord._charge_mode_cache[sn] = ("SCHEDULED", coord_mod.time.monotonic())
+    assert coord._resolve_charge_mode_pref(sn) == "SCHEDULED_CHARGING"
+
+    coord._charge_mode_cache[sn] = (
+        "GREEN_CHARGING",
+        coord_mod.time.monotonic() - coord_mod.CHARGE_MODE_CACHE_TTL - 1,
+    )
+    coord.data[sn]["charge_mode"] = "IDLE"
+    assert coord._resolve_charge_mode_pref(sn) is None
 
 
 def test_resolve_charge_mode_pref_handles_errors(coordinator_factory):
@@ -2152,6 +2402,18 @@ def test_resolve_charge_mode_pref_handles_errors(coordinator_factory):
     assert coord._resolve_charge_mode_pref(sn) is None
 
 
+def test_charge_mode_normalizers_handle_invalid_values(coordinator_factory):
+    coord = coordinator_factory(serials=["EV1"])
+
+    class BadStr:
+        def __str__(self):
+            raise ValueError("bad")
+
+    assert coord._normalize_effective_charge_mode(BadStr()) is None  # noqa: SLF001
+    assert coord._normalize_effective_charge_mode("   ") is None  # noqa: SLF001
+    assert coord._normalize_effective_charge_mode("custom") is None  # noqa: SLF001
+
+
 @pytest.mark.asyncio
 async def test_ensure_charge_mode_updates_cache(coordinator_factory):
     coord = coordinator_factory(serials=["EV1"])
@@ -2167,6 +2429,14 @@ async def test_ensure_charge_mode_handles_errors(coordinator_factory):
     coord = coordinator_factory(serials=["EV1"])
     coord.client.set_charge_mode = AsyncMock(side_effect=RuntimeError("boom"))
     await coord._ensure_charge_mode("EV1", "GREEN_CHARGING")
+
+
+def test_set_charge_mode_cache_ignores_unknown_mode(coordinator_factory):
+    coord = coordinator_factory(serials=["EV1"])
+
+    coord.set_charge_mode_cache("EV1", "custom")
+
+    assert "EV1" not in coord._charge_mode_cache
 
 
 def test_has_embedded_charge_mode_detects_nested():
@@ -2199,8 +2469,8 @@ async def test_attempt_auto_refresh_updates_tokens(monkeypatch, coordinator_fact
 @pytest.mark.asyncio
 async def test_get_charge_mode_uses_cache(coordinator_factory):
     coord = coordinator_factory(serials=["SN1"])
-    coord._charge_mode_cache["SN1"] = ("SMART", coord_mod.time.monotonic())
-    assert await coord._get_charge_mode("SN1") == "SMART"
+    coord._charge_mode_cache["SN1"] = ("GREEN_CHARGING", coord_mod.time.monotonic())
+    assert await coord._get_charge_mode("SN1") == "GREEN_CHARGING"
 
     coord._charge_mode_cache.clear()
     coord.client.charge_mode = AsyncMock(return_value=None)

--- a/tests/components/enphase_ev/test_coordinator_edge_cases.py
+++ b/tests/components/enphase_ev/test_coordinator_edge_cases.py
@@ -831,16 +831,21 @@ async def test_get_charge_mode_uses_cache_and_client(monkeypatch, hass):
 
     coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
     coord.hass = hass
-    coord._charge_mode_cache = {"EV1": ("CACHED", coord_mod.time.monotonic())}
-    coord.client = SimpleNamespace(charge_mode=AsyncMock(return_value="REMOTE"))
+    coord._charge_mode_cache = {"EV1": ("MANUAL_CHARGING", coord_mod.time.monotonic())}
+    coord.client = SimpleNamespace(
+        charge_mode=AsyncMock(return_value="SCHEDULED_CHARGING")
+    )
 
     cached = await coord._get_charge_mode("EV1")
-    assert cached == "CACHED"
+    assert cached == "MANUAL_CHARGING"
 
-    coord._charge_mode_cache["EV1"] = ("OLD", coord_mod.time.monotonic() - 1_000)
+    coord._charge_mode_cache["EV1"] = (
+        "MANUAL_CHARGING",
+        coord_mod.time.monotonic() - 1_000,
+    )
     result = await coord._get_charge_mode("EV1")
-    assert result == "REMOTE"
-    assert coord._charge_mode_cache["EV1"][0] == "REMOTE"
+    assert result == "SCHEDULED_CHARGING"
+    assert coord._charge_mode_cache["EV1"][0] == "SCHEDULED_CHARGING"
 
     coord.client.charge_mode = AsyncMock(side_effect=RuntimeError("fail"))
     result = await coord._get_charge_mode("EV2")
@@ -853,9 +858,9 @@ def test_set_charge_mode_cache_updates(monkeypatch, hass):
     coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
     coord._charge_mode_cache = {}
 
-    coord.set_charge_mode_cache("EV1", "SMART")
+    coord.set_charge_mode_cache("EV1", "SCHEDULED")
     value, ts = coord._charge_mode_cache["EV1"]
-    assert value == "SMART"
+    assert value == "SCHEDULED_CHARGING"
     assert ts >= 0
 
 
@@ -1057,7 +1062,7 @@ async def test_async_update_data_handles_complex_payload(monkeypatch, hass):
 
     data = await coord._async_update_data()
 
-    assert data["EV1"]["charge_mode"] == "ECO"
+    assert data["EV1"]["charge_mode"] == "IDLE"
     assert data["EV1"]["session_kwh"] == pytest.approx(0.5)
     assert data["EV1"]["session_charge_level"] == 18
     assert data["EV1"]["session_cost"] == pytest.approx(3.457)

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -227,9 +227,14 @@ def test_charge_mode_select_current_option_paths(coordinator_factory):
 
     coord.data[RANDOM_SERIAL]["charge_mode_pref"] = ""
     coord.data[RANDOM_SERIAL]["charge_mode"] = "experimental_mode"
-    assert sel.current_option == "Experimental_Mode"
+    assert sel.current_option is None
+
+    coord.set_charge_mode_cache(RANDOM_SERIAL, "SCHEDULED_CHARGING")
+    coord.data[RANDOM_SERIAL]["charge_mode"] = "CUSTOM"
+    assert sel.current_option == "Scheduled"
 
     coord.data[RANDOM_SERIAL]["charge_mode"] = ""
+    coord._charge_mode_cache.clear()  # noqa: SLF001
     assert sel.current_option is None
 
 


### PR DESCRIPTION
## Summary
- normalize charge mode handling so scheduler preferences only use valid selectable modes https://github.com/barneyonline/ha-enphase-energy/discussions/388
- use a short-lived cached scheduler preference when Enphase omits the preference API response, instead of persisting stale coordinator state
- add regressions covering custom schedule payloads, cache TTL expiry, and select-state fallback behavior

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m coverage erase && python -m coverage run -m pytest tests/components/enphase_ev -q && python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/select.py --fail-under=100"
