### PR TITLE
Extract battery runtime helpers

### DIFF
--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    BATTERY_PROFILE_DEFAULT_RESERVE,
+    BATTERY_PROFILE_LABELS,
+    SAVINGS_OPERATION_MODE_SUBTYPE,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .coordinator import EnphaseCoordinator
+
+
+class BatteryRuntime:
+    """Battery profile selection and pending-state helpers."""
+
+    def __init__(self, coordinator: EnphaseCoordinator) -> None:
+        self.coordinator = coordinator
+
+    @staticmethod
+    def normalize_battery_profile_key(value: object) -> str | None:
+        if value is None:
+            return None
+        try:
+            normalized = str(value).strip().lower()
+        except Exception:  # noqa: BLE001
+            return None
+        return normalized or None
+
+    @staticmethod
+    def battery_profile_label(profile: str | None) -> str | None:
+        if not profile:
+            return None
+        if profile in BATTERY_PROFILE_LABELS:
+            return BATTERY_PROFILE_LABELS[profile]
+        try:
+            return str(profile).replace("_", " ").replace("-", " ").title()
+        except Exception:  # noqa: BLE001
+            return None
+
+    @staticmethod
+    def _normalize_pending_sub_type(
+        coordinator: EnphaseCoordinator, profile: str, sub_type: str | None
+    ) -> str | None:
+        if profile != "cost_savings":
+            return None
+        return coordinator._normalize_battery_sub_type(sub_type)
+
+    def clear_battery_pending(self) -> None:
+        coord = self.coordinator
+        coord._battery_pending_profile = None
+        coord._battery_pending_reserve = None
+        coord._battery_pending_sub_type = None
+        coord._battery_pending_requested_at = None
+        coord._battery_pending_require_exact_settings = True
+        coord._sync_battery_profile_pending_issue()
+
+    def set_battery_pending(
+        self,
+        *,
+        profile: str,
+        reserve: int,
+        sub_type: str | None,
+        require_exact_settings: bool = True,
+    ) -> None:
+        coord = self.coordinator
+        coord._battery_pending_profile = profile
+        coord._battery_pending_reserve = reserve
+        coord._battery_pending_sub_type = self._normalize_pending_sub_type(
+            coord, profile, sub_type
+        )
+        coord._battery_pending_requested_at = dt_util.utcnow()
+        coord._battery_pending_require_exact_settings = bool(require_exact_settings)
+        coord._sync_battery_profile_pending_issue()
+
+    def effective_profile_matches_pending(self) -> bool:
+        coord = self.coordinator
+        pending_profile = getattr(coord, "_battery_pending_profile", None)
+        if not pending_profile:
+            return False
+        if getattr(coord, "_battery_profile", None) != pending_profile:
+            return False
+        if not getattr(coord, "_battery_pending_require_exact_settings", True):
+            return True
+        pending_reserve = getattr(coord, "_battery_pending_reserve", None)
+        if (
+            pending_reserve is not None
+            and getattr(coord, "_battery_backup_percentage", None) != pending_reserve
+        ):
+            return False
+        if pending_profile != "cost_savings":
+            return True
+        pending_subtype = coord._normalize_battery_sub_type(
+            getattr(coord, "_battery_pending_sub_type", None)
+        )
+        effective_subtype = coord._normalize_battery_sub_type(
+            getattr(coord, "_battery_operation_mode_sub_type", None)
+        )
+        if pending_subtype == SAVINGS_OPERATION_MODE_SUBTYPE:
+            return effective_subtype == SAVINGS_OPERATION_MODE_SUBTYPE
+        if pending_subtype is None:
+            return effective_subtype != SAVINGS_OPERATION_MODE_SUBTYPE
+        return pending_subtype == effective_subtype
+
+    def remember_battery_reserve(
+        self, profile: str | None, reserve: int | None
+    ) -> None:
+        if not profile or reserve is None:
+            return
+        normalized = self.normalize_battery_profile_key(profile)
+        if not normalized or normalized not in BATTERY_PROFILE_DEFAULT_RESERVE:
+            return
+        self.coordinator._battery_profile_reserve_memory[normalized] = int(reserve)
+
+    def target_reserve_for_profile(self, profile: str) -> int:
+        remembered = self.coordinator._battery_profile_reserve_memory.get(profile)
+        if remembered is not None:
+            return self.coordinator._normalize_battery_reserve_for_profile(
+                profile, remembered
+            )
+        default = BATTERY_PROFILE_DEFAULT_RESERVE.get(profile, 20)
+        return self.coordinator._normalize_battery_reserve_for_profile(profile, default)
+
+    def current_savings_sub_type(self) -> str | None:
+        selected_subtype = self.coordinator.battery_selected_operation_mode_sub_type
+        if selected_subtype == SAVINGS_OPERATION_MODE_SUBTYPE:
+            return SAVINGS_OPERATION_MODE_SUBTYPE
+        return None

