### PR TITLE
Standardize heatpump runtime async boundaries

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1166,7 +1166,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     async def _async_refresh_hems_support_preflight(
         self, *, force: bool = False
     ) -> None:
-        await self.heatpump_runtime._async_refresh_hems_support_preflight(force=force)
+        await self.heatpump_runtime.async_refresh_hems_support_preflight(force=force)
 
     async def async_ensure_heatpump_runtime_diagnostics(
         self, *, force: bool = False
@@ -3433,12 +3433,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     async def _async_refresh_heatpump_runtime_state(
         self, *, force: bool = False
     ) -> None:
-        await self.heatpump_runtime._async_refresh_heatpump_runtime_state(force=force)
+        await self.heatpump_runtime.async_refresh_heatpump_runtime_state(force=force)
 
     async def _async_refresh_heatpump_daily_consumption(
         self, *, force: bool = False
     ) -> None:
-        await self.heatpump_runtime._async_refresh_heatpump_daily_consumption(
+        await self.heatpump_runtime.async_refresh_heatpump_daily_consumption(
             force=force
         )
 
@@ -3544,7 +3544,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         )
 
     async def _async_refresh_heatpump_power(self, *, force: bool = False) -> None:
-        await self.heatpump_runtime._async_refresh_heatpump_power(force=force)
+        await self.heatpump_runtime.async_refresh_heatpump_power(force=force)
 
     def _clear_current_power_consumption(self) -> None:
         self._current_power_consumption_w = None

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -153,6 +153,11 @@ class HeatpumpRuntime:
             now + HEMS_SUPPORT_PREFLIGHT_CACHE_TTL
         )
 
+    async def async_refresh_hems_support_preflight(
+        self, *, force: bool = False
+    ) -> None:
+        await self._async_refresh_hems_support_preflight(force=force)
+
     async def async_ensure_heatpump_runtime_diagnostics(
         self, *, force: bool = False
     ) -> None:
@@ -374,6 +379,11 @@ class HeatpumpRuntime:
         snapshot["source"] = f"hems_heatpump_state:{device_uid}"
         self._heatpump_runtime_state = snapshot
 
+    async def async_refresh_heatpump_runtime_state(
+        self, *, force: bool = False
+    ) -> None:
+        await self._async_refresh_heatpump_runtime_state(force=force)
+
     def _heatpump_daily_window(self) -> tuple[str, str, str, tuple[str, str]] | None:
         tz_name = self._site_timezone_name()
         try:
@@ -548,6 +558,11 @@ class HeatpumpRuntime:
             snapshot["day_key"] = marker[0]
             snapshot["timezone"] = marker[1]
         self._heatpump_daily_consumption = snapshot
+
+    async def async_refresh_heatpump_daily_consumption(
+        self, *, force: bool = False
+    ) -> None:
+        await self._async_refresh_heatpump_daily_consumption(force=force)
 
     def _heatpump_power_candidate_device_uids(self) -> list[str | None]:
         candidates: list[str | None] = []
@@ -1012,6 +1027,9 @@ class HeatpumpRuntime:
                 self._heatpump_power_sample_utc = None
         elif sample_index is not None:
             self._heatpump_power_sample_utc = dt_util.utcnow()
