### PR TITLE
[codex] Add AI Optimisation battery profile support

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2846,7 +2846,8 @@ class EnphaseEVClient:
 
         GET /service/evse_scheduler/api/v1/iqevc/charging-mode/<site>/<sn>/preference
         Requires Authorization: Bearer <jwt> in addition to existing cookies.
-        Returns one of: GREEN_CHARGING, SCHEDULED_CHARGING, MANUAL_CHARGING when enabled.
+        Returns one of: SMART_CHARGING, GREEN_CHARGING, SCHEDULED_CHARGING,
+        MANUAL_CHARGING when enabled.
         """
         url = f"{BASE_URL}/service/evse_scheduler/api/v1/iqevc/charging-mode/{self._site}/{sn}/preference"
         headers = dict(self._h)
@@ -2860,7 +2861,12 @@ class EnphaseEVClient:
         try:
             modes = (data.get("data") or {}).get("modes") or {}
             # Prefer the mode whose 'enabled' is true
-            for key in ("greenCharging", "scheduledCharging", "manualCharging"):
+            for key in (
+                "smartCharging",
+                "greenCharging",
+                "scheduledCharging",
+                "manualCharging",
+            ):
                 m = modes.get(key)
                 if isinstance(m, dict) and m.get("enabled"):
                     return m.get("chargingMode")
@@ -2872,7 +2878,8 @@ class EnphaseEVClient:
         """Set the charging mode via scheduler API.
 
         PUT /service/evse_scheduler/api/v1/iqevc/charging-mode/<site>/<sn>/preference
