### PR TITLE
Retain cloud power readings across malformed latest-power payloads

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -3395,7 +3395,33 @@ class EnphaseEVClient:
 
         url = f"{BASE_URL}/app-api/{self._site}/get_latest_power"
         data = await self._json("GET", url)
-        return self._normalize_latest_power_payload(data)
+        normalized = self._normalize_latest_power_payload(data)
+        if normalized is not None:
+            return normalized
+
+        top_level_keys: list[str] = []
+        nested_keys: list[str] = []
+        payload_type = type(data).__name__
+        if isinstance(data, dict):
+            top_level_keys = sorted(str(key) for key in data.keys())
+            nested = data.get("latest_power")
+            if not isinstance(nested, dict):
+                candidate = data.get("data")
+                if isinstance(candidate, dict):
+                    nested = candidate.get("latest_power")
+                    if not isinstance(nested, dict):
+                        nested = candidate
+            if isinstance(nested, dict):
+                nested_keys = sorted(str(key) for key in nested.keys())
+
+        _LOGGER.debug(
+            "Invalid latest power payload for site %s (payload_type=%s, top_level_keys=%s, nested_keys=%s)",
+            redact_site_id(self._site),
+            payload_type,
+            top_level_keys,
+            nested_keys,
+        )
+        return None
 
     async def show_livestream(self) -> dict[str, object] | None:
         """Return live-status/vitals capability flags when available."""

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -5655,7 +5655,7 @@ class EnphaseCloudLatencySensor(_SiteBaseEntity):
         return _cloud_device_info(self._coord.site_id)
 
 
-class EnphaseCurrentPowerConsumptionSensor(_SiteBaseEntity):
+class EnphaseCurrentPowerConsumptionSensor(_SiteBaseEntity, RestoreSensor):
     _attr_translation_key = "current_production_power"
     _attr_device_class = SensorDeviceClass.POWER
     _attr_native_unit_of_measurement = UnitOfPower.WATT
@@ -5669,16 +5669,91 @@ class EnphaseCurrentPowerConsumptionSensor(_SiteBaseEntity):
             "Current Production Power",
             type_key=None,
         )
+        self._last_good_value: float | None = None
+        self._last_good_sample_utc: datetime | None = None
+        self._last_good_source: str | None = None
+        self._last_good_reported_units: str | None = None
+        self._last_good_reported_precision: int | None = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        last = await self.async_get_last_sensor_data()
+        if last is not None:
+            try:
+                restored = (
+                    float(last.native_value) if last.native_value is not None else None
+                )
+            except Exception:  # noqa: BLE001
+                restored = None
+            if restored is not None and math.isfinite(restored):
+                self._last_good_value = restored
+
+        try:
+            last_state = await self.async_get_last_state()
+        except Exception:  # noqa: BLE001
+            last_state = None
+        if last_state is None:
+            return
+        attrs = last_state.attributes or {}
+        sample_raw = attrs.get("sampled_at_utc")
+        if isinstance(sample_raw, str):
+            parsed = dt_util.parse_datetime(sample_raw)
+            if parsed is not None:
+                if parsed.tzinfo is None:
+                    parsed = parsed.replace(tzinfo=timezone.utc)
+                self._last_good_sample_utc = parsed.astimezone(timezone.utc)
+        source = attrs.get("source")
+        if isinstance(source, str) and source.strip():
+            self._last_good_source = source
+        units = attrs.get("reported_units")
+        if isinstance(units, str) and units.strip():
+            self._last_good_reported_units = units
+        precision = attrs.get("reported_precision")
+        try:
+            if precision is not None:
+                self._last_good_reported_precision = int(precision)
+        except Exception:  # noqa: BLE001
+            self._last_good_reported_precision = None
+
+    def _current_or_cached_snapshot(
+        self,
+    ) -> tuple[float | None, datetime | None, str | None, str | None, int | None]:
+        value = self._coord.current_power_consumption_w
+        sample_utc = self._coord.current_power_consumption_sample_utc
+        source = self._coord.current_power_consumption_source
+        units = self._coord.current_power_consumption_reported_units
+        precision = self._coord.current_power_consumption_reported_precision
+
+        if value is not None:
+            self._last_good_value = float(value)
+            self._last_good_sample_utc = sample_utc
+            self._last_good_source = source
+            self._last_good_reported_units = units
+            self._last_good_reported_precision = precision
+            return float(value), sample_utc, source, units, precision
+
+        return (
+            self._last_good_value,
+            self._last_good_sample_utc,
+            self._last_good_source,
+            self._last_good_reported_units,
+            self._last_good_reported_precision,
+        )
 
     @property
     def available(self) -> bool:
         if not super().available:
             return False
