### PR TITLE
Clamp site power spikes to lifetime interval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed the derived `Current Grid Power` sensor so tiny or skewed lifetime-energy timestamp gaps no longer create impossible import/export spikes. The interval floor now also applies when restoring the last live site-power samples after restart.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -1027,18 +1027,20 @@ class _SiteLifetimePowerRestoreData(ExtraStoredData):
     previous_live_flow_kwh: dict[str, float]
     previous_live_energy_ts: float | None
     previous_live_sample_ts: float | None
+    last_live_interval_minutes: float | None
 
     def as_dict(self) -> dict[str, object]:
         return {
             "previous_live_flow_kwh": dict(self.previous_live_flow_kwh),
             "previous_live_energy_ts": self.previous_live_energy_ts,
             "previous_live_sample_ts": self.previous_live_sample_ts,
+            "last_live_interval_minutes": self.last_live_interval_minutes,
         }
 
     @classmethod
     def from_dict(cls, data: dict | None) -> "_SiteLifetimePowerRestoreData":
         if not isinstance(data, dict):
-            return cls({}, None, None)
+            return cls({}, None, None, None)
 
         previous_live_flow_kwh: dict[str, float] = {}
         raw_previous_live_flow_kwh = data.get("previous_live_flow_kwh")
@@ -1064,6 +1066,9 @@ class _SiteLifetimePowerRestoreData(ExtraStoredData):
             previous_live_flow_kwh=previous_live_flow_kwh,
             previous_live_energy_ts=_as_float(data.get("previous_live_energy_ts")),
             previous_live_sample_ts=_as_float(data.get("previous_live_sample_ts")),
+            last_live_interval_minutes=_as_float(
+                data.get("last_live_interval_minutes")
+            ),
         )
 
 
@@ -5026,6 +5031,7 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
         self._previous_live_flow_kwh: dict[str, float] = {}
         self._previous_live_energy_ts: float | None = None
         self._previous_live_sample_ts: float | None = None
+        self._last_live_interval_minutes: float | None = None
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
@@ -5094,6 +5100,7 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
         }
         self._previous_live_energy_ts = extra_data.previous_live_energy_ts
         self._previous_live_sample_ts = extra_data.previous_live_sample_ts
+        self._last_live_interval_minutes = extra_data.last_live_interval_minutes
         self._restore_live_history()
 
     def _restore_live_history(self) -> None:
@@ -5141,6 +5148,8 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
                 ),
                 default_window_s=self._DEFAULT_WINDOW_S,
             )
+            if self._last_live_interval_minutes is not None:
+                window_s = max(window_s, self._last_live_interval_minutes * 60.0)
             self._last_window_s = window_s
             if abs(signed_delta_kwh) <= self._MIN_DELTA_KWH:
                 self._last_power_w = 0
@@ -5309,6 +5318,44 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
             now = now.replace(tzinfo=timezone.utc)
         return now.timestamp(), now.isoformat()
 
+    @staticmethod
+    def _coerce_interval_minutes(raw: object) -> float | None:
+        try:
+            interval_minutes = float(raw)
+        except Exception:
+            return None
+        return interval_minutes if interval_minutes > 0 else None
+
+    def _minimum_window_seconds(
+        self,
+        flows: dict[str, object],
+        current_values: dict[str, float],
+    ) -> float | None:
+        interval_minutes_values: list[float] = []
+
+        for flow_key in self._flow_signs:
+            if flow_key not in current_values:
+                continue
+            entry = flows.get(flow_key)
+            raw_interval = None
+            if isinstance(entry, SiteEnergyFlow):
+                raw_interval = entry.interval_minutes
+            elif isinstance(entry, dict):
+                raw_interval = entry.get("interval_minutes")
+            interval_minutes = self._coerce_interval_minutes(raw_interval)
+            if interval_minutes is not None:
+                interval_minutes_values.append(interval_minutes)
+
+        meta_interval_minutes = self._coerce_interval_minutes(
+            self._site_energy_meta().get("interval_minutes")
+        )
+        if meta_interval_minutes is not None:
+            interval_minutes_values.append(meta_interval_minutes)
+
+        if not interval_minutes_values:
+            return None
+        return max(interval_minutes_values) * 60.0
+
     @property
     def available(self) -> bool:
         if not super().available:
@@ -5428,6 +5475,12 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
             previous_energy_ts=self._last_energy_ts,
             default_window_s=self._DEFAULT_WINDOW_S,
         )
+        minimum_window_s = self._minimum_window_seconds(flows, current_values)
+        self._last_live_interval_minutes = (
+            minimum_window_s / 60.0 if minimum_window_s is not None else None
+        )
+        if minimum_window_s is not None and window_s < minimum_window_s:
+            window_s = minimum_window_s
         self._last_energy_ts = sample_ts
         self._last_window_s = window_s
         self._live_flow_sample_count += 1
@@ -5464,6 +5517,7 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
             previous_live_flow_kwh=dict(self._previous_live_flow_kwh),
             previous_live_energy_ts=self._previous_live_energy_ts,
             previous_live_sample_ts=self._previous_live_sample_ts,
+            last_live_interval_minutes=self._last_live_interval_minutes,
         )
 
 

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -1235,6 +1235,44 @@ def test_site_grid_power_sensor_from_lifetime_export_energy(
     assert sensor.translation_key == "site_grid_power"
 
 
+def test_site_grid_power_sensor_uses_interval_floor_for_tiny_timestamp_gap(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseGridPowerSensor(coord)
+    base_ts = datetime(2024, 1, 2, tzinfo=timezone.utc)
+    coord.energy.site_energy = {
+        "grid_export": SiteEnergyFlow(
+            value_kwh=1.0,
+            bucket_count=1,
+            fields_used=["solar_grid"],
+            start_date="2024-01-01",
+            last_report_date=base_ts,
+            update_pending=False,
+            source_unit="Wh",
+            last_reset_at=None,
+            interval_minutes=5,
+        )
+    }
+
+    assert sensor.native_value is None
+
+    coord.energy.site_energy["grid_export"] = SiteEnergyFlow(
+        value_kwh=1.2,
+        bucket_count=1,
+        fields_used=["solar_grid"],
+        start_date="2024-01-01",
+        last_report_date=base_ts + timedelta(seconds=5),
+        update_pending=False,
+        source_unit="Wh",
+        last_reset_at=None,
+        interval_minutes=5,
+    )
+
+    assert sensor.native_value == -2400
+    assert sensor.extra_state_attributes["last_window_seconds"] == pytest.approx(300.0)
+
+
 def test_site_grid_power_sensor_stays_available_at_zero_when_channel_known(
     coordinator_factory,
 ) -> None:
@@ -1513,6 +1551,7 @@ async def test_site_lifetime_power_sensor_restores_two_live_samples_for_same_buc
                 "previous_live_flow_kwh": {"grid_import": 1.0},
                 "previous_live_energy_ts": base_ts.timestamp(),
                 "previous_live_sample_ts": base_ts.timestamp(),
+                "last_live_interval_minutes": 5.0,
             }
 
     sensor.async_get_last_state = AsyncMock(return_value=LastState())
@@ -1536,6 +1575,59 @@ async def test_site_lifetime_power_sensor_restores_two_live_samples_for_same_buc
     assert sensor.available is True
     assert sensor.native_value == 6000
     assert sensor.extra_state_attributes["method"] == "restored_lifetime_energy_window"
+
+
+@pytest.mark.asyncio
+async def test_site_lifetime_power_sensor_restore_uses_interval_floor_for_tiny_gap(
+    hass, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseGridPowerSensor(coord)
+    sensor.hass = hass
+    base_ts = datetime(2024, 1, 2, tzinfo=timezone.utc)
+
+    class LastState:
+        state = "-144000000"
+        attributes = {
+            "last_flow_kwh": {"grid_export": 1.2},
+            "last_energy_ts": (base_ts + timedelta(seconds=5)).timestamp(),
+            "last_sample_ts": (base_ts + timedelta(seconds=5)).timestamp(),
+            "last_power_w": -144000000,
+            "last_window_seconds": 5.0,
+            "last_report_date": (base_ts + timedelta(seconds=5)).isoformat(),
+        }
+
+    class LastExtra:
+        def as_dict(self):
+            return {
+                "previous_live_flow_kwh": {"grid_export": 1.0},
+                "previous_live_energy_ts": base_ts.timestamp(),
+                "previous_live_sample_ts": base_ts.timestamp(),
+                "last_live_interval_minutes": 5.0,
+            }
+
+    sensor.async_get_last_state = AsyncMock(return_value=LastState())
+    sensor.async_get_last_extra_data = AsyncMock(return_value=LastExtra())
+    await sensor.async_added_to_hass()
+
+    coord.energy.site_energy = {
+        "grid_export": SiteEnergyFlow(
+            value_kwh=1.2,
+            bucket_count=1,
+            fields_used=["solar_grid"],
+            start_date="2024-01-01",
+            last_report_date=base_ts + timedelta(seconds=5),
+            update_pending=False,
+            source_unit="Wh",
+            last_reset_at=None,
+            interval_minutes=5,
+        )
+    }
+
+    assert sensor.available is True
+    assert sensor.native_value == -2400
+    assert sensor.extra_state_attributes["method"] == "restored_lifetime_energy_window"
+    assert sensor.extra_state_attributes["last_window_seconds"] == pytest.approx(300.0)
 
 
 @pytest.mark.asyncio
@@ -1854,6 +1946,15 @@ def test_site_lifetime_power_sensor_helper_edge_cases(
     }
     ts, _ = sensor._sample_timestamp(flows)
     assert ts == datetime(2024, 1, 5, tzinfo=timezone.utc).timestamp()
+    assert sensor._minimum_window_seconds(flows, {"grid_import": 1.0}) is None
+
+    flows["grid_import"]["interval_minutes"] = 5
+    assert sensor._minimum_window_seconds(flows, {"grid_import": 1.0}) == pytest.approx(
+        300.0
+    )
+
+    coord.site_energy_meta = {"interval_minutes": 15}  # type: ignore[assignment]
+    assert sensor._minimum_window_seconds({}, {}) == pytest.approx(900.0)
 
     battery_sensor = EnphaseBatteryPowerSensor(coordinator_factory())
     battery_sensor._last_flow_kwh = {"battery_discharge": 1.0}
@@ -1883,6 +1984,7 @@ def test_site_lifetime_power_restore_data_helper_edges() -> None:
     assert restore_data.previous_live_flow_kwh == {}
     assert restore_data.previous_live_energy_ts is None
     assert restore_data.previous_live_sample_ts is None
+    assert restore_data.last_live_interval_minutes is None
 
     parsed = _SiteLifetimePowerRestoreData.from_dict(
         {
@@ -1894,15 +1996,18 @@ def test_site_lifetime_power_restore_data_helper_edges() -> None:
             },
             "previous_live_energy_ts": object(),
             "previous_live_sample_ts": "1700000000",
+            "last_live_interval_minutes": "5",
         }
     )
     assert parsed.previous_live_flow_kwh == {"grid_import": 1.5}
     assert parsed.previous_live_energy_ts is None
     assert parsed.previous_live_sample_ts == pytest.approx(1_700_000_000.0)
+    assert parsed.last_live_interval_minutes == pytest.approx(5.0)
     assert parsed.as_dict() == {
         "previous_live_flow_kwh": {"grid_import": 1.5},
         "previous_live_energy_ts": None,
         "previous_live_sample_ts": pytest.approx(1_700_000_000.0),
+        "last_live_interval_minutes": pytest.approx(5.0),
     }
 
 


### PR DESCRIPTION
## Summary
- clamp derived site power calculations to the reported lifetime-energy interval so tiny timestamp gaps do not generate impossible `Current Grid Power` spikes
- persist the live interval in restored site-power state so the same interval floor applies after restart
- add regression coverage for live and restored tiny-gap samples, helper interval-floor branches, and document the fix in the changelog

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_site_energy.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/sensor.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
