### PR TITLE
Align heat pump runtime and daily telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Fixed the derived `Current Grid Power` sensor so tiny or skewed lifetime-energy timestamp gaps no longer create impossible import/export spikes. The interval floor now also applies when restoring the last live site-power samples after restart.
+- Fixed heat-pump runtime, SG-Ready, and daily-consumption reporting to use the updated HEMS runtime and energy-consumption endpoints instead of inferring operating state from inventory health.
 
 ### 🔧 Improvements
-- None
+- Split heat-pump runtime status, connectivity status, SG-Ready mode, and component-status entities so the heat-pump layout aligns more closely with the other device families.
 
 ### 🔄 Other changes
 - None

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems using the same
 - Guided onboarding for site selection and device-category enablement
 - Unified support for EV chargers, gateway, battery, and microinverter entities
 - EV charging controls and session telemetry, including charge-mode aware behavior
+- Heat-pump runtime status, connectivity, SG-Ready mode, power, and current-day consumption details sourced from HEMS endpoints
 - Site and battery energy telemetry, including derived grid-import, grid-export, and battery power sensors for Home Assistant Energy Dashboard use
 - Health diagnostics, service-availability tracking, and actionable repair issues
 - Broad localization support across all user-facing integration strings

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -4018,6 +4018,269 @@ class EnphaseEVClient:
             raise
         return self._normalize_lifetime_energy_payload(data)
 
+    @staticmethod
+    def _clean_optional_text(value: object) -> str | None:
+        """Return a trimmed string value when present."""
+
+        if value is None:
+            return None
+        try:
+            text = str(value).strip()
+        except Exception:  # noqa: BLE001
+            return None
+        return text or None
+
+    @classmethod
+    def _heatpump_sg_ready_mode_details(cls, value: object) -> dict[str, object]:
+        """Map raw HEMS SG Ready mode labels to app-facing semantics."""
+
+        text = cls._clean_optional_text(value)
+        if text is None:
+            return {
+                "sg_ready_mode_label": None,
+                "sg_ready_active": None,
+                "sg_ready_contact_state": None,
+            }
+        normalized = text.upper()
+        if normalized == "MODE_2":
+            return {
+                "sg_ready_mode_label": "Normal",
+                "sg_ready_active": False,
+                "sg_ready_contact_state": "open",
+            }
+        if normalized == "MODE_3":
+            return {
+                "sg_ready_mode_label": "Recommended",
+                "sg_ready_active": True,
+                "sg_ready_contact_state": "closed",
+            }
+        return {
+            "sg_ready_mode_label": None,
+            "sg_ready_active": None,
+            "sg_ready_contact_state": None,
+        }
+
+    @classmethod
+    def _normalize_hems_heatpump_state_payload(cls, payload: object) -> dict | None:
+        """Normalize HEMS heat-pump runtime state payloads."""
+
+        if not isinstance(payload, dict):
+            return None
+        data = payload.get("data")
+        if not isinstance(data, dict):
+            data = payload
+        device_uid = cls._clean_optional_text(
+            data.get("device_uid")
+            if data.get("device_uid") is not None
+            else data.get("device-uid")
+        )
+        heatpump_status = cls._clean_optional_text(
+            data.get("heatpump_status")
+            if data.get("heatpump_status") is not None
+            else data.get("heatpump-status")
+        )
+        sg_ready_mode_raw = cls._clean_optional_text(
+            data.get("sg_ready_mode")
+            if data.get("sg_ready_mode") is not None
+            else data.get("sg-ready-mode")
+        )
+        details = cls._heatpump_sg_ready_mode_details(sg_ready_mode_raw)
+        normalized: dict[str, object] = {
+            "type": cls._clean_optional_text(payload.get("type")),
+            "timestamp": payload.get("timestamp"),
+            "device_uid": device_uid,
+            "heatpump_status": heatpump_status,
+            "sg_ready_mode_raw": sg_ready_mode_raw,
+            "sg_ready_mode_label": details.get("sg_ready_mode_label"),
+            "sg_ready_active": details.get("sg_ready_active"),
+            "sg_ready_contact_state": details.get("sg_ready_contact_state"),
+            "vpp_sgready_mode_override": cls._clean_optional_text(
+                data.get("vpp_sgready_mode_override")
+                if data.get("vpp_sgready_mode_override") is not None
+                else data.get("vpp-sgready-mode-override")
+            ),
+            "last_report_at": (
+                data.get("last_report_at")
+                if data.get("last_report_at") is not None
+                else data.get("last-report-at")
+            ),
+        }
+        return normalized
+
+    @classmethod
+    def _normalize_hems_daily_consumption_entry(
+        cls, payload: object
+    ) -> dict[str, object] | None:
+        """Normalize a HEMS daily-consumption device entry."""
+
+        if not isinstance(payload, dict):
+            return None
+        device_uid = cls._clean_optional_text(
+            payload.get("device_uid")
+            if payload.get("device_uid") is not None
+            else payload.get("device-uid")
+        )
+        device_name = cls._clean_optional_text(
+            payload.get("device_name")
+            if payload.get("device_name") is not None
+            else payload.get("device-name")
+        )
+        buckets: list[dict[str, object]] = []
+        raw_buckets = payload.get("consumption")
+        if isinstance(raw_buckets, list):
+            for item in raw_buckets:
+                if not isinstance(item, dict):
+                    continue
+                bucket: dict[str, object] = {
+                    "solar": cls._coerce_lifetime_energy_value(item.get("solar")),
+                    "battery": cls._coerce_lifetime_energy_value(item.get("battery")),
+                    "grid": cls._coerce_lifetime_energy_value(item.get("grid")),
+                    "details": [],
+                }
+                details = item.get("details")
+                if isinstance(details, list):
+                    bucket["details"] = [
+                        cls._coerce_lifetime_energy_value(detail) for detail in details
+                    ]
+                buckets.append(bucket)
+        return {
+            "device_uid": device_uid,
+            "device_name": device_name,
+            "consumption": buckets,
+        }
+
+    @classmethod
+    def _normalize_hems_energy_consumption_payload(cls, payload: object) -> dict | None:
+        """Normalize HEMS daily energy-consumption payloads."""
+
+        if not isinstance(payload, dict):
+            return None
+        data = payload.get("data")
+        if not isinstance(data, dict):
+            data = payload
+
+        normalized: dict[str, object] = {
+            "type": cls._clean_optional_text(payload.get("type")),
+            "timestamp": payload.get("timestamp"),
+            "data": {
+                "heat-pump": [],
+                "evse": [],
+                "water-heater": [],
+            },
+        }
+        families = normalized["data"]
+        assert isinstance(families, dict)
+        for family_key in ("heat-pump", "evse", "water-heater"):
+            raw_family = data.get(family_key)
+            if raw_family is None:
+                raw_family = data.get(family_key.replace("-", "_"))
+            if not isinstance(raw_family, list):
+                continue
+            entries: list[dict[str, object]] = []
+            for item in raw_family:
+                normalized_entry = cls._normalize_hems_daily_consumption_entry(item)
+                if normalized_entry is not None:
+                    entries.append(normalized_entry)
+            families[family_key] = entries
+        return normalized
+
+    async def hems_heatpump_state(
+        self, device_uid: str, *, timezone: str | None = None
+    ) -> dict | None:
+        """Return HEMS heat-pump runtime state when available."""
+
+        device_uid = str(device_uid or "").strip()
+        if not device_uid:
+            return None
+        url = URL(
+            f"https://hems-integration.enphaseenergy.com/api/v1/hems/{self._site}/heatpump/{device_uid}/state"
+        )
+        if timezone:
+            url = url.update_query({"timezone": str(timezone).strip()})
+        try:
+            data = await self._json("GET", str(url), headers=self._hems_headers)
+            self._hems_site_supported = True
+        except Unauthorized:
+            _LOGGER.debug(
+                "HEMS heat pump state endpoint unavailable for site %s (unauthorized)",
+                redact_site_id(self._site),
+            )
+            return None
+        except InvalidPayloadError as err:
+            if _is_optional_non_json_payload(err):
+                _LOGGER.debug(
+                    "HEMS heat pump state endpoint unavailable for site %s (%s)",
+                    redact_site_id(self._site),
+                    redact_text(err.summary, site_ids=(self._site,)),
+                )
+                return None
+            raise
+        except aiohttp.ClientResponseError as err:
+            if err.status in (401, 403, 404) or _is_hems_invalid_site_error(err):
+                if _is_hems_invalid_site_error(err):
+                    self._hems_site_supported = False
+                _LOGGER.debug(
+                    "HEMS heat pump state endpoint unavailable for site %s (status=%s)",
+                    redact_site_id(self._site),
+                    err.status,
+                )
+                return None
+            raise
+        return self._normalize_hems_heatpump_state_payload(data)
+
+    async def hems_energy_consumption(
+        self,
+        *,
+        start_at: str,
+        end_at: str,
+        timezone: str,
+        step: str = "P1D",
+    ) -> dict | None:
+        """Return HEMS daily device energy-consumption buckets when available."""
+
+        url = str(
+            URL(
+                f"https://hems-integration.enphaseenergy.com/api/v1/hems/{self._site}/energy-consumption"
+            ).update_query(
+                {
+                    "from": start_at,
+                    "to": end_at,
+                    "timezone": timezone,
+                    "step": step,
+                }
+            )
+        )
+        try:
+            data = await self._json("GET", url, headers=self._hems_headers)
+            self._hems_site_supported = True
+        except Unauthorized:
+            _LOGGER.debug(
+                "HEMS energy consumption endpoint unavailable for site %s (unauthorized)",
+                redact_site_id(self._site),
+            )
+            return None
+        except InvalidPayloadError as err:
+            if _is_optional_non_json_payload(err):
+                _LOGGER.debug(
+                    "HEMS energy consumption endpoint unavailable for site %s (%s)",
+                    redact_site_id(self._site),
+                    redact_text(err.summary, site_ids=(self._site,)),
+                )
+                return None
+            raise
+        except aiohttp.ClientResponseError as err:
+            if err.status in (401, 403, 404) or _is_hems_invalid_site_error(err):
+                if _is_hems_invalid_site_error(err):
+                    self._hems_site_supported = False
+                _LOGGER.debug(
+                    "HEMS energy consumption endpoint unavailable for site %s (status=%s)",
+                    redact_site_id(self._site),
+                    err.status,
+                )
+                return None
+            raise
+        return self._normalize_hems_energy_consumption_payload(data)
+
     @classmethod
     def _normalize_hems_power_timeseries_payload(cls, payload: object) -> dict | None:
         """Normalize HEMS heat-pump power timeseries payloads."""

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -16,7 +16,11 @@ from .coordinator import EnphaseCoordinator
 from .device_info_helpers import _cloud_device_info
 from .entity import EnphaseBaseEntity
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
-from .sensor import _heatpump_sg_ready_semantics, _heatpump_type_snapshot
+from .sensor import (
+    _heatpump_runtime_device_uid,
+    _heatpump_runtime_snapshot,
+    _heatpump_sg_ready_semantics,
+)
 
 PARALLEL_UPDATES = 0
 
@@ -65,14 +69,14 @@ async def async_setup_entry(
                 [SiteCloudReachableBinarySensor(coord)], update_before_add=False
             )
             site_entity_added = True
-        heatpump_available = _type_available(coord, "heatpump")
-        if heatpump_available and not heatpump_sg_ready_entity_added:
+        heatpump_runtime_available = _heatpump_runtime_device_uid(coord) is not None
+        if heatpump_runtime_available and not heatpump_sg_ready_entity_added:
             async_add_entities(
                 [HeatPumpSgReadyActiveBinarySensor(coord)],
                 update_before_add=False,
             )
             heatpump_sg_ready_entity_added = True
-        elif inventory_ready and not heatpump_available:
+        elif inventory_ready and not heatpump_runtime_available:
             _async_remove_site_binary_entity("heat_pump_sg_ready_active")
         serials = [sn for sn in coord.iter_serials() if sn and sn not in known_serials]
         if not serials:
@@ -224,60 +228,48 @@ class HeatPumpSgReadyActiveBinarySensor(CoordinatorEntity, BinarySensorEntity):
         )
 
     def _snapshot(self) -> dict[str, object]:
-        return _heatpump_type_snapshot(self._coord, device_type="SG_READY_GATEWAY")
-
-    def _status_text(self) -> str | None:
-        status = self._snapshot().get("native_status")
-        return (
-            str(status).strip() if status is not None and str(status).strip() else None
-        )
-
-    def _active_member_count(self) -> int:
-        snapshot = self._snapshot()
-        members = snapshot.get("members")
-        if not isinstance(members, list):
-            return 0
-        active = 0
-        for member in members:
-            if not isinstance(member, dict):
-                continue
-            status = (
-                member.get("statusText")
-                if member.get("statusText") is not None
-                else (
-                    member.get("status_text")
-                    if member.get("status_text") is not None
-                    else member.get("status")
-                )
-            )
-            details = _heatpump_sg_ready_semantics(status)
-            if details.get("sg_ready_contact_state") == "closed":
-                active += 1
-        return active
+        return _heatpump_runtime_snapshot(self._coord)
 
     @property
     def available(self) -> bool:
         if not _type_available(self._coord, "heatpump"):
             return False
-        return int(self._snapshot().get("member_count", 0) or 0) > 0
+        runtime_uid_getter = getattr(self._coord, "_heatpump_runtime_device_uid", None)
+        if callable(runtime_uid_getter):
+            try:
+                if not runtime_uid_getter():
+                    return False
+            except Exception:  # noqa: BLE001
+                return False
+        snapshot = self._snapshot()
+        return any(
+            snapshot.get(key) is not None
+            for key in ("sg_ready_active", "sg_ready_mode_raw", "sg_ready_mode_label")
+        )
 
     @property
     def is_on(self) -> bool:
-        return self._active_member_count() > 0
+        return bool(self._snapshot().get("sg_ready_active"))
 
     @property
     def extra_state_attributes(self):
         snapshot = self._snapshot()
-        details = _heatpump_sg_ready_semantics(snapshot.get("native_status"))
+        details = _heatpump_sg_ready_semantics(
+            snapshot.get("sg_ready_mode_label") or snapshot.get("sg_ready_mode_raw")
+        )
         return {
-            "status_text": snapshot.get("native_status"),
-            "member_count": snapshot.get("member_count"),
-            "active_member_count": self._active_member_count(),
-            "status_summary": snapshot.get("status_summary"),
-            "latest_reported_utc": snapshot.get("latest_reported_utc"),
-            "hems_data_stale": snapshot.get("hems_data_stale"),
-            "hems_last_success_utc": snapshot.get("hems_last_success_utc"),
-            "hems_last_success_age_s": snapshot.get("hems_last_success_age_s"),
+            "device_uid": snapshot.get("device_uid"),
+            "heatpump_status_raw": snapshot.get("heatpump_status"),
+            "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
+            "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
+            "sg_ready_active": snapshot.get("sg_ready_active"),
+            "sg_ready_contact_state": snapshot.get("sg_ready_contact_state"),
+            "vpp_sgready_mode_override": snapshot.get("vpp_sgready_mode_override"),
+            "last_report_at": snapshot.get("last_report_at"),
+            "source": snapshot.get("source"),
+            "last_error": getattr(
+                self._coord, "heatpump_runtime_state_last_error", None
+            ),
             **details,
         }
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -134,6 +134,10 @@ HEMS_DEVICES_STALE_AFTER_S = 90.0
 # Keep these caches short so we do not hold stale or empty telemetry for minutes.
 HEMS_DEVICES_CACHE_TTL = 15.0
 HEATPUMP_RUNTIME_DIAGNOSTICS_CACHE_TTL = 60.0
