### PR TITLE
Stabilize heat pump power telemetry and battery diagnostics

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1715,6 +1715,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             return
         await self._async_refresh_system_dashboard(force=True)
 
+    async def async_ensure_battery_status_diagnostics(self) -> None:
+        """Ensure battery-status payloads exist for diagnostics exports."""
+
+        if isinstance(getattr(self, "_battery_status_payload", None), dict):
+            return
+        await self._async_refresh_battery_status(force=True)
+
     async def _async_refresh_hems_support_preflight(
         self, *, force: bool = False
     ) -> None:
@@ -5802,26 +5809,49 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             current_index = int(elapsed_seconds // interval_seconds)
             latest_index = min(latest_index, current_index)
             latest_completed_index = min(latest_index, current_index - 1)
-        for index in range(latest_index, -1, -1):
-            raw_value = values[index]
-            if raw_value is None:
-                continue
-            try:
-                value = float(raw_value)
-            except Exception:
-                continue
-            if value != value or value in (float("inf"), float("-inf")):
-                continue
-            # Prefer the last completed bucket over an in-progress bucket when the
-            # current/open bucket is still zero-filled by the backend.
-            if (
-                latest_completed_index is not None
-                and index > latest_completed_index
-                and value <= 0
-            ):
-                continue
-            return index, value
-        return None
+
+        def _sample_in_range(
+            start_index: int,
+            end_index: int,
+        ) -> tuple[int, float] | None:
+            for index in range(start_index, end_index - 1, -1):
+                raw_value = values[index]
+                if raw_value is None:
+                    continue
+                try:
+                    value = float(raw_value)
+                except Exception:
+                    continue
+                if value != value or value in (float("inf"), float("-inf")):
+                    continue
+                return index, value
+            return None
+
+        def _is_provisional_open_bucket(
+            open_value: float,
+            completed_value: float,
+        ) -> bool:
+            if open_value <= 0:
+                return True
+            if completed_value <= 0:
+                return False
+            return open_value <= 10.0 and open_value <= (completed_value * 0.1)
+
+        # HEMS often exposes an open/in-progress bucket whose value starts near
+        # zero and only converges after the interval closes. Prefer the completed
+        # bucket only when the open bucket still looks clearly provisional.
+        if latest_completed_index is not None and latest_index > latest_completed_index:
+            open_sample = _sample_in_range(latest_index, latest_completed_index + 1)
+            completed_sample = _sample_in_range(latest_completed_index, 0)
+            if open_sample is None:
+                return completed_sample
+            if completed_sample is None:
+                return open_sample
+            if _is_provisional_open_bucket(open_sample[1], completed_sample[1]):
+                return completed_sample
+            return open_sample
+
+        return _sample_in_range(latest_index, 0)
 
     @staticmethod
     def _infer_heatpump_interval_minutes(

--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -289,6 +289,39 @@ def _microinverter_summary(payload: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _battery_status_summary_for_diagnostics(summary: Any) -> dict[str, Any]:
+    """Return a battery-status summary without identifier-keyed maps."""
+
+    if not isinstance(summary, dict):
+        return {}
+    safe_keys = (
+        "aggregate_charge_pct",
+        "aggregate_status",
+        "aggregate_charge_source",
+        "included_count",
+        "contributing_count",
+        "excluded_count",
+        "available_energy_kwh",
+        "max_capacity_kwh",
+        "site_current_charge_pct",
+        "site_available_energy_kwh",
+        "site_max_capacity_kwh",
+        "site_available_power_kw",
+        "site_max_power_kw",
+        "site_total_micros",
+        "site_active_micros",
+        "site_inactive_micros",
+        "site_included_count",
+        "site_excluded_count",
+        "worst_status",
+    )
+    return {
+        key: summary.get(key)
+        for key in safe_keys
+        if summary.get(key) not in (None, {}, [])
+    }
+
+
 async def async_get_config_entry_diagnostics(hass, entry):
     data = async_redact_data(dict(entry.data), TO_REDACT)
     options = dict(getattr(entry, "options", {}) or {})
@@ -609,6 +642,26 @@ async def async_get_device_diagnostics(hass, entry, device):
                                         system_dashboard_payload[key] = value
             if system_dashboard_payload:
                 payload["system_dashboard_details"] = system_dashboard_payload
+        if type_key == "encharge" and coord is not None:
+            ensure_battery_status = getattr(
+                coord, "async_ensure_battery_status_diagnostics", None
+            )
+            if callable(ensure_battery_status):
+                try:
+                    await ensure_battery_status()
+                except DIAGNOSTIC_CAPTURE_ERRORS:
+                    pass
+            battery_status_payload = getattr(coord, "battery_status_payload", None)
+            if not isinstance(battery_status_payload, dict):
+                battery_status_payload = getattr(coord, "_battery_status_payload", None)
+            if isinstance(battery_status_payload, dict) and battery_status_payload:
+                payload["battery_status_payload"] = battery_status_payload
+
+            battery_status_summary = _battery_status_summary_for_diagnostics(
+                getattr(coord, "battery_status_summary", None)
+            )
+            if battery_status_summary:
+                payload["battery_status_summary"] = battery_status_summary
         if type_key == "heatpump" and coord is not None:
             ensure_heatpump_runtime = getattr(
                 coord, "async_ensure_heatpump_runtime_diagnostics", None

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2717,6 +2717,114 @@ def test_heatpump_latest_power_sample_skips_open_zero_bucket(
     ) == (0, 560.0)
 
 
+def test_heatpump_latest_power_sample_skips_open_low_partial_bucket(
+    coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = coordinator_factory(serials=[])
+    fixed_now = datetime(2026, 2, 27, 0, 7, tzinfo=timezone.utc)
+    monkeypatch.setattr(coord_mod.dt_util, "utcnow", lambda: fixed_now)
+
+    assert coord._heatpump_latest_power_sample(  # noqa: SLF001
+        {
+            "heat_pump_consumption": [560.0, 4.0, 0.0],
+            "start_date": "2026-02-27T00:00:00Z",
+            "interval_minutes": 5,
+        }
+    ) == (0, 560.0)
+
+
+def test_heatpump_latest_power_sample_keeps_open_bucket_when_higher(
+    coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = coordinator_factory(serials=[])
+    fixed_now = datetime(2026, 2, 27, 0, 7, tzinfo=timezone.utc)
+    monkeypatch.setattr(coord_mod.dt_util, "utcnow", lambda: fixed_now)
+
+    assert coord._heatpump_latest_power_sample(  # noqa: SLF001
+        {
+            "heat_pump_consumption": [560.0, 600.0, 0.0],
+            "start_date": "2026-02-27T00:00:00Z",
+            "interval_minutes": 5,
+        }
+    ) == (1, 600.0)
+
+
+def test_heatpump_latest_power_sample_keeps_open_bucket_when_lower_but_substantial(
+    coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = coordinator_factory(serials=[])
+    fixed_now = datetime(2026, 2, 27, 0, 7, tzinfo=timezone.utc)
+    monkeypatch.setattr(coord_mod.dt_util, "utcnow", lambda: fixed_now)
+
+    assert coord._heatpump_latest_power_sample(  # noqa: SLF001
+        {
+            "heat_pump_consumption": [560.0, 300.0, 0.0],
+            "start_date": "2026-02-27T00:00:00Z",
+            "interval_minutes": 5,
+        }
+    ) == (1, 300.0)
+
+
+def test_heatpump_latest_power_sample_uses_open_bucket_when_completed_non_positive(
+    coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = coordinator_factory(serials=[])
+    fixed_now = datetime(2026, 2, 27, 0, 7, tzinfo=timezone.utc)
+    monkeypatch.setattr(coord_mod.dt_util, "utcnow", lambda: fixed_now)
+
+    assert coord._heatpump_latest_power_sample(  # noqa: SLF001
+        {
+            "heat_pump_consumption": [0.0, 4.0, 0.0],
+            "start_date": "2026-02-27T00:00:00Z",
+            "interval_minutes": 5,
+        }
+    ) == (1, 4.0)
+
+
+def test_heatpump_latest_power_sample_falls_back_when_open_bucket_missing(
+    coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    coord = coordinator_factory(serials=[])
+    fixed_now = datetime(2026, 2, 27, 0, 7, tzinfo=timezone.utc)
+    monkeypatch.setattr(coord_mod.dt_util, "utcnow", lambda: fixed_now)
+
+    assert coord._heatpump_latest_power_sample(  # noqa: SLF001
+        {
+            "heat_pump_consumption": [560.0, None, 0.0],
+            "start_date": "2026-02-27T00:00:00Z",
+            "interval_minutes": 5,
+        }
+    ) == (0, 560.0)
+
+
+@pytest.mark.asyncio
+async def test_ensure_battery_status_diagnostics_uses_cache_and_refreshes(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._battery_status_payload = {"storages": []}  # noqa: SLF001
+    coord._async_refresh_battery_status = AsyncMock()  # noqa: SLF001
+
+    await coord.async_ensure_battery_status_diagnostics()
+
+    coord._async_refresh_battery_status.assert_not_awaited()
+
+    coord._battery_status_payload = None  # noqa: SLF001
+    await coord.async_ensure_battery_status_diagnostics()
+
+    coord._async_refresh_battery_status.assert_awaited_once_with(force=True)
+
+
 def test_heatpump_latest_power_sample_normalizes_naive_utcnow(
     coordinator_factory, monkeypatch
 ) -> None:

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -118,6 +118,7 @@ def test_gateway_diagnostics_helper_branches() -> None:
     assert overflow_counts["connectivity"] == "offline"
     assert diagnostics._microinverter_summary({"count": 2})["connectivity"] == "unknown"
     assert diagnostics._microinverter_summary({})["connectivity"] is None
+    assert diagnostics._battery_status_summary_for_diagnostics(None) == {}
 
 
 class DummyClient(SimpleNamespace):
@@ -183,6 +184,20 @@ class DummyCoordinator(SimpleNamespace):
         self._battery_status_payload = {
             "current_charge": "48%",
             "storages": [{"serial_number": "BT0001", "status": "normal"}],
+        }
+        self.battery_status_summary = {
+            "aggregate_charge_pct": 48.0,
+            "aggregate_status": "normal",
+            "aggregate_charge_source": "site_current_charge",
+            "included_count": 1,
+            "contributing_count": 0,
+            "excluded_count": 0,
+            "site_current_charge_pct": 48.0,
+            "site_available_power_kw": 3.2,
+            "worst_status": "normal",
+            "battery_order": ["BT0001"],
+            "per_battery_status": {"BT0001": "normal"},
+            "worst_storage_key": "BT0001",
         }
         self._grid_control_check_payload = {
             "disableGridControl": False,
@@ -478,6 +493,9 @@ class DummyCoordinator(SimpleNamespace):
         }
 
     async def async_ensure_heatpump_runtime_diagnostics(self):
+        return None
+
+    async def async_ensure_battery_status_diagnostics(self):
         return None
 
     def heatpump_runtime_diagnostics(self):
@@ -1401,6 +1419,7 @@ async def test_device_diagnostics_encharge_includes_system_dashboard_details(
 ) -> None:
     coord = DummyCoordinator()
     coord.async_ensure_system_dashboard_diagnostics = AsyncMock()
+    coord.async_ensure_battery_status_diagnostics = AsyncMock()
     coord.type_bucket = lambda type_key: (
         {  # type: ignore[attr-defined]
             "type_label": "Battery",
@@ -1422,6 +1441,7 @@ async def test_device_diagnostics_encharge_includes_system_dashboard_details(
 
     result = await diagnostics.async_get_device_diagnostics(hass, config_entry, device)
     coord.async_ensure_system_dashboard_diagnostics.assert_awaited_once()
+    coord.async_ensure_battery_status_diagnostics.assert_awaited_once()
     assert result["system_dashboard_details"]["connectivity"]["rssi"] == -61
     assert result["system_dashboard_details"]["software"]["app_version"] == "1.2.3"
     assert result["system_dashboard_details"]["operation_mode"]["mode"] == "backup"
@@ -1431,6 +1451,51 @@ async def test_device_diagnostics_encharge_includes_system_dashboard_details(
         ]
         == "**REDACTED**"
     )
+    assert (
+        result["battery_status_payload"]["storages"][0]["serial_number"]
+        == "**REDACTED**"
+    )
+    assert result["battery_status_summary"]["aggregate_charge_pct"] == 48.0
+    assert result["battery_status_summary"]["site_available_power_kw"] == 3.2
+    assert "battery_order" not in result["battery_status_summary"]
+    assert "per_battery_status" not in result["battery_status_summary"]
+
+
+@pytest.mark.asyncio
+async def test_device_diagnostics_encharge_ignores_battery_status_prefetch_failure(
+    hass, config_entry
+) -> None:
+    coord = DummyCoordinator()
+    coord.async_ensure_system_dashboard_diagnostics = AsyncMock()
+    coord.async_ensure_battery_status_diagnostics = AsyncMock(
+        side_effect=RuntimeError("boom")
+    )
+    coord._battery_status_payload = None
+    coord.battery_status_summary = {}
+    coord.type_bucket = lambda type_key: (
+        {  # type: ignore[attr-defined]
+            "type_label": "Battery",
+            "count": 1,
+            "devices": [{"serial_number": "BAT-1", "name": "Battery 1"}],
+        }
+        if type_key == "encharge"
+        else None
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"type:{RANDOM_SITE_ID}:encharge")},
+        manufacturer="Enphase",
+        name="Battery",
+    )
+
+    result = await diagnostics.async_get_device_diagnostics(hass, config_entry, device)
+
+    coord.async_ensure_battery_status_diagnostics.assert_awaited_once()
+    assert "battery_status_payload" not in result
+    assert "battery_status_summary" not in result
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- stabilize heat pump power selection so clearly provisional open HEMS buckets do not override valid completed samples
- add battery-status diagnostics prefetching for encharge device exports and include a safe parsed summary
- add regression coverage for the new coordinator and diagnostics paths

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/diagnostics.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_diagnostics.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/diagnostics.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