--- a/custom_components/enphase_ev/const.py
+++ b/custom_components/enphase_ev/const.py
@@ -48,11 +48,17 @@ DEFAULT_API_TIMEOUT = 15
 DEFAULT_SESSION_HISTORY_INTERVAL_MIN = 10
 DEFAULT_NOMINAL_VOLTAGE = 230
 BATTERY_PROFILE_PENDING_TIMEOUT_S = 900.0
+BATTERY_PROFILE_LABELS = {
+    "self-consumption": "Self-Consumption",
+    "cost_savings": "Savings",
+    "backup_only": "Full Backup",
+}
 BATTERY_PROFILE_DEFAULT_RESERVE = {
     "self-consumption": 20,
     "cost_savings": 20,
     "backup_only": 100,
 }
+SAVINGS_OPERATION_MODE_SUBTYPE = "prioritize-energy"
 GREEN_BATTERY_SETTING = "USE_BATTERY_FOR_SELF_CONSUMPTION"
 AUTH_APP_SETTING = "sessionAuthentication"
 AUTH_RFID_SETTING = "rfidSessionAuthentication"

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -42,7 +42,6 @@ from .api import (
 from .const import (
     AUTH_APP_SETTING,
     AUTH_RFID_SETTING,
-    BATTERY_PROFILE_DEFAULT_RESERVE,
     CONF_ACCESS_TOKEN,
     CONF_COOKIE,
     CONF_EAUTH,
@@ -75,9 +74,11 @@ from .const import (
     OPT_NOMINAL_VOLTAGE,
     OPT_SLOW_POLL_INTERVAL,
     OPT_SESSION_HISTORY_INTERVAL,
+    SAVINGS_OPERATION_MODE_SUBTYPE,
     DEFAULT_SESSION_HISTORY_INTERVAL_MIN,
     SAFE_LIMIT_AMPS,
 )
+from .battery_runtime import BatteryRuntime
 from .coordinator_diagnostics import CoordinatorDiagnostics
 from .device_types import (
     member_is_retired,
@@ -174,7 +175,6 @@ SYSTEM_DASHBOARD_TYPE_KEY_MAP: dict[str, str] = {
     "inverters": "microinverter",
     "modems": "modem",
 }
-SAVINGS_OPERATION_MODE_SUBTYPE = "prioritize-energy"
 BATTERY_PROFILE_WRITE_DEBOUNCE_S = 2.0
 BATTERY_SETTINGS_WRITE_DEBOUNCE_S = 2.0
 DISCOVERY_SNAPSHOT_STORE_VERSION = 1
@@ -207,11 +207,6 @@ class CoordinatorTopologySnapshot:
     inventory_ready: bool
 
 
-BATTERY_PROFILE_LABELS = {
-    "self-consumption": "Self-Consumption",
-    "cost_savings": "Savings",
-    "backup_only": "Full Backup",
-}
 BATTERY_MIN_SOC_FALLBACK = 5
 BATTERY_GRID_MODE_LABELS = {
     "importexport": "Import and Export",
@@ -464,6 +459,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             publish_callback=self.async_set_updated_data,
             logger=_LOGGER,
         )
+        self.battery_runtime = BatteryRuntime(self)
         self.diagnostics = CoordinatorDiagnostics(self)
 
     def __setattr__(self, name, value):
@@ -9152,24 +9148,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @staticmethod
     def _normalize_battery_profile_key(value: object) -> str | None:
-        if value is None:
-            return None
-        try:
-            normalized = str(value).strip().lower()
-        except Exception:  # noqa: BLE001
-            return None
-        return normalized or None
+        return BatteryRuntime.normalize_battery_profile_key(value)
 
     @staticmethod
     def _battery_profile_label(profile: str | None) -> str | None:
-        if not profile:
-            return None
-        if profile in BATTERY_PROFILE_LABELS:
-            return BATTERY_PROFILE_LABELS[profile]
-        try:
-            return str(profile).replace("_", " ").replace("-", " ").title()
-        except Exception:  # noqa: BLE001
-            return None
+        return BatteryRuntime.battery_profile_label(profile)
 
     @staticmethod
     def _normalize_battery_sub_type(value: object) -> str | None:
@@ -9594,10 +9577,6 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def battery_reserve_editable(self) -> bool:
         if not self.battery_controls_available:
             return False
-        # Prefer cfgControl.show (used by Enlighten app) over the
-        # legacy showBatteryBackupPercentage flag which is unreliable
-        # on EMEA sites.  Use cfgControl whenever present; fall back
-        # to legacy only when the field is absent.
         cfg_show = getattr(self, "_battery_cfg_control_show", None)
         if cfg_show is not None:
             if cfg_show is False:
@@ -11081,12 +11060,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._clear_storm_guard_pending()
 
     def _clear_battery_pending(self) -> None:
-        self._battery_pending_profile = None
-        self._battery_pending_reserve = None
-        self._battery_pending_sub_type = None
-        self._battery_pending_requested_at = None
-        self._battery_pending_require_exact_settings = True
-        self._sync_battery_profile_pending_issue()
+        self.battery_runtime.clear_battery_pending()
 
     def _set_battery_pending(
         self,
@@ -11096,16 +11070,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         sub_type: str | None,
         require_exact_settings: bool = True,
     ) -> None:
-        self._battery_pending_profile = profile
-        self._battery_pending_reserve = reserve
-        self._battery_pending_sub_type = (
-            self._normalize_battery_sub_type(sub_type)
-            if profile == "cost_savings"
-            else None
+        self.battery_runtime.set_battery_pending(
+            profile=profile,
+            reserve=reserve,
+            sub_type=sub_type,
+            require_exact_settings=require_exact_settings,
         )
-        self._battery_pending_requested_at = dt_util.utcnow()
-        self._battery_pending_require_exact_settings = bool(require_exact_settings)
-        self._sync_battery_profile_pending_issue()
 
     def _assert_battery_profile_write_allowed(self) -> None:
         lock = getattr(self, "_battery_profile_write_lock", None)
@@ -11139,46 +11109,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return bounded
 
     def _effective_profile_matches_pending(self) -> bool:
-        pending_profile = self._battery_pending_profile
-        if not pending_profile:
-            return False
-        if self._battery_profile != pending_profile:
-            return False
-        if not getattr(self, "_battery_pending_require_exact_settings", True):
-            return True
-        if self._battery_pending_reserve is not None:
-            if self._battery_backup_percentage != self._battery_pending_reserve:
-                return False
-        if pending_profile == "cost_savings":
-            pending_subtype = self._normalize_battery_sub_type(
-                self._battery_pending_sub_type
-            )
-            effective_subtype = self._normalize_battery_sub_type(
-                self._battery_operation_mode_sub_type
-            )
-            if pending_subtype == SAVINGS_OPERATION_MODE_SUBTYPE:
-                if effective_subtype != SAVINGS_OPERATION_MODE_SUBTYPE:
-                    return False
-            elif pending_subtype is None:
-                # OFF/default savings payload omits subtype; backend may echo
-                # an implementation-specific non-prioritize value.
-                if effective_subtype == SAVINGS_OPERATION_MODE_SUBTYPE:
-                    return False
-            elif pending_subtype != effective_subtype:
-                return False
-        return True
+        return self.battery_runtime.effective_profile_matches_pending()
 
     def _remember_battery_reserve(
         self, profile: str | None, reserve: int | None
     ) -> None:
-        if not profile or reserve is None:
-            return
-        normalized = self._normalize_battery_profile_key(profile)
-        if not normalized:
-            return
-        if normalized not in BATTERY_PROFILE_DEFAULT_RESERVE:
-            return
-        self._battery_profile_reserve_memory[normalized] = int(reserve)
+        self.battery_runtime.remember_battery_reserve(profile, reserve)
 
     def _parse_battery_profile_payload(self, payload: object) -> None:
         if not isinstance(payload, dict):
@@ -12303,21 +12239,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return payload or None
 
     def _target_reserve_for_profile(self, profile: str) -> int:
-        if profile == "backup_only":
-            return 100
-        remembered = self._battery_profile_reserve_memory.get(profile)
-        if remembered is not None:
-            return self._normalize_battery_reserve_for_profile(profile, remembered)
-        default = BATTERY_PROFILE_DEFAULT_RESERVE.get(profile, 20)
-        return self._normalize_battery_reserve_for_profile(profile, default)
+        return self.battery_runtime.target_reserve_for_profile(profile)
 
     def _current_savings_sub_type(self) -> str | None:
-        selected_subtype = self.battery_selected_operation_mode_sub_type
-        if selected_subtype is None:
-            return None
-        if selected_subtype == SAVINGS_OPERATION_MODE_SUBTYPE:
-            return SAVINGS_OPERATION_MODE_SUBTYPE
-        return None
+        return self.battery_runtime.current_savings_sub_type()
 
     async def _async_apply_battery_profile(
         self,

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+from custom_components.enphase_ev.battery_runtime import BatteryRuntime
+from custom_components.enphase_ev.const import SAVINGS_OPERATION_MODE_SUBTYPE
+
+
+def test_battery_runtime_normalizes_labels() -> None:
+    runtime = BatteryRuntime(SimpleNamespace())
+
+    assert runtime.normalize_battery_profile_key(" Cost_Savings ") == "cost_savings"
+    assert runtime.normalize_battery_profile_key(None) is None
+    assert runtime.battery_profile_label("backup_only") == "Full Backup"
+    assert runtime.battery_profile_label("regional-profile") == "Regional Profile"
+    assert runtime.battery_profile_label(None) is None
+
+
+def test_battery_runtime_pending_helpers_and_matching(
+    coordinator_factory, mock_issue_registry
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+
+    runtime.set_battery_pending(
+        profile="cost_savings",
+        reserve=25,
+        sub_type=SAVINGS_OPERATION_MODE_SUBTYPE,
+        require_exact_settings=False,
+    )
+
+    assert coord._battery_pending_profile == "cost_savings"  # noqa: SLF001
+    assert coord._battery_pending_reserve == 25  # noqa: SLF001
+    assert (
+        coord._battery_pending_sub_type == SAVINGS_OPERATION_MODE_SUBTYPE
+    )  # noqa: SLF001
+    assert coord._battery_pending_requested_at is not None  # noqa: SLF001
+    coord._battery_profile = "cost_savings"  # noqa: SLF001
+    assert runtime.effective_profile_matches_pending() is True
+
+    runtime.clear_battery_pending()
+
+    assert coord._battery_pending_profile is None  # noqa: SLF001
+    assert coord._battery_pending_requested_at is None  # noqa: SLF001
+    assert mock_issue_registry.created == []
+
+
+def test_battery_runtime_matching_handles_exact_savings_subtype_branches(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+    coord._battery_pending_profile = "cost_savings"  # noqa: SLF001
+    coord._battery_profile = "cost_savings"  # noqa: SLF001
+    coord._battery_pending_require_exact_settings = True  # noqa: SLF001
+    coord._battery_pending_reserve = 30  # noqa: SLF001
+    coord._battery_backup_percentage = 30  # noqa: SLF001
+
+    coord._battery_pending_sub_type = SAVINGS_OPERATION_MODE_SUBTYPE  # noqa: SLF001
+    coord._battery_operation_mode_sub_type = (
+        SAVINGS_OPERATION_MODE_SUBTYPE  # noqa: SLF001
+    )
+    assert runtime.effective_profile_matches_pending() is True
+
+    coord._battery_operation_mode_sub_type = None  # noqa: SLF001
+    assert runtime.effective_profile_matches_pending() is False
+
+    coord._battery_pending_sub_type = None  # noqa: SLF001
+    coord._battery_operation_mode_sub_type = "other"  # noqa: SLF001
+    assert runtime.effective_profile_matches_pending() is True
+
+    coord._battery_operation_mode_sub_type = (
+        SAVINGS_OPERATION_MODE_SUBTYPE  # noqa: SLF001
+    )
+    assert runtime.effective_profile_matches_pending() is False
+
+
+def test_battery_runtime_target_reserve_and_current_savings_subtype(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = BatteryRuntime(coord)
+    coord._battery_profile_reserve_memory = {"cost_savings": 35}  # noqa: SLF001
+    coord._battery_pending_profile = "cost_savings"  # noqa: SLF001
+    coord._battery_pending_sub_type = SAVINGS_OPERATION_MODE_SUBTYPE  # noqa: SLF001
+
+    assert runtime.target_reserve_for_profile("cost_savings") == 35
+    assert runtime.target_reserve_for_profile("backup_only") == 100
+    assert runtime.current_savings_sub_type() == SAVINGS_OPERATION_MODE_SUBTYPE
+
+    runtime.remember_battery_reserve("self-consumption", 28)
+    assert (
+        coord._battery_profile_reserve_memory["self-consumption"] == 28
+    )  # noqa: SLF001
+
+    runtime.remember_battery_reserve("custom", 44)
+    assert "custom" not in coord._battery_profile_reserve_memory
+
+
+def test_battery_runtime_current_savings_subtype_uses_coordinator_property() -> None:
+    coordinator = SimpleNamespace(battery_selected_operation_mode_sub_type="other")
+    runtime = BatteryRuntime(coordinator)
+
+    assert runtime.current_savings_sub_type() is None
+
+    coordinator.battery_selected_operation_mode_sub_type = (
+        SAVINGS_OPERATION_MODE_SUBTYPE
+    )
+    assert runtime.current_savings_sub_type() == SAVINGS_OPERATION_MODE_SUBTYPE
+
+
+def test_battery_runtime_set_pending_records_current_time(monkeypatch) -> None:
+    requested_at = datetime.now(UTC) + timedelta(minutes=5)
+    coordinator = SimpleNamespace(
+        _normalize_battery_sub_type=lambda value: value,
+        _sync_battery_profile_pending_issue=lambda: None,
+    )
+    runtime = BatteryRuntime(coordinator)
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.battery_runtime.dt_util.utcnow",
+        lambda: requested_at,
+    )
+
+    runtime.set_battery_pending(
+        profile="self-consumption",
+        reserve=15,
+        sub_type="ignored",
+    )
+
+    assert coordinator._battery_pending_requested_at == requested_at
+    assert coordinator._battery_pending_sub_type is None

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -108,6 +108,15 @@ def test_coordinator_payload_health_state_delegates_to_diagnostics(
     assert state["available"] is True
 
 
+def test_coordinator_missing_battery_runtime_raises_attribute_error() -> None:
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    coord = EnphaseCoordinator.__new__(EnphaseCoordinator)
+
+    with pytest.raises(AttributeError, match="battery_runtime"):
+        _ = coord.battery_runtime
+
+
 class _RefreshOwner:
     def __init__(self) -> None:
         self.calls: list[str] = []


### PR DESCRIPTION
## Summary
- extract battery pending-state and reserve helper logic into a dedicated `BatteryRuntime` collaborator
- keep coordinator battery-facing public properties on `EnphaseCoordinator` so entity behavior and override points stay stable
- add runtime-focused tests plus a coordinator regression covering the explicit `battery_runtime` collaborator

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/const.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_coordinator_redesign.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/const.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/coordinator.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"`