+HEATPUMP_RUNTIME_STATE_CACHE_TTL = 15.0
+HEATPUMP_RUNTIME_STATE_FAILURE_BACKOFF_S = 900.0
+HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL = 300.0
+HEATPUMP_DAILY_CONSUMPTION_FAILURE_BACKOFF_S = 900.0
 HEATPUMP_POWER_CACHE_TTL = 15.0
 HEATPUMP_POWER_FAILURE_BACKOFF_S = 900.0
 SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES: tuple[str, ...] = (
@@ -476,6 +480,15 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._show_livestream_payload: dict[str, object] | None = None
         self._heatpump_events_payloads: list[dict[str, object]] = []
         self._heatpump_runtime_diagnostics_error: str | None = None
+        self._heatpump_runtime_state: dict[str, object] | None = None
+        self._heatpump_runtime_state_cache_until: float | None = None
+        self._heatpump_runtime_state_backoff_until: float | None = None
+        self._heatpump_runtime_state_last_error: str | None = None
+        self._heatpump_daily_consumption: dict[str, object] | None = None
+        self._heatpump_daily_consumption_cache_until: float | None = None
+        self._heatpump_daily_consumption_backoff_until: float | None = None
+        self._heatpump_daily_consumption_last_error: str | None = None
+        self._heatpump_daily_consumption_cache_key: tuple[str, str] | None = None
         self._devices_inventory_ready: bool = False
         self._current_power_consumption_w: float | None = None
         self._current_power_consumption_sample_utc: datetime | None = None
@@ -1751,12 +1764,38 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._show_livestream_payload = None
             self._heatpump_events_payloads = []
             self._heatpump_runtime_diagnostics_error = None
+            self._heatpump_runtime_state = None
+            self._heatpump_runtime_state_cache_until = None
+            self._heatpump_runtime_state_backoff_until = None
+            self._heatpump_runtime_state_last_error = None
+            self._heatpump_daily_consumption = None
+            self._heatpump_daily_consumption_cache_until = None
+            self._heatpump_daily_consumption_backoff_until = None
+            self._heatpump_daily_consumption_last_error = None
+            self._heatpump_daily_consumption_cache_key = None
             return
 
         now = time.monotonic()
         if not force and self._heatpump_runtime_diagnostics_cache_until is not None:
             if now < self._heatpump_runtime_diagnostics_cache_until:
                 return
+
+        try:
+            await self._async_refresh_heatpump_runtime_state(force=force)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Heat pump runtime-state diagnostics refresh failed for site %s: %s",
+                redact_site_id(self.site_id),
+                redact_text(err, site_ids=(self.site_id,)),
+            )
+        try:
+            await self._async_refresh_heatpump_daily_consumption(force=force)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Heat pump daily-consumption diagnostics refresh failed for site %s: %s",
+                redact_site_id(self.site_id),
+                redact_text(err, site_ids=(self.site_id,)),
+            )
 
         self._heatpump_runtime_diagnostics_error = None
 
@@ -1920,6 +1959,34 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                         lambda: self._async_refresh_current_power_consumption(),
                     ),
                 ),
+            )
+            heatpump_runtime_started = time.monotonic()
+            try:
+                await self._async_refresh_heatpump_runtime_state()
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Skipping heat pump runtime refresh for site %s during warmup: %s",
+                    redact_site_id(self.site_id),
+                    redact_text(err, site_ids=(self.site_id,)),
+                )
+            warmup_timings["heatpump_runtime_s"] = round(
+                time.monotonic() - heatpump_runtime_started, 3
+            )
+            heatpump_daily_started = time.monotonic()
+            try:
+                await self._async_refresh_heatpump_daily_consumption()
+            except asyncio.CancelledError:
+                raise
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Skipping heat pump daily-consumption refresh for site %s during warmup: %s",
+                    redact_site_id(self.site_id),
+                    redact_text(err, site_ids=(self.site_id,)),
+                )
+            warmup_timings["heatpump_daily_s"] = round(
+                time.monotonic() - heatpump_daily_started, 3
             )
             heatpump_started = time.monotonic()
             try:
@@ -4805,6 +4872,19 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         except Exception:
             return datetime.now(tz=_tz.utc).date().isoformat()
 
+    def _site_timezone_name(self) -> str:
+        """Return the site timezone name when available."""
+
+        tz_name = getattr(self, "_battery_timezone", None)
+        if isinstance(tz_name, str) and tz_name.strip():
+            try:
+                ZoneInfo(tz_name.strip())
+            except Exception:
+                pass
+            else:
+                return tz_name.strip()
+        return "UTC"
+
     @staticmethod
     def _format_inverter_model_summary(model_counts: dict[str, int]) -> str | None:
         clean: dict[str, int] = {}
@@ -5403,6 +5483,270 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             if uid:
                 return uid
         return None
+
+    def _heatpump_runtime_device_uid(self) -> str | None:
+        """Return the dedicated heat-pump UID used for runtime-state requests."""
+
+        for member in self._type_bucket_members("heatpump"):
+            if self._heatpump_member_device_type(member) != "HEAT_PUMP":
+                continue
+            uid = self._type_member_text(member, "device_uid")
+            if uid:
+                return uid
+        return None
+
+    async def _async_refresh_heatpump_runtime_state(
+        self, *, force: bool = False
+    ) -> None:
+        now = time.monotonic()
+        if not self.has_type("heatpump"):
+            self._heatpump_runtime_state = None
+            self._heatpump_runtime_state_cache_until = None
+            self._heatpump_runtime_state_backoff_until = None
+            self._heatpump_runtime_state_last_error = None
+            return
+        if (
+            not force
+            and self._heatpump_runtime_state_cache_until is not None
+            and now < self._heatpump_runtime_state_cache_until
+        ):
+            return
+        if (
+            not force
+            and self._heatpump_runtime_state_backoff_until is not None
+            and now < self._heatpump_runtime_state_backoff_until
+        ):
+            return
+
+        await self._async_refresh_hems_support_preflight(force=force)
+        if getattr(self.client, "hems_site_supported", None) is False:
+            self._heatpump_runtime_state = None
+            self._heatpump_runtime_state_cache_until = (
+                now + HEATPUMP_RUNTIME_STATE_CACHE_TTL
+            )
+            self._heatpump_runtime_state_backoff_until = None
+            self._heatpump_runtime_state_last_error = None
+            return
+
+        device_uid = self._heatpump_runtime_device_uid()
+        if not device_uid:
+            self._heatpump_runtime_state = None
+            self._heatpump_runtime_state_cache_until = (
+                now + HEATPUMP_RUNTIME_STATE_CACHE_TTL
+            )
+            self._heatpump_runtime_state_backoff_until = None
+            self._heatpump_runtime_state_last_error = None
+            return
+
+        fetcher = getattr(self.client, "hems_heatpump_state", None)
+        if not callable(fetcher):
+            return
+
+        try:
+            payload = await fetcher(
+                device_uid=device_uid,
+                timezone=self._site_timezone_name(),
+            )
+        except Exception as err:  # noqa: BLE001
+            self._heatpump_runtime_state_last_error = (
+                redact_text(err, site_ids=(self.site_id,)) or err.__class__.__name__
+            )
+            self._heatpump_runtime_state_backoff_until = (
+                now + HEATPUMP_RUNTIME_STATE_FAILURE_BACKOFF_S
+            )
+            self._heatpump_runtime_state_cache_until = None
+            return
+
+        self._heatpump_runtime_state_cache_until = (
+            now + HEATPUMP_RUNTIME_STATE_CACHE_TTL
+        )
+        self._heatpump_runtime_state_backoff_until = None
+        self._heatpump_runtime_state_last_error = None
+        if not isinstance(payload, dict):
+            self._heatpump_runtime_state = None
+            return
+        snapshot = dict(payload)
+        snapshot["source"] = f"hems_heatpump_state:{device_uid}"
+        self._heatpump_runtime_state = snapshot
+
+    async def _async_refresh_heatpump_daily_consumption(
+        self, *, force: bool = False
+    ) -> None:
+        now = time.monotonic()
+        if not self.has_type("heatpump"):
+            self._heatpump_daily_consumption = None
+            self._heatpump_daily_consumption_cache_until = None
+            self._heatpump_daily_consumption_backoff_until = None
+            self._heatpump_daily_consumption_last_error = None
+            self._heatpump_daily_consumption_cache_key = None
+            return
+        window = self._heatpump_daily_window()
+        if window is None:
+            return
+        start_at, end_at, tz_name, marker = window
+        if (
+            not force
+            and self._heatpump_daily_consumption_cache_until is not None
+            and self._heatpump_daily_consumption_cache_key == marker
+            and now < self._heatpump_daily_consumption_cache_until
+        ):
+            return
+        if (
+            not force
+            and self._heatpump_daily_consumption_backoff_until is not None
+            and self._heatpump_daily_consumption_cache_key == marker
+            and now < self._heatpump_daily_consumption_backoff_until
+        ):
+            return
+
+        await self._async_refresh_hems_support_preflight(force=force)
+        if getattr(self.client, "hems_site_supported", None) is False:
+            self._heatpump_daily_consumption = None
+            self._heatpump_daily_consumption_cache_until = (
+                now + HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL
+            )
+            self._heatpump_daily_consumption_backoff_until = None
+            self._heatpump_daily_consumption_last_error = None
+            self._heatpump_daily_consumption_cache_key = marker
+            return
+
+        fetcher = getattr(self.client, "hems_energy_consumption", None)
+        if not callable(fetcher):
+            return
+
+        try:
+            payload = await fetcher(
+                start_at=start_at,
+                end_at=end_at,
+                timezone=tz_name,
+                step="P1D",
+            )
+        except Exception as err:  # noqa: BLE001
+            self._heatpump_daily_consumption_last_error = (
+                redact_text(err, site_ids=(self.site_id,)) or err.__class__.__name__
+            )
+            self._heatpump_daily_consumption_backoff_until = (
+                now + HEATPUMP_DAILY_CONSUMPTION_FAILURE_BACKOFF_S
+            )
+            self._heatpump_daily_consumption_cache_until = None
+            self._heatpump_daily_consumption_cache_key = marker
+            return
+
+        self._heatpump_daily_consumption_cache_until = (
+            now + HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL
+        )
+        self._heatpump_daily_consumption_backoff_until = None
+        self._heatpump_daily_consumption_last_error = None
+        self._heatpump_daily_consumption_cache_key = marker
+        if not isinstance(payload, dict):
+            self._heatpump_daily_consumption = None
+            return
+        snapshot = self._build_heatpump_daily_consumption_snapshot(payload)
+        if snapshot is not None:
+            snapshot["day_key"] = marker[0]
+            snapshot["timezone"] = marker[1]
+        self._heatpump_daily_consumption = snapshot
+
+    def _heatpump_daily_window(self) -> tuple[str, str, str, tuple[str, str]] | None:
+        """Return the current site-day ISO window and its cache marker."""
+
+        tz_name = self._site_timezone_name()
+        try:
+            tz = ZoneInfo(tz_name)
+        except Exception:
+            tz_name = "UTC"
+            tz = _tz.utc
+        day_key = self._site_local_current_date()
+        try:
+            day_start = datetime.combine(
+                datetime.fromisoformat(day_key).date(),
+                dt_time.min,
+                tzinfo=tz,
+            )
+        except Exception:
+            return None
+        day_end = day_start + timedelta(days=1)
+        marker = (day_key, tz_name)
+        return day_start.isoformat(), day_end.isoformat(), tz_name, marker
+
+    @staticmethod
+    def _sum_optional_values(values: object) -> float | None:
+        if not isinstance(values, list):
+            return None
+        total = 0.0
+        found = False
+        for item in values:
+            if item is None:
+                continue
+            try:
+                numeric = float(item)
+            except Exception:
+                continue
+            if numeric != numeric or numeric in (float("inf"), float("-inf")):
+                continue
+            total += numeric
+            found = True
+        return total if found else None
+
+    def _build_heatpump_daily_consumption_snapshot(
+        self, payload: object
+    ) -> dict[str, object] | None:
+        """Return the primary heat-pump daily-consumption snapshot."""
+
+        if not isinstance(payload, dict):
+            return None
+        families = payload.get("data")
+        if not isinstance(families, dict):
+            return None
+        family = families.get("heat-pump")
+        if not isinstance(family, list) or not family:
+            return None
+
+        preferred_uid = self._heatpump_runtime_device_uid()
+        selected: dict[str, object] | None = None
+        for entry in family:
+            if not isinstance(entry, dict):
+                continue
+            if preferred_uid and entry.get("device_uid") == preferred_uid:
+                selected = entry
+                break
+            if preferred_uid is None and selected is None:
+                selected = entry
+        if not isinstance(selected, dict):
+            return None
+
+        buckets = selected.get("consumption")
+        first_bucket = None
+        if isinstance(buckets, list):
+            for bucket in buckets:
+                if isinstance(bucket, dict):
+                    first_bucket = bucket
+                    break
+        if not isinstance(first_bucket, dict):
+            return None
+
+        return {
+            "device_uid": selected.get("device_uid"),
+            "device_name": selected.get("device_name"),
+            "daily_energy_wh": self._sum_optional_values(first_bucket.get("details")),
+            "daily_solar_wh": self._coerce_optional_float(first_bucket.get("solar")),
+            "daily_battery_wh": self._coerce_optional_float(
+                first_bucket.get("battery")
+            ),
+            "daily_grid_wh": self._coerce_optional_float(first_bucket.get("grid")),
+            "details": (
+                list(first_bucket.get("details"))
+                if isinstance(first_bucket.get("details"), list)
+                else []
+            ),
+            "source": (
+                f"hems_energy_consumption:{selected.get('device_uid')}"
+                if selected.get("device_uid")
+                else "hems_energy_consumption"
+            ),
+            "endpoint_type": payload.get("type"),
+            "endpoint_timestamp": payload.get("timestamp"),
+        }
 
     def _heatpump_power_candidate_device_uids(self) -> list[str | None]:
         candidates: list[str | None] = []
@@ -7049,6 +7393,18 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         """Return captured live/detail heat-pump payloads for diagnostics."""
 
         return {
+            "runtime_state": self._copy_diagnostics_value(
+                getattr(self, "_heatpump_runtime_state", None)
+            ),
+            "runtime_state_last_error": getattr(
+                self, "_heatpump_runtime_state_last_error", None
+            ),
+            "daily_consumption": self._copy_diagnostics_value(
+                getattr(self, "_heatpump_daily_consumption", None)
+            ),
+            "daily_consumption_last_error": getattr(
+                self, "_heatpump_daily_consumption_last_error", None
+            ),
             "show_livestream_payload": self._copy_diagnostics_value(
                 getattr(self, "_show_livestream_payload", None)
             ),
@@ -7546,6 +7902,28 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                             lambda: self._async_refresh_inverters(),
                         ),
                     ),
+                )
+                heatpump_runtime_started = time.monotonic()
+                try:
+                    await self._async_refresh_heatpump_runtime_state()
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.debug(
+                        "Skipping heat pump runtime refresh: %s",
+                        redact_text(err, site_ids=(self.site_id,)),
+                    )
+                phase_timings["heatpump_runtime_s"] = round(
+                    time.monotonic() - heatpump_runtime_started, 3
+                )
+                heatpump_daily_started = time.monotonic()
+                try:
+                    await self._async_refresh_heatpump_daily_consumption()
+                except Exception as err:  # noqa: BLE001
+                    _LOGGER.debug(
+                        "Skipping heat pump daily-consumption refresh: %s",
+                        redact_text(err, site_ids=(self.site_id,)),
+                    )
+                phase_timings["heatpump_daily_s"] = round(
+                    time.monotonic() - heatpump_daily_started, 3
                 )
                 heatpump_started = time.monotonic()
                 try:
@@ -8882,6 +9260,22 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._sync_site_energy_discovery_state()
             self._sync_site_energy_issue()
             self._sync_battery_profile_pending_issue()
+            heatpump_runtime_start = time.monotonic()
+            try:
+                await self._async_refresh_heatpump_runtime_state()
+            except Exception:  # noqa: BLE001
+                pass
+            phase_timings["heatpump_runtime_s"] = round(
+                time.monotonic() - heatpump_runtime_start, 3
+            )
+            heatpump_daily_start = time.monotonic()
+            try:
+                await self._async_refresh_heatpump_daily_consumption()
+            except Exception:  # noqa: BLE001
+                pass
+            phase_timings["heatpump_daily_s"] = round(
+                time.monotonic() - heatpump_daily_start, 3
+            )
             heatpump_power_start = time.monotonic()
             try:
                 await self._async_refresh_heatpump_power()
@@ -10572,6 +10966,42 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             if isinstance(item, dict):
                 out.append(dict(item))
         return out
+
+    @property
+    def heatpump_runtime_state(self) -> dict[str, object]:
+        value = getattr(self, "_heatpump_runtime_state", None)
+        if isinstance(value, dict):
+            return dict(value)
+        return {}
+
+    @property
+    def heatpump_runtime_state_last_error(self) -> str | None:
+        value = getattr(self, "_heatpump_runtime_state_last_error", None)
+        if value is None:
+            return None
+        try:
+            text = str(value).strip()
+        except Exception:
+            return None
+        return text or None
+
+    @property
+    def heatpump_daily_consumption(self) -> dict[str, object]:
+        value = getattr(self, "_heatpump_daily_consumption", None)
+        if isinstance(value, dict):
+            return dict(value)
+        return {}
+
+    @property
+    def heatpump_daily_consumption_last_error(self) -> str | None:
+        value = getattr(self, "_heatpump_daily_consumption_last_error", None)
+        if value is None:
+            return None
+        try:
+            text = str(value).strip()
+        except Exception:
+            return None
+        return text or None
 
     @property
     def heatpump_power_w(self) -> float | None:

