### PR TITLE
Prepare 2.6.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,29 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v2.6.0 - 2026-03-28
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Added AI Optimisation battery profile support, including runtime handling for the new battery profile mode.
+
+### 🐛 Bug fixes
+- Preserved Green mode when refreshing battery profile state from a fresh payload so existing battery operating mode is not lost during profile updates.
+- Mapped IQ Battery LED runtime status `15` to `Idle` for battery status reporting.
+- Hardened site power outlier handling so anomalous samples are filtered more safely during live power calculations.
+- Stabilized heat-pump power diagnostics and standardized heat-pump runtime async boundaries so runtime refreshes keep telemetry and diagnostics consistent.
+
+### 🔧 Improvements
+- Reworked the coordinator refresh pipeline and continued the runtime ownership split by extracting battery, EVSE, heat-pump, and inventory runtime logic into dedicated helpers.
+- Refactored coordinator state and diagnostics helpers and extracted remaining coordinator issue-management paths to reduce coordinator complexity and clarify runtime responsibilities.
+- Redesigned runtime test ownership and expanded refactor coverage to support the runtime extraction work.
+
+### 🔄 Other changes
+- Documented the tariff API endpoint in `docs/api/`.
+- Refreshed GitHub issue templates.
+
 ## v2.5.0 - 2026-03-24
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.5.0"
+  "version": "2.6.0"
 }


### PR DESCRIPTION
## Summary
- bump the integration manifest version to `2.6.0`
- add the `v2.6.0` changelog entry covering all commits since `v2.5.0`

## Why
- prepare the repository metadata and release notes for the `2.6.0` release

## Testing
- Not run; metadata-only release prep change
