### PR TITLE
Fix startup site power restore spikes

### DIFF
--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -5105,6 +5105,22 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
         self._last_live_interval_minutes: float | None = None
         self._restored_method_explicit = False
 
+    def _clear_restored_live_history(self, *, discard_power: bool = False) -> None:
+        """Drop restored live-history samples that are not safe to reuse."""
+
+        self._previous_live_flow_kwh = {}
+        self._previous_live_energy_ts = None
+        self._previous_live_sample_ts = None
+        if discard_power:
+            self._restored_power_w = None
+
+    def _restored_flows_zeroed(self, flows: dict[str, float]) -> bool:
+        """Return True when every restored flow is effectively zero."""
+
+        return bool(flows) and all(
+            abs(value) <= self._MIN_DELTA_KWH for value in flows.values()
+        )
+
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         last_state = await self.async_get_last_state()
@@ -5166,23 +5182,20 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
     def _restore_live_history(self) -> None:
         """Restore a valid two-sample live history when available."""
 
-        restored_baseline_zeroed = self._last_flow_kwh and all(
-            abs(value) <= self._MIN_DELTA_KWH for value in self._last_flow_kwh.values()
+        restored_baseline_zeroed = self._restored_flows_zeroed(self._last_flow_kwh)
+        restored_previous_zeroed = self._restored_flows_zeroed(
+            self._previous_live_flow_kwh
         )
 
         if self._restored_method_explicit and self._last_method in {
             "seeded",
             "no_live_data",
         }:
-            self._previous_live_flow_kwh = {}
-            self._previous_live_energy_ts = None
-            self._previous_live_sample_ts = None
+            self._clear_restored_live_history(discard_power=True)
             return
 
         if restored_baseline_zeroed and not self._restored_method_explicit:
-            self._previous_live_flow_kwh = {}
-            self._previous_live_energy_ts = None
-            self._previous_live_sample_ts = None
+            self._clear_restored_live_history(discard_power=True)
             return
 
         if (
@@ -5190,9 +5203,17 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
             and self._last_method in {"lifetime_reset", "restored_lifetime_reset"}
             and restored_baseline_zeroed
         ):
-            self._previous_live_flow_kwh = {}
-            self._previous_live_energy_ts = None
-            self._previous_live_sample_ts = None
+            self._clear_restored_live_history(discard_power=True)
+            return
+
+        if (
+            restored_previous_zeroed
+            and not restored_baseline_zeroed
+            and any(
+                value > self._RESET_DROP_KWH for value in self._last_flow_kwh.values()
+            )
+        ):
+            self._clear_restored_live_history(discard_power=True)
             return
 
         if (
@@ -5202,9 +5223,7 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
             or self._previous_live_sample_ts is None
             or self._previous_live_sample_ts >= self._last_sample_ts
         ):
-            self._previous_live_flow_kwh = {}
-            self._previous_live_energy_ts = None
-            self._previous_live_sample_ts = None
+            self._clear_restored_live_history(discard_power=True)
             return
 
         reset_detected = False
@@ -5237,6 +5256,7 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
                 ),
                 default_window_s=self._DEFAULT_WINDOW_S,
             )
+            window_s = max(window_s, self._DEFAULT_WINDOW_S)
             if self._last_live_interval_minutes is not None:
                 window_s = max(window_s, self._last_live_interval_minutes * 60.0)
             self._last_window_s = window_s
@@ -5464,9 +5484,6 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
         self._last_report_date_iso = sample_iso
         if self._last_sample_ts is not None and sample_ts == self._last_sample_ts:
             if self._live_flow_sample_count >= 2:
-                return self._last_power_w
-            if self._restored_power_w is not None and current_values:
-                self._last_power_w = self._restored_power_w
                 return self._last_power_w
             return None
 

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -1802,7 +1802,7 @@ async def test_site_lifetime_power_sensor_restore_uses_interval_floor_for_tiny_g
 
 
 @pytest.mark.asyncio
-async def test_site_lifetime_power_sensor_reuses_same_bucket_restore_without_extra_history(
+async def test_site_lifetime_power_sensor_does_not_reuse_same_bucket_restore_without_extra_history(
     hass, coordinator_factory
 ) -> None:
     coord = coordinator_factory()
@@ -1840,7 +1840,175 @@ async def test_site_lifetime_power_sensor_reuses_same_bucket_restore_without_ext
     }
 
     assert sensor.available is True