--- a/custom_components/enphase_ev/icons.json
+++ b/custom_components/enphase_ev/icons.json
@@ -627,7 +627,10 @@
       "heat_pump_status": {
         "default": "mdi:hvac"
       },
-      "heat_pump_sg_ready_gateway": {
+      "heat_pump_connectivity_status": {
+        "default": "mdi:lan-connect"
+      },
+      "heat_pump_sg_ready_mode": {
         "default": "mdi:lan-connect"
       },
       "heat_pump_energy_meter": {

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -412,12 +412,15 @@ async def async_setup_entry(
             _type_available(coord, "microinverter")
         )
         heatpump_available = _type_available(coord, "heatpump")
+        heatpump_runtime_available = _heatpump_runtime_device_uid(coord) is not None
         heatpump_site_entity_keys: tuple[str, ...] = (
             "heat_pump_status",
-            "heat_pump_sg_ready_gateway",
+            "heat_pump_connectivity_status",
+            "heat_pump_sg_ready_mode",
             "heat_pump_energy_meter",
             "heat_pump_last_reported",
             "heat_pump_power",
+            "heat_pump_sg_ready_gateway",
         )
         site_energy_specs: dict[str, tuple[str, str]] = {
             "solar_production": ("site_solar_production", "Site Solar Production"),
@@ -609,21 +612,35 @@ async def async_setup_entry(
                 EnphaseMicroinverterLastReportedSensor(coord),
             )
         if heatpump_available:
+            if heatpump_runtime_available:
+                _add_site_entity(
+                    "heat_pump_status",
+                    EnphaseHeatPumpStatusSensor(coord),
+                )
+                _async_remove_site_sensor_entity("heat_pump_sg_ready_gateway")
+                _add_site_entity(
+                    "heat_pump_sg_ready_mode",
+                    EnphaseHeatPumpSgReadyModeSensor(coord),
+                )
+                _add_site_entity(
+                    "heat_pump_last_reported",
+                    EnphaseHeatPumpLastReportedSensor(coord),
+                )
+            elif inventory_ready:
+                for entity_key in (
+                    "heat_pump_status",
+                    "heat_pump_sg_ready_mode",
+                    "heat_pump_last_reported",
+                    "heat_pump_sg_ready_gateway",
+                ):
+                    _async_remove_site_sensor_entity(entity_key)
             _add_site_entity(
-                "heat_pump_status",
-                EnphaseHeatPumpStatusSensor(coord),
-            )
-            _add_site_entity(
-                "heat_pump_sg_ready_gateway",
-                EnphaseHeatPumpSgReadyGatewaySensor(coord),
+                "heat_pump_connectivity_status",
+                EnphaseHeatPumpConnectivityStatusSensor(coord),
             )
             _add_site_entity(
                 "heat_pump_energy_meter",
                 EnphaseHeatPumpEnergyMeterSensor(coord),
-            )
-            _add_site_entity(
-                "heat_pump_last_reported",
-                EnphaseHeatPumpLastReportedSensor(coord),
             )
             _add_site_entity(
                 "heat_pump_power",
@@ -4112,6 +4129,31 @@ def _heatpump_type_snapshot(
     }
 
 
+def _heatpump_runtime_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
+    snapshot = getattr(coord, "heatpump_runtime_state", None)
+    if isinstance(snapshot, dict):
+        return dict(snapshot)
+    return {}
+
+
+def _heatpump_runtime_device_uid(coord: EnphaseCoordinator) -> str | None:
+    getter = getattr(coord, "_heatpump_runtime_device_uid", None)
+    if callable(getter):
+        try:
+            return _gateway_clean_text(getter())
+        except Exception:  # noqa: BLE001
+            return None
+    return None
+
+
+def _heatpump_runtime_last_reported(snapshot: dict[str, object]) -> datetime | None:
+    return _gateway_parse_timestamp(
+        snapshot.get("last_report_at")
+        if snapshot.get("last_report_at") is not None
+        else snapshot.get("last_reported_at")
+    )
+
+
 def _title_case_status(value: object) -> str | None:
     text = _gateway_clean_text(value)
     if text is None:
@@ -4243,13 +4285,13 @@ def _heatpump_sg_ready_semantics(status_text: object) -> dict[str, object]:
     if not text:
         return {}
     normalized = text.casefold()
-    if normalized == "recommended":
+    if normalized in {"recommended", "mode_3", "mode3"}:
         return {
             "sg_ready_mode": 3,
             "sg_ready_contact_state": "closed",
             "status_explanation": "Recommended means the SG Ready contact is closed.",
         }
-    if normalized == "normal":
+    if normalized in {"normal", "mode_2", "mode2"}:
         return {
             "sg_ready_mode": 2,
             "sg_ready_contact_state": "open",
@@ -4978,6 +5020,25 @@ class EnphaseSiteEnergySensor(_SiteBaseEntity, RestoreSensor):
                     attrs["heat_pump_power_w"] = round(float(heatpump_power), 3)
                 except Exception:  # noqa: BLE001
                     attrs["heat_pump_power_w"] = None
+            daily = getattr(self._coord, "heatpump_daily_consumption", None)
+            if isinstance(daily, dict):
+                for key in (
+                    "daily_energy_wh",
+                    "daily_solar_wh",
+                    "daily_battery_wh",
+                    "daily_grid_wh",
+                    "device_uid",
+                    "device_name",
+                    "source",
+                ):
+                    if key not in daily:
+                        continue
+                    attr_key = {
+                        "device_uid": "daily_device_uid",
+                        "device_name": "daily_device_name",
+                        "source": "daily_source",
+                    }.get(key, key)
+                    attrs[attr_key] = daily.get(key)
         return attrs
 
 
@@ -6658,13 +6719,77 @@ class EnphaseMicroinverterLastReportedSensor(_SiteBaseEntity):
 class EnphaseHeatPumpStatusSensor(_SiteBaseEntity):
     _attr_translation_key = "heat_pump_status"
     _attr_entity_registry_enabled_default = True
+
+    def __init__(self, coord: EnphaseCoordinator):
+        super().__init__(
+            coord, "heat_pump_status", "Heat Pump Status", type_key="heatpump"
+        )
+
+    def _snapshot(self) -> dict[str, object]:
+        return _heatpump_runtime_snapshot(self._coord)
+
+    def _runtime_device_uid(self) -> str | None:
+        getter = getattr(self._coord, "_heatpump_runtime_device_uid", None)
+        if callable(getter):
+            try:
+                return getter()
+            except Exception:  # noqa: BLE001
+                return None
+        uid = self._snapshot().get("device_uid")
+        return _gateway_clean_text(uid)
+
+    @property
+    def available(self) -> bool:
+        if not super().available:
+            return False
+        if not self._runtime_device_uid():
+            return False
+        return self.native_value is not None
+
+    @property
+    def native_value(self):
+        return _title_case_status(self._snapshot().get("heatpump_status"))
+
+    @property
+    def extra_state_attributes(self):
+        snapshot = self._snapshot()
+        last_reported = _heatpump_runtime_last_reported(snapshot)
+        sg_ready_details = _heatpump_sg_ready_semantics(
+            snapshot.get("sg_ready_mode_label") or snapshot.get("sg_ready_mode_raw")
+        )
+        return {
+            "device_uid": snapshot.get("device_uid"),
+            "heatpump_status_raw": snapshot.get("heatpump_status"),
+            "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
+            "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
+            "sg_ready_active": snapshot.get("sg_ready_active"),
+            "sg_ready_contact_state": snapshot.get("sg_ready_contact_state"),
+            "vpp_sgready_mode_override": snapshot.get("vpp_sgready_mode_override"),
+            "last_report_at_utc": (
+                last_reported.isoformat() if last_reported is not None else None
+            ),
+            "source": snapshot.get("source"),
+            "last_error": getattr(
+                self._coord, "heatpump_runtime_state_last_error", None
+            ),
+            **sg_ready_details,
+        }
+
+
+class EnphaseHeatPumpConnectivityStatusSensor(_SiteBaseEntity):
+    _attr_translation_key = "heat_pump_connectivity_status"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = True
     _unrecorded_attributes = _SiteBaseEntity._unrecorded_attributes.union(
         {"members", "latest_reported_device"}
     )
 
     def __init__(self, coord: EnphaseCoordinator):
         super().__init__(
-            coord, "heat_pump_status", "Heat Pump Status", type_key="heatpump"
+            coord,
+            "heat_pump_connectivity_status",
+            "Heat Pump Connectivity Status",
+            type_key="heatpump",
         )
 
     @property
@@ -6678,8 +6803,9 @@ class EnphaseHeatPumpStatusSensor(_SiteBaseEntity):
 
     @property
     def native_value(self):
-        snapshot = _heatpump_snapshot(self._coord)
-        return snapshot.get("overall_status_text")
+        return _title_case_status(
+            _heatpump_snapshot(self._coord).get("overall_status_text")
+        )
 
     @property
     def extra_state_attributes(self):
@@ -6749,10 +6875,6 @@ class _EnphaseHeatPumpDeviceTypeSensor(_SiteBaseEntity):
             if isinstance(members, list)
             else []
         )
-        flattened_members = [
-            _gateway_flat_member_attributes(member) for member in safe_members
-        ]
-        sg_ready_details = _heatpump_sg_ready_semantics(snapshot.get("native_status"))
         return {
             "device_type": snapshot.get("device_type"),
             "member_count": snapshot.get("member_count"),
@@ -6764,21 +6886,79 @@ class _EnphaseHeatPumpDeviceTypeSensor(_SiteBaseEntity):
             "hems_last_success_utc": snapshot.get("hems_last_success_utc"),
             "hems_last_success_age_s": snapshot.get("hems_last_success_age_s"),
             "members": safe_members,
-            "member_attributes": flattened_members,
-            **sg_ready_details,
+            "member_attributes": [
+                _gateway_flat_member_attributes(member) for member in safe_members
+            ],
         }
 
 
-class EnphaseHeatPumpSgReadyGatewaySensor(_EnphaseHeatPumpDeviceTypeSensor):
-    _attr_translation_key = "heat_pump_sg_ready_gateway"
+class EnphaseHeatPumpSgReadyModeSensor(_SiteBaseEntity):
+    _attr_translation_key = "heat_pump_sg_ready_mode"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = True
 
     def __init__(self, coord: EnphaseCoordinator):
         super().__init__(
             coord,
-            key="heat_pump_sg_ready_gateway",
-            name="Heat Pump SG Ready Gateway",
-            device_type="SG_READY_GATEWAY",
+            "heat_pump_sg_ready_mode",
+            "Heat Pump SG-Ready Mode",
+            type_key="heatpump",
         )
+
+    def _snapshot(self) -> dict[str, object]:
+        return _heatpump_runtime_snapshot(self._coord)
+
+    def _runtime_device_uid(self) -> str | None:
+        getter = getattr(self._coord, "_heatpump_runtime_device_uid", None)
+        if callable(getter):
+            try:
+                return getter()
+            except Exception:  # noqa: BLE001
+                return None
+        uid = self._snapshot().get("device_uid")
+        return _gateway_clean_text(uid)
+
+    @property
+    def available(self) -> bool:
+        if not super().available:
+            return False
+        if not self._runtime_device_uid():
+            return False
+        snapshot = self._snapshot()
+        return any(
+            snapshot.get(key) is not None
+            for key in ("sg_ready_mode_label", "sg_ready_mode_raw")
+        )
+
+    @property
+    def native_value(self):
+        snapshot = self._snapshot()
+        return snapshot.get("sg_ready_mode_label") or snapshot.get("sg_ready_mode_raw")
+
+    @property
+    def extra_state_attributes(self):
+        snapshot = self._snapshot()
+        last_reported = _heatpump_runtime_last_reported(snapshot)
+        details = _heatpump_sg_ready_semantics(
+            snapshot.get("sg_ready_mode_label") or snapshot.get("sg_ready_mode_raw")
+        )
+        return {
+            "device_uid": snapshot.get("device_uid"),
+            "heatpump_status_raw": snapshot.get("heatpump_status"),
+            "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
+            "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
+            "sg_ready_active": snapshot.get("sg_ready_active"),
+            "sg_ready_contact_state": snapshot.get("sg_ready_contact_state"),
+            "vpp_sgready_mode_override": snapshot.get("vpp_sgready_mode_override"),
+            "last_report_at_utc": (
+                last_reported.isoformat() if last_reported is not None else None
+            ),
+            "source": snapshot.get("source"),
+            "last_error": getattr(
+                self._coord, "heatpump_runtime_state_last_error", None
+            ),
+            **details,
+        }
 
 
 class EnphaseHeatPumpEnergyMeterSensor(_EnphaseHeatPumpDeviceTypeSensor):
@@ -6788,7 +6968,7 @@ class EnphaseHeatPumpEnergyMeterSensor(_EnphaseHeatPumpDeviceTypeSensor):
         super().__init__(
             coord,
             key="heat_pump_energy_meter",
-            name="Heat Pump Energy Meter",
+            name="Heat Pump Energy Meter Status",
             device_type="ENERGY_METER",
         )
 
@@ -6814,23 +6994,33 @@ class EnphaseHeatPumpLastReportedSensor(_SiteBaseEntity):
     def available(self) -> bool:
         if not super().available:
             return False
-        return _heatpump_snapshot(self._coord).get("latest_reported") is not None
+        if _heatpump_runtime_device_uid(self._coord) is None:
+            return False
+        return (
+            _heatpump_runtime_last_reported(_heatpump_runtime_snapshot(self._coord))
+            is not None
+        )
 
     @property
     def native_value(self):
-        return _heatpump_snapshot(self._coord).get("latest_reported")
+        return _heatpump_runtime_last_reported(_heatpump_runtime_snapshot(self._coord))
 
     @property
     def extra_state_attributes(self):
-        snapshot = _heatpump_snapshot(self._coord)
+        snapshot = _heatpump_runtime_snapshot(self._coord)
+        last_reported = _heatpump_runtime_last_reported(snapshot)
         return {
-            "latest_reported_device": snapshot.get("latest_reported_device"),
-            "without_last_report_count": snapshot.get("without_last_report_count"),
-            "total_devices": snapshot.get("total_devices"),
-            "status_summary": snapshot.get("status_summary"),
-            "hems_data_stale": snapshot.get("hems_data_stale"),
-            "hems_last_success_utc": snapshot.get("hems_last_success_utc"),
-            "hems_last_success_age_s": snapshot.get("hems_last_success_age_s"),
+            "device_uid": snapshot.get("device_uid"),
+            "heatpump_status_raw": snapshot.get("heatpump_status"),
+            "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
+            "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
+            "last_report_at_utc": (
+                last_reported.isoformat() if last_reported is not None else None
+            ),
+            "source": snapshot.get("source"),
+            "last_error": getattr(
+                self._coord, "heatpump_runtime_state_last_error", None
+            ),
         }
 
 

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -910,16 +910,19 @@
         "name": "Microinverter Last Reported"
       },
       "heat_pump_status": {
-        "name": "Heat Pump Status"
+        "name": "Heat Pump Runtime Status"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Heat Pump SG-Ready Gateway"
+      "heat_pump_connectivity_status": {
+        "name": "Heat Pump Connectivity Status"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Heat Pump SG-Ready Mode"
       },
       "heat_pump_energy_meter": {
-        "name": "Heat Pump Energy Meter"
+        "name": "Heat Pump Energy Meter Status"
       },
       "heat_pump_last_reported": {
-        "name": "Heat Pump Last Reported"
+        "name": "Heat Pump Runtime Last Reported"
       },
       "heat_pump_power": {
         "name": "Heat Pump Power"

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Статус на термопомпата"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "SG-Ready Gateway на термопомпата"
-      },
       "heat_pump_energy_meter": {
         "name": "Енергиен измервател на термопомпата"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Мощност на термопомпата"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Статус на термопомпата"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "SG-Ready Gateway на термопомпата"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Stav tepelného čerpadla"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "SG-Ready brána tepelného čerpadla"
-      },
       "heat_pump_energy_meter": {
         "name": "Měřič energie tepelného čerpadla"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Výkon tepelného čerpadla"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Stav tepelného čerpadla"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "SG-Ready brána tepelného čerpadla"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Varmepumpestatus"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Varmepumpens SG-Ready-gateway"
-      },
       "heat_pump_energy_meter": {
         "name": "Varmepumpens energimåler"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Varmepumpeeffekt"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Varmepumpestatus"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Varmepumpens SG-Ready-gateway"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Wärmepumpenstatus"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "SG-Ready-Gateway der Wärmepumpe"
-      },
       "heat_pump_energy_meter": {
         "name": "Energiemesser der Wärmepumpe"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Wärmepumpenleistung"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Wärmepumpenstatus"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "SG-Ready-Gateway der Wärmepumpe"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Κατάσταση αντλίας θερμότητας"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Πύλη SG-Ready αντλίας θερμότητας"
-      },
       "heat_pump_energy_meter": {
         "name": "Μετρητής ενέργειας αντλίας θερμότητας"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Ισχύς αντλίας θερμότητας"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Κατάσταση αντλίας θερμότητας"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Πύλη SG-Ready αντλίας θερμότητας"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -957,19 +957,22 @@
         "name": "IQ Energy Router_{index}"
       },
       "heat_pump_status": {
-        "name": "Heat Pump Status"
-      },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Heat Pump SG-Ready Gateway"
+        "name": "Heat Pump Runtime Status"
       },
       "heat_pump_energy_meter": {
-        "name": "Heat Pump Energy Meter"
+        "name": "Heat Pump Energy Meter Status"
       },
       "heat_pump_last_reported": {
-        "name": "Heat Pump Last Reported"
+        "name": "Heat Pump Runtime Last Reported"
       },
       "heat_pump_power": {
         "name": "Heat Pump Power"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Heat Pump Connectivity Status"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Heat Pump SG-Ready Mode"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -957,19 +957,22 @@
         "name": "IQ Energy Router_{index}"
       },
       "heat_pump_status": {
-        "name": "Heat Pump Status"
-      },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Heat Pump SG-Ready Gateway"
+        "name": "Heat Pump Runtime Status"
       },
       "heat_pump_energy_meter": {
-        "name": "Heat Pump Energy Meter"
+        "name": "Heat Pump Energy Meter Status"
       },
       "heat_pump_last_reported": {
-        "name": "Heat Pump Last Reported"
+        "name": "Heat Pump Runtime Last Reported"
       },
       "heat_pump_power": {
         "name": "Heat Pump Power"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Heat Pump Connectivity Status"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Heat Pump SG-Ready Mode"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -957,19 +957,22 @@
         "name": "IQ Energy Router_{index}"
       },
       "heat_pump_status": {
-        "name": "Heat Pump Status"
-      },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Heat Pump SG-Ready Gateway"
+        "name": "Heat Pump Runtime Status"
       },
       "heat_pump_energy_meter": {
-        "name": "Heat Pump Energy Meter"
+        "name": "Heat Pump Energy Meter Status"
       },
       "heat_pump_last_reported": {
-        "name": "Heat Pump Last Reported"
+        "name": "Heat Pump Runtime Last Reported"
       },
       "heat_pump_power": {
         "name": "Heat Pump Power"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Heat Pump Connectivity Status"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Heat Pump SG-Ready Mode"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -957,19 +957,22 @@
         "name": "IQ Energy Router_{index}"
       },
       "heat_pump_status": {
-        "name": "Heat Pump Status"
-      },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Heat Pump SG-Ready Gateway"
+        "name": "Heat Pump Runtime Status"
       },
       "heat_pump_energy_meter": {
-        "name": "Heat Pump Energy Meter"
+        "name": "Heat Pump Energy Meter Status"
       },
       "heat_pump_last_reported": {
-        "name": "Heat Pump Last Reported"
+        "name": "Heat Pump Runtime Last Reported"
       },
       "heat_pump_power": {
         "name": "Heat Pump Power"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Heat Pump Connectivity Status"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Heat Pump SG-Ready Mode"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -957,19 +957,22 @@
         "name": "IQ Energy Router_{index}"
       },
       "heat_pump_status": {
-        "name": "Heat Pump Status"
-      },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Heat Pump SG-Ready Gateway"
+        "name": "Heat Pump Runtime Status"
       },
       "heat_pump_energy_meter": {
-        "name": "Heat Pump Energy Meter"
+        "name": "Heat Pump Energy Meter Status"
       },
       "heat_pump_last_reported": {
-        "name": "Heat Pump Last Reported"
+        "name": "Heat Pump Runtime Last Reported"
       },
       "heat_pump_power": {
         "name": "Heat Pump Power"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Heat Pump Connectivity Status"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Heat Pump SG-Ready Mode"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -957,19 +957,22 @@
         "name": "IQ Energy Router_{index}"
       },
       "heat_pump_status": {
-        "name": "Heat Pump Status"
-      },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Heat Pump SG-Ready Gateway"
+        "name": "Heat Pump Runtime Status"
       },
       "heat_pump_energy_meter": {
-        "name": "Heat Pump Energy Meter"
+        "name": "Heat Pump Energy Meter Status"
       },
       "heat_pump_last_reported": {
-        "name": "Heat Pump Last Reported"
+        "name": "Heat Pump Runtime Last Reported"
       },
       "heat_pump_power": {
         "name": "Heat Pump Power"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Heat Pump Connectivity Status"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Heat Pump SG-Ready Mode"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Estado de la bomba de calor"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Gateway SG-Ready de la bomba de calor"
-      },
       "heat_pump_energy_meter": {
         "name": "Medidor de energía de la bomba de calor"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Potencia de la bomba de calor"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Estado de la bomba de calor"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Gateway SG-Ready de la bomba de calor"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Soojuspumba olek"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Soojuspumba SG-Ready lüüs"
-      },
       "heat_pump_energy_meter": {
         "name": "Soojuspumba energiaarvesti"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Soojuspumba võimsus"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Soojuspumba olek"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Soojuspumba SG-Ready lüüs"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Lämpöpumpun tila"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Lämpöpumpun SG-Ready-yhdyskäytävä"
-      },
       "heat_pump_energy_meter": {
         "name": "Lämpöpumpun energiamittari"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Lämpöpumpun teho"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Lämpöpumpun tila"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Lämpöpumpun SG-Ready-yhdyskäytävä"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -957,19 +957,22 @@
         "name": "Routeur d'énergie IQ_{index}"
       },
       "heat_pump_status": {
-        "name": "État de la pompe à chaleur"
-      },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Passerelle SG-Ready de la pompe à chaleur"
+        "name": "État de fonctionnement de la pompe à chaleur"
       },
       "heat_pump_energy_meter": {
-        "name": "Compteur d'énergie de la pompe à chaleur"
+        "name": "État du compteur d'énergie de la pompe à chaleur"
       },
       "heat_pump_last_reported": {
-        "name": "Dernier signalement de la pompe à chaleur"
+        "name": "Dernier rapport de fonctionnement de la pompe à chaleur"
       },
       "heat_pump_power": {
         "name": "Puissance de la pompe à chaleur"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "État de connectivité de la pompe à chaleur"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Mode SG-Ready de la pompe à chaleur"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Hőszivattyú állapota"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Hőszivattyú SG-Ready átjáró"
-      },
       "heat_pump_energy_meter": {
         "name": "Hőszivattyú energiamérő"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Hőszivattyú teljesítménye"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Hőszivattyú állapota"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Hőszivattyú SG-Ready átjáró"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Stato della pompa di calore"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Gateway SG-Ready della pompa di calore"
-      },
       "heat_pump_energy_meter": {
         "name": "Misuratore di energia della pompa di calore"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Potenza della pompa di calore"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Stato della pompa di calore"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Gateway SG-Ready della pompa di calore"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Šilumos siurblio būsena"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Šilumos siurblio SG-Ready šliuzas"
-      },
       "heat_pump_energy_meter": {
         "name": "Šilumos siurblio energijos skaitiklis"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Šilumos siurblio galia"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Šilumos siurblio būsena"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Šilumos siurblio SG-Ready šliuzas"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Siltumsūkņa statuss"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Siltumsūkņa SG-Ready vārteja"
-      },
       "heat_pump_energy_meter": {
         "name": "Siltumsūkņa enerģijas skaitītājs"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Siltumsūkņa jauda"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Siltumsūkņa statuss"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Siltumsūkņa SG-Ready vārteja"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Varmepumpestatus"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Varmepumpens SG-Ready-gateway"
-      },
       "heat_pump_energy_meter": {
         "name": "Varmepumpens energimåler"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Varmepumpeeffekt"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Varmepumpestatus"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Varmepumpens SG-Ready-gateway"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Warmtepompstatus"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "SG-Ready-gateway van de warmtepomp"
-      },
       "heat_pump_energy_meter": {
         "name": "Energiemeter van de warmtepomp"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Vermogen van de warmtepomp"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Warmtepompstatus"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "SG-Ready-gateway van de warmtepomp"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Status pompy ciepła"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Bramka SG-Ready pompy ciepła"
-      },
       "heat_pump_energy_meter": {
         "name": "Licznik energii pompy ciepła"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Moc pompy ciepła"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Status pompy ciepła"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Bramka SG-Ready pompy ciepła"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Status da bomba de calor"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Gateway SG-Ready da bomba de calor"
-      },
       "heat_pump_energy_meter": {
         "name": "Medidor de energia da bomba de calor"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Potência da bomba de calor"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Status da bomba de calor"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Gateway SG-Ready da bomba de calor"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Starea pompei de căldură"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Gateway SG-Ready al pompei de căldură"
-      },
       "heat_pump_energy_meter": {
         "name": "Contor de energie al pompei de căldură"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Puterea pompei de căldură"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Starea pompei de căldură"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Gateway SG-Ready al pompei de căldură"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -959,9 +959,6 @@
       "heat_pump_status": {
         "name": "Värmepumpstatus"
       },
-      "heat_pump_sg_ready_gateway": {
-        "name": "Värmepumpens SG-Ready-gateway"
-      },
       "heat_pump_energy_meter": {
         "name": "Värmepumpens energimätare"
       },
@@ -970,6 +967,12 @@
       },
       "heat_pump_power": {
         "name": "Värmepumpseffekt"
+      },
+      "heat_pump_connectivity_status": {
+        "name": "Värmepumpstatus"
+      },
+      "heat_pump_sg_ready_mode": {
+        "name": "Värmepumpens SG-Ready-gateway"
       }
     },
     "number": {

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3307,6 +3307,415 @@ async def test_hems_consumption_lifetime_uses_control_headers() -> None:
 
 
 @pytest.mark.asyncio
+async def test_hems_heatpump_state_normalization_and_headers() -> None:
+    client = _make_client()
+    client.update_credentials(
+        cookie="enlighten_manager_token_production=BEAR; XSRF-TOKEN=xsrf",
+        eauth="EAUTH",
+    )
+    client._json = AsyncMock(
+        return_value={
+            "type": "hems-heatpump-details",
+            "timestamp": "2026-03-20T08:19:17.945447902Z",
+            "data": {
+                "device-uid": "HP-1",
+                "heatpump-status": "RUNNING",
+                "sg-ready-mode": "MODE_3",
+                "vpp-sgready-mode-override": "NONE",
+                "last-report-at": "2026-03-20T08:18:59.604Z",
+            },
+        }
+    )
+
+    payload = await client.hems_heatpump_state("HP-1", timezone="Europe/Berlin")
+
+    assert payload == {
+        "type": "hems-heatpump-details",
+        "timestamp": "2026-03-20T08:19:17.945447902Z",
+        "device_uid": "HP-1",
+        "heatpump_status": "RUNNING",
+        "sg_ready_mode_raw": "MODE_3",
+        "sg_ready_mode_label": "Recommended",
+        "sg_ready_active": True,
+        "sg_ready_contact_state": "closed",
+        "vpp_sgready_mode_override": "NONE",
+        "last_report_at": "2026-03-20T08:18:59.604Z",
+    }
+    args, kwargs = client._json.await_args
+    assert args[0] == "GET"
+    assert (
+        args[1]
+        == "https://hems-integration.enphaseenergy.com/api/v1/hems/SITE/heatpump/HP-1/state?timezone=Europe/Berlin"
+    )
+    assert callable(kwargs["headers"])
+    headers = kwargs["headers"]()
+    assert headers["Authorization"] == "Bearer BEAR"
+    assert headers["e-auth-token"] == "EAUTH"
+    assert headers["X-CSRF-Token"] == "xsrf"
+
+
+def test_hems_heatpump_state_normalizers_cover_edge_cases() -> None:
+    class BadString:
+        def __str__(self) -> str:
+            raise ValueError("boom")
+
+    assert api.EnphaseEVClient._clean_optional_text(None) is None
+    assert api.EnphaseEVClient._clean_optional_text(BadString()) is None
+    assert api.EnphaseEVClient._heatpump_sg_ready_mode_details(None) == {
+        "sg_ready_mode_label": None,
+        "sg_ready_active": None,
+        "sg_ready_contact_state": None,
+    }
+    assert api.EnphaseEVClient._heatpump_sg_ready_mode_details("MODE_2") == {
+        "sg_ready_mode_label": "Normal",
+        "sg_ready_active": False,
+        "sg_ready_contact_state": "open",
+    }
+    assert api.EnphaseEVClient._heatpump_sg_ready_mode_details("MODE_99") == {
+        "sg_ready_mode_label": None,
+        "sg_ready_active": None,
+        "sg_ready_contact_state": None,
+    }
+    assert api.EnphaseEVClient._normalize_hems_heatpump_state_payload(["bad"]) is None
+    assert api.EnphaseEVClient._normalize_hems_heatpump_state_payload(
+        {
+            "type": "hems-heatpump-details",
+            "device-uid": "HP-2",
+            "heatpump-status": "IDLE",
+            "sg-ready-mode": "MODE_2",
+            "vpp-sgready-mode-override": "NONE",
+            "last-report-at": "2026-03-20T08:18:59.604Z",
+        }
+    ) == {
+        "type": "hems-heatpump-details",
+        "timestamp": None,
+        "device_uid": "HP-2",
+        "heatpump_status": "IDLE",
+        "sg_ready_mode_raw": "MODE_2",
+        "sg_ready_mode_label": "Normal",
+        "sg_ready_active": False,
+        "sg_ready_contact_state": "open",
+        "vpp_sgready_mode_override": "NONE",
+        "last_report_at": "2026-03-20T08:18:59.604Z",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("side_effect", [api.Unauthorized(), _make_cre(404)])
+async def test_hems_heatpump_state_optional_failures_return_none(
+    monkeypatch, side_effect
+) -> None:
+    client = _make_client()
+    monkeypatch.setattr(client, "_json", AsyncMock(side_effect=side_effect))
+
+    assert await client.hems_heatpump_state("HP-1") is None
+
+
+@pytest.mark.asyncio
+async def test_hems_heatpump_state_optional_invalid_payload_and_invalid_site() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=_make_optional_payload_error(
+            "/api/v1/hems/SITE/heatpump/HP-1/state"
+        )
+    )
+
+    assert await client.hems_heatpump_state("HP-1") is None
+
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=_make_cre(
+            550,
+            json.dumps({"error": {"status": "INVALID_SITE", "message": "unsupported"}}),
+        )
+    )
+
+    assert await client.hems_heatpump_state("HP-1") is None
+    assert client.hems_site_supported is False
+
+
+@pytest.mark.asyncio
+async def test_hems_heatpump_state_reraises_non_optional_errors() -> None:
+    client = _make_client()
+    invalid_json = api.InvalidPayloadError(
+        "Invalid JSON response",
+        status=200,
+        content_type="application/json",
+        endpoint="/api/v1/hems/SITE/heatpump/HP-1/state",
+    )
+    client._json = AsyncMock(side_effect=invalid_json)
+
+    with pytest.raises(api.InvalidPayloadError):
+        await client.hems_heatpump_state("HP-1")
+
+    client = _make_client()
+    client._json = AsyncMock(side_effect=_make_cre(500))
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.hems_heatpump_state("HP-1")
+
+
+@pytest.mark.asyncio
+async def test_hems_heatpump_state_skips_blank_device_uid() -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=AssertionError("should not fetch"))
+
+    assert await client.hems_heatpump_state("   ") is None
+    client._json.assert_not_awaited()
+
+
+def test_hems_energy_consumption_normalizers_cover_edge_cases() -> None:
+    assert api.EnphaseEVClient._normalize_hems_daily_consumption_entry(["bad"]) is None
+    assert api.EnphaseEVClient._normalize_hems_daily_consumption_entry(
+        {
+            "device-uid": "HP-1",
+            "device-name": "Waermepumpe",
+            "consumption": [
+                "skip-me",
+                {"solar": "1.0", "details": [2.0, "bad", None]},
+            ],
+        }
+    ) == {
+        "device_uid": "HP-1",
+        "device_name": "Waermepumpe",
+        "consumption": [
+            {
+                "solar": 1.0,
+                "battery": None,
+                "grid": None,
+                "details": [2.0, None, None],
+            }
+        ],
+    }
+    assert (
+        api.EnphaseEVClient._normalize_hems_energy_consumption_payload(["bad"]) is None
+    )
+    assert api.EnphaseEVClient._normalize_hems_energy_consumption_payload(
+        {
+            "type": "hems-device-details",
+            "timestamp": "2026-03-20T07:53:00.739143826Z",
+            "heat_pump": [
+                {
+                    "device_uid": "HP-1",
+                    "device_name": "Waermepumpe",
+                    "consumption": [{"solar": 1.0, "details": [2.0]}],
+                }
+            ],
+            "evse": "not-a-list",
+            "water_heater": [
+                {
+                    "device_uid": "WH-1",
+                    "device_name": "Boiler",
+                    "consumption": [{"grid": 3.0, "details": [4.0]}],
+                }
+            ],
+        }
+    ) == {
+        "type": "hems-device-details",
+        "timestamp": "2026-03-20T07:53:00.739143826Z",
+        "data": {
+            "heat-pump": [
+                {
+                    "device_uid": "HP-1",
+                    "device_name": "Waermepumpe",
+                    "consumption": [
+                        {
+                            "solar": 1.0,
+                            "battery": None,
+                            "grid": None,
+                            "details": [2.0],
+                        }
+                    ],
+                }
+            ],
+            "evse": [],
+            "water-heater": [
+                {
+                    "device_uid": "WH-1",
+                    "device_name": "Boiler",
+                    "consumption": [
+                        {
+                            "solar": None,
+                            "battery": None,
+                            "grid": 3.0,
+                            "details": [4.0],
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_hems_energy_consumption_normalization_and_query() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        return_value={
+            "type": "hems-device-details",
+            "timestamp": "2026-03-20T07:53:00.739143826Z",
+            "data": {
+                "heat-pump": [
+                    {
+                        "device-uid": "HP-1",
+                        "device-name": "Waermepumpe",
+                        "consumption": [
+                            {
+                                "solar": 1.0,
+                                "battery": "2.0",
+                                "grid": 3,
+                                "details": [47.0, "53.0", "bad"],
+                            }
+                        ],
+                    }
+                ],
+                "evse": [],
+                "water-heater": [
+                    {
+                        "device-uid": "WH-1",
+                        "device-name": "Boiler",
+                        "consumption": [{"solar": 4.0, "details": [5.0]}],
+                    }
+                ],
+            },
+        }
+    )
+
+    payload = await client.hems_energy_consumption(
+        start_at="2026-03-20T00:00:00+01:00",
+        end_at="2026-03-21T00:00:00+01:00",
+        timezone="Europe/Berlin",
+    )
+
+    assert payload == {
+        "type": "hems-device-details",
+        "timestamp": "2026-03-20T07:53:00.739143826Z",
+        "data": {
+            "heat-pump": [
+                {
+                    "device_uid": "HP-1",
+                    "device_name": "Waermepumpe",
+                    "consumption": [
+                        {
+                            "solar": 1.0,
+                            "battery": 2.0,
+                            "grid": 3.0,
+                            "details": [47.0, 53.0, None],
+                        }
+                    ],
+                }
+            ],
+            "evse": [],
+            "water-heater": [
+                {
+                    "device_uid": "WH-1",
+                    "device_name": "Boiler",
+                    "consumption": [
+                        {
+                            "solar": 4.0,
+                            "battery": None,
+                            "grid": None,
+                            "details": [5.0],
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+    args, _kwargs = client._json.await_args
+    assert args[0] == "GET"
+    assert "from=2026-03-20T00:00:00%2B01:00" in args[1]
+    assert "to=2026-03-21T00:00:00%2B01:00" in args[1]
+    assert "timezone=Europe/Berlin" in args[1]
+    assert "step=P1D" in args[1]
+
+
+@pytest.mark.asyncio
+async def test_hems_energy_consumption_optional_invalid_payload_and_invalid_site() -> (
+    None
+):
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=_make_optional_payload_error("/api/v1/hems/SITE/energy-consumption")
+    )
+
+    assert (
+        await client.hems_energy_consumption(
+            start_at="2026-03-20T00:00:00+01:00",
+            end_at="2026-03-21T00:00:00+01:00",
+            timezone="Europe/Berlin",
+        )
+        is None
+    )
+
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=_make_cre(
+            550,
+            json.dumps(
+                {
+                    "error": {
+                        "status": "INVALID_SITE",
+                        "message": "site is not a valid hems site",
+                    }
+                }
+            ),
+        )
+    )
+
+    assert (
+        await client.hems_energy_consumption(
+            start_at="2026-03-20T00:00:00+01:00",
+            end_at="2026-03-21T00:00:00+01:00",
+            timezone="Europe/Berlin",
+        )
+        is None
+    )
+    assert client.hems_site_supported is False
+
+
+@pytest.mark.asyncio
+async def test_hems_energy_consumption_optional_and_reraise_variants() -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=api.Unauthorized())
+
+    assert (
+        await client.hems_energy_consumption(
+            start_at="2026-03-20T00:00:00+01:00",
+            end_at="2026-03-21T00:00:00+01:00",
+            timezone="Europe/Berlin",
+        )
+        is None
+    )
+
+    client = _make_client()
+    invalid_json = api.InvalidPayloadError(
+        "Invalid JSON response",
+        status=200,
+        content_type="application/json",
+        endpoint="/api/v1/hems/SITE/energy-consumption",
+    )
+    client._json = AsyncMock(side_effect=invalid_json)
+
+    with pytest.raises(api.InvalidPayloadError):
+        await client.hems_energy_consumption(
+            start_at="2026-03-20T00:00:00+01:00",
+            end_at="2026-03-21T00:00:00+01:00",
+            timezone="Europe/Berlin",
+        )
+
+    client = _make_client()
+    client._json = AsyncMock(side_effect=_make_cre(500))
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.hems_energy_consumption(
+            start_at="2026-03-20T00:00:00+01:00",
+            end_at="2026-03-21T00:00:00+01:00",
+            timezone="Europe/Berlin",
+        )
+
+
+@pytest.mark.asyncio
 async def test_hems_devices_uses_dedicated_endpoint_and_headers() -> None:
     client = _make_client()
     client.update_credentials(

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-import time
 from types import SimpleNamespace
 from typing import Callable
 from unittest.mock import MagicMock
@@ -204,7 +203,51 @@ async def test_async_setup_entry_keeps_site_sensor_when_inventory_unknown(
 
     assert any(isinstance(ent, SiteCloudReachableBinarySensor) for ent in added)
     assert len([ent for ent in added if hasattr(ent, "_sn")]) == 3
-    assert any(isinstance(ent, HeatPumpSgReadyActiveBinarySensor) for ent in added)
+    assert not any(isinstance(ent, HeatPumpSgReadyActiveBinarySensor) for ent in added)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_heatpump_sg_ready_binary_without_dedicated_controller(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[], data={})
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 2,
+                "devices": [
+                    {
+                        "device_type": "SG_READY_GATEWAY",
+                        "device_uid": "HP-SG-1",
+                        "name": "SG Ready Gateway",
+                    },
+                    {
+                        "device_type": "ENERGY_METER",
+                        "device_uid": "HP-EM-1",
+                        "name": "Energy Meter",
+                    },
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    monkeypatch.setattr(
+        coord, "async_add_topology_listener", lambda callback: _stub_listener()
+    )
+    added = []
+
+    def _collect(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _collect)
+
+    assert any(isinstance(ent, SiteCloudReachableBinarySensor) for ent in added)
+    assert not any(isinstance(ent, HeatPumpSgReadyActiveBinarySensor) for ent in added)
 
 
 @pytest.mark.asyncio
@@ -351,9 +394,9 @@ async def test_async_setup_entry_adds_heatpump_sg_ready_binary_sensor_when_type_
                 "count": 1,
                 "devices": [
                     {
-                        "device_type": "SG_READY_GATEWAY",
-                        "name": "SG Ready Gateway",
-                        "statusText": "Recommended",
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-1",
+                        "name": "Heat Pump",
                     }
                 ],
             },
@@ -389,9 +432,9 @@ async def test_async_setup_entry_prunes_heatpump_sg_ready_binary_sensor_when_typ
                 "count": 1,
                 "devices": [
                     {
-                        "device_type": "SG_READY_GATEWAY",
-                        "name": "SG Ready Gateway",
-                        "statusText": "Recommended",
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-1",
+                        "name": "Heat Pump",
                     }
                 ],
             },
@@ -444,6 +487,108 @@ async def test_async_setup_entry_prunes_heatpump_sg_ready_binary_sensor_when_typ
         DOMAIN,
         f"{DOMAIN}_site_{coord.site_id}_heat_pump_sg_ready_active",
     )
+    fake_registry.async_remove.assert_called_once_with(
+        "binary_sensor.heat_pump_sg_ready_active"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_prunes_heatpump_sg_ready_binary_sensor_when_dedicated_controller_removed(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[], data={})
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "type_label": "Gateway",
+                "count": 1,
+                "devices": [{"name": "IQ Gateway"}],
+            },
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 3,
+                "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-1",
+                        "name": "Heat Pump",
+                    },
+                    {
+                        "device_type": "ENERGY_METER",
+                        "device_uid": "HP-EM-1",
+                        "name": "Energy Meter",
+                    },
+                    {
+                        "device_type": "SG_READY_GATEWAY",
+                        "device_uid": "HP-SG-1",
+                        "name": "SG Ready Gateway",
+                    },
+                ],
+            },
+        },
+        ["envoy", "heatpump"],
+    )
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    callbacks: list[Callable[[], None]] = []
+
+    def _capture_listener(callback: Callable[[], None]) -> Callable[[], None]:
+        callbacks.append(callback)
+        return _stub_listener()
+
+    fake_registry = SimpleNamespace(
+        async_get_entity_id=MagicMock(
+            return_value="binary_sensor.heat_pump_sg_ready_active"
+        ),
+        async_remove=MagicMock(),
+    )
+    monkeypatch.setattr(coord, "async_add_topology_listener", _capture_listener)
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.binary_sensor.er.async_get",
+        lambda _hass: fake_registry,
+    )
+
+    added = []
+
+    def _collect(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _collect)
+    assert any(isinstance(ent, HeatPumpSgReadyActiveBinarySensor) for ent in added)
+
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "type_label": "Gateway",
+                "count": 1,
+                "devices": [{"name": "IQ Gateway"}],
+            },
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 2,
+                "devices": [
+                    {
+                        "device_type": "ENERGY_METER",
+                        "device_uid": "HP-EM-1",
+                        "name": "Energy Meter",
+                    },
+                    {
+                        "device_type": "SG_READY_GATEWAY",
+                        "device_uid": "HP-SG-1",
+                        "name": "SG Ready Gateway",
+                    },
+                ],
+            },
+        },
+        ["envoy", "heatpump"],
+    )
+    callbacks[0]()
+
     fake_registry.async_remove.assert_called_once_with(
         "binary_sensor.heat_pump_sg_ready_active"
     )