-        Body: { "mode": "MANUAL_CHARGING" | "SCHEDULED_CHARGING" | "GREEN_CHARGING" }
+        Body: { "mode": "MANUAL_CHARGING" | "SCHEDULED_CHARGING" |
+        "GREEN_CHARGING" | "SMART_CHARGING" }
         """
         url = f"{BASE_URL}/service/evse_scheduler/api/v1/iqevc/charging-mode/{self._site}/{sn}/preference"
         headers = dict(self._h)

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -624,7 +624,7 @@ class BatteryRuntime:
     def _normalize_pending_sub_type(
         coordinator: EnphaseCoordinator, profile: str, sub_type: str | None
     ) -> str | None:
-        if profile != "cost_savings":
+        if profile not in {"cost_savings", "ai_optimisation"}:
             return None
         func = getattr(coordinator, "normalize_battery_sub_type", None)
         if callable(func):
@@ -677,7 +677,7 @@ class BatteryRuntime:
             and getattr(state, "_battery_backup_percentage", None) != pending_reserve
         ):
             return False
-        if pending_profile != "cost_savings":
+        if pending_profile not in {"cost_savings", "ai_optimisation"}:
             return True
         pending_subtype = self._normalize_battery_sub_type(
             getattr(state, "_battery_pending_sub_type", None)
@@ -713,6 +713,15 @@ class BatteryRuntime:
         if selected_subtype == SAVINGS_OPERATION_MODE_SUBTYPE:
             return SAVINGS_OPERATION_MODE_SUBTYPE
         return None
+
+    def target_operation_mode_sub_type(self, profile: str) -> str | None:
+        normalized_profile = self.normalize_battery_profile_key(profile)
+        if normalized_profile not in {"cost_savings", "ai_optimisation"}:
+            return None
+        current_sub_type = self.current_savings_sub_type()
+        if normalized_profile == "ai_optimisation":
+            return current_sub_type or SAVINGS_OPERATION_MODE_SUBTYPE
+        return current_sub_type
 
     def normalize_battery_reserve_for_profile(self, profile: str, reserve: int) -> int:
         if profile == "backup_only":
@@ -868,9 +877,14 @@ class BatteryRuntime:
         )
         normalized_sub_type = (
             coord.normalize_battery_sub_type(sub_type)
-            if normalized_profile == "cost_savings"
+            if normalized_profile in {"cost_savings", "ai_optimisation"}
             else None
         )
+        if (
+            normalized_profile == "ai_optimisation"
+            and normalized_sub_type != SAVINGS_OPERATION_MODE_SUBTYPE
+        ):
+            normalized_sub_type = SAVINGS_OPERATION_MODE_SUBTYPE
         async with state._battery_profile_write_lock:
             state._battery_profile_last_write_mono = time.monotonic()
             try:
@@ -1081,7 +1095,7 @@ class BatteryRuntime:
             )
         if subtype is not None:
             state._battery_operation_mode_sub_type = subtype
-        elif profile != "cost_savings":
+        elif profile not in {"cost_savings", "ai_optimisation"}:
             state._battery_operation_mode_sub_type = None
         if supports_mqtt is not None:
             state._battery_supports_mqtt = supports_mqtt
@@ -1297,6 +1311,9 @@ class BatteryRuntime:
         state._battery_show_savings_mode = self._coerce_optional_bool(
             data.get("showSavingsMode")
         )
+        state._battery_show_ai_opti_savings_mode = self._coerce_optional_bool(
+            data.get("showAiOptiSavingsMode")
+        )
         state._battery_show_storm_guard = self._coerce_optional_bool(
             data.get("showStormGuard")
         )
@@ -1425,7 +1442,10 @@ class BatteryRuntime:
         )
         if settings_subtype is not None:
             state._battery_operation_mode_sub_type = settings_subtype
-        elif (settings_profile or state._battery_profile) != "cost_savings":
+        elif (settings_profile or state._battery_profile) not in {
+            "cost_savings",
+            "ai_optimisation",
+        }:
             state._battery_operation_mode_sub_type = None
         storm_state = self.normalize_storm_guard_state(data.get("stormGuardState"))
         if storm_state is not None:
@@ -2361,9 +2381,7 @@ class BatteryRuntime:
         if profile == "backup_only":
             raise ServiceValidationError("Full Backup reserve is fixed at 100%.")
         normalized = self.normalize_battery_reserve_for_profile(profile, reserve)
-        sub_type = (
-            self.current_savings_sub_type() if profile == "cost_savings" else None
-        )
+        sub_type = self.target_operation_mode_sub_type(profile)
         await self.async_apply_battery_profile(
             profile=profile,
             reserve=normalized,
@@ -2393,9 +2411,7 @@ class BatteryRuntime:
         if profile not in coord.battery_profile_option_keys:
             raise ServiceValidationError("Selected battery profile is not supported.")
         reserve = self.target_reserve_for_profile(profile)
-        sub_type = (
-            self.current_savings_sub_type() if profile == "cost_savings" else None
-        )
+        sub_type = self.target_operation_mode_sub_type(profile)
         await self.async_apply_battery_profile(
             profile=profile,
             reserve=reserve,

--- a/custom_components/enphase_ev/const.py
+++ b/custom_components/enphase_ev/const.py
@@ -61,11 +61,13 @@ HEATPUMP_POWER_FAILURE_BACKOFF_S = 900.0
 BATTERY_PROFILE_LABELS = {
     "self-consumption": "Self-Consumption",
     "cost_savings": "Savings",
+    "ai_optimisation": "AI Optimisation",
     "backup_only": "Full Backup",
 }
 BATTERY_PROFILE_DEFAULT_RESERVE = {
     "self-consumption": 20,
     "cost_savings": 20,
+    "ai_optimisation": 10,
     "backup_only": 100,
 }
 SAVINGS_OPERATION_MODE_SUBTYPE = "prioritize-energy"

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -6227,7 +6227,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def battery_selected_operation_mode_sub_type(self) -> str | None:
         return (
             getattr(self, "_battery_pending_sub_type", None)
-            if getattr(self, "_battery_pending_profile", None) == "cost_savings"
+            if getattr(self, "_battery_pending_profile", None)
+            in {"cost_savings", "ai_optimisation"}
             else getattr(self, "_battery_operation_mode_sub_type", None)
         )
 
@@ -6375,6 +6376,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             options.append("self-consumption")
         if getattr(self, "_battery_show_savings_mode", None):
             options.append("cost_savings")
+        if getattr(self, "_battery_show_ai_opti_savings_mode", None):
+            options.append("ai_optimisation")
         if getattr(self, "_battery_show_full_backup", None):
             options.append("backup_only")
         current = getattr(self, "_battery_profile", None)

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -44,6 +44,8 @@ CHARGE_MODE_PREFERENCE_MAP: dict[str, str] = {
     "SCHEDULED_CHARGING": "SCHEDULED_CHARGING",
     "GREEN": "GREEN_CHARGING",
     "GREEN_CHARGING": "GREEN_CHARGING",
+    "SMART": "SMART_CHARGING",
+    "SMART_CHARGING": "SMART_CHARGING",
 }
 EFFECTIVE_CHARGE_MODE_VALUES: frozenset[str] = frozenset(
     {
@@ -331,10 +333,11 @@ class EvseRuntime:
                     mode = str(mode_raw).strip().upper()
                 except Exception:
                     mode = ""
-            if mode == "GREEN_CHARGING":
+            if mode in {"GREEN_CHARGING", "SMART_CHARGING"}:
                 _LOGGER.debug(
-                    "Skipping auto-resume for charger %s because mode is GREEN_CHARGING",
+                    "Skipping auto-resume for charger %s because mode is %s",
                     redact_identifier(sn_str),
+                    mode,
                 )
                 continue
             last_attempt = coord._auto_resume_attempts.get(sn_str)
@@ -1340,7 +1343,7 @@ class EvseRuntime:
             include_level = True
             strict = True
             enforce_mode = "SCHEDULED_CHARGING"
-        elif mode == "GREEN_CHARGING":
+        elif mode in {"GREEN_CHARGING", "SMART_CHARGING"}:
             include_level = False
             strict = True
         return ChargeModeStartPreferences(

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -19,12 +19,47 @@ from .runtime_data import EnphaseConfigEntry, get_runtime_data
 
 PARALLEL_UPDATES = 0
 
-LABELS = {
+BASE_LABELS = {
     "MANUAL_CHARGING": "Manual",
     "SCHEDULED_CHARGING": "Scheduled",
-    "GREEN_CHARGING": "Green",
 }
-REV_LABELS = {v: k for k, v in LABELS.items()}
+
+
+def _smart_charging_context(coord: EnphaseCoordinator, sn: str | None = None) -> bool:
+    if sn is None:
+        return False
+    try:
+        data = (coord.data or {}).get(sn, {})
+    except Exception:
+        data = {}
+    for key in ("charge_mode_pref", "charge_mode"):
+        try:
+            value = str(data.get(key) or "").strip().upper()
+        except Exception:
+            value = ""
+        if value == "SMART_CHARGING":
+            return True
+    cache_entry = getattr(coord, "_charge_mode_cache", {}).get(sn)
+    if cache_entry:
+        try:
+            return str(cache_entry[0]).strip().upper() == "SMART_CHARGING"
+        except Exception:
+            return False
+    battery_profile_pref = getattr(
+        coord, "_battery_profile_charge_mode_preference", None
+    )
+    if callable(battery_profile_pref):
+        try:
+            return battery_profile_pref(sn) == "SMART_CHARGING"
+        except Exception:
+            return False
+    return False
+
+
+def _solar_mode(coord: EnphaseCoordinator, sn: str | None = None) -> tuple[str, str]:
+    if _smart_charging_context(coord, sn):
+        return "SMART_CHARGING", "Smart"
+    return "GREEN_CHARGING", "Green"
 
 
 def _site_has_battery(coord: EnphaseCoordinator) -> bool:
@@ -186,7 +221,12 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
 
     @property
     def options(self) -> list[str]:
-        return list(LABELS.values())
+        _solar_mode_key, solar_label = _solar_mode(self._coord, self._sn)
+        return [
+            BASE_LABELS["MANUAL_CHARGING"],
+            BASE_LABELS["SCHEDULED_CHARGING"],
+            solar_label,
+        ]
 
     @property
     def available(self) -> bool:  # type: ignore[override]
@@ -198,14 +238,28 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
         val = resolve_pref(self._sn) if callable(resolve_pref) else None
         if not val:
             return None
-        return LABELS.get(val)
+        if val == "MANUAL_CHARGING":
+            return BASE_LABELS[val]
+        if val == "SCHEDULED_CHARGING":
+            return BASE_LABELS[val]
+        if val in {"GREEN_CHARGING", "SMART_CHARGING"}:
+            return _solar_mode(self._coord, self._sn)[1]
+        return None
 
     async def async_select_option(self, option: str) -> None:
         if not self._coord.scheduler_available:
             raise HomeAssistantError(
                 "Charging mode selection is unavailable while the Enphase scheduler service is down."
             )
-        mode = REV_LABELS.get(option, option.upper())
+        solar_mode_key, solar_label = _solar_mode(self._coord, self._sn)
+        if option == BASE_LABELS["MANUAL_CHARGING"]:
+            mode = "MANUAL_CHARGING"
+        elif option == BASE_LABELS["SCHEDULED_CHARGING"]:
+            mode = "SCHEDULED_CHARGING"
+        elif option == solar_label:
+            mode = solar_mode_key
+        else:
+            mode = option.upper()
         try:
             await self._coord.client.set_charge_mode(self._sn, mode)
             self._coord.mark_scheduler_available()

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -2436,6 +2436,7 @@ class EnphaseChargeModeSensor(EnphaseBaseEntity, SensorEntity):
             "IMMEDIATE": "mdi:flash",
             "SCHEDULED_CHARGING": "mdi:calendar-clock",
             "GREEN_CHARGING": "mdi:leaf",
+            "SMART_CHARGING": "mdi:leaf",
             "IDLE": "mdi:timer-sand-paused",
         }
         return mapping.get(mode, "mdi:car-electric")

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -250,6 +250,7 @@ class BatteryState:
     _battery_show_consumption: bool | None = None
     _battery_show_charge_from_grid: bool | None = None
     _battery_show_savings_mode: bool | None = None
+    _battery_show_ai_opti_savings_mode: bool | None = None
     _battery_show_storm_guard: bool | None = None
     _battery_show_full_backup: bool | None = None
     _battery_show_battery_backup_percentage: bool | None = None

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -2654,6 +2654,52 @@ Response:
 }
 ```
 
+Observed AI Optimization variant:
+```json
+{
+  "meta": {
+    "serverTimeStamp": "<timestamp>"
+  },
+  "data": {
+    "config": {
+      "profile": "ai_optimisation",
+      "modeSyncStatus": "synced",
+      "stormActive": false,
+      "isModeCancellable": true,
+      "pendingModesOffGrid": false,
+      "pendingSchedulesOffGrid": false
+    },
+    "modes": {
+      "smartCharging": {
+        "chargingMode": "SMART_CHARGING",
+        "enabled": true,
+        "showSettings": false,
+        "isHidden": false,
+        "isDisabledByStorm": false,
+        "goalsEnabled": 0,
+        "defaultGoalAdded": false
+      },
+      "scheduledCharging": {
+        "chargingMode": "SCHEDULED_CHARGING",
+        "enabled": false,
+        "showSettings": false,
+        "isHidden": false,
+        "isDisabledByStorm": false,
+        "schedulesEnabled": 0
+      },
+      "manualCharging": {
+        "chargingMode": "MANUAL_CHARGING",
+        "enabled": false,
+        "showSettings": false,
+        "isHidden": false,
+        "isDisabledByStorm": false
+      }
+    }
+  },
+  "error": {}
+}
+```
+
 ### 4.2 Set Charge Mode
 ```
 PUT /service/evse_scheduler/api/v1/iqevc/charging-mode/<site_id>/<sn>/preference
@@ -2661,6 +2707,9 @@ Body: { "mode": "MANUAL_CHARGING" }
 Headers: Authorization: Bearer <token>
 ```
 Success response mirrors the GET payload.
+
+Observed mode values include `MANUAL_CHARGING`, `SCHEDULED_CHARGING`,
+`GREEN_CHARGING`, and `SMART_CHARGING`.
 
 ### 4.3 Green Charging Settings (Battery Support)
 ```
@@ -2849,32 +2898,92 @@ Example response (anonymized):
     "showProduction": true,
     "showConsumption": true,
     "hasEncharge": true,
+    "hasAcb": false,
+    "hasGenerator": false,
     "hasEnpower": true,
-    "countryCode": "XX",
-    "region": "XX",
-    "locale": "en-XX",
-    "timezone": "Region/City",
-    "showChargeFromGrid": true,
+    "countryCode": "AU",
+    "region": "AU",
+    "locale": "en-AU",
+    "ownerOrHostMaskedEmail": "u*******r@example.com",
+    "timezone": "Australia/Melbourne",
+    "showChargeFromGrid": false,
+    "isEnsemble": true,
+    "hasOjasDevice": false,
     "showSavingsMode": true,
+    "showAiOptiSavingsMode": true,
+    "siteStage": 5,
+    "isEmea": false,
+    "isDTSupported": false,
+    "isIQGWScheduleSupported": true,
+    "isDTEnabled": false,
+    "isDTSite": false,
+    "restrictCfg": false,
+    "isHemsActivationPending": true,
+    "isTariffNEM3": false,
+    "tariffTypeId": {
+      "importType": "tou",
+      "exportType": "tou"
+    },
+    "isHemsAuthPending": false,
+    "isHemsSite": false,
+    "isNEM3Supported": false,
+    "isNEM3Site": false,
+    "calibrationProgress": false,
+    "acceptedGICDisclaimer": false,
+    "featureDetails": {
+      "98daf27c08a25a0a": false,
+      "3951a76025fc7d6c": false,
+      "HEMS_EV_Custom_Schedule": true,
+      "a3f9c1e7b82d4a6f": false,
+      "554ed34b3f489c08": true,
+      "a56e30d62ecc443f": true,
+      "f3a9b7c4d681e25f": true,
+      "Disable_Storm_Guard_Grid_Charging": false,
+      "714ed62b9f489c98": true,
+      "2e6W81086bd123F8": false,
+      "ae9fc99447fa52a0": true,
+      "734ed62b3f489c98": true,
+      "b7def45a12d67e3f": false,
+      "af356d446af0e3b4": false,
+      "dtpfu43qwqxr5327": false,
+      "b707fae2750a4965": true,
+      "2e6W81086cd123F9": false,
+      "671b7d2591d1adc1": true,
+      "pm221c316d32ad3e": false,
+      "00eb0092160e4279": false,
+      "61df86665efcb677": false,
+      "a8cbe12f09b34c1d": true,
+      "534ed33b3f489c98": true,
+      "66f7a67f71be52f7": true
+    },
     "showStormGuard": true,
+    "showCriticalAlertsOverride": false,
+    "showVLS": true,
+    "isIQ8site": false,
     "showFullBackup": true,
     "showBatteryBackupPercentage": true,
-    "isChargingModesEnabled": true,
-    "batteryGridMode": "ImportExport",
-    "featureDetails": {
-      "HEMS_EV_Custom_Schedule": true,
-      "Disable_Storm_Guard_Grid_Charging": false
-    },
+    "isCollarPresent": false,
+    "isCollarInstalled": false,
     "userDetails": {
+      "isHost": false,
       "isOwner": true,
       "isInstaller": false,
-      "email": "u******r@example.com"
+      "isMaintainer": false,
+      "email": "u******r@example.com",
+      "isDemoUser": false
     },
     "siteStatus": {
       "code": "normal",
       "text": "Normal",
       "severity": "warning"
-    }
+    },
+    "isChargingModesEnabled": true,
+    "isUseBatteryForEVSESupported": false,
+    "batteryGridMode": "ImportExport",
+    "batteryLimitSupport": false,
+    "isHemsOptScheduleSupported": true,
+    "isChangePending": false,
+    "isThermostatSmartModeAllowed": false
   }
 }
 ```
@@ -2929,11 +3038,28 @@ Example response (anonymized):
 PUT /service/batteryConfig/api/v1/profile/<site_id>?userId=<user_id>
 Headers: X-XSRF-Token: <token>
 ```
-Updates the system profile (Self-Consumption, Savings, Full Backup) and reserve percentage.
+Updates the system profile and reserve percentage. Observed profile keys include
+`self-consumption`, `cost_savings`, `backup_only`, and `ai_optimisation`.
 
 Example payloads observed:
 ```json
 { "profile": "self-consumption", "batteryBackupPercentage": 10 }
+```
+
+```json
+{
+  "profile": "self-consumption",
+  "batteryBackupPercentage": 20,
+  "devices": [
+    {
+      "uuid": "<evse_uuid>",
+      "profileConfig": "full",
+      "chargeMode": "SMART",
+      "deviceType": "iqEvse",
+      "enable": false
+    }
+  ]
+}
 ```
 
 ```json
@@ -2967,6 +3093,22 @@ Example payloads observed:
 }
 ```
 
+```json
+{
+  "profile": "ai_optimisation",
+  "batteryBackupPercentage": 10,
+  "operationModeSubType": "prioritize-energy",
+  "devices": [
+    {
+      "uuid": "<evse_uuid>",
+      "chargeMode": "MANUAL",
+      "deviceType": "iqEvse",
+      "enable": false
+    }
+  ]
+}
+```
+
 Response:
 ```json
 { "message": "success" }
@@ -2974,6 +3116,8 @@ Response:
 
 Notes:
 - The reserve slider enforces a 10% minimum (Self-Consumption) and 100% for Full Backup. The Savings profile uses a reserve slider plus a "Use battery after peak hours" toggle; `operationModeSubType` appears to track this state (only `prioritize-energy` observed so far).
+- The AI Optimization flow uses the profile key `ai_optimisation` and also sends `operationModeSubType: "prioritize-energy"` with the EVSE device payload.
+- Switching away from AI Optimization may still include an EVSE `devices` payload. In the observed AI -> Self-Consumption transition, the EVSE payload included `profileConfig: "full"` and `chargeMode: "SMART"`.
 - After saving a mode change, the profile may remain in a pending state until the change takes effect. During this window, a separate cancel endpoint can be used.
 
 ```

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -2401,6 +2401,29 @@ async def test_charge_mode_extracts_enabled_mode() -> None:
 
 
 @pytest.mark.asyncio
+async def test_charge_mode_extracts_enabled_smart_mode() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        return_value={
+            "data": {
+                "modes": {
+                    "smartCharging": {
+                        "enabled": True,
+                        "chargingMode": "SMART_CHARGING",
+                    },
+                    "scheduledCharging": {
+                        "enabled": False,
+                        "chargingMode": "SCHEDULED_CHARGING",
+                    },
+                }
+            }
+        }
+    )
+
+    assert await client.charge_mode("SN") == "SMART_CHARGING"
+
+
+@pytest.mark.asyncio
 async def test_charge_mode_handles_unexpected_shape() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"data": {"modes": "invalid"}})

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -23,6 +23,7 @@ def test_battery_runtime_normalizes_labels() -> None:
 
     assert runtime.normalize_battery_profile_key(" Cost_Savings ") == "cost_savings"
     assert runtime.normalize_battery_profile_key(None) is None
+    assert runtime.battery_profile_label("ai_optimisation") == "AI Optimisation"
     assert runtime.battery_profile_label("backup_only") == "Full Backup"
     assert runtime.battery_profile_label("regional-profile") == "Regional Profile"
     assert runtime.battery_profile_label(None) is None
@@ -92,11 +93,15 @@ def test_battery_runtime_target_reserve_and_current_savings_subtype(
 ) -> None:
     coord = coordinator_factory()
     runtime = BatteryRuntime(coord)
-    coord._battery_profile_reserve_memory = {"cost_savings": 35}  # noqa: SLF001
-    coord._battery_pending_profile = "cost_savings"  # noqa: SLF001
+    coord._battery_profile_reserve_memory = {  # noqa: SLF001
+        "cost_savings": 35,
+        "ai_optimisation": 12,
+    }
+    coord._battery_pending_profile = "ai_optimisation"  # noqa: SLF001
     coord._battery_pending_sub_type = SAVINGS_OPERATION_MODE_SUBTYPE  # noqa: SLF001
 
     assert runtime.target_reserve_for_profile("cost_savings") == 35
+    assert runtime.target_reserve_for_profile("ai_optimisation") == 12
     assert runtime.target_reserve_for_profile("backup_only") == 100
     assert runtime.current_savings_sub_type() == SAVINGS_OPERATION_MODE_SUBTYPE
 
@@ -114,11 +119,24 @@ def test_battery_runtime_current_savings_subtype_uses_coordinator_property() -> 
     runtime = BatteryRuntime(coordinator)
 
     assert runtime.current_savings_sub_type() is None
+    assert runtime.target_operation_mode_sub_type("cost_savings") is None
+    assert (
+        runtime.target_operation_mode_sub_type("ai_optimisation")
+        == SAVINGS_OPERATION_MODE_SUBTYPE
+    )
 
     coordinator.battery_selected_operation_mode_sub_type = (
         SAVINGS_OPERATION_MODE_SUBTYPE
     )
     assert runtime.current_savings_sub_type() == SAVINGS_OPERATION_MODE_SUBTYPE
+    assert (
+        runtime.target_operation_mode_sub_type("cost_savings")
+        == SAVINGS_OPERATION_MODE_SUBTYPE
+    )
+    assert (
+        runtime.target_operation_mode_sub_type("ai_optimisation")
+        == SAVINGS_OPERATION_MODE_SUBTYPE
+    )
 
 
 def test_battery_runtime_set_pending_records_current_time(monkeypatch) -> None:
@@ -642,7 +660,7 @@ def test_battery_runtime_parse_profile_payload_branches_and_helpers(
     coord.battery_runtime.parse_battery_profile_payload([])
     coord.battery_runtime.parse_battery_site_settings_payload([])
     coord.battery_runtime.parse_battery_site_settings_payload(
-        {"showChargeFromGrid": True}
+        {"showChargeFromGrid": True, "showAiOptiSavingsMode": True}
     )
 
     coord.battery_runtime.parse_battery_profile_payload(
@@ -726,13 +744,42 @@ def test_battery_runtime_parse_profile_payload_branches_and_helpers(
     assert coord._target_reserve_for_profile("backup_only") == 100  # noqa: SLF001
     coord._battery_profile_reserve_memory.pop("cost_savings", None)  # noqa: SLF001
     assert coord._target_reserve_for_profile("cost_savings") == 20  # noqa: SLF001
+    coord._battery_profile_reserve_memory.pop("ai_optimisation", None)  # noqa: SLF001
+    assert coord._target_reserve_for_profile("ai_optimisation") == 10  # noqa: SLF001
     assert coord._target_reserve_for_profile("regional_special") == 20  # noqa: SLF001
     assert coord._current_savings_sub_type() is None  # noqa: SLF001
     coord._battery_pending_profile = "cost_savings"  # noqa: SLF001
     coord._battery_pending_sub_type = "prioritize-energy"  # noqa: SLF001
     assert coord._current_savings_sub_type() == "prioritize-energy"  # noqa: SLF001
+    coord._battery_pending_profile = "ai_optimisation"  # noqa: SLF001
+    assert coord._current_savings_sub_type() == "prioritize-energy"  # noqa: SLF001
     coord._battery_pending_sub_type = "other"  # noqa: SLF001
     assert coord._current_savings_sub_type() is None  # noqa: SLF001
+
+
+def test_battery_runtime_ai_profile_parses_and_clears_pending(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_pending_profile = "ai_optimisation"  # noqa: SLF001
+    coord._battery_pending_reserve = 10  # noqa: SLF001
+    coord._battery_pending_sub_type = "prioritize-energy"  # noqa: SLF001
+    coord._battery_pending_requested_at = datetime.now(UTC)  # noqa: SLF001
+
+    coord.battery_runtime.parse_battery_profile_payload(
+        {
+            "data": {
+                "profile": "ai_optimisation",
+                "batteryBackupPercentage": 10,
+                "operationModeSubType": "prioritize-energy",
+            }
+        }
+    )
+
+    assert coord.battery_profile == "ai_optimisation"
+    assert coord.battery_effective_operation_mode_sub_type == "prioritize-energy"
+    assert coord.battery_profile_display == "AI Optimisation"
+    assert coord.battery_profile_pending is False
 
 
 def test_battery_runtime_parse_status_payload_aggregates_and_skips_excluded(

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -2492,7 +2492,10 @@ def test_charge_mode_preference_helpers(coordinator_factory):
 
     coord.data[sn]["charge_mode_pref"] = None
     coord._charge_mode_cache[sn] = ("SMART", coord_mod.time.monotonic())
-    assert coord._resolve_charge_mode_pref(sn) is None
+    assert coord._resolve_charge_mode_pref(sn) == "SMART_CHARGING"
+    prefs = coord._charge_mode_start_preferences(sn)
+    assert prefs.include_level is False
+    assert prefs.strict is True
 
     coord._charge_mode_cache[sn] = ("SCHEDULED", coord_mod.time.monotonic())
     assert coord._resolve_charge_mode_pref(sn) == "SCHEDULED_CHARGING"

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -38,6 +38,7 @@ async def test_refresh_battery_site_settings_parses_flags(coordinator_factory) -
                 "showConsumption": True,
                 "showChargeFromGrid": True,
                 "showSavingsMode": True,
+                "showAiOptiSavingsMode": True,
                 "showStormGuard": True,
                 "showFullBackup": False,
                 "showBatteryBackupPercentage": True,
@@ -71,7 +72,11 @@ async def test_refresh_battery_site_settings_parses_flags(coordinator_factory) -
     assert coord.battery_user_is_owner is True
     assert coord.battery_user_is_installer is False
     assert coord.battery_site_status_code == "normal"
-    assert coord.battery_profile_option_keys == ["self-consumption", "cost_savings"]
+    assert coord.battery_profile_option_keys == [
+        "self-consumption",
+        "cost_savings",
+        "ai_optimisation",
+    ]
 
 
 @pytest.mark.asyncio
@@ -79,9 +84,11 @@ async def test_set_system_profile_uses_remembered_reserve(coordinator_factory) -
     coord = coordinator_factory()
     coord._battery_show_charge_from_grid = True  # noqa: SLF001
     coord._battery_show_savings_mode = True  # noqa: SLF001
+    coord._battery_show_ai_opti_savings_mode = True  # noqa: SLF001
     coord._battery_show_full_backup = True  # noqa: SLF001
     coord._battery_profile = "self-consumption"  # noqa: SLF001
     coord._battery_profile_reserve_memory["cost_savings"] = 35  # noqa: SLF001
+    coord._battery_profile_reserve_memory["ai_optimisation"] = 12  # noqa: SLF001
     coord.async_request_refresh = AsyncMock()
     coord.kick_fast = MagicMock()
     coord.client.set_battery_profile = AsyncMock(return_value={"message": "success"})
@@ -104,6 +111,15 @@ async def test_set_system_profile_uses_remembered_reserve(coordinator_factory) -
     kwargs = coord.client.set_battery_profile.await_args.kwargs
     assert kwargs["profile"] == "regional_special"
     assert kwargs["battery_backup_percentage"] == 20
+
+    coord.client.set_battery_profile.reset_mock()
+    coord._battery_profile_last_write_mono = time.monotonic() - 10  # noqa: SLF001
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    await coord.async_set_system_profile("ai_optimisation")
+    kwargs = coord.client.set_battery_profile.await_args.kwargs
+    assert kwargs["profile"] == "ai_optimisation"
+    assert kwargs["battery_backup_percentage"] == 12
+    assert kwargs["operation_mode_sub_type"] == "prioritize-energy"
 
 
 @pytest.mark.asyncio
@@ -287,6 +303,7 @@ async def test_site_only_update_refreshes_battery_profile_and_settings(
             "data": {
                 "showChargeFromGrid": True,
                 "showSavingsMode": True,
+                "showAiOptiSavingsMode": True,
                 "showFullBackup": True,
                 "showBatteryBackupPercentage": True,
                 "hasEncharge": True,
@@ -307,6 +324,7 @@ async def test_site_only_update_refreshes_battery_profile_and_settings(
     assert coord.battery_profile_option_keys == [
         "self-consumption",
         "cost_savings",
+        "ai_optimisation",
         "backup_only",
     ]
     # Stale caches should keep site-only updates stable without extra fetches.
@@ -442,6 +460,24 @@ async def test_battery_profile_forbidden_after_permission_change_returns_permiss
 
 
 @pytest.mark.asyncio
+async def test_ai_profile_write_defaults_required_subtype(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.client.set_battery_profile = AsyncMock(return_value={"message": "success"})
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+
+    await coord._async_apply_battery_profile(  # noqa: SLF001
+        profile="ai_optimisation",
+        reserve=10,
+        sub_type=None,
+    )
+
+    kwargs = coord.client.set_battery_profile.await_args.kwargs
+    assert kwargs["profile"] == "ai_optimisation"
+    assert kwargs["operation_mode_sub_type"] == "prioritize-energy"
+
+
+@pytest.mark.asyncio
 async def test_battery_profile_unauthorized_translates_to_reauth_error(
     coordinator_factory,
 ) -> None:
@@ -513,6 +549,7 @@ def test_battery_profile_property_helpers_cover_branches(coordinator_factory) ->
     coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
     coord._battery_show_charge_from_grid = True  # noqa: SLF001
     coord._battery_show_savings_mode = True  # noqa: SLF001
+    coord._battery_show_ai_opti_savings_mode = True  # noqa: SLF001
     coord._battery_profile = "self-consumption"  # noqa: SLF001
     coord._battery_show_full_backup = True  # noqa: SLF001
 
@@ -523,9 +560,14 @@ def test_battery_profile_property_helpers_cover_branches(coordinator_factory) ->
     assert coord.battery_has_encharge is True
     assert coord.battery_show_battery_backup_percentage is True
     assert "cost_savings" in coord.battery_profile_option_keys
+    assert "ai_optimisation" in coord.battery_profile_option_keys
     assert coord.battery_profile_display == "Savings"
     assert coord.battery_effective_profile_display == "Self-Consumption"
     assert coord.savings_use_battery_after_peak is True
+
+    coord._battery_pending_profile = "ai_optimisation"  # noqa: SLF001
+    assert coord.battery_selected_operation_mode_sub_type == "prioritize-energy"
+    assert coord.savings_use_battery_after_peak is None
 
     coord._battery_has_encharge = False  # noqa: SLF001
     assert coord.battery_controls_available is False
@@ -634,6 +676,14 @@ def test_battery_pending_match_and_memory_branches(coordinator_factory) -> None:
     coord._battery_operation_mode_sub_type = "another-regional-saving"  # noqa: SLF001
     assert coord._effective_profile_matches_pending() is False  # noqa: SLF001
 
+    coord._battery_pending_profile = "ai_optimisation"  # noqa: SLF001
+    coord._battery_profile = "ai_optimisation"  # noqa: SLF001
+    coord._battery_pending_reserve = 18  # noqa: SLF001
+    coord._battery_backup_percentage = 18  # noqa: SLF001
+    coord._battery_pending_sub_type = "prioritize-energy"  # noqa: SLF001
+    coord._battery_operation_mode_sub_type = "prioritize-energy"  # noqa: SLF001
+    assert coord._effective_profile_matches_pending() is True  # noqa: SLF001
+
     coord._remember_battery_reserve(None, 20)  # noqa: SLF001
 
     class BadProfile:
@@ -707,6 +757,17 @@ async def test_battery_profile_setter_validation_and_fallbacks(
     with pytest.raises(ServiceValidationError, match="Savings profile must be active"):
         await coord.async_set_savings_use_battery_after_peak(False)
 
+    coord._battery_profile = "ai_optimisation"  # noqa: SLF001
+    coord._battery_backup_percentage = 10  # noqa: SLF001
+    coord._battery_operation_mode_sub_type = "prioritize-energy"  # noqa: SLF001
+    coord._battery_profile_last_write_mono = time.monotonic() - 10  # noqa: SLF001
+    coord.client.set_battery_profile.reset_mock()
+    await coord.async_set_battery_reserve(5)
+    kwargs = coord.client.set_battery_profile.await_args.kwargs
+    assert kwargs["battery_backup_percentage"] == 5
+    assert kwargs["operation_mode_sub_type"] == "prioritize-energy"
+
+    coord._clear_battery_pending()  # noqa: SLF001
     coord._battery_profile = "cost_savings"  # noqa: SLF001
     coord._battery_backup_percentage = None  # noqa: SLF001
     coord._battery_profile_reserve_memory.pop("cost_savings", None)  # noqa: SLF001

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -48,6 +48,7 @@ def test_evse_runtime_helper_paths(coordinator_factory) -> None:
     assert runtime.apply_amp_limits("EV1", 50) == 40
     assert runtime.pick_start_amps("EV1", requested=None, fallback=16) == 24
     assert runtime.normalize_charge_mode_preference("scheduled") == "SCHEDULED_CHARGING"
+    assert runtime.normalize_charge_mode_preference("smart") == "SMART_CHARGING"
     assert runtime.normalize_effective_charge_mode("idle") == "IDLE"
     assert runtime.resolve_charge_mode_pref("EV1") == "SCHEDULED_CHARGING"
     prefs = runtime.charge_mode_start_preferences("EV1")
@@ -95,6 +96,12 @@ def test_evse_runtime_battery_profile_charge_mode_preference_paths(
 
     coord._configured_serials = {"EV1", "EV2"}  # noqa: SLF001
     assert runtime.battery_profile_charge_mode_preference("EV1") is None
+
+    coord._configured_serials = {"EV1"}  # noqa: SLF001
+    coord._battery_profile_devices = [  # noqa: SLF001
+        {"uuid": "evse-1", "chargeMode": "SMART", "enable": True}
+    ]
+    assert runtime.battery_profile_charge_mode_preference("EV1") == "SMART_CHARGING"
 
 
 def test_evse_runtime_battery_profile_charge_mode_preference_error_paths() -> None:

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -247,6 +247,133 @@ def test_charge_mode_select_current_option_paths(coordinator_factory):
     assert sel.current_option is None
 
 
+def test_charge_mode_select_uses_smart_label_for_smart_mode(coordinator_factory):
+    from custom_components.enphase_ev.select import ChargeModeSelect
+
+    coord = coordinator_factory()
+    coord.data[RANDOM_SERIAL]["charge_mode_pref"] = "SMART_CHARGING"
+    coord.data[RANDOM_SERIAL]["charge_mode"] = "SMART_CHARGING"
+
+    sel = ChargeModeSelect(coord, RANDOM_SERIAL)
+
+    assert "Smart" in sel.options
+    assert "Green" not in sel.options
+    assert sel.current_option == "Smart"
+
+
+@pytest.mark.asyncio
+async def test_charge_mode_select_sets_smart_mode_for_single_evse_profile_context(
+    coordinator_factory,
+):
+    from custom_components.enphase_ev.select import ChargeModeSelect
+
+    coord = coordinator_factory()
+    coord._storm_guard_cache_until = 10.0**12  # noqa: SLF001
+    coord._battery_profile_devices = [  # noqa: SLF001
+        {"uuid": RANDOM_SERIAL, "chargeMode": "SMART", "enable": False}
+    ]
+    coord.client.set_charge_mode = AsyncMock(return_value={"status": "accepted"})
+    coord.async_request_refresh = AsyncMock()
+
+    sel = ChargeModeSelect(coord, RANDOM_SERIAL)
+    assert "Smart" in sel.options
+    await sel.async_select_option("Smart")
+
+    coord.client.set_charge_mode.assert_awaited_once_with(
+        RANDOM_SERIAL, "SMART_CHARGING"
+    )
+
+
+@pytest.mark.asyncio
+async def test_charge_mode_select_keeps_green_for_other_evse_on_ai_site(
+    coordinator_factory,
+):
+    from custom_components.enphase_ev.select import ChargeModeSelect
+
+    other_serial = "SERIAL-2"
+    coord = coordinator_factory(serials=[RANDOM_SERIAL, other_serial])
+    coord._battery_profile = "ai_optimisation"  # noqa: SLF001
+    coord.client.set_charge_mode = AsyncMock(return_value={"status": "accepted"})
+    coord.async_request_refresh = AsyncMock()
+
+    sel = ChargeModeSelect(coord, other_serial)
+
+    assert "Green" in sel.options
+    assert "Smart" not in sel.options
+
+    await sel.async_select_option("Green")
+
+    coord.client.set_charge_mode.assert_awaited_once_with(
+        other_serial, "GREEN_CHARGING"
+    )
+
+
+def test_charge_mode_select_helper_branches(coordinator_factory):
+    from custom_components.enphase_ev.select import (
+        ChargeModeSelect,
+        _smart_charging_context,
+    )
+
+    coord = coordinator_factory()
+    assert _smart_charging_context(coord) is False
+    coord._battery_profile_charge_mode_preference = None  # noqa: SLF001
+    assert _smart_charging_context(coord, RANDOM_SERIAL) is False
+
+    class BrokenData:
+        def get(self, _sn, default=None):
+            raise RuntimeError("boom")
+
+    coord.data = BrokenData()
+    assert _smart_charging_context(coord, RANDOM_SERIAL) is False
+
+    coord = coordinator_factory()
+
+    class BadString:
+        def __str__(self):
+            raise ValueError("boom")
+
+    coord.data[RANDOM_SERIAL]["charge_mode_pref"] = BadString()
+    assert _smart_charging_context(coord, RANDOM_SERIAL) is False
+
+    coord.data[RANDOM_SERIAL]["charge_mode_pref"] = "SMART_CHARGING"
+    assert _smart_charging_context(coord, RANDOM_SERIAL) is True
+
+    coord.data[RANDOM_SERIAL]["charge_mode_pref"] = None
+    coord._charge_mode_cache[RANDOM_SERIAL] = (BadString(), 1.0)  # noqa: SLF001
+    assert _smart_charging_context(coord, RANDOM_SERIAL) is False
+
+    coord = coordinator_factory()
+    coord._battery_profile = "ai_optimisation"  # noqa: SLF001
+    assert _smart_charging_context(coord, RANDOM_SERIAL) is False
+    coord._battery_profile_charge_mode_preference = lambda _sn: (  # noqa: SLF001
+        _ for _ in ()
+    ).throw(RuntimeError("boom"))
+    assert _smart_charging_context(coord, RANDOM_SERIAL) is False
+
+    coord.data[RANDOM_SERIAL]["charge_mode_pref"] = "MANUAL_CHARGING"
+    sel = ChargeModeSelect(coord, RANDOM_SERIAL)
+    assert sel.current_option == "Manual"
+
+    coord._resolve_charge_mode_pref = lambda _sn: "EXPERIMENTAL"  # noqa: SLF001
+    assert sel.current_option is None
+
+
+@pytest.mark.asyncio
+async def test_charge_mode_select_unknown_option_falls_back_to_uppercase(
+    coordinator_factory,
+):
+    from custom_components.enphase_ev.select import ChargeModeSelect
+
+    coord = coordinator_factory()
+    coord.client.set_charge_mode = AsyncMock(return_value={"status": "accepted"})
+    coord.async_request_refresh = AsyncMock()
+    sel = ChargeModeSelect(coord, RANDOM_SERIAL)
+
+    await sel.async_select_option("experimental")
+
+    coord.client.set_charge_mode.assert_awaited_once_with(RANDOM_SERIAL, "EXPERIMENTAL")
+
+
 def test_charge_mode_select_unavailable_when_scheduler_down(coordinator_factory):
     from custom_components.enphase_ev.select import ChargeModeSelect
 
@@ -379,12 +506,18 @@ def test_system_profile_select_options_and_current(coordinator_factory):
     coord = coordinator_factory()
     coord._battery_show_charge_from_grid = True  # noqa: SLF001
     coord._battery_show_savings_mode = True  # noqa: SLF001
+    coord._battery_show_ai_opti_savings_mode = True  # noqa: SLF001
     coord._battery_show_full_backup = True  # noqa: SLF001
     coord._battery_profile = "self-consumption"  # noqa: SLF001
 
     sel = SystemProfileSelect(coord)
 
-    assert sel.options == ["Self-Consumption", "Savings", "Full Backup"]
+    assert sel.options == [
+        "Self-Consumption",
+        "Savings",
+        "AI Optimisation",
+        "Full Backup",
+    ]
     assert sel.current_option == "Self-Consumption"
 
 
@@ -421,6 +554,7 @@ async def test_system_profile_select_sets_profile(coordinator_factory):
     coord = coordinator_factory()
     coord._battery_show_charge_from_grid = True  # noqa: SLF001
     coord._battery_show_savings_mode = True  # noqa: SLF001
+    coord._battery_show_ai_opti_savings_mode = True  # noqa: SLF001
     coord._battery_profile = "self-consumption"  # noqa: SLF001
     coord.async_set_system_profile = AsyncMock()
 
@@ -428,6 +562,9 @@ async def test_system_profile_select_sets_profile(coordinator_factory):
     await sel.async_select_option("Savings")
 
     coord.async_set_system_profile.assert_awaited_once_with("cost_savings")
+
+    await sel.async_select_option("AI Optimisation")
+    coord.async_set_system_profile.assert_awaited_with("ai_optimisation")
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -1307,10 +1307,15 @@ def test_system_profile_status_sensor_states():
         battery_profile_display="Self-Consumption",
         battery_selected_backup_percentage=20,
         battery_selected_operation_mode_sub_type=None,
-        battery_profile_option_keys=["self-consumption", "cost_savings"],
+        battery_profile_option_keys=[
+            "self-consumption",
+            "cost_savings",
+            "ai_optimisation",
+        ],
         battery_profile_option_labels={
             "self-consumption": "Self-Consumption",
             "cost_savings": "Savings",
+            "ai_optimisation": "AI Optimisation",
         },
         battery_supports_mqtt=True,
         battery_profile_polling_interval=60,
@@ -1343,19 +1348,19 @@ def test_system_profile_status_sensor_states():
     assert sensor.device_info["identifiers"] == {("enphase_ev", "type:site:envoy")}
 
     coord.battery_profile_pending = True
-    coord.battery_pending_profile = "cost_savings"
+    coord.battery_pending_profile = "ai_optimisation"
     coord.battery_pending_backup_percentage = 25
     coord.battery_pending_operation_mode_sub_type = "prioritize-energy"
     coord.battery_pending_requested_at = datetime(2025, 1, 1, tzinfo=timezone.utc)
-    coord.battery_selected_profile = "cost_savings"
-    coord.battery_profile_display = "Savings"
+    coord.battery_selected_profile = "ai_optimisation"
+    coord.battery_profile_display = "AI Optimisation"
     coord.battery_selected_backup_percentage = 25
     coord.battery_selected_operation_mode_sub_type = "prioritize-energy"
     assert sensor.native_value == "Updating..."
     attrs = sensor.extra_state_attributes
     assert attrs["pending"] is True
-    assert attrs["requested_profile"] == "cost_savings"
-    assert attrs["requested_profile_label"] == "Savings"
+    assert attrs["requested_profile"] == "ai_optimisation"
+    assert attrs["requested_profile_label"] == "AI Optimisation"
     assert attrs["supports_mqtt"] is True
     assert attrs["cfg_control_show"] is True
     assert attrs["site_country_code"] == "US"
@@ -2119,6 +2124,25 @@ def test_charge_mode_sensor_attributes():
     assert sensor.extra_state_attributes["schedule_reminder_enabled"] is None
     coord.data[sn]["schedule_reminder_enabled"] = "maybe"
     assert sensor.extra_state_attributes["schedule_reminder_enabled"] is None
+
+
+def test_charge_mode_sensor_smart_icon():
+    from custom_components.enphase_ev.sensor import EnphaseChargeModeSensor
+
+    sn = RANDOM_SERIAL
+    coord = _mk_coord_with(
+        sn,
+        {
+            "sn": sn,
+            "name": "Garage EV",
+            "charge_mode_pref": "SMART_CHARGING",
+            "charge_mode": "SMART_CHARGING",
+        },
+    )
+
+    sensor = EnphaseChargeModeSensor(coord, sn)
+    assert sensor.native_value == "SMART_CHARGING"
+    assert sensor.icon == "mdi:leaf"
 
 
 def test_last_session_sensor_exposes_auth_metadata(monkeypatch):

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -1268,6 +1268,11 @@ def test_savings_use_battery_switch_availability(coordinator_factory) -> None:
     coord._battery_profile = "self-consumption"  # noqa: SLF001
     assert sw.available is False
 
+    coord._battery_profile = "ai_optimisation"  # noqa: SLF001
+    coord._battery_operation_mode_sub_type = "prioritize-energy"  # noqa: SLF001
+    assert sw.available is False
+    assert sw.is_on is False
+
 
 def test_savings_use_battery_switch_unavailable_without_coordinator(
     coordinator_factory,


### PR DESCRIPTION
## Summary
- add first-class support for the `ai_optimisation` battery system profile, including the observed `showAiOptiSavingsMode` site-settings flag and AI profile payload shape
- update EV charging mode handling so charger-specific Smart Charging support is recognized without relabeling every charger on multi-EVSE sites
- expand `docs/api/api_spec.md` with the newer BatteryConfig and EV scheduler payloads, including the AI -> Self-Consumption transition details

## Why
Issue [#425](https://github.com/barneyonline/ha-enphase-energy/issues/425) reported that Enphase had introduced the missing AI Optimization mode but the integration did not yet expose or document it.

## Impact
- Home Assistant users can now see and select `AI Optimisation` as a supported Enphase system profile where the backend exposes it
- AI profile writes include the required `operationModeSubType` even when switching from non-subtype modes
- Smart Charging UI behavior follows charger-specific scheduler/profile evidence instead of the site profile alone

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/const.py custom_components/enphase_ev/state_models.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/api.py custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/select.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_coordinator_battery_profile.py tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_select_charge_mode.py tests/components/enphase_ev/test_sensors.py tests/components/enphase_ev/test_switch_module.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/const.py custom_components/enphase_ev/state_models.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/api.py custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/select.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_coordinator_battery_profile.py tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_select_charge_mode.py tests/components/enphase_ev/test_sensors.py tests/components/enphase_ev/test_switch_module.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_select_charge_mode.py tests/components/enphase_ev/test_sensors.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_coordinator_battery_profile.py tests/components/enphase_ev/test_select_charge_mode.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/evse_runtime.py,custom_components/enphase_ev/select.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/const.py,custom_components/enphase_ev/state_models.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/select.py --fail-under=100"`