-        return self._coord.current_power_consumption_w is not None
+        value, _sample_utc, _source, _units, _precision = (
+            self._current_or_cached_snapshot()
+        )
+        return value is not None
 
     @property
     def native_value(self):
-        value = self._coord.current_power_consumption_w
+        value, _sample_utc, _source, _units, _precision = (
+            self._current_or_cached_snapshot()
+        )
         if value is None:
             return None
         rounded = round(value, 3)
@@ -5688,17 +5763,16 @@ class EnphaseCurrentPowerConsumptionSensor(_SiteBaseEntity):
 
     @property
     def extra_state_attributes(self):
+        _value, sample_utc, source, units, precision = (
+            self._current_or_cached_snapshot()
+        )
         return {
             "sampled_at_utc": (
-                self._coord.current_power_consumption_sample_utc.isoformat()
-                if self._coord.current_power_consumption_sample_utc is not None
-                else None
+                sample_utc.isoformat() if sample_utc is not None else None
             ),
-            "source": self._coord.current_power_consumption_source,
-            "reported_units": self._coord.current_power_consumption_reported_units,
-            "reported_precision": (
-                self._coord.current_power_consumption_reported_precision
-            ),
+            "source": source,
+            "reported_units": units,
+            "reported_precision": precision,
         }
 
     @property

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3039,6 +3039,48 @@ async def test_latest_power_normalization() -> None:
     )
 
 
+@pytest.mark.asyncio
+async def test_latest_power_logs_invalid_payload_shape(caplog) -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        return_value={
+            "latest_power": {
+                "units": "W",
+                "time": 1_773_207_600,
+            }
+        }
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        payload = await client.latest_power()
+
+    assert payload is None
+    assert "Invalid latest power payload for site" in caplog.text
+    assert "top_level_keys=['latest_power']" in caplog.text
+    assert "nested_keys=['time', 'units']" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_latest_power_logs_invalid_nested_data_payload_shape(caplog) -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        return_value={
+            "data": {
+                "units": "W",
+                "time": 1_773_207_600,
+            }
+        }
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        payload = await client.latest_power()
+
+    assert payload is None
+    assert "Invalid latest power payload for site" in caplog.text
+    assert "top_level_keys=['data']" in caplog.text
+    assert "nested_keys=['time', 'units']" in caplog.text
+
+
 def test_normalize_latest_power_payload_rejects_invalid_shapes() -> None:
     client = _make_client()
 

--- a/tests/components/enphase_ev/test_latency_and_connectivity.py
+++ b/tests/components/enphase_ev/test_latency_and_connectivity.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
 
 import pytest
+from unittest.mock import AsyncMock
 
 from homeassistant.util import dt as dt_util
 
@@ -100,6 +101,115 @@ def test_current_power_consumption_sensor_edge_paths():
     coord.last_success_utc = datetime(2026, 3, 11, 5, 41, tzinfo=timezone.utc)
     coord._current_power_consumption_w = 752.1254
     assert sensor.native_value == pytest.approx(752.125)