@@ -562,11 +707,9 @@ def test_heatpump_sg_ready_active_binary_sensor_metadata(
                 "count": 1,
                 "devices": [
                     {
-                        "device_type": "SG_READY_GATEWAY",
-                        "device_uid": "HP-SG-1",
-                        "name": "SG Ready Gateway",
-                        "statusText": "Recommended",
-                        "last_report": "2026-03-03T07:30:00Z",
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-1",
+                        "name": "Heat Pump",
                         "model": "Europa Mini WP",
                         "serial_number": "HP-1",
                     }
@@ -575,14 +718,21 @@ def test_heatpump_sg_ready_active_binary_sensor_metadata(
         },
         ["heatpump"],
     )
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-1",
+        "heatpump_status": "RUNNING",
+        "sg_ready_mode_raw": "MODE_3",
+        "sg_ready_mode_label": "Recommended",
+        "sg_ready_active": True,
+        "sg_ready_contact_state": "closed",
+        "vpp_sgready_mode_override": "NONE",
+        "last_report_at": "2026-03-03T07:30:00Z",
+        "source": "hems_heatpump_state:HP-1",
+    }
+    coord._heatpump_runtime_state_last_error = None  # noqa: SLF001
     monkeypatch.setattr(
         coord, "async_add_topology_listener", lambda callback: _stub_listener()
     )
