### PR TITLE
Harden site power outlier handling

### DIFF
--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -5620,16 +5620,8 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
             self._last_window_s = None
             return None
 
-        prior_last_flow_kwh = dict(self._last_flow_kwh)
-        prior_last_energy_ts = self._last_energy_ts
-        prior_last_sample_ts = self._last_sample_ts
         prior_last_power_w = self._last_power_w
-        prior_last_window_s = self._last_window_s
-        prior_previous_live_flow_kwh = dict(self._previous_live_flow_kwh)
-        prior_previous_live_energy_ts = self._previous_live_energy_ts
-        prior_previous_live_sample_ts = self._previous_live_sample_ts
         prior_live_sample_count = self._live_flow_sample_count
-        prior_live_interval_minutes = self._last_live_interval_minutes
 
         reset_detected = False
         signed_delta_kwh = 0.0
@@ -5700,17 +5692,8 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
             current_values=current_values,
             previous_values=previous_live_flow_kwh,
         ):
-            self._last_flow_kwh = prior_last_flow_kwh
-            self._last_energy_ts = prior_last_energy_ts
-            self._last_sample_ts = prior_last_sample_ts
             self._last_power_w = prior_last_power_w
-            self._last_window_s = prior_last_window_s
             self._last_method = "outlier_ignored"
-            self._previous_live_flow_kwh = prior_previous_live_flow_kwh
-            self._previous_live_energy_ts = prior_previous_live_energy_ts
-            self._previous_live_sample_ts = prior_previous_live_sample_ts
-            self._live_flow_sample_count = prior_live_sample_count
-            self._last_live_interval_minutes = prior_live_interval_minutes
             return prior_last_power_w if prior_live_sample_count >= 2 else None
         self._last_power_w = candidate_power_w
         self._last_method = "lifetime_energy_window"

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -2011,7 +2011,7 @@ async def test_site_lifetime_power_sensor_discards_restored_power_when_extra_his
     assert sensor.native_value is None
 
 
-def test_site_grid_power_sensor_ignores_implausible_outlier_and_keeps_last_good_baseline(
+def test_site_grid_power_sensor_ignores_implausible_outlier_but_advances_baseline(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -2059,10 +2059,10 @@ def test_site_grid_power_sensor_ignores_implausible_outlier_and_keeps_last_good_
     )
     assert sensor.native_value == -2400
     assert sensor.extra_state_attributes["method"] == "outlier_ignored"
-    assert sensor.extra_state_attributes["last_flow_kwh"] == {"grid_export": 1.2}
+    assert sensor.extra_state_attributes["last_flow_kwh"] == {"grid_export": 11.2}
 
     coord.energy.site_energy["grid_export"] = SiteEnergyFlow(
-        value_kwh=1.4,
+        value_kwh=11.4,
         bucket_count=1,
         fields_used=["solar_grid"],
         start_date="2024-01-01",
@@ -2072,8 +2072,50 @@ def test_site_grid_power_sensor_ignores_implausible_outlier_and_keeps_last_good_
         last_reset_at=None,
         interval_minutes=5,
     )
-    assert sensor.native_value == -1200
+    assert sensor.native_value == -2400
     assert sensor.extra_state_attributes["method"] == "lifetime_energy_window"
+
+
+def test_site_grid_power_sensor_recovers_after_sustained_high_power_post_reset(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    sensor = EnphaseGridPowerSensor(coord)
+    base_ts = datetime(2024, 1, 2, tzinfo=timezone.utc)
+
+    coord.energy.site_energy = {
+        "grid_import": SiteEnergyFlow(
+            value_kwh=0.0,
+            bucket_count=1,
+            fields_used=["import"],
+            start_date="2024-01-01",
+            last_report_date=base_ts,
+            update_pending=False,
+            source_unit="Wh",
+            last_reset_at=None,
+            interval_minutes=5,
+        )
+    }
+    assert sensor.native_value is None
+
+    latest_value = None
+    for step in range(1, 8):
+        coord.energy.site_energy["grid_import"] = SiteEnergyFlow(
+            value_kwh=step * 10.0,
+            bucket_count=1,
+            fields_used=["import"],
+            start_date="2024-01-01",
+            last_report_date=base_ts + timedelta(minutes=step * 5),
+            update_pending=False,
+            source_unit="Wh",
+            last_reset_at=None,
+            interval_minutes=5,
+        )
+        latest_value = sensor.native_value
+
+    assert latest_value == 120000
+    assert sensor.extra_state_attributes["method"] == "lifetime_energy_window"
+    assert sensor.extra_state_attributes["last_flow_kwh"] == {"grid_import": 70.0}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- harden derived site grid and battery power sensors against corrupt lifetime-energy spikes without hard-capping legitimate large sites
- discard rejected restored baselines so startup recovery can reseed cleanly on the next sample
- add regressions for live outliers, restored outliers, large plausible deltas, and helper edge cases

## Testing
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_site_energy.py"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/sensor.py --fail-under=100"
- docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