+
+    async def async_refresh_heatpump_power(self, *, force: bool = False) -> None:
+        await self._async_refresh_heatpump_power(force=force)
 
     def heatpump_runtime_diagnostics(self) -> dict[str, object]:
         return {

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -373,11 +373,11 @@ async def test_coordinator_inventory_and_heatpump_wrapper_delegation(
     heatpump._heatpump_power_candidate_is_recommended.return_value = True
     heatpump._heatpump_power_candidate_type_rank.return_value = 3
     heatpump._heatpump_power_selection_key.return_value = (1, 1, 1, 1, 10.0, 1, 0)
-    heatpump._async_refresh_hems_support_preflight = AsyncMock()
+    heatpump.async_refresh_hems_support_preflight = AsyncMock()
     heatpump.async_ensure_heatpump_runtime_diagnostics = AsyncMock()
-    heatpump._async_refresh_heatpump_runtime_state = AsyncMock()
-    heatpump._async_refresh_heatpump_daily_consumption = AsyncMock()
-    heatpump._async_refresh_heatpump_power = AsyncMock()
+    heatpump.async_refresh_heatpump_runtime_state = AsyncMock()
+    heatpump.async_refresh_heatpump_daily_consumption = AsyncMock()
+    heatpump.async_refresh_heatpump_power = AsyncMock()
     coord.heatpump_runtime = heatpump
 
     monkeypatch.setattr(
@@ -515,15 +515,15 @@ async def test_coordinator_inventory_and_heatpump_wrapper_delegation(
         authoritative=True,
     )
     inventory._async_refresh_system_dashboard.assert_awaited_once_with(force=True)
-    heatpump._async_refresh_hems_support_preflight.assert_awaited_once_with(force=True)
+    heatpump.async_refresh_hems_support_preflight.assert_awaited_once_with(force=True)
     heatpump.async_ensure_heatpump_runtime_diagnostics.assert_awaited_once_with(
         force=True
     )
-    heatpump._async_refresh_heatpump_runtime_state.assert_awaited_once_with(force=True)
-    heatpump._async_refresh_heatpump_daily_consumption.assert_awaited_once_with(
+    heatpump.async_refresh_heatpump_runtime_state.assert_awaited_once_with(force=True)
+    heatpump.async_refresh_heatpump_daily_consumption.assert_awaited_once_with(
         force=True
     )
-    heatpump._async_refresh_heatpump_power.assert_awaited_once_with(force=True)
+    heatpump.async_refresh_heatpump_power.assert_awaited_once_with(force=True)
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import logging
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 from custom_components.enphase_ev import parsing_helpers as parsing_helpers_mod
 from custom_components.enphase_ev import api
+from custom_components.enphase_ev import heatpump_runtime as heatpump_runtime_mod
 from custom_components.enphase_ev.heatpump_runtime import HeatpumpRuntime
 from custom_components.enphase_ev.parsing_helpers import (
     coerce_optional_bool,
@@ -60,6 +61,35 @@ async def test_heatpump_runtime_fetcher_falls_back_when_uninspectable(
         BadSignatureFetcher(),
         force=True,
     ) == {"ok": True}
+
+
+@pytest.mark.asyncio
+async def test_heatpump_runtime_public_async_wrappers(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory().heatpump_runtime
+    runtime._async_refresh_hems_support_preflight = AsyncMock()  # type: ignore[assignment]  # noqa: SLF001
+    runtime._async_refresh_heatpump_runtime_state = AsyncMock()  # type: ignore[assignment]  # noqa: SLF001
+    runtime._async_refresh_heatpump_daily_consumption = AsyncMock()  # type: ignore[assignment]  # noqa: SLF001
+    runtime._async_refresh_heatpump_power = AsyncMock()  # type: ignore[assignment]  # noqa: SLF001
+
+    await runtime.async_refresh_hems_support_preflight(force=True)
+    await runtime.async_refresh_heatpump_runtime_state(force=True)
+    await runtime.async_refresh_heatpump_daily_consumption(force=True)
+    await runtime.async_refresh_heatpump_power(force=True)
+
+    runtime._async_refresh_hems_support_preflight.assert_awaited_once_with(  # noqa: SLF001
+        force=True
+    )
+    runtime._async_refresh_heatpump_runtime_state.assert_awaited_once_with(  # noqa: SLF001
+        force=True
+    )
+    runtime._async_refresh_heatpump_daily_consumption.assert_awaited_once_with(  # noqa: SLF001
+        force=True
+    )
+    runtime._async_refresh_heatpump_power.assert_awaited_once_with(  # noqa: SLF001
+        force=True
+    )
 
 
 @pytest.mark.asyncio
@@ -125,11 +155,11 @@ async def test_coordinator_heatpump_runtime_wrapper_delegation(
     runtime._heatpump_power_candidate_is_recommended.return_value = True
     runtime._heatpump_power_candidate_type_rank.return_value = 3
     runtime._heatpump_power_selection_key.return_value = (1, 1, 1, 3, 500.0, 1, 0)
-    runtime._async_refresh_hems_support_preflight = AsyncMock()
+    runtime.async_refresh_hems_support_preflight = AsyncMock()
     runtime.async_ensure_heatpump_runtime_diagnostics = AsyncMock()
-    runtime._async_refresh_heatpump_runtime_state = AsyncMock()
-    runtime._async_refresh_heatpump_daily_consumption = AsyncMock()
-    runtime._async_refresh_heatpump_power = AsyncMock()
+    runtime.async_refresh_heatpump_runtime_state = AsyncMock()
+    runtime.async_refresh_heatpump_daily_consumption = AsyncMock()
+    runtime.async_refresh_heatpump_power = AsyncMock()
     runtime.heatpump_runtime_diagnostics.return_value = {"runtime_state": {}}
     runtime.heatpump_runtime_state = {"device_uid": "HP-1"}
     runtime.heatpump_runtime_state_last_error = "runtime boom"
@@ -232,15 +262,15 @@ async def test_coordinator_heatpump_runtime_wrapper_delegation(
         requested_uid="HP-1",
         sample=(0, 500.0),
     )
-    runtime._async_refresh_hems_support_preflight.assert_awaited_once_with(force=True)
+    runtime.async_refresh_hems_support_preflight.assert_awaited_once_with(force=True)
     runtime.async_ensure_heatpump_runtime_diagnostics.assert_awaited_once_with(
         force=True
     )
-    runtime._async_refresh_heatpump_runtime_state.assert_awaited_once_with(force=True)
-    runtime._async_refresh_heatpump_daily_consumption.assert_awaited_once_with(
+    runtime.async_refresh_heatpump_runtime_state.assert_awaited_once_with(force=True)
+    runtime.async_refresh_heatpump_daily_consumption.assert_awaited_once_with(
         force=True
     )
-    runtime._async_refresh_heatpump_power.assert_awaited_once_with(force=True)
+    runtime.async_refresh_heatpump_power.assert_awaited_once_with(force=True)
 
 
 def test_heatpump_and_parsing_helper_guards() -> None:
@@ -272,6 +302,320 @@ def test_heatpump_and_parsing_helper_guards() -> None:
         2026, 3, 27, 12, 0, tzinfo=timezone.utc
     )
 
+
+def test_heatpump_runtime_helper_edge_branches(coordinator_factory) -> None:
+    runtime = coordinator_factory().heatpump_runtime
+
+    runtime._type_device_buckets = {  # noqa: SLF001
+        "heatpump": {"devices": [{"device_type": "ENERGY_METER"}]}
+    }
+    assert runtime._heatpump_primary_member() == {
+        "device_type": "ENERGY_METER"
+    }  # noqa: SLF001
+
+    runtime._type_device_buckets = {  # noqa: SLF001
+        "heatpump": {
+            "devices": [
+                {"device_type": "ENERGY_METER"},
+                {"device_type": "SG_READY_GATEWAY", "device_uid": "GW-1"},
+                {
+                    "device_type": "HEAT_PUMP",
+                    "device_uid": "HP-1",
+                    "uid": "HP-ALIAS",
+                    "serial_number": "SER-1",
+                    "parent": "GW-1",
+                    "statusText": "Recommended",
+                },
+                {
+                    "device_type": "HEAT_PUMP",
+                    "uid": "HP-2",
+                    "statusText": "Recommended",
+                },
+            ]
+        }
+    }
+
+    assert runtime._heatpump_primary_device_uid() == "HP-1"  # noqa: SLF001
+    assert runtime._heatpump_runtime_device_uid() == "HP-1"  # noqa: SLF001
+    assert runtime._heatpump_member_for_uid("missing") is None  # noqa: SLF001
+    assert runtime._heatpump_member_aliases(None) == []  # noqa: SLF001
+    assert runtime._heatpump_member_alias_map()["HP-ALIAS"] == "HP-1"  # noqa: SLF001
+    marker = runtime._heatpump_power_inventory_marker()  # noqa: SLF001
+    assert marker[0][0] == "GW-1"
+    assert (
+        runtime._heatpump_power_candidate_is_recommended(None) is False
+    )  # noqa: SLF001
+    assert (
+        runtime._heatpump_power_candidate_is_recommended("HP-1") is True
+    )  # noqa: SLF001
+    assert (
+        runtime._heatpump_power_candidate_is_recommended("GW-1") is True
+    )  # noqa: SLF001
+
+    runtime._type_device_buckets = {"heatpump": {"devices": []}}  # noqa: SLF001
+    assert (
+        runtime._heatpump_power_candidate_is_recommended("HP-1") is False
+    )  # noqa: SLF001
+
+    runtime._type_device_buckets = {  # noqa: SLF001
+        "heatpump": {"devices": [{"device_uid": "FALLBACK-1"}]}
+    }
+    assert runtime._heatpump_primary_device_uid() == "FALLBACK-1"  # noqa: SLF001
+
+    runtime._type_device_buckets = {"heatpump": {"devices": [{}]}}  # noqa: SLF001
+    assert runtime._heatpump_primary_device_uid() is None  # noqa: SLF001
+    assert runtime._heatpump_power_inventory_marker()[0][0] == "idx:0"  # noqa: SLF001
+
+
+def test_heatpump_runtime_power_helper_edge_branches(monkeypatch) -> None:
+    class BadStart:
+        def __add__(self, _other):
+            raise OverflowError("boom")
+
+    assert (
+        HeatpumpRuntime._infer_heatpump_interval_minutes(
+            None, 1, datetime.now(timezone.utc)
+        )
+        is None
+    )
+    assert (
+        HeatpumpRuntime._infer_heatpump_interval_minutes(
+            BadStart(), 1, datetime.now(timezone.utc)
+        )
+        is None
+    )
+    assert HeatpumpRuntime._heatpump_latest_power_sample("bad") is None
+    assert (
+        HeatpumpRuntime._heatpump_latest_power_sample({"heat_pump_consumption": "bad"})
+        is None
+    )
+
+    naive_now = datetime(2026, 3, 27, 12, 0)
+    monkeypatch.setattr(heatpump_runtime_mod.dt_util, "utcnow", lambda: naive_now)
+
+    future_payload = {
+        "start_date": "3026-03-27T00:00:00Z",
+        "interval_minutes": 60,
+        "heat_pump_consumption": [1.0],
+    }
+    assert HeatpumpRuntime._heatpump_latest_power_sample(future_payload) is None
+
+    payload = {
+        "start_date": "2026-03-27T00:00:00Z",
+        "interval_minutes": 60,
+        "heat_pump_consumption": [None, "bad", float("inf"), 0.5, 10.0],
+    }
+    assert HeatpumpRuntime._heatpump_latest_power_sample(payload) == (4, 10.0)
+
+    open_only_payload = {
+        "start_date": "2026-03-27T00:00:00Z",
+        "interval_minutes": 60,
+        "heat_pump_consumption": [None, None, 2.0],
+    }
+    assert HeatpumpRuntime._heatpump_latest_power_sample(open_only_payload) == (2, 2.0)
+
+    invalid_payload = {
+        "start_date": "2026-03-27T00:00:00Z",
+        "interval_minutes": 60,
+        "heat_pump_consumption": [None, "bad", float("nan")],
+    }
+    assert HeatpumpRuntime._heatpump_latest_power_sample(invalid_payload) is None
+
+    monkeypatch.setattr(
+        heatpump_runtime_mod.dt_util,
+        "utcnow",
+        lambda: datetime(2026, 3, 27, 2, 30),
+    )
+    provisional_payload = {
+        "start_date": "2026-03-27T00:00:00Z",
+        "interval_minutes": 60,
+        "heat_pump_consumption": [50.0, 2.0, 0.1],
+    }
+    assert HeatpumpRuntime._heatpump_latest_power_sample(provisional_payload) == (
+        1,
+        2.0,
+    )
+
+    completed_zero_payload = {
+        "start_date": "2026-03-27T00:00:00Z",
+        "interval_minutes": 60,
+        "heat_pump_consumption": [50.0, 0.0, 1.0],
+    }
+    assert HeatpumpRuntime._heatpump_latest_power_sample(completed_zero_payload) == (
+        2,
+        1.0,
+    )
+
+    open_missing_payload = {
+        "start_date": "2026-03-27T00:00:00Z",
+        "interval_minutes": 60,
+        "heat_pump_consumption": [50.0, 2.0, None],
+    }
+    assert HeatpumpRuntime._heatpump_latest_power_sample(open_missing_payload) == (
+        1,
+        2.0,
+    )
+
+    completed_missing_payload = {
+        "start_date": "2026-03-27T00:00:00Z",
+        "interval_minutes": 60,
+        "heat_pump_consumption": [None, None, 3.0],
+    }
+    assert HeatpumpRuntime._heatpump_latest_power_sample(completed_missing_payload) == (
+        2,
+        3.0,
+    )
+
+    open_selected_payload = {
+        "start_date": "2026-03-27T00:00:00Z",
+        "interval_minutes": 60,
+        "heat_pump_consumption": [50.0, 2.0, 5.0],
+    }
+    assert HeatpumpRuntime._heatpump_latest_power_sample(open_selected_payload) == (
+        2,
+        5.0,
+    )
+
+    assert (
+        HeatpumpRuntime._infer_heatpump_interval_minutes(
+            datetime(2026, 3, 27, tzinfo=timezone.utc),
+            1,
+            datetime(2026, 3, 28, tzinfo=timezone.utc),
+        )
+        == 60
+    )
+
+
+@pytest.mark.asyncio
+async def test_heatpump_runtime_diagnostics_and_refresh_edge_branches(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.heatpump_runtime
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 2,
+                "devices": [
+                    {"device_type": "HEAT_PUMP", "device_uid": "HP-1"},
+                    {"device_type": "HEAT_PUMP", "device_uid": "HP-2"},
+                    {"device_type": "HEAT_PUMP"},
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+
+    runtime._async_refresh_heatpump_runtime_state = AsyncMock(side_effect=RuntimeError("runtime"))  # type: ignore[assignment]  # noqa: SLF001
+    runtime._async_refresh_heatpump_daily_consumption = AsyncMock(side_effect=RuntimeError("daily"))  # type: ignore[assignment]  # noqa: SLF001
+    coord.client.show_livestream = AsyncMock(return_value={"live": True})
+    coord.client.heat_pump_events_json = AsyncMock(
+        side_effect=["EVENT_SCALAR", ["list-payload"]]
+    )
+    coord.client.iq_er_events_json = AsyncMock(return_value="EVENT_NONE")
+
+    def _redact(payload):
+        if payload == "EVENT_SCALAR":
+            return "scalar"
+        if payload == "EVENT_NONE":
+            return None
+        return payload
+
+    monkeypatch.setattr(coord, "_redact_battery_payload", _redact)
+
+    await runtime.async_ensure_heatpump_runtime_diagnostics(force=True)
+
+    diagnostics = coord.heatpump_runtime_diagnostics()
+    assert diagnostics["show_livestream_payload"] == {"live": True}
+    assert diagnostics["events_payloads"][0]["payload"] == {"value": "scalar"}
+    assert diagnostics["events_payloads"][1]["payload"] == ["list-payload"]
+
+    runtime._heatpump_runtime_diagnostics_cache_until = None  # noqa: SLF001
+    coord.client.show_livestream = AsyncMock(return_value=None)
+    coord.client.heat_pump_events_json = None
+    coord.client.iq_er_events_json = None
+    await runtime.async_ensure_heatpump_runtime_diagnostics(force=True)
+    assert coord.heatpump_runtime_diagnostics()["show_livestream_payload"] is None
+
+    runtime._heatpump_runtime_diagnostics_cache_until = None  # noqa: SLF001
+    coord.client.show_livestream = AsyncMock(side_effect=RuntimeError("live boom"))
+    await runtime.async_ensure_heatpump_runtime_diagnostics(force=True)
+    assert coord.heatpump_runtime_diagnostics()["show_livestream_payload"] is None
+    assert coord.heatpump_runtime_diagnostics()["last_error"] == "live boom"
+
+    runtime._heatpump_power_cache_until = time.monotonic() + 60  # noqa: SLF001
+    coord.client.hems_power_timeseries = AsyncMock(
+        side_effect=AssertionError("no fetch")
+    )
+    await runtime.async_refresh_heatpump_power()
+    coord.client.hems_power_timeseries.assert_not_awaited()
+
+    runtime._heatpump_power_cache_until = None  # noqa: SLF001
+    runtime._heatpump_power_backoff_until = time.monotonic() + 60  # noqa: SLF001
+    await runtime.async_refresh_heatpump_power()
+    coord.client.hems_power_timeseries.assert_not_awaited()
+
+    runtime._heatpump_power_backoff_until = None  # noqa: SLF001
+    coord.client._hems_site_supported = False  # noqa: SLF001
+    await runtime.async_refresh_heatpump_power(force=True)
+    assert coord.heatpump_power_source is None
+
+    coord.client._hems_site_supported = True  # noqa: SLF001
+    coord.client.hems_power_timeseries = None
+    await runtime.async_refresh_heatpump_power(force=True)
+
+    coord.client.hems_power_timeseries = AsyncMock(return_value="bad")
+    await runtime.async_refresh_heatpump_power(force=True)
+    assert coord.heatpump_power_w is None
+
+    coord.client.hems_power_timeseries = AsyncMock(
+        return_value={"device_uid": "HP-1", "heat_pump_consumption": [None]}
+    )
+    await runtime.async_refresh_heatpump_power(force=True)
+    assert coord.heatpump_power_w is None
+
+    monkeypatch.setattr(
+        heatpump_runtime_mod.dt_util, "utcnow", lambda: datetime(2026, 3, 27, 12, 0)
+    )
+    monkeypatch.setattr(
+        heatpump_runtime_mod,
+        "timedelta",
+        lambda **kwargs: (_ for _ in ()).throw(OverflowError("boom")),
+    )
+    coord.client.hems_power_timeseries = AsyncMock(
+        return_value={
+            "device_uid": "HP-1",
+            "start_date": "2026-03-27T00:00:00Z",
+            "interval_minutes": 60,
+            "heat_pump_consumption": [1.0],
+        }
+    )
+    await runtime.async_refresh_heatpump_power(force=True)
+    assert coord.heatpump_power_sample_utc is None
+
+    monkeypatch.setattr(
+        heatpump_runtime_mod.dt_util, "utcnow", lambda: datetime(2026, 3, 27, 12, 0)
+    )
+    monkeypatch.setattr(heatpump_runtime_mod, "timedelta", timedelta)
+    coord.client.hems_power_timeseries = AsyncMock(
+        return_value={
+            "device_uid": "HP-1",
+            "start_date": "2026-03-27T00:00:00Z",
+            "heat_pump_consumption": [1.0],
+        }
+    )
+    await runtime.async_refresh_heatpump_power(force=True)
+    assert coord.heatpump_power_sample_utc is not None
+
+    class BadFloat:
+        def __float__(self) -> float:
+            raise RuntimeError("boom")
+
+    class BadString:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
     assert coerce_optional_float(BadFloat()) is None
     assert coerce_optional_float(float("inf")) == float("inf")
     assert coerce_optional_float(True) == 1.0
@@ -282,6 +626,48 @@ def test_heatpump_and_parsing_helper_guards() -> None:
     assert coerce_optional_bool("disabled") is False
     assert coerce_optional_bool(None) is None
     assert type_member_text(None, "name") is None
+
+
+def test_heatpump_runtime_recommended_parent_matching(coordinator_factory) -> None:
+    runtime = coordinator_factory().heatpump_runtime
+
+    class BadString:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    runtime._type_device_buckets = {  # noqa: SLF001
+        "heatpump": {
+            "devices": [
+                {"device_uid": "PARENT-1", "statusText": "Recommended"},
+                {"device_uid": "CHILD-1", "parent": "PARENT-1"},
+                {
+                    "device_uid": "REC-CHILD",
+                    "parent": "PARENT-1",
+                    "statusText": "Recommended",
+                },
+            ]
+        }
+    }
+
+    assert (
+        runtime._heatpump_power_candidate_is_recommended("CHILD-1") is True
+    )  # noqa: SLF001
+
+    runtime._type_device_buckets = {  # noqa: SLF001
+        "heatpump": {
+            "devices": [
+                {"device_uid": "CHILD-1", "parent": "PARENT-1"},
+                {
+                    "device_uid": "REC-CHILD",
+                    "parent": "PARENT-1",
+                    "statusText": "Recommended",
+                },
+            ]
+        }
+    }
+    assert (
+        runtime._heatpump_power_candidate_is_recommended("CHILD-1") is True
+    )  # noqa: SLF001
     assert (
         type_member_text({"name": BadString(), "serial": "SERIAL-1"}, "name", "serial")
         == "SERIAL-1"


### PR DESCRIPTION
## Summary
- expose public async heatpump runtime refresh methods for preflight, runtime state, daily consumption, and power refresh
- route coordinator delegation through the public heatpump runtime boundary instead of private runtime methods
- add direct regression coverage for the new public async boundary and the remaining heatpump helper branches needed to keep touched modules at 100% coverage

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_inventory_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_coordinator_redesign.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/heatpump_runtime.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"`