-    coord._hems_devices_last_success_utc = datetime(
-        2026, 3, 3, 7, 31, tzinfo=timezone.utc
-    )  # noqa: SLF001
-    coord._hems_devices_last_success_mono = time.monotonic() - 30  # noqa: SLF001
-    coord._hems_devices_using_stale = True  # noqa: SLF001
 
     sensor = HeatPumpSgReadyActiveBinarySensor(coord)
     assert sensor.translation_key == "heat_pump_sg_ready_active"
@@ -591,40 +741,31 @@ def test_heatpump_sg_ready_active_binary_sensor_metadata(
     assert sensor.is_on is True
 
     attrs = sensor.extra_state_attributes
-    assert attrs["status_text"] == "Recommended"
-    assert attrs["active_member_count"] == 1
+    assert attrs["device_uid"] == "HP-1"
+    assert attrs["heatpump_status_raw"] == "RUNNING"
+    assert attrs["sg_ready_mode_raw"] == "MODE_3"
+    assert attrs["sg_ready_mode_label"] == "Recommended"
+    assert attrs["sg_ready_active"] is True
     assert attrs["sg_ready_mode"] == 3
     assert attrs["sg_ready_contact_state"] == "closed"
     assert attrs["status_explanation"] == (
         "Recommended means the SG Ready contact is closed."
     )
-    assert attrs["latest_reported_utc"] == "2026-03-03T07:30:00+00:00"
-    assert attrs["hems_data_stale"] is True
-    assert attrs["hems_last_success_utc"] == "2026-03-03T07:31:00+00:00"
-    assert attrs["hems_last_success_age_s"] is not None
+    assert attrs["last_report_at"] == "2026-03-03T07:30:00Z"
+    assert attrs["source"] == "hems_heatpump_state:HP-1"
 
     info = sensor.device_info
     assert info["name"] == "Heat Pump"
     assert info["model"] == "Europa Mini WP"
     assert info["serial_number"] == "HP-1"
 
-    coord._set_type_device_buckets(  # noqa: SLF001
-        {
-            "heatpump": {
-                "type_key": "heatpump",
-                "type_label": "Heat Pump",
-                "count": 1,
-                "devices": [
-                    {
-                        "device_type": "SG_READY_GATEWAY",
-                        "name": "SG Ready Gateway",
-                        "statusText": "Normal",
-                    }
-                ],
-            }
-        },
-        ["heatpump"],
-    )
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        **coord._heatpump_runtime_state,
+        "sg_ready_mode_raw": "MODE_2",
+        "sg_ready_mode_label": "Normal",
+        "sg_ready_active": False,
+        "sg_ready_contact_state": "open",
+    }
     assert sensor.is_on is False
 
     coord._set_type_device_buckets(  # noqa: SLF001
@@ -669,6 +810,14 @@ def test_heatpump_sg_ready_active_binary_sensor_uses_dedicated_hems_inventory(
         }
     }
     coord._merge_heatpump_type_bucket()  # noqa: SLF001
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-CTRL-1",
+        "heatpump_status": "RUNNING",
+        "sg_ready_mode_raw": "MODE_3",
+        "sg_ready_mode_label": "Recommended",
+        "sg_ready_active": True,
+        "last_report_at": "2026-03-03T07:30:00Z",
+    }
     monkeypatch.setattr(
         coord, "async_add_topology_listener", lambda callback: _stub_listener()
     )
@@ -679,10 +828,7 @@ def test_heatpump_sg_ready_active_binary_sensor_uses_dedicated_hems_inventory(
     assert (
         sensor.unique_id == f"{DOMAIN}_site_{coord.site_id}_heat_pump_sg_ready_active"
     )
-    assert (
-        sensor.extra_state_attributes["latest_reported_utc"]
-        == "2026-03-03T07:30:00+00:00"
-    )
+    assert sensor.extra_state_attributes["last_report_at"] == "2026-03-03T07:30:00Z"
 
 
 def test_heatpump_sg_ready_active_binary_sensor_stays_on_for_mixed_member_statuses(
@@ -694,8 +840,13 @@ def test_heatpump_sg_ready_active_binary_sensor_stays_on_for_mixed_member_status
             "heatpump": {
                 "type_key": "heatpump",
                 "type_label": "Heat Pump",
-                "count": 2,
+                "count": 3,
                 "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-1",
+                        "name": "Heat Pump",
+                    },
                     {
                         "device_type": "SG_READY_GATEWAY",
                         "device_uid": "HP-SG-1",
@@ -713,6 +864,13 @@ def test_heatpump_sg_ready_active_binary_sensor_stays_on_for_mixed_member_status
         },
         ["heatpump"],
     )
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-1",
+        "heatpump_status": "RUNNING",
+        "sg_ready_mode_raw": "MODE_3",
+        "sg_ready_mode_label": "Recommended",
+        "sg_ready_active": True,
+    }
     monkeypatch.setattr(
         coord, "async_add_topology_listener", lambda callback: _stub_listener()
     )