-    assert sensor.native_value == 6000
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes["method"] == "seeded"
+
+
+@pytest.mark.asyncio
+async def test_site_lifetime_power_sensor_ignores_same_bucket_restore_with_tiny_window_without_extra_history(
+    hass, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseGridPowerSensor(coord)
+    sensor.hass = hass
+    base_ts = datetime(2024, 1, 2, tzinfo=timezone.utc)
+
+    class LastState:
+        state = "-144000000"
+        attributes = {
+            "last_flow_kwh": {"grid_export": 1.2},
+            "last_energy_ts": (base_ts + timedelta(seconds=5)).timestamp(),
+            "last_sample_ts": (base_ts + timedelta(seconds=5)).timestamp(),
+            "last_power_w": -144000000,
+            "last_window_seconds": 5.0,
+            "last_report_date": (base_ts + timedelta(seconds=5)).isoformat(),
+        }
+
+    sensor.async_get_last_state = AsyncMock(return_value=LastState())
+    sensor.async_get_last_extra_data = AsyncMock(return_value=None)
+    await sensor.async_added_to_hass()
+
+    coord.energy.site_energy = {
+        "grid_export": SiteEnergyFlow(
+            value_kwh=1.2,
+            bucket_count=1,
+            fields_used=["solar_grid"],
+            start_date="2024-01-01",
+            last_report_date=base_ts + timedelta(seconds=5),
+            update_pending=False,
+            source_unit="Wh",
+            last_reset_at=None,
+            interval_minutes=5,
+        )
+    }
+
+    assert sensor.available is True
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes["method"] == "seeded"
+
+
+@pytest.mark.asyncio
+async def test_site_lifetime_power_sensor_ignores_zeroed_previous_restore_history(
+    hass, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseGridPowerSensor(coord)
+    sensor.hass = hass
+    base_ts = datetime(2024, 1, 2, tzinfo=timezone.utc)
+
+    class LastState:
+        state = "-207236928"
+        attributes = {
+            "last_flow_kwh": {
+                "grid_import": 1809.87,
+                "grid_export": 19079.614,
+            },
+            "last_energy_ts": (base_ts + timedelta(minutes=5)).timestamp(),
+            "last_sample_ts": (base_ts + timedelta(minutes=5)).timestamp(),
+            "last_power_w": -207236928,
+            "last_window_seconds": 300.0,
+            "last_report_date": (base_ts + timedelta(minutes=5)).isoformat(),
+        }
+
+    class LastExtra:
+        def as_dict(self):
+            return {
+                "previous_live_flow_kwh": {
+                    "grid_import": 0.0,
+                    "grid_export": 0.0,
+                },
+                "previous_live_energy_ts": base_ts.timestamp(),
+                "previous_live_sample_ts": base_ts.timestamp(),
+                "last_live_interval_minutes": 5.0,
+            }
+
+    sensor.async_get_last_state = AsyncMock(return_value=LastState())
+    sensor.async_get_last_extra_data = AsyncMock(return_value=LastExtra())
+    await sensor.async_added_to_hass()
+
+    assert sensor._restored_power_w is None
+
+    coord.energy.site_energy = {
+        "grid_import": SiteEnergyFlow(
+            value_kwh=1809.87,
+            bucket_count=1,
+            fields_used=["import"],
+            start_date="2024-01-02",
+            last_report_date=base_ts + timedelta(minutes=5),
+            update_pending=False,
+            source_unit="Wh",
+            last_reset_at=None,
+            interval_minutes=5,
+        ),
+        "grid_export": SiteEnergyFlow(
+            value_kwh=19079.614,
+            bucket_count=1,
+            fields_used=["solar_grid"],
+            start_date="2024-01-02",
+            last_report_date=base_ts + timedelta(minutes=5),
+            update_pending=False,
+            source_unit="Wh",
+            last_reset_at=None,
+            interval_minutes=5,
+        ),
+    }
+
+    assert sensor.available is True
+    assert sensor.native_value is None
+    assert sensor.extra_state_attributes["method"] == "seeded"
+
+
+@pytest.mark.asyncio
+async def test_site_lifetime_power_sensor_discards_restored_power_when_extra_history_is_invalid(
+    hass, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseGridPowerSensor(coord)
+    sensor.hass = hass
+    base_ts = datetime(2024, 1, 2, tzinfo=timezone.utc)
+
+    class LastState:
+        state = "6000"
+        attributes = {
+            "last_flow_kwh": {"grid_import": 1.5},
+            "last_energy_ts": (base_ts + timedelta(minutes=5)).timestamp(),
+            "last_sample_ts": (base_ts + timedelta(minutes=5)).timestamp(),
+            "last_power_w": 6000,
+            "last_window_seconds": 300.0,
+            "last_report_date": (base_ts + timedelta(minutes=5)).isoformat(),
+        }
+
+    class LastExtra:
+        def as_dict(self):
+            return {
+                "previous_live_flow_kwh": {"grid_import": 1.0},
+                "previous_live_energy_ts": (base_ts + timedelta(minutes=5)).timestamp(),
+                "previous_live_sample_ts": (base_ts + timedelta(minutes=5)).timestamp(),
+                "last_live_interval_minutes": 5.0,
+            }
+
+    sensor.async_get_last_state = AsyncMock(return_value=LastState())
+    sensor.async_get_last_extra_data = AsyncMock(return_value=LastExtra())
+    await sensor.async_added_to_hass()
+
+    assert sensor._restored_power_w is None
+
+    coord.energy.site_energy = {
+        "grid_import": SiteEnergyFlow(
+            value_kwh=1.5,
+            bucket_count=1,
+            fields_used=["import"],
+            start_date="2024-01-02",
+            last_report_date=base_ts + timedelta(minutes=5),
+            update_pending=False,
+            source_unit="Wh",
+            last_reset_at=None,
+            interval_minutes=5,
+        )
+    }
+
+    assert sensor.available is True
+    assert sensor.native_value is None
 
 
 @pytest.mark.asyncio
@@ -2010,7 +2178,7 @@ async def test_site_lifetime_power_sensor_restore_edge_cases(
     sensor2.async_get_last_state = AsyncMock(return_value=AttrState())
     await sensor2.async_added_to_hass()
     assert sensor2._last_power_w == 0
-    assert sensor2._restored_power_w == 321
+    assert sensor2._restored_power_w is None
     assert sensor2.native_value is None
 
 


### PR DESCRIPTION
## Summary
- harden site grid and battery power startup restore logic so ambiguous or invalid restore state seeds fresh history instead of replaying stale megawatt spikes
- discard restored power when persisted live-history metadata is missing, zeroed, or timestamp-invalid, and keep the restore window floored to a safe minimum
- add regression coverage for legacy same-bucket restore replay and invalid extra-history cases

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_site_energy.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/sensor.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
