### PR TITLE
Fix Green mode fallback when scheduler preference is empty

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -5037,6 +5037,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             )
             if charge_mode_pref is None:
                 charge_mode_pref = self._cached_charge_mode_preference(sn)
+            if charge_mode_pref is None:
+                charge_mode_pref = self._battery_profile_charge_mode_preference(sn)
 
             charge_mode = self._normalize_effective_charge_mode(
                 obj.get("chargeMode")
@@ -7710,6 +7712,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self, sn: str, *, now: float | None = None
     ) -> str | None:
         return self.evse_runtime.cached_charge_mode_preference(sn, now=now)
+
+    def _battery_profile_charge_mode_preference(self, sn: str) -> str | None:
+        return self.evse_runtime.battery_profile_charge_mode_preference(sn)
 
     @staticmethod
     def _normalize_charge_mode_preference(value: object) -> str | None:

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -1244,11 +1244,46 @@ class EvseRuntime:
         cached = self.cached_charge_mode_preference(sn_str)
         if cached is not None:
             candidates.append(cached)
+        battery_profile = self.battery_profile_charge_mode_preference(sn_str)
+        if battery_profile is not None:
+            candidates.append(battery_profile)
         for raw in candidates:
             value = self.normalize_charge_mode_preference(raw)
             if value is not None:
                 return value
         return None
+
+    def battery_profile_charge_mode_preference(self, sn: str) -> str | None:
+        coord = self.coordinator
+        sn_str = str(sn)
+        configured_serials = self.normalize_serials(
+            getattr(coord, "_configured_serials", ())
+        )
+        if configured_serials:
+            if len(configured_serials) != 1 or sn_str not in configured_serials:
+                return None
+        else:
+            serials = self.normalize_serials(getattr(coord, "serials", ()))
+            if len(serials) != 1 or sn_str not in serials:
+                return None
+        cache_until = getattr(coord, "_storm_guard_cache_until", None)
+        if cache_until is None:
+            return None
+        try:
+            if time.monotonic() >= float(cache_until):
+                return None
+        except Exception:
+            return None
+        try:
+            devices = getattr(coord, "_battery_profile_devices", None)
+        except Exception:
+            return None
+        if not isinstance(devices, list) or len(devices) != 1:
+            return None
+        device = devices[0]
+        if not isinstance(device, dict):
+            return None
+        return self.normalize_charge_mode_preference(device.get("chargeMode"))
 
     def cached_charge_mode_preference(
         self,

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -2237,6 +2237,90 @@ async def test_async_update_data_drops_expired_cached_charge_preference_when_sta
 
 
 @pytest.mark.asyncio
+async def test_async_update_data_uses_battery_profile_charge_mode_when_scheduler_pref_missing(
+    coordinator_factory,
+):
+    coord = coordinator_factory(
+        serials=["EV1"],
+        data={
+            "EV1": {
+                "sn": "EV1",
+                "name": "Garage EV",
+                "charge_mode": "IDLE",
+            }
+        },
+    )
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._scheduler_available = False  # noqa: SLF001
+    coord._scheduler_backoff_active = lambda: False  # type: ignore[assignment]  # noqa: SLF001
+    coord._charge_mode_cache["EV1"] = (
+        "GREEN_CHARGING",
+        coord_mod.time.monotonic() - CHARGE_MODE_CACHE_TTL - 1,
+    )
+    coord._storm_guard_cache_until = coord_mod.time.monotonic() + 300  # noqa: SLF001
+    coord._battery_profile_devices = [  # noqa: SLF001
+        {"uuid": "evse-1", "chargeMode": "GREEN", "enable": True}
+    ]
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": "EV1",
+                    "name": "Garage EV",
+                    "connectors": [
+                        {
+                            "connectorStatusType": coord_mod.SUSPENDED_EVSE_STATUS,
+                            "connectorStatusReason": "INSUFFICIENT_SOLAR",
+                        }
+                    ],
+                    "sch_d": {"status": 1, "info": [{"type": "CUSTOM"}]},
+                    "session_d": {},
+                    "charging": False,
+                }
+            ],
+            "ts": 1_700_000_000,
+        }
+    )
+    coord.summary = SimpleNamespace(
+        prepare_refresh=lambda **kwargs: False,
+        async_fetch=AsyncMock(return_value=[]),
+        invalidate=lambda: None,
+    )
+    coord.evse_timeseries.async_refresh = AsyncMock(return_value=None)  # noqa: SLF001
+    coord.evse_timeseries.merge_charger_payloads = MagicMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord.energy._async_refresh_site_energy = AsyncMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord._async_refresh_battery_site_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_status = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_backup_history = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_schedules = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_guard_profile = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_alert = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_grid_control_check = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_devices_inventory = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_dry_contact_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_hems_devices = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_inverters = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_current_power_consumption = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_heatpump_power = AsyncMock()  # noqa: SLF001
+    coord._async_resolve_green_battery_settings = AsyncMock(
+        return_value={}
+    )  # noqa: SLF001
+    coord._async_resolve_auth_settings = AsyncMock(return_value={})  # noqa: SLF001
+    coord._get_charge_mode = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
+    coord._sync_battery_profile_pending_issue = MagicMock()  # noqa: SLF001
+
+    result = await coord._async_update_data()  # noqa: SLF001
+
+    assert result["EV1"]["charge_mode_pref"] == "GREEN_CHARGING"
+    assert result["EV1"]["charge_mode"] == "GREEN_CHARGING"
+
+
+@pytest.mark.asyncio
 async def test_async_update_data_handles_numeric_ts(
     coordinator_factory,
 ):

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
@@ -12,6 +13,7 @@ from homeassistant.util import dt as dt_util
 from custom_components.enphase_ev.evse_runtime import (
     FAST_TOGGLE_POLL_HOLD_S,
     ChargeModeStartPreferences,
+    EvseRuntime,
 )
 
 