@@ -721,19 +879,14 @@ def test_heatpump_sg_ready_active_binary_sensor_stays_on_for_mixed_member_status
     assert sensor.available is True
     assert sensor.is_on is True
     attrs = sensor.extra_state_attributes
-    assert attrs["status_text"] == "Normal"
-    assert attrs["active_member_count"] == 1
+    assert attrs["sg_ready_mode_label"] == "Recommended"
+    assert attrs["sg_ready_active"] is True
 
 
 def test_heatpump_sg_ready_active_binary_sensor_helper_edge_cases(
     coordinator_factory, monkeypatch
 ) -> None:
     coord = coordinator_factory(serials=[], data={})
-    monkeypatch.setattr(
-        coord, "async_add_topology_listener", lambda callback: _stub_listener()
-    )
-    sensor = HeatPumpSgReadyActiveBinarySensor(coord)
-
     coord._set_type_device_buckets(  # noqa: SLF001
         {
             "heatpump": {
@@ -742,55 +895,39 @@ def test_heatpump_sg_ready_active_binary_sensor_helper_edge_cases(
                 "count": 1,
                 "devices": [
                     {
-                        "device_type": "SG_READY_GATEWAY",
-                        "name": "SG Ready Gateway",
-                        "status_text": "Recommended",
-                    },
-                    "bad-member",
-                ],
-            }
-        },
-        ["heatpump"],
-    )
-    assert sensor._status_text() == "Recommended"  # noqa: SLF001
-    assert sensor._active_member_count() == 1  # noqa: SLF001
-
-    coord._set_type_device_buckets(  # noqa: SLF001
-        {
-            "heatpump": {
-                "type_key": "heatpump",
-                "type_label": "Heat Pump",
-                "count": 1,
-                "devices": [
-                    {
-                        "device_type": "SG_READY_GATEWAY",
-                        "name": "SG Ready Gateway",
-                        "status": "Normal",
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-1",
+                        "name": "Heat Pump",
                     }
                 ],
             }
         },
         ["heatpump"],
     )
-    assert sensor._status_text() == "Normal"  # noqa: SLF001
-    assert sensor._active_member_count() == 0  # noqa: SLF001
-
-    coord._set_type_device_buckets(  # noqa: SLF001
-        {
-            "heatpump": {
-                "type_key": "heatpump",
-                "type_label": "Heat Pump",
-                "count": 1,
-                "devices": [],
-            }
-        },
-        ["heatpump"],
+    monkeypatch.setattr(
+        coord, "async_add_topology_listener", lambda callback: _stub_listener()
     )
-    assert sensor._status_text() is None  # noqa: SLF001
-    monkeypatch.setattr(sensor, "_snapshot", lambda: {"members": None})
-    assert sensor._active_member_count() == 0  # noqa: SLF001
-    monkeypatch.setattr(sensor, "_snapshot", lambda: {"members": ["bad-member"]})
-    assert sensor._active_member_count() == 0  # noqa: SLF001
+    sensor = HeatPumpSgReadyActiveBinarySensor(coord)
+
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-1",
+        "sg_ready_mode_raw": "MODE_3",
+        "sg_ready_mode_label": "Recommended",
+        "sg_ready_active": True,
+    }
+    assert sensor.available is True
+    assert sensor.is_on is True
+
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-1",
+        "sg_ready_mode_raw": "MODE_2",
+        "sg_ready_mode_label": "Normal",
+        "sg_ready_active": False,
+    }
+    assert sensor.is_on is False
+
+    monkeypatch.setattr(sensor, "_snapshot", lambda: {})
+    assert sensor.available is False
 
 
 def test_heatpump_sg_ready_active_binary_sensor_unavailable_without_type(
@@ -800,6 +937,37 @@ def test_heatpump_sg_ready_active_binary_sensor_unavailable_without_type(
     coord.has_type_for_entities = lambda _type_key: False  # type: ignore[assignment]
     monkeypatch.setattr(
         coord, "async_add_topology_listener", lambda callback: _stub_listener()
+    )
+
+    sensor = HeatPumpSgReadyActiveBinarySensor(coord)
+    assert sensor.available is False
+
+
+def test_heatpump_sg_ready_active_binary_sensor_handles_runtime_uid_errors(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[], data={})
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-1",
+        "sg_ready_mode_raw": "MODE_3",
+        "sg_ready_mode_label": "Recommended",
+        "sg_ready_active": True,
+    }
+    monkeypatch.setattr(
+        coord,
+        "_heatpump_runtime_device_uid",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
     )
 
     sensor = HeatPumpSgReadyActiveBinarySensor(coord)

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1838,6 +1838,386 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
 
 
 @pytest.mark.asyncio
+async def test_refresh_heatpump_runtime_state_uses_dedicated_heatpump_uid(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 3,
+                "devices": [
+                    {
+                        "device_type": "SG_READY_GATEWAY",
+                        "device_uid": "HP-SG-1",
+                    },
+                    {
+                        "device_type": "ENERGY_METER",
+                        "device_uid": "HP-EM-1",
+                    },
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-1",
+                    },
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    coord.client.hems_heatpump_state = AsyncMock(
+        return_value={
+            "device_uid": "HP-1",
+            "heatpump_status": "RUNNING",
+            "sg_ready_mode_raw": "MODE_3",
+            "sg_ready_mode_label": "Recommended",
+            "sg_ready_active": True,
+            "sg_ready_contact_state": "closed",
+            "last_report_at": "2026-03-20T08:18:59.604Z",
+        }
+    )
+
+    await coord._async_refresh_heatpump_runtime_state(force=True)  # noqa: SLF001
+
+    coord.client.hems_heatpump_state.assert_awaited_once()
+    assert coord.client.hems_heatpump_state.await_args.kwargs["device_uid"] == "HP-1"
+    assert coord.heatpump_runtime_state["device_uid"] == "HP-1"
+    assert coord.heatpump_runtime_state["source"] == "hems_heatpump_state:HP-1"
+
+
+@pytest.mark.asyncio
+async def test_refresh_heatpump_runtime_state_covers_cache_and_error_paths(
+    coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._async_refresh_hems_support_preflight = AsyncMock(  # noqa: SLF001
+        return_value=None
+    )
+    mono_now = 1_000.0
+    monkeypatch.setattr(coord_mod.time, "monotonic", lambda: mono_now)
+
+    coord.client.hems_heatpump_state = AsyncMock(side_effect=AssertionError("cached"))
+    coord._heatpump_runtime_state_cache_until = mono_now + 10  # noqa: SLF001
+    await coord._async_refresh_heatpump_runtime_state()  # noqa: SLF001
+    coord.client.hems_heatpump_state.assert_not_awaited()
+
+    coord._heatpump_runtime_state_cache_until = None  # noqa: SLF001
+    coord._heatpump_runtime_state_backoff_until = mono_now + 10  # noqa: SLF001
+    await coord._async_refresh_heatpump_runtime_state()  # noqa: SLF001
+    coord.client.hems_heatpump_state.assert_not_awaited()
+
+    coord._heatpump_runtime_state_backoff_until = None  # noqa: SLF001
+    coord.client._hems_site_supported = False  # noqa: SLF001
+    await coord._async_refresh_heatpump_runtime_state(force=True)  # noqa: SLF001
+    assert coord.heatpump_runtime_state == {}
+    assert coord.heatpump_runtime_state_last_error is None
+
+    coord.client._hems_site_supported = None  # noqa: SLF001
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP"}],
+            }
+        },
+        ["heatpump"],
+    )
+    await coord._async_refresh_heatpump_runtime_state(force=True)  # noqa: SLF001
+    assert coord.heatpump_runtime_state == {}
+
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    coord.client.hems_heatpump_state = None
+    await coord._async_refresh_heatpump_runtime_state(force=True)  # noqa: SLF001
+
+    coord.client.hems_heatpump_state = AsyncMock(side_effect=RuntimeError("boom"))
+    await coord._async_refresh_heatpump_runtime_state(force=True)  # noqa: SLF001
+    assert coord.heatpump_runtime_state_last_error == "boom"
+    assert coord._heatpump_runtime_state_backoff_until is not None  # noqa: SLF001
+
+    coord._heatpump_runtime_state_backoff_until = None  # noqa: SLF001
+    coord.client.hems_heatpump_state = AsyncMock(return_value=None)
+    await coord._async_refresh_heatpump_runtime_state(force=True)  # noqa: SLF001
+    assert coord.heatpump_runtime_state == {}
+
+
+@pytest.mark.asyncio
+async def test_refresh_heatpump_daily_consumption_tracks_site_day(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._devices_inventory_payload = {"curr_date_site": "2026-03-20"}  # noqa: SLF001
+    coord._battery_timezone = "Europe/Berlin"  # noqa: SLF001
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    coord.client.hems_energy_consumption = AsyncMock(
+        return_value={
+            "type": "hems-device-details",
+            "timestamp": "2026-03-20T07:53:00.739143826Z",
+            "data": {
+                "heat-pump": [
+                    {
+                        "device_uid": "HP-1",
+                        "device_name": "Waermepumpe",
+                        "consumption": [
+                            {
+                                "solar": 10.0,
+                                "battery": 20.0,
+                                "grid": 200.0,
+                                "details": [230.0],
+                            }
+                        ],
+                    }
+                ]
+            },
+        }
+    )
+
+    await coord._async_refresh_heatpump_daily_consumption(force=True)  # noqa: SLF001
+
+    coord.client.hems_energy_consumption.assert_awaited_once()
+    kwargs = coord.client.hems_energy_consumption.await_args.kwargs
+    assert kwargs["timezone"] == "Europe/Berlin"
+    assert kwargs["step"] == "P1D"
+    assert kwargs["start_at"].startswith("2026-03-20T00:00:00")
+    assert kwargs["end_at"].startswith("2026-03-21T00:00:00")
+    assert coord.heatpump_daily_consumption["daily_energy_wh"] == pytest.approx(230.0)
+    assert coord.heatpump_daily_consumption["daily_grid_wh"] == pytest.approx(200.0)
+    assert coord.heatpump_daily_consumption["source"] == "hems_energy_consumption:HP-1"
+
+
+def test_heatpump_daily_helper_and_property_edge_cases(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._battery_timezone = "Not/A-Timezone"  # noqa: SLF001
+    assert coord._site_timezone_name() == "UTC"  # noqa: SLF001
+    coord._site_timezone_name = lambda: "Not/A-Timezone"  # type: ignore[assignment]  # noqa: SLF001
+    coord._site_local_current_date = lambda: "bad-date"  # type: ignore[assignment]  # noqa: SLF001
+    assert coord._heatpump_daily_window() is None  # noqa: SLF001
+
+    assert coord._sum_optional_values("bad") is None  # noqa: SLF001
+    assert (
+        coord._sum_optional_values([None, "bad", float("inf")]) is None
+    )  # noqa: SLF001
+    assert coord._sum_optional_values([1.0, "2.5", float("nan")]) == pytest.approx(
+        3.5
+    )  # noqa: SLF001
+
+    assert (
+        coord._build_heatpump_daily_consumption_snapshot(["bad"]) is None
+    )  # noqa: SLF001
+    assert (
+        coord._build_heatpump_daily_consumption_snapshot({"data": []}) is None
+    )  # noqa: SLF001
+    assert (  # noqa: SLF001
+        coord._build_heatpump_daily_consumption_snapshot({"data": {"heat-pump": []}})
+        is None
+    )
+
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    snapshot = coord._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
+        {
+            "data": {
+                "heat-pump": [
+                    "skip-me",
+                    {
+                        "device_uid": "HP-2",
+                        "device_name": "Backup",
+                        "consumption": [
+                            "skip-me",
+                            {
+                                "solar": "1.0",
+                                "battery": "2.0",
+                                "grid": "3.0",
+                                "details": [4.0, "bad", None],
+                            },
+                        ],
+                    },
+                ]
+            }
+        }
+    )
+    assert snapshot is None
+
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [{"device_type": "ENERGY_METER", "device_uid": "HP-EM-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    snapshot = coord._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
+        {
+            "data": {
+                "heat-pump": [
+                    {
+                        "device_uid": "HP-2",
+                        "device_name": "Backup",
+                        "consumption": [
+                            {
+                                "solar": "1.0",
+                                "battery": "2.0",
+                                "grid": "3.0",
+                                "details": [4.0, "bad", None],
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+    )
+    assert snapshot == {
+        "device_uid": "HP-2",
+        "device_name": "Backup",
+        "daily_energy_wh": pytest.approx(4.0),
+        "daily_solar_wh": pytest.approx(1.0),
+        "daily_battery_wh": pytest.approx(2.0),
+        "daily_grid_wh": pytest.approx(3.0),
+        "details": [4.0, "bad", None],
+        "source": "hems_energy_consumption:HP-2",
+        "endpoint_type": None,
+        "endpoint_timestamp": None,
+    }
+    assert (
+        coord._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
+            {"data": {"heat-pump": [{"device_uid": "HP-1", "consumption": ["bad"]}]}}
+        )
+        is None
+    )
+    assert (
+        coord._build_heatpump_daily_consumption_snapshot(
+            {"data": {"heat-pump": ["skip-me"]}}
+        )
+        is None
+    )
+
+    class BadString:
+        def __str__(self) -> str:
+            raise ValueError("boom")
+
+    assert coord.heatpump_runtime_state == {}
+    coord._heatpump_runtime_state_last_error = BadString()  # noqa: SLF001
+    assert coord.heatpump_runtime_state_last_error is None
+    assert coord.heatpump_daily_consumption == {}
+    coord._heatpump_daily_consumption_last_error = BadString()  # noqa: SLF001
+    assert coord.heatpump_daily_consumption_last_error is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_heatpump_daily_consumption_covers_cache_and_error_paths(
+    coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._async_refresh_hems_support_preflight = AsyncMock(  # noqa: SLF001
+        return_value=None
+    )
+    mono_now = 2_000.0
+    monkeypatch.setattr(coord_mod.time, "monotonic", lambda: mono_now)
+    marker = ("2026-03-20", "UTC")
+    coord._heatpump_daily_window = lambda: (  # type: ignore[assignment]  # noqa: SLF001
+        "2026-03-20T00:00:00+00:00",
+        "2026-03-21T00:00:00+00:00",
+        "UTC",
+        marker,
+    )
+
+    coord.client.hems_energy_consumption = AsyncMock(
+        side_effect=AssertionError("cached")
+    )
+    coord._heatpump_daily_consumption_cache_key = marker  # noqa: SLF001
+    coord._heatpump_daily_consumption_cache_until = mono_now + 10  # noqa: SLF001
+    await coord._async_refresh_heatpump_daily_consumption()  # noqa: SLF001
+    coord.client.hems_energy_consumption.assert_not_awaited()
+
+    coord._heatpump_daily_consumption_cache_until = None  # noqa: SLF001
+    coord._heatpump_daily_consumption_backoff_until = mono_now + 10  # noqa: SLF001
+    await coord._async_refresh_heatpump_daily_consumption()  # noqa: SLF001
+    coord.client.hems_energy_consumption.assert_not_awaited()
+
+    coord._heatpump_daily_window = lambda: None  # type: ignore[assignment]  # noqa: SLF001
+    await coord._async_refresh_heatpump_daily_consumption(force=True)  # noqa: SLF001
+
+    coord._heatpump_daily_window = lambda: (  # type: ignore[assignment]  # noqa: SLF001
+        "2026-03-20T00:00:00+00:00",
+        "2026-03-21T00:00:00+00:00",
+        "UTC",
+        marker,
+    )
+    coord.client._hems_site_supported = False  # noqa: SLF001
+    await coord._async_refresh_heatpump_daily_consumption(force=True)  # noqa: SLF001
+    assert coord.heatpump_daily_consumption == {}
+    assert coord.heatpump_daily_consumption_last_error is None
+
+    coord.client._hems_site_supported = None  # noqa: SLF001
+    coord.client.hems_energy_consumption = None
+    await coord._async_refresh_heatpump_daily_consumption(force=True)  # noqa: SLF001
+
+    coord.client.hems_energy_consumption = AsyncMock(side_effect=RuntimeError("boom"))
+    await coord._async_refresh_heatpump_daily_consumption(force=True)  # noqa: SLF001
+    assert coord.heatpump_daily_consumption_last_error == "boom"
+    assert coord._heatpump_daily_consumption_backoff_until is not None  # noqa: SLF001
+
+    coord._heatpump_daily_consumption_backoff_until = None  # noqa: SLF001
+    coord.client.hems_energy_consumption = AsyncMock(return_value=None)
+    await coord._async_refresh_heatpump_daily_consumption(force=True)  # noqa: SLF001
+    assert coord.heatpump_daily_consumption == {}
+
+
+@pytest.mark.asyncio
 async def test_refresh_current_power_consumption_tracks_latest_sample(
     coordinator_factory,
 ) -> None:
@@ -2981,6 +3361,10 @@ async def test_heatpump_runtime_diagnostics_clears_stale_state_when_type_removed
     await coord.async_ensure_heatpump_runtime_diagnostics(force=True)
 
     assert coord.heatpump_runtime_diagnostics() == {
+        "runtime_state": None,
+        "runtime_state_last_error": None,
+        "daily_consumption": None,
+        "daily_consumption_last_error": None,
         "show_livestream_payload": None,
         "events_payloads": [],
         "last_error": None,
@@ -3037,6 +3421,39 @@ async def test_heatpump_runtime_diagnostics_show_livestream_failure_clears_paylo
 
     assert coord.heatpump_runtime_diagnostics()["show_livestream_payload"] is None
     assert coord.heatpump_runtime_diagnostics()["last_error"] == "live boom"
+
+
+@pytest.mark.asyncio
+async def test_heatpump_runtime_diagnostics_ignores_runtime_refresh_failures(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._async_refresh_heatpump_runtime_state = AsyncMock(  # noqa: SLF001
+        side_effect=RuntimeError("runtime boom")
+    )
+    coord._async_refresh_heatpump_daily_consumption = AsyncMock(  # noqa: SLF001
+        side_effect=RuntimeError("daily boom")
+    )
+    coord.client.show_livestream = None
+    coord.client.heat_pump_events_json = None
+    coord.client.iq_er_events_json = None
+
+    await coord.async_ensure_heatpump_runtime_diagnostics(force=True)
+
+    diagnostics = coord.heatpump_runtime_diagnostics()
+    assert diagnostics["last_error"] is None
+    assert diagnostics["runtime_state"] is None
+    assert diagnostics["daily_consumption"] is None
 
 
 @pytest.mark.asyncio
@@ -3590,6 +4007,65 @@ async def test_async_update_data_site_only_refreshes_hems_before_heatpump_power(
         side_effect=lambda: order.append("hems")
     )
     coord._async_refresh_inverters = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_heatpump_runtime_state = AsyncMock(  # noqa: SLF001
+        side_effect=lambda: order.append("heatpump_runtime")
+    )
+    coord._async_refresh_heatpump_daily_consumption = AsyncMock(  # noqa: SLF001
+        side_effect=lambda: order.append("heatpump_daily")
+    )
+    coord._async_refresh_heatpump_power = AsyncMock(  # noqa: SLF001
+        side_effect=lambda: order.append("heatpump_power")
+    )
+
+    assert await coord._async_update_data() == {}  # noqa: SLF001
+    assert order == [
+        "devices",
+        "hems",
+        "heatpump_runtime",
+        "heatpump_daily",
+        "heatpump_power",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_site_only_ignores_runtime_and_daily_refresh_errors(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord.site_only = True
+    coord._has_successful_refresh = True  # noqa: SLF001
+    order: list[str] = []
+    coord.energy._async_refresh_site_energy = AsyncMock(  # noqa: SLF001
+        return_value=None
+    )
+    coord._async_refresh_battery_site_settings = AsyncMock(  # noqa: SLF001
+        return_value=None
+    )
+    coord._async_refresh_battery_status = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_battery_backup_history = AsyncMock(  # noqa: SLF001
+        return_value=None
+    )
+    coord._async_refresh_battery_settings = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_storm_guard_profile = AsyncMock(  # noqa: SLF001
+        return_value=None
+    )
+    coord._async_refresh_storm_alert = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_grid_control_check = AsyncMock(  # noqa: SLF001
+        return_value=None
+    )
+    coord._async_refresh_devices_inventory = AsyncMock(  # noqa: SLF001
+        side_effect=lambda: order.append("devices")
+    )
+    coord._async_refresh_hems_devices = AsyncMock(  # noqa: SLF001
+        side_effect=lambda: order.append("hems")
+    )
+    coord._async_refresh_inverters = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_heatpump_runtime_state = AsyncMock(  # noqa: SLF001
+        side_effect=RuntimeError("runtime")
+    )
+    coord._async_refresh_heatpump_daily_consumption = AsyncMock(  # noqa: SLF001
+        side_effect=RuntimeError("daily")
+    )
     coord._async_refresh_heatpump_power = AsyncMock(  # noqa: SLF001
         side_effect=lambda: order.append("heatpump_power")
     )
@@ -3638,6 +4114,56 @@ async def test_async_update_data_continues_when_heatpump_refresh_raises(
     coord._async_refresh_heatpump_power = AsyncMock(
         side_effect=RuntimeError("boom")
     )  # noqa: SLF001
+
+    result = await coord._async_update_data()  # noqa: SLF001
+    assert RANDOM_SERIAL in result
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_continues_when_runtime_and_daily_refresh_raise(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord.summary = SimpleNamespace(
+        prepare_refresh=lambda **_: False,
+        async_fetch=AsyncMock(return_value=[]),
+        invalidate=MagicMock(),
+    )
+    coord.session_history = SimpleNamespace(
+        get_cache_view=lambda *_, **__: SimpleNamespace(
+            sessions=[], needs_refresh=False, blocked=False
+        ),
+        sum_energy=lambda *_: 0.0,
+    )
+    coord.client.status = AsyncMock(
+        return_value={
+            "ts": "2026-02-28T00:00:00Z",
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "EV",
+                    "connectors": [{}],
+                    "pluggedIn": False,
+                    "charging": False,
+                    "faulted": False,
+                    "session_d": {},
+                }
+            ],
+        }
+    )
+    coord.energy._async_refresh_site_energy = AsyncMock(  # noqa: SLF001
+        return_value=None
+    )
+    coord._async_refresh_inverters = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_hems_devices = AsyncMock(return_value=None)  # noqa: SLF001
+    coord._async_refresh_heatpump_runtime_state = AsyncMock(  # noqa: SLF001
+        side_effect=RuntimeError("runtime")
+    )
+    coord._async_refresh_heatpump_daily_consumption = AsyncMock(  # noqa: SLF001
+        side_effect=RuntimeError("daily")
+    )
+    coord._async_refresh_heatpump_power = AsyncMock(return_value=None)  # noqa: SLF001
 
     result = await coord._async_update_data()  # noqa: SLF001
     assert RANDOM_SERIAL in result
@@ -6424,6 +6950,39 @@ async def test_startup_warmup_runner_and_task_edge_paths(
 
     coord = coordinator_factory()
     coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
+    coord._async_refresh_heatpump_runtime_state = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        side_effect=RuntimeError("runtime")
+    )
+    coord._async_refresh_heatpump_daily_consumption = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        side_effect=RuntimeError("daily")
+    )
+    await coord._async_startup_warmup_runner()  # noqa: SLF001
+    assert "heatpump_runtime_s" in coord._warmup_phase_timings  # noqa: SLF001
+    assert "heatpump_daily_s" in coord._warmup_phase_timings  # noqa: SLF001
+    coord._schedule_discovery_snapshot_save.assert_called_once()  # type: ignore[attr-defined]
+
+    coord = coordinator_factory()
+    coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
+    coord._async_refresh_heatpump_runtime_state = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        side_effect=asyncio.CancelledError()
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await coord._async_startup_warmup_runner()  # noqa: SLF001
+    assert coord._warmup_in_progress is False  # noqa: SLF001
+    coord._schedule_discovery_snapshot_save.assert_called_once()  # type: ignore[attr-defined]
+
+    coord = coordinator_factory()
+    coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
+    coord._async_refresh_heatpump_daily_consumption = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        side_effect=asyncio.CancelledError()
+    )
+    with pytest.raises(asyncio.CancelledError):
+        await coord._async_startup_warmup_runner()  # noqa: SLF001
+    assert coord._warmup_in_progress is False  # noqa: SLF001
+    coord._schedule_discovery_snapshot_save.assert_called_once()  # type: ignore[attr-defined]
+
+    coord = coordinator_factory()
+    coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
     coord._async_refresh_heatpump_power = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=asyncio.CancelledError()
     )
@@ -8801,6 +9360,12 @@ async def test_update_data_site_only_orders_topology_mutations_deterministically
     async def _record_heatpump_power() -> None:
         await _record("heatpump_power")
 
+    async def _record_heatpump_runtime() -> None:
+        await _record("heatpump_runtime")
+
+    async def _record_heatpump_daily() -> None:
+        await _record("heatpump_daily")
+
     coord._async_refresh_battery_site_settings = AsyncMock(
         return_value=None
     )  # noqa: SLF001
@@ -8836,6 +9401,12 @@ async def test_update_data_site_only_orders_topology_mutations_deterministically
     coord._async_refresh_inverters = AsyncMock(
         side_effect=_record_inverters
     )  # noqa: SLF001
+    coord._async_refresh_heatpump_runtime_state = AsyncMock(
+        side_effect=_record_heatpump_runtime
+    )  # noqa: SLF001
+    coord._async_refresh_heatpump_daily_consumption = AsyncMock(
+        side_effect=_record_heatpump_daily
+    )  # noqa: SLF001
     coord._async_refresh_heatpump_power = AsyncMock(
         side_effect=_record_heatpump_power
     )  # noqa: SLF001
@@ -8847,6 +9418,8 @@ async def test_update_data_site_only_orders_topology_mutations_deterministically
         "devices_inventory",
         "hems_devices",
         "inverters",
+        "heatpump_runtime",
+        "heatpump_daily",
         "heatpump_power",
     ]
 

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -380,6 +380,22 @@ class DummyCoordinator(SimpleNamespace):
                 "catalog_source_age_seconds": 42.0,
             }
         )
+        self._heatpump_runtime_state = {
+            "device_uid": "HP-1",
+            "heatpump_status": "RUNNING",
+            "sg_ready_mode_raw": "MODE_3",
+            "sg_ready_mode_label": "Recommended",
+            "sg_ready_active": True,
+            "last_report_at": "2026-03-01T00:00:00+00:00",
+            "source": "hems_heatpump_state:HP-1",
+        }
+        self._heatpump_runtime_state_last_error = None
+        self._heatpump_daily_consumption = {
+            "device_uid": "HP-1",
+            "daily_energy_wh": 230.0,
+            "source": "hems_energy_consumption:HP-1",
+        }
+        self._heatpump_daily_consumption_last_error = None
         self._show_livestream_payload = {"live_status": True, "live_vitals": True}
         self._heatpump_events_payloads = [
             {
@@ -466,6 +482,10 @@ class DummyCoordinator(SimpleNamespace):
 
     def heatpump_runtime_diagnostics(self):
         return {
+            "runtime_state": self._heatpump_runtime_state,
+            "runtime_state_last_error": self._heatpump_runtime_state_last_error,
+            "daily_consumption": self._heatpump_daily_consumption,
+            "daily_consumption_last_error": self._heatpump_daily_consumption_last_error,
             "show_livestream_payload": self._show_livestream_payload,
             "events_payloads": self._heatpump_events_payloads,
             "last_error": self._heatpump_runtime_diagnostics_error,

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -1753,10 +1753,11 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
     coordinator_factory,
 ) -> None:
     from custom_components.enphase_ev.sensor import (
+        EnphaseHeatPumpConnectivityStatusSensor,
         EnphaseHeatPumpEnergyMeterSensor,
         EnphaseHeatPumpLastReportedSensor,
         EnphaseHeatPumpPowerSensor,
-        EnphaseHeatPumpSgReadyGatewaySensor,
+        EnphaseHeatPumpSgReadyModeSensor,
         EnphaseHeatPumpStatusSensor,
     )
 
@@ -1827,6 +1828,18 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
     coord._heatpump_power_device_uid = "HP-1"  # noqa: SLF001
     coord._heatpump_power_source = "hems_power_timeseries:HP-1"  # noqa: SLF001
     coord._heatpump_power_last_error = None  # noqa: SLF001
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-1",
+        "heatpump_status": "RUNNING",
+        "sg_ready_mode_raw": "MODE_3",
+        "sg_ready_mode_label": "Recommended",
+        "sg_ready_active": True,
+        "sg_ready_contact_state": "closed",
+        "vpp_sgready_mode_override": "NONE",
+        "last_report_at": "2026-02-27T09:15:59Z",
+        "source": "hems_heatpump_state:HP-1",
+    }
+    coord._heatpump_runtime_state_last_error = None  # noqa: SLF001
     coord._hems_devices_last_success_utc = datetime(
         2026, 2, 27, 9, 16, tzinfo=timezone.utc
     )  # noqa: SLF001
@@ -1834,30 +1847,36 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
     coord._hems_devices_using_stale = True  # noqa: SLF001
 
     status_sensor = EnphaseHeatPumpStatusSensor(coord)
-    assert status_sensor.native_value == "Normal"
+    assert status_sensor.native_value == "Running"
     status_attrs = status_sensor.extra_state_attributes
-    assert status_attrs["total_devices"] == 3
-    assert status_attrs["status_counts"]["warning"] == 1
-    assert status_attrs["device_type_counts"]["HEAT_PUMP"] == 1
-    assert status_attrs["hems_data_stale"] is True
-    assert status_attrs["hems_last_success_utc"] == "2026-02-27T09:16:00+00:00"
-    assert status_attrs["hems_last_success_age_s"] is not None
+    assert status_attrs["device_uid"] == "HP-1"
+    assert status_attrs["heatpump_status_raw"] == "RUNNING"
+    assert status_attrs["sg_ready_mode_raw"] == "MODE_3"
+    assert status_attrs["sg_ready_active"] is True
+    assert status_attrs["sg_ready_contact_state"] == "closed"
+    assert status_attrs["last_report_at_utc"] == "2026-02-27T09:15:59+00:00"
 
-    sg_sensor = EnphaseHeatPumpSgReadyGatewaySensor(coord)
+    connectivity_sensor = EnphaseHeatPumpConnectivityStatusSensor(coord)
+    assert connectivity_sensor.native_value == "Normal"
+    connectivity_attrs = connectivity_sensor.extra_state_attributes
+    assert connectivity_attrs["total_devices"] == 3
+    assert connectivity_attrs["status_counts"]["warning"] == 1
+    assert connectivity_attrs["device_type_counts"]["HEAT_PUMP"] == 1
+    assert connectivity_attrs["hems_data_stale"] is True
+    assert connectivity_attrs["hems_last_success_utc"] == "2026-02-27T09:16:00+00:00"
+    assert connectivity_attrs["hems_last_success_age_s"] is not None
+
+    sg_sensor = EnphaseHeatPumpSgReadyModeSensor(coord)
     assert sg_sensor.native_value == "Recommended"
     sg_attrs = sg_sensor.extra_state_attributes
-    assert sg_attrs["device_type"] == "SG_READY_GATEWAY"
-    assert sg_attrs["member_count"] == 1
-    assert sg_attrs["members"][0]["device_uid"] == "HP-SG-1"
-    assert sg_attrs["status_counts"]["normal"] == 1
-    assert sg_attrs["status_summary"].startswith("Normal 1")
+    assert sg_attrs["device_uid"] == "HP-1"
+    assert sg_attrs["heatpump_status_raw"] == "RUNNING"
+    assert sg_attrs["sg_ready_mode_raw"] == "MODE_3"
     assert sg_attrs["sg_ready_mode"] == 3
     assert sg_attrs["sg_ready_contact_state"] == "closed"
     assert sg_attrs["status_explanation"] == (
         "Recommended means the SG Ready contact is closed."
     )
-    assert sg_attrs["hems_data_stale"] is True
-    assert sg_attrs["hems_last_success_utc"] == "2026-02-27T09:16:00+00:00"
 
     meter_sensor = EnphaseHeatPumpEnergyMeterSensor(coord)
     assert meter_sensor.native_value == "Warning"
@@ -1868,14 +1887,14 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
 
     last_reported_sensor = EnphaseHeatPumpLastReportedSensor(coord)
     assert last_reported_sensor.available is True
-    assert last_reported_sensor.native_value is not None
-    assert (
-        last_reported_sensor.extra_state_attributes["latest_reported_device"][
-            "device_uid"
-        ]
-        == "HP-EM-1"
+    assert last_reported_sensor.native_value == datetime(
+        2026, 2, 27, 9, 15, 59, tzinfo=timezone.utc
     )
-    assert last_reported_sensor.extra_state_attributes["hems_data_stale"] is True
+    assert last_reported_sensor.extra_state_attributes["device_uid"] == "HP-1"
+    assert (
+        last_reported_sensor.extra_state_attributes["source"]
+        == "hems_heatpump_state:HP-1"
+    )
 
     power_sensor = EnphaseHeatPumpPowerSensor(coord)
     assert power_sensor.available is True
@@ -2001,9 +2020,10 @@ def test_heatpump_sensor_availability_edge_paths(
     coordinator_factory, monkeypatch
 ) -> None:
     from custom_components.enphase_ev.sensor import (
+        EnphaseHeatPumpConnectivityStatusSensor,
         EnphaseHeatPumpLastReportedSensor,
         EnphaseHeatPumpPowerSensor,
-        EnphaseHeatPumpSgReadyGatewaySensor,
+        EnphaseHeatPumpSgReadyModeSensor,
         EnphaseHeatPumpStatusSensor,
         EnphaseSiteEnergySensor,
     )
@@ -2026,14 +2046,15 @@ def test_heatpump_sensor_availability_edge_paths(
     coord.last_update_success = False
     coord.last_success_utc = None
     assert EnphaseHeatPumpStatusSensor(coord).available is False
-    assert EnphaseHeatPumpSgReadyGatewaySensor(coord).available is False
+    assert EnphaseHeatPumpSgReadyModeSensor(coord).available is False
     assert EnphaseHeatPumpLastReportedSensor(coord).available is False
     assert EnphaseHeatPumpPowerSensor(coord).available is False
+    assert EnphaseHeatPumpConnectivityStatusSensor(coord).available is False
 
     coord.last_update_success = True
     coord._devices_inventory_ready = True  # noqa: SLF001
-    assert EnphaseHeatPumpStatusSensor(coord).available is True
-    assert EnphaseHeatPumpSgReadyGatewaySensor(coord).available is True
+    assert EnphaseHeatPumpStatusSensor(coord).available is False
+    assert EnphaseHeatPumpSgReadyModeSensor(coord).available is False
     coord._set_type_device_buckets(  # noqa: SLF001
         {
             "heatpump": {
@@ -2046,6 +2067,24 @@ def test_heatpump_sensor_availability_edge_paths(
         ["heatpump"],
     )
     coord._devices_inventory_ready = False  # noqa: SLF001
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-1",
+        "heatpump_status": "IDLE",
+        "sg_ready_mode_raw": "MODE_2",
+        "sg_ready_mode_label": "Normal",
+        "last_report_at": "2026-02-27T09:00:00Z",
+    }
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
     assert EnphaseHeatPumpStatusSensor(coord).available is True
 
     coord._heatpump_power_last_error = "fetch failed"  # noqa: SLF001
@@ -2073,6 +2112,145 @@ def test_heatpump_sensor_availability_edge_paths(
         "Site Heat Pump Consumption",
     )
     assert site_sensor.extra_state_attributes["heat_pump_power_w"] is None
+
+
+def test_heatpump_runtime_sensor_uid_fallback_and_error_paths(
+    coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.sensor import (
+        _heatpump_runtime_snapshot,
+        _heatpump_sg_ready_semantics,
+        EnphaseHeatPumpConnectivityStatusSensor,
+        EnphaseHeatPumpEnergyMeterSensor,
+        EnphaseHeatPumpLastReportedSensor,
+        EnphaseHeatPumpSgReadyModeSensor,
+        EnphaseHeatPumpStatusSensor,
+    )
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord.last_update_success = True
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": " HP-1 ",
+        "heatpump_status": "RUNNING",
+        "sg_ready_mode_raw": "MODE_3",
+        "sg_ready_mode_label": "Recommended",
+    }
+
+    monkeypatch.setattr(
+        coord,
+        "_heatpump_runtime_device_uid",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    assert EnphaseHeatPumpStatusSensor(coord).available is False
+    assert EnphaseHeatPumpSgReadyModeSensor(coord).available is False
+
+    monkeypatch.setattr(coord, "_heatpump_runtime_device_uid", None, raising=False)
+    assert EnphaseHeatPumpStatusSensor(coord).available is True
+    assert EnphaseHeatPumpSgReadyModeSensor(coord).available is True
+
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 0,
+                "devices": [],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    assert EnphaseHeatPumpConnectivityStatusSensor(coord).available is False
+    assert EnphaseHeatPumpEnergyMeterSensor(coord).available is False
+    assert (
+        _heatpump_runtime_snapshot(SimpleNamespace(heatpump_runtime_state=None)) == {}
+    )
+    assert _heatpump_sg_ready_semantics("unexpected") == {}
+
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    meter_sensor = EnphaseHeatPumpEnergyMeterSensor(coord)
+    monkeypatch.setattr(meter_sensor, "_snapshot", lambda: {"member_count": 0})
+    assert meter_sensor.available is False
+
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 1,
+                "devices": [{"device_type": "ENERGY_METER", "device_uid": "HP-EM-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-1",
+        "last_report_at": "2026-02-27T09:00:00Z",
+    }
+    assert EnphaseHeatPumpLastReportedSensor(coord).available is False
+
+
+def test_heatpump_connectivity_sensor_availability_paths(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import (
+        EnphaseHeatPumpConnectivityStatusSensor,
+    )
+
+    coord = coordinator_factory(serials=[RANDOM_SERIAL])
+    coord.last_update_success = True
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+
+    sensor = EnphaseHeatPumpConnectivityStatusSensor(coord)
+    assert sensor.available is True
+
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 0,
+                "devices": [],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._devices_inventory_ready = False  # noqa: SLF001
+    assert sensor.available is True
+
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    assert sensor.available is False
 
 
 def test_heatpump_snapshot_fallback_covers_summary_error_and_type_snapshot_paths() -> (
@@ -4505,6 +4683,15 @@ def test_site_heat_pump_energy_sensor_uses_heatpump_device_info(
     )
     coord.type_device_info = lambda key: expected if key == "heatpump" else None  # type: ignore[assignment]
     coord._heatpump_power_w = 725.125  # noqa: SLF001
+    coord._heatpump_daily_consumption = {  # noqa: SLF001
+        "daily_energy_wh": 230.0,
+        "daily_solar_wh": 10.0,
+        "daily_battery_wh": 20.0,
+        "daily_grid_wh": 200.0,
+        "device_uid": "HP-1",
+        "device_name": "Heat Pump",
+        "source": "hems_energy_consumption:HP-1",
+    }
     coord.energy.site_energy = {
         "heat_pump": {
             "value_kwh": 2.0,
@@ -4525,6 +4712,11 @@ def test_site_heat_pump_energy_sensor_uses_heatpump_device_info(
     assert sensor.device_info is expected
     attrs = sensor.extra_state_attributes
     assert attrs["heat_pump_power_w"] == pytest.approx(725.125)
+    assert attrs["daily_energy_wh"] == pytest.approx(230.0)
+    assert attrs["daily_grid_wh"] == pytest.approx(200.0)
+    assert attrs["daily_device_uid"] == "HP-1"
+    assert attrs["daily_device_name"] == "Heat Pump"
+    assert attrs["daily_source"] == "hems_energy_consumption:HP-1"
 
 
 def test_site_heat_pump_energy_sensor_ignores_phantom_heatpump_device_info(
@@ -4922,10 +5114,11 @@ async def test_async_setup_entry_adds_heatpump_site_entities(
     hass, config_entry, coordinator_factory
 ) -> None:
     from custom_components.enphase_ev.sensor import (
+        EnphaseHeatPumpConnectivityStatusSensor,
         EnphaseHeatPumpEnergyMeterSensor,
         EnphaseHeatPumpLastReportedSensor,
         EnphaseHeatPumpPowerSensor,
-        EnphaseHeatPumpSgReadyGatewaySensor,
+        EnphaseHeatPumpSgReadyModeSensor,
         EnphaseHeatPumpStatusSensor,
         async_setup_entry,
     )
@@ -4961,6 +5154,14 @@ async def test_async_setup_entry_adds_heatpump_site_entities(
     )
     coord._devices_inventory_ready = True  # noqa: SLF001
     coord._heatpump_power_w = 640.0  # noqa: SLF001
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-1",
+        "heatpump_status": "RUNNING",
+        "sg_ready_mode_raw": "MODE_3",
+        "sg_ready_mode_label": "Recommended",
+        "sg_ready_active": True,
+        "last_report_at": "2026-02-27T09:15:59Z",
+    }
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     added: list[Any] = []
@@ -4971,9 +5172,71 @@ async def test_async_setup_entry_adds_heatpump_site_entities(
     await async_setup_entry(hass, config_entry, _capture)
 
     assert any(isinstance(ent, EnphaseHeatPumpStatusSensor) for ent in added)
-    assert any(isinstance(ent, EnphaseHeatPumpSgReadyGatewaySensor) for ent in added)
+    assert any(
+        isinstance(ent, EnphaseHeatPumpConnectivityStatusSensor) for ent in added
+    )
+    assert any(isinstance(ent, EnphaseHeatPumpSgReadyModeSensor) for ent in added)
     assert any(isinstance(ent, EnphaseHeatPumpEnergyMeterSensor) for ent in added)
     assert any(isinstance(ent, EnphaseHeatPumpLastReportedSensor) for ent in added)
+    assert any(isinstance(ent, EnphaseHeatPumpPowerSensor) for ent in added)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_runtime_only_heatpump_site_entities_without_dedicated_controller(
+    hass, config_entry, coordinator_factory
+) -> None:
+    from custom_components.enphase_ev.sensor import (
+        EnphaseHeatPumpConnectivityStatusSensor,
+        EnphaseHeatPumpEnergyMeterSensor,
+        EnphaseHeatPumpLastReportedSensor,
+        EnphaseHeatPumpPowerSensor,
+        EnphaseHeatPumpSgReadyModeSensor,
+        EnphaseHeatPumpStatusSensor,
+        async_setup_entry,
+    )
+
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 2,
+                "devices": [
+                    {
+                        "device_type": "SG_READY_GATEWAY",
+                        "device_uid": "HP-SG-1",
+                        "statusText": "Normal",
+                    },
+                    {
+                        "device_type": "ENERGY_METER",
+                        "device_uid": "HP-EM-1",
+                        "statusText": "Normal",
+                    },
+                ],
+                "overall_status_text": "Normal",
+            }
+        },
+        ["heatpump"],
+    )
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._heatpump_power_w = 640.0  # noqa: SLF001
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    added: list[Any] = []
+
+    def _capture(entities, update_before_add=False):
+        added.extend(entities)
+
+    await async_setup_entry(hass, config_entry, _capture)
+
+    assert not any(isinstance(ent, EnphaseHeatPumpStatusSensor) for ent in added)
+    assert not any(isinstance(ent, EnphaseHeatPumpSgReadyModeSensor) for ent in added)
+    assert not any(isinstance(ent, EnphaseHeatPumpLastReportedSensor) for ent in added)
+    assert any(
+        isinstance(ent, EnphaseHeatPumpConnectivityStatusSensor) for ent in added
+    )
+    assert any(isinstance(ent, EnphaseHeatPumpEnergyMeterSensor) for ent in added)
     assert any(isinstance(ent, EnphaseHeatPumpPowerSensor) for ent in added)
 
 
@@ -5014,6 +5277,55 @@ async def test_async_setup_entry_prunes_stale_heatpump_site_entities_when_unavai
     await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
 
     assert ent_reg.async_get(entity_id) is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_prunes_stale_runtime_heatpump_site_entities_without_dedicated_controller(
+    hass, config_entry, coordinator_factory
+) -> None:
+    from homeassistant.helpers import entity_registry as er
+
+    from custom_components.enphase_ev.const import DOMAIN
+    from custom_components.enphase_ev.sensor import async_setup_entry
+
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 2,
+                "devices": [
+                    {"device_type": "SG_READY_GATEWAY", "device_uid": "HP-SG-1"},
+                    {"device_type": "ENERGY_METER", "device_uid": "HP-EM-1"},
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    ent_reg = er.async_get(hass)
+    runtime_unique_ids = [
+        f"{DOMAIN}_site_{coord.site_id}_heat_pump_status",
+        f"{DOMAIN}_site_{coord.site_id}_heat_pump_sg_ready_mode",
+        f"{DOMAIN}_site_{coord.site_id}_heat_pump_last_reported",
+    ]
+    entity_ids = [
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            suggested_object_id=unique_id.rsplit("_", 1)[-1],
+        ).entity_id
+        for unique_id in runtime_unique_ids
+    ]
+    assert all(ent_reg.async_get(entity_id) is not None for entity_id in entity_ids)
+
+    await async_setup_entry(hass, config_entry, lambda *_args, **_kwargs: None)
+
+    assert all(ent_reg.async_get(entity_id) is None for entity_id in entity_ids)
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -191,11 +191,13 @@ def test_heatpump_inventory_strings_localized_for_non_english_locales() -> None:
     )
     en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
     assert (
-        _at_path(en_data, "entity.sensor.heat_pump_status.name") == "Heat Pump Status"
+        _at_path(en_data, "entity.sensor.heat_pump_status.name")
+        == "Heat Pump Runtime Status"
     )
     paths = [
         "entity.sensor.heat_pump_status.name",
-        "entity.sensor.heat_pump_sg_ready_gateway.name",
+        "entity.sensor.heat_pump_connectivity_status.name",
+        "entity.sensor.heat_pump_sg_ready_mode.name",
         "entity.sensor.heat_pump_energy_meter.name",
         "entity.sensor.heat_pump_last_reported.name",
         "entity.sensor.heat_pump_power.name",
@@ -246,15 +248,20 @@ def test_french_heatpump_inventory_strings_are_specific() -> None:
     )
     fr_data = json.loads((translations_dir / "fr.json").read_text(encoding="utf-8"))
     expected = {
-        "entity.sensor.heat_pump_status.name": "État de la pompe à chaleur",
-        "entity.sensor.heat_pump_sg_ready_gateway.name": (
-            "Passerelle SG-Ready de la pompe à chaleur"
+        "entity.sensor.heat_pump_status.name": (
+            "État de fonctionnement de la pompe à chaleur"
+        ),
+        "entity.sensor.heat_pump_connectivity_status.name": (
+            "État de connectivité de la pompe à chaleur"
+        ),
+        "entity.sensor.heat_pump_sg_ready_mode.name": (
+            "Mode SG-Ready de la pompe à chaleur"
         ),
         "entity.sensor.heat_pump_energy_meter.name": (
-            "Compteur d'énergie de la pompe à chaleur"
+            "État du compteur d'énergie de la pompe à chaleur"
         ),
         "entity.sensor.heat_pump_last_reported.name": (
-            "Dernier signalement de la pompe à chaleur"
+            "Dernier rapport de fonctionnement de la pompe à chaleur"
         ),
         "entity.sensor.heat_pump_power.name": "Puissance de la pompe à chaleur",
         "entity.binary_sensor.heat_pump_sg_ready_active.name": (
@@ -277,10 +284,13 @@ def test_heatpump_inventory_strings_are_not_site_consumption_concatenations() ->
     for locale in translations_dir.glob("*.json"):
         data = json.loads(locale.read_text(encoding="utf-8"))
         prefix = _at_path(data, "entity.sensor.site_heat_pump_consumption.name")
+        assert _at_path(data, "entity.sensor.heat_pump_connectivity_status.name") != (
+            f"{prefix} {_at_path(data, 'entity.sensor.gateway_connectivity_status.name')}"
+        ), f"{locale.name} reintroduced concatenated heat pump connectivity label"
         assert _at_path(data, "entity.sensor.heat_pump_status.name") != (
             f"{prefix} {_at_path(data, 'entity.sensor.battery_overall_status.name')}"
         ), f"{locale.name} reintroduced concatenated heat pump status label"
-        assert _at_path(data, "entity.sensor.heat_pump_sg_ready_gateway.name") != (
+        assert _at_path(data, "entity.sensor.heat_pump_sg_ready_mode.name") != (
             f"{prefix} SG-Ready Gateway"
         ), f"{locale.name} reintroduced concatenated SG-Ready label"
         assert _at_path(data, "entity.sensor.heat_pump_energy_meter.name") != (


### PR DESCRIPTION
## Summary
- switch heat pump runtime and SG-Ready state to the dedicated HEMS heat-pump runtime endpoint instead of inferring operating state from inventory health
- add cached current-day HEMS heat-pump consumption enrichment while keeping the existing lifetime site heat-pump consumption sensor state unchanged
- split heat-pump runtime, connectivity, component-status, and SG-Ready entities so the layout aligns with the other device families and prune the legacy SG-Ready gateway entity

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m coverage erase && python -m coverage run -m pytest tests/components/enphase_ev -q && python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/binary_sensor.py --fail-under=100"`
