### PR TITLE
Map battery LED status 15 to idle

### DIFF
--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -77,6 +77,7 @@ BATTERY_LED_STATUS_STATE_MAP: dict[int, str] = {
     12: "charging",
     13: "discharging",
     14: "idle",
+    15: "idle",
     17: "idle",
 }
 

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -2260,7 +2260,7 @@ Observed structure:
 - `excluded=true` marks batteries excluded from active fleet calculations; included/excluded counters are exposed at the top level.
 - Percentage fields (`current_charge`, `battery_soh`) are string percentages in observed payloads.
 - Status appears as normalized code (`status`, for example `normal`) plus a display label (`statusText`, for example `Normal`).
-- `led_status` is the raw battery LED/runtime status code. The integration currently interprets `12` as charging, `13` as discharging, `14` as idle, and `17` as idle; any other value is treated as unknown runtime state.
+- `led_status` is the raw battery LED/runtime status code. The integration currently interprets `12` as charging, `13` as discharging, `14` as idle, `15` as idle, and `17` as idle; any other value is treated as unknown runtime state.
 
 Observed battery LED legend:
 - Rapidly Flashing Yellow: Starting up / establishing communications

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -639,6 +639,10 @@ def test_battery_storage_detail_sensors_state_and_attributes():
     assert status.native_value == "idle"
     assert status.extra_state_attributes["state"] == 14
 
+    snapshot["led_status"] = 15
+    assert status.native_value == "idle"
+    assert status.extra_state_attributes["state"] == 15
+
     snapshot["led_status"] = 99
     assert status.native_value == "unknown"
     assert status.extra_state_attributes["state"] == 99


### PR DESCRIPTION
## Summary
- map battery `led_status` value `15` to the same `Idle` runtime state as the existing idle LED codes
- add regression coverage for the new LED status mapping in the battery status sensor test
- update the API spec battery status notes to document `15` alongside the other known `led_status` values

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_sensors.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/sensor.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