@@ -55,6 +57,78 @@ def test_evse_runtime_helper_paths(coordinator_factory) -> None:
         strict=True,
         enforce_mode="SCHEDULED_CHARGING",
     )
+
+
+def test_evse_runtime_battery_profile_charge_mode_preference_paths(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    runtime = coord.evse_runtime
+
+    assert runtime.battery_profile_charge_mode_preference("EV1") is None
+
+    coord._storm_guard_cache_until = 10.0**12  # noqa: SLF001
+    coord._battery_profile_devices = [  # noqa: SLF001
+        {"uuid": "evse-1", "chargeMode": "GREEN", "enable": True}
+    ]
+    assert runtime.battery_profile_charge_mode_preference("EV1") == "GREEN_CHARGING"
+
+    coord._storm_guard_cache_until = 0.0  # noqa: SLF001
+    assert runtime.battery_profile_charge_mode_preference("EV1") is None
+
+    coord._storm_guard_cache_until = 10.0**12  # noqa: SLF001
+    coord._battery_profile_devices = ["bad"]  # noqa: SLF001
+    assert runtime.battery_profile_charge_mode_preference("EV1") is None
+
+    coord._battery_profile_devices = [  # noqa: SLF001
+        {"uuid": "evse-1", "chargeMode": "GREEN", "enable": True},
+        {"uuid": "evse-2", "chargeMode": "MANUAL", "enable": True},
+    ]
+    assert runtime.battery_profile_charge_mode_preference("EV1") is None
+
+    coord.serials.add("EV2")
+    coord._configured_serials = {"EV1"}  # noqa: SLF001
+    coord._battery_profile_devices = [  # noqa: SLF001
+        {"uuid": "evse-1", "chargeMode": "GREEN", "enable": True}
+    ]
+    assert runtime.battery_profile_charge_mode_preference("EV1") == "GREEN_CHARGING"
+
+    coord._configured_serials = {"EV1", "EV2"}  # noqa: SLF001
+    assert runtime.battery_profile_charge_mode_preference("EV1") is None
+
+
+def test_evse_runtime_battery_profile_charge_mode_preference_error_paths() -> None:
+    runtime = EvseRuntime(
+        SimpleNamespace(
+            _configured_serials=set(),
+            serials={"EV1", "EV2"},
+            _storm_guard_cache_until=10.0**12,
+            _battery_profile_devices=[{"chargeMode": "GREEN"}],
+        )
+    )
+    assert runtime.battery_profile_charge_mode_preference("EV1") is None
+
+    runtime = EvseRuntime(
+        SimpleNamespace(
+            _configured_serials={"EV1"},
+            serials={"EV1"},
+            _storm_guard_cache_until="bad",
+            _battery_profile_devices=[{"chargeMode": "GREEN"}],
+        )
+    )
+    assert runtime.battery_profile_charge_mode_preference("EV1") is None
+
+    class _BrokenDevices:
+        _configured_serials = {"EV1"}
+        serials = {"EV1"}
+        _storm_guard_cache_until = 10.0**12
+
+        @property
+        def _battery_profile_devices(self):
+            raise RuntimeError("boom")
+
+    runtime = EvseRuntime(_BrokenDevices())
+    assert runtime.battery_profile_charge_mode_preference("EV1") is None
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -235,6 +235,14 @@ def test_charge_mode_select_current_option_paths(coordinator_factory):
     assert sel.current_option == "Scheduled"
 
     coord.data[RANDOM_SERIAL]["charge_mode"] = ""
+    coord._storm_guard_cache_until = 10.0**12  # noqa: SLF001
+    coord._battery_profile_devices = [  # noqa: SLF001
+        {"uuid": "evse-1", "chargeMode": "GREEN", "enable": True}
+    ]
+    coord._charge_mode_cache.clear()  # noqa: SLF001
+    assert sel.current_option == "Green"
+
+    coord._storm_guard_cache_until = 0.0  # noqa: SLF001
     coord._charge_mode_cache.clear()  # noqa: SLF001
     assert sel.current_option is None
 


### PR DESCRIPTION
## Summary
- preserve Green charging preference when the scheduler preference endpoint omits mode data but the fresh battery profile still reports the EVSE as `GREEN`
- only use the battery-profile fallback for configured single-charger sites with a fresh Storm Guard/profile payload, so stale profile data does not override later mode changes
- add regression coverage for the 5-minute cache-expiry case, selector behavior, and the new fallback guard rails

## Why
The scheduler-backed `preferred_mode` cache expires after 300 seconds. When the scheduler preference endpoint keeps returning no mode, the integration dropped `preferred_mode` to `None` and fell back to derived `IDLE`/`IMMEDIATE` states even though the battery profile still showed the charger in Green mode.

Issue reference: https://github.com/barneyonline/ha-enphase-energy/issues/424

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/evse_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_select_charge_mode.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/evse_runtime.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