+
+
+def test_current_power_consumption_sensor_keeps_last_good_runtime_sample():
+    from custom_components.enphase_ev.sensor import EnphaseCurrentPowerConsumptionSensor
+
+    coord = _make_site_coord()
+    coord.last_success_utc = datetime(2026, 3, 11, 5, 41, tzinfo=timezone.utc)
+    coord._current_power_consumption_w = 752.0
+    coord._current_power_consumption_sample_utc = datetime(
+        2026, 3, 11, 5, 40, tzinfo=timezone.utc
+    )
+    coord._current_power_consumption_reported_units = "W"
+    coord._current_power_consumption_reported_precision = 0
+    coord._current_power_consumption_source = "app-api:get_latest_power"
+
+    sensor = EnphaseCurrentPowerConsumptionSensor(coord)
+
+    assert sensor.native_value == 752
+    assert sensor.available is True
+
+    coord._current_power_consumption_w = None
+    coord._current_power_consumption_sample_utc = None
+    coord._current_power_consumption_reported_units = None
+    coord._current_power_consumption_reported_precision = None
+    coord._current_power_consumption_source = None
+
+    assert sensor.available is True
+    assert sensor.native_value == 752
+    assert sensor.extra_state_attributes == {
+        "sampled_at_utc": "2026-03-11T05:40:00+00:00",
+        "source": "app-api:get_latest_power",
+        "reported_units": "W",
+        "reported_precision": 0,
+    }
+
+
+@pytest.mark.asyncio
+async def test_current_power_consumption_sensor_restores_last_good_state(
+    monkeypatch,
+):
+    from custom_components.enphase_ev.sensor import EnphaseCurrentPowerConsumptionSensor
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    coord = _make_site_coord()
+    coord.last_success_utc = datetime(2026, 3, 11, 5, 41, tzinfo=timezone.utc)
+
+    async def _noop(self):
+        return None
+
+    monkeypatch.setattr(CoordinatorEntity, "async_added_to_hass", _noop)
+
+    sensor = EnphaseCurrentPowerConsumptionSensor(coord)
+    sensor.async_get_last_sensor_data = AsyncMock(  # type: ignore[method-assign]
+        return_value=type("LastSensorData", (), {"native_value": "752.0"})()
+    )
+    sensor.async_get_last_state = AsyncMock(  # type: ignore[method-assign]
+        return_value=type(
+            "LastState",
+            (),
+            {
+                "attributes": {
+                    "sampled_at_utc": "2026-03-11T05:40:00",
+                    "source": "app-api:get_latest_power",
+                    "reported_units": "W",
+                    "reported_precision": object(),
+                }
+            },
+        )()
+    )
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.available is True
+    assert sensor.native_value == 752
+    assert sensor.extra_state_attributes == {
+        "sampled_at_utc": "2026-03-11T05:40:00+00:00",
+        "source": "app-api:get_latest_power",
+        "reported_units": "W",
+        "reported_precision": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_current_power_consumption_sensor_restore_tolerates_last_state_error(
+    monkeypatch,
+):
+    from custom_components.enphase_ev.sensor import EnphaseCurrentPowerConsumptionSensor
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    coord = _make_site_coord()
+    coord.last_success_utc = datetime(2026, 3, 11, 5, 41, tzinfo=timezone.utc)
+
+    async def _noop(self):
+        return None
+
+    monkeypatch.setattr(CoordinatorEntity, "async_added_to_hass", _noop)
+
+    sensor = EnphaseCurrentPowerConsumptionSensor(coord)
+    sensor.async_get_last_sensor_data = AsyncMock(  # type: ignore[method-assign]
+        return_value=type("LastSensorData", (), {"native_value": "bad"})()
+    )
+    sensor.async_get_last_state = AsyncMock(  # type: ignore[method-assign]
+        side_effect=RuntimeError("boom")
+    )
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.available is False
+    assert sensor.native_value is None
 
 
 def test_site_cloud_reachable_binary_sensor_states():


### PR DESCRIPTION
## Summary
- retain the last good cloud current-power sample when `get_latest_power` returns malformed data
- log invalid `latest_power` payload shapes for easier field diagnostics
- add restore and malformed-payload regression coverage for the cloud power sensor

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_latency_and_connectivity.py"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m coverage erase && python3 -m coverage run -m pytest tests/components/enphase_ev -q && python3 -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/sensor.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
