### PR TITLE
[codex] Improve battery settings parsing and docs

### DIFF
--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -726,8 +726,9 @@ class BatteryRuntime:
     def normalize_battery_reserve_for_profile(self, profile: str, reserve: int) -> int:
         if profile == "backup_only":
             return 100
-        min_reserve = self.battery_min_soc_floor()
-        bounded = max(min_reserve, min(100, int(reserve)))
+        min_reserve = self.battery_reserve_min_bound()
+        max_reserve = self.battery_reserve_max_bound()
+        bounded = max(min_reserve, min(max_reserve, int(reserve)))
         return bounded
 
     def battery_min_soc_floor(self) -> int:
@@ -738,6 +739,41 @@ class BatteryRuntime:
         if value is None:
             return BATTERY_MIN_SOC_FALLBACK
         return max(0, min(100, int(value)))
+
+    def battery_reserve_min_bound(self) -> int:
+        value = self._coerce_int(
+            getattr(self.battery_state, "_battery_backup_percentage_min", None),
+            default=None,
+        )
+        if value is None:
+            return self.battery_min_soc_floor()
+        return max(0, min(100, int(value)))
+
+    def battery_reserve_max_bound(self) -> int:
+        value = self._coerce_int(
+            getattr(self.battery_state, "_battery_backup_percentage_max", None),
+            default=None,
+        )
+        if value is None:
+            return 100
+        return max(0, min(100, int(value)))
+
+    def _apply_cfg_control_state(self, cfg_control: object) -> None:
+        state = self.battery_state
+        if not isinstance(cfg_control, dict):
+            return
+        state._battery_cfg_control_show = self._coerce_optional_bool(
+            cfg_control.get("show")
+        )
+        state._battery_cfg_control_enabled = self._coerce_optional_bool(
+            cfg_control.get("enabled")
+        )
+        state._battery_cfg_control_schedule_supported = self._coerce_optional_bool(
+            cfg_control.get("scheduleSupported")
+        )
+        state._battery_cfg_control_force_schedule_supported = (
+            self._coerce_optional_bool(cfg_control.get("forceScheduleSupported"))
+        )
 
     def assert_battery_profile_write_allowed(self) -> None:
         coord = self.coordinator
@@ -945,6 +981,7 @@ class BatteryRuntime:
         self.parse_battery_settings_payload(
             payload,
             clear_missing_schedule_times=False,
+            clear_missing_reserve_bounds=False,
         )
         state._battery_settings_cache_until = None
         coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
@@ -1027,20 +1064,7 @@ class BatteryRuntime:
         supports_mqtt = self._coerce_optional_bool(data.get("supportsMqtt"))
         evse_storm_enabled = self._coerce_optional_bool(data.get("evseStormEnabled"))
         storm_state = self.normalize_storm_guard_state(data.get("stormGuardState"))
-        cfg_control = data.get("cfgControl")
-        if isinstance(cfg_control, dict):
-            state._battery_cfg_control_show = self._coerce_optional_bool(
-                cfg_control.get("show")
-            )
-            state._battery_cfg_control_enabled = self._coerce_optional_bool(
-                cfg_control.get("enabled")
-            )
-            state._battery_cfg_control_schedule_supported = self._coerce_optional_bool(
-                cfg_control.get("scheduleSupported")
-            )
-            state._battery_cfg_control_force_schedule_supported = (
-                self._coerce_optional_bool(cfg_control.get("forceScheduleSupported"))
-            )
+        self._apply_cfg_control_state(data.get("cfgControl"))
         devices: list[dict[str, object]] = []
         profile_evse_device: dict[str, object] | None = None
         raw_devices = data.get("devices")
@@ -1370,6 +1394,7 @@ class BatteryRuntime:
         payload: object,
         *,
         clear_missing_schedule_times: bool = True,
+        clear_missing_reserve_bounds: bool = True,
     ) -> None:
         state = self.battery_state
         if not isinstance(payload, dict):
@@ -1426,6 +1451,24 @@ class BatteryRuntime:
         settings_reserve = self._coerce_optional_int(
             data.get("batteryBackupPercentage")
         )
+        settings_reserve_min = self._coerce_optional_int(
+            data.get("batteryBackupPercentageMin")
+        )
+        if settings_reserve_min is not None:
+            state._battery_backup_percentage_min = max(
+                0, min(100, int(settings_reserve_min))
+            )
+        elif clear_missing_reserve_bounds:
+            state._battery_backup_percentage_min = None
+        settings_reserve_max = self._coerce_optional_int(
+            data.get("batteryBackupPercentageMax")
+        )
+        if settings_reserve_max is not None:
+            state._battery_backup_percentage_max = max(
+                0, min(100, int(settings_reserve_max))
+            )
+        elif clear_missing_reserve_bounds:
+            state._battery_backup_percentage_max = None
         if settings_reserve is not None:
             state._battery_backup_percentage = (
                 self.normalize_battery_reserve_for_profile(
@@ -1451,6 +1494,7 @@ class BatteryRuntime:
         if storm_state is not None:
             state._storm_guard_state = storm_state
         self.sync_storm_guard_pending(storm_state)
+        self._apply_cfg_control_state(data.get("cfgControl"))
         raw_devices = data.get("devices")
         if isinstance(raw_devices, dict):
             iq_evse = raw_devices.get("iqEvse")

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -6455,11 +6455,24 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         profile = self.battery_selected_profile
         if profile == "backup_only":
             return 100
-        return self._battery_min_soc_floor()
+        value = self._coerce_optional_int(
+            getattr(self, "_battery_backup_percentage_min", None)
+        )
+        if value is None:
+            return self._battery_min_soc_floor()
+        return max(0, min(100, int(value)))
 
     @property
     def battery_reserve_max(self) -> int:
-        return 100
+        profile = self.battery_selected_profile
+        if profile == "backup_only":
+            return 100
+        value = self._coerce_optional_int(
+            getattr(self, "_battery_backup_percentage_max", None)
+        )
+        if value is None:
+            return 100
+        return max(0, min(100, int(value)))
 
     @property
     def battery_grid_mode(self) -> str | None:
@@ -6489,14 +6502,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def charge_from_grid_control_available(self) -> bool:
         if getattr(self, "_battery_has_encharge", None) is False:
             return False
-        # Prefer cfgControl.show/enabled (used by Enlighten app) over
-        # the legacy hideChargeFromGrid flag which is unreliable on
-        # EMEA sites.  Use cfgControl whenever present; fall back to
-        # legacy only when both fields are absent.
+        # Prefer cfgControl.show (used by Enlighten app) over the
+        # legacy hideChargeFromGrid flag which is unreliable on EMEA
+        # sites. cfgControl.enabled appears to reflect current toggle
+        # state on some homeowner payloads, so it is not authoritative
+        # for control availability.
         cfg_show = getattr(self, "_battery_cfg_control_show", None)
-        cfg_enabled = getattr(self, "_battery_cfg_control_enabled", None)
-        if cfg_show is not None or cfg_enabled is not None:
-            if cfg_show is False or cfg_enabled is False:
+        if cfg_show is not None:
+            if cfg_show is False:
                 return False
         else:
             if getattr(self, "_battery_hide_charge_from_grid", None) is True:

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -269,6 +269,8 @@ class BatteryState:
     _battery_site_status_severity: str | None = None
     _battery_profile: str | None = None
     _battery_backup_percentage: int | None = None
+    _battery_backup_percentage_min: int | None = None
+    _battery_backup_percentage_max: int | None = None
     _battery_operation_mode_sub_type: str | None = None
     _battery_supports_mqtt: bool | None = None
     _battery_polling_interval_s: int | None = None

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -2306,11 +2306,12 @@ Observed structure:
 GET /pv/settings/<site_id>/battery_status.json
 Headers:
   Accept: */*
-  Cookie: ...; XSRF-TOKEN=<token>; ...   # authenticated Enlighten web session cookies
-  e-auth-token: <token>
+  Cookie: <authenticated Enlighten web session cookies>
+  e-auth-token: <session token>
   X-Requested-With: XMLHttpRequest
 ```
 Returns the battery card payload used in Enlighten web/app for site-level and per-battery SoC, power, and status details.
+The raw web capture also included live cookies, XSRF tokens, a request ID, and browser metadata; those are omitted here because they are account-specific and not required to describe the schema.
 
 Example response (anonymized):
 ```json
@@ -2353,8 +2354,8 @@ Example response (anonymized):
       "cycle_count": 115,
       "battery_mode": "Self-Consumption",
       "rated_power": 3840,
-      "battery_phase_count": 1,
-      "is_flex_phase": false,
+      "battery_phase_count": 3,
+      "is_flex_phase": true,
       "battery_soh": "100%"
     },
     {
@@ -2382,8 +2383,8 @@ Example response (anonymized):
       "cycle_count": 115,
       "battery_mode": "Self-Consumption",
       "rated_power": 3840,
-      "battery_phase_count": 1,
-      "is_flex_phase": false,
+      "battery_phase_count": 3,
+      "is_flex_phase": true,
       "battery_soh": "100%"
     }
   ]
@@ -2391,11 +2392,15 @@ Example response (anonymized):
 ```
 Observed structure:
 - Top-level metrics summarize combined battery behavior (`current_charge`, energy/power totals, microinverter counts).
+- `show_battery_banner` is a UI hint flag; observed value so far: `false`.
 - `storages[]` contains one object per battery with SoC, power, status, reporting timestamp, and event/error metadata.
-- `excluded=true` marks batteries excluded from active fleet calculations; included/excluded counters are exposed at the top level.
+- `excluded` has been observed as `false`; `true` is still the documented exclusion indicator when a battery is omitted from active fleet calculations.
 - Percentage fields (`current_charge`, `battery_soh`) are string percentages in observed payloads.
-- Status appears as normalized code (`status`, for example `normal`) plus a display label (`statusText`, for example `Normal`).
+- Status appears as normalized code (`status`) plus a display label (`statusText`); observed pair so far: `normal` / `Normal`.
+- `battery_mode` is a display string; observed value so far: `Self-Consumption`.
+- `battery_phase_count` and `is_flex_phase` vary by hardware/site topology; observed combinations so far: `1` / `false` and `3` / `true`.
 - `led_status` is the raw battery LED/runtime status code. The integration currently interprets `12` as charging, `13` as discharging, `14` as idle, `15` as idle, and `17` as idle; any other value is treated as unknown runtime state.
+- `led_status` should be interpreted alongside `status`/`statusText`; observed values in captures so far: `12` and `17`.
 
 Observed battery LED legend:
 - Rapidly Flashing Yellow: Starting up / establishing communications
@@ -3352,20 +3357,62 @@ Example response (anonymized):
   "type": "battery-details",
   "timestamp": "<timestamp>",
   "data": {
+    "supportsMqtt": true,
+    "pollingInterval": 60,
+    "drEventActive": false,
+    "drEventMode": "",
     "profile": "self-consumption",
-    "batteryBackupPercentage": 20,
-    "stormGuardState": "disabled",
-    "hideChargeFromGrid": false,
+    "batteryBackupPercentage": 5,
+    "requestedConfigMqtt": {},
+    "requestedConfig": {},
+    "stormGuardState": "enabled",
+    "showStormGuardAlert": false,
+    "acceptedItcDisclaimer": "<timestamp>",
+    "hideChargeFromGrid": true,
     "envoySupportsVls": true,
     "chargeBeginTime": 120,
     "chargeEndTime": 300,
     "batteryGridMode": "ImportExport",
-    "veryLowSoc": 15,
-    "veryLowSocMin": 10,
+    "veryLowSoc": 5,
+    "veryLowSocMin": 5,
     "veryLowSocMax": 25,
-    "chargeFromGrid": true,
+    "chargeFromGrid": false,
     "chargeFromGridScheduleEnabled": true,
-    "acceptedItcDisclaimer": "<timestamp>",
+    "batteryBackupPercentageMax": 100,
+    "batteryBackupPercentageMin": 5,
+    "previousBatteryBackupPercentage": {
+      "self-consumption": 30,
+      "cost_savings": 30,
+      "backup_only": 100,
+      "expert": 30,
+      "ai_optimisation": 5
+    },
+    "systemTask": false,
+    "dtgControl": {
+      "show": true,
+      "showDaySchedule": true,
+      "enabled": false,
+      "locked": false,
+      "scheduleSupported": true,
+      "startTime": 960,
+      "endTime": 1140
+    },
+    "cfgControl": {
+      "show": true,
+      "showDaySchedule": true,
+      "enabled": false,
+      "locked": false,
+      "scheduleSupported": true,
+      "forceScheduleSupported": true,
+      "forceScheduleOpted": true
+    },
+    "rbdControl": {
+      "show": true,
+      "showDaySchedule": true,
+      "enabled": false,
+      "locked": false,
+      "scheduleSupported": true
+    },
     "devices": {
       "iqEvse": { "useBatteryFrSelfConsumption": true }
     }
@@ -3404,12 +3451,26 @@ Response:
 ```
 
 Notes:
-- `batteryGridMode` matches the Battery Mode card ("ImportExport" renders as "Import and Export") and is controlled by interconnection settings.
+- The raw capture contained live cookies, JWTs, XSRF tokens, site IDs, and user IDs. Only the endpoint shape and sanitized field values are recorded here.
+- `supportsMqtt` and `pollingInterval` indicate whether the page can use the MQTT-backed battery settings flow and how often the UI expects state refreshes. Observed values so far: `supportsMqtt=true`, `pollingInterval=60`.
+- `requestedConfig` and `requestedConfigMqtt` were empty objects in the capture; they appear to be placeholders for pending configuration writes or async acknowledgements. Observed values so far: `{}` for both fields.
+- `drEventActive` / `drEventMode` look like demand-response state flags; observed values so far: `false` / `""`.
+- `profile` is the backend battery profile code. Observed values in this endpoint so far: `self-consumption`.
+- `stormGuardState` is the backend Storm Guard state. Observed values in captures so far: `enabled`, `disabled`.
+- `showStormGuardAlert` is a UI flag. Observed value so far: `false`.
+- `batteryGridMode` matches the Battery Mode card ("ImportExport" renders as "Import and Export") and is controlled by interconnection settings. Observed value so far: `ImportExport`.
+- `batteryBackupPercentage` is the active reserve percentage. Observed values in captures so far: `5`, `20`.
+- `batteryBackupPercentageMin` / `batteryBackupPercentageMax` expose the allowed reserve slider bounds, while `previousBatteryBackupPercentage` preserves the last reserve value used for each profile. Observed bounds so far: `5` and `100`.
 - `chargeFromGrid` backs the "Charge battery from the grid" toggle. Enabling it shows a disclaimer dialog; the confirmation sets `acceptedItcDisclaimer` and unlocks the schedule controls.
-- The schedule checkbox ("Also up to 100% during this schedule") is represented by `chargeFromGridScheduleEnabled`; `chargeBeginTime`/`chargeEndTime` are minutes after midnight (local).
+- Observed `chargeFromGrid` values so far: `true`, `false`.
+- The schedule checkbox ("Also up to 100% during this schedule") is represented by `chargeFromGridScheduleEnabled`; `chargeBeginTime`/`chargeEndTime` are minutes after midnight (local). Observed values so far: `chargeFromGridScheduleEnabled=true`, `chargeBeginTime=120`, `chargeEndTime=300`.
 - When the schedule is enabled, the status payload reports `chargeFromGridScheduleEnabled: true` and `cfgControl.forceScheduleOpted: true`.
 - Captured writes used `acceptedItcDisclaimer: true`, while subsequent reads returned a timestamp string; the backend normalizes the acknowledgement state internally.
-- `veryLowSoc` drives the "Battery shutdown level" slider, clamped between `veryLowSocMin` and `veryLowSocMax`.
+- `veryLowSoc` drives the "Battery shutdown level" slider, clamped between `veryLowSocMin` and `veryLowSocMax`. Observed values so far: `veryLowSoc=5` and `15`, `veryLowSocMin=5` and `10`, `veryLowSocMax=25`.
+- `dtgControl`, `cfgControl`, and `rbdControl` are per-feature UI capability blocks. In the March 28, 2026 homeowner capture they each exposed `show`, `enabled`, `locked`, and schedule-support fields even though the corresponding toggles were off. Observed booleans so far: `show=true`, `showDaySchedule=true`, `enabled=false`, `locked=false`, `scheduleSupported=true`, plus `cfgControl.forceScheduleSupported=true` and `cfgControl.forceScheduleOpted=true`.
+- `hideChargeFromGrid` may be `true` even when charge-from-grid schedule fields are still present in the payload, so clients should not infer field absence from UI visibility. Observed values so far: `true`, `false`.
+- `systemTask` remained `false` in the capture and likely flags backend-owned operations that temporarily lock manual changes. Observed value so far: `false`.
+- `devices.iqEvse.useBatteryFrSelfConsumption` exposes whether an IQ EV charger can draw from battery during self-consumption mode. Observed value so far: `true`.
 - Two equivalent write variants were observed:
   - REST-only flows use `PUT /batterySettings/<site_id>?source=enho&userId=<user_id>`.
   - MQTT-backed RBD flows on `supportsMqtt=true` systems use `PUT /batterySettings/<site_id>?userId=<user_id>` after opening the MQTT response stream.
@@ -3862,13 +3923,26 @@ Some sites issue a JWT-like access token via `https://entrez.enphaseenergy.com/a
 | `current_charge` | Site battery state-of-charge percentage string (for example `"48%"`) |
 | `available_energy` / `max_capacity` | Site battery available/maximum capacity in kWh |
 | `available_power` / `max_power` | Site battery instantaneous/maximum power in kW |
+| `show_battery_banner` | Battery-card UI hint flag from `/pv/settings/<site_id>/battery_status.json`; observed value so far: `false` |
 | `storages[].serial_number` | Battery serial identifier |
-| `storages[].excluded` | Battery inclusion flag |
-| `storages[].led_status` | Raw battery LED/runtime status code |
-| `storages[].status` / `storages[].statusText` | Battery status code + display label |
+| `storages[].excluded` | Battery inclusion flag; observed value so far: `false` |
+| `storages[].led_status` | Raw battery LED/runtime status code; observed values so far: `12`, `17` |
+| `storages[].status` / `storages[].statusText` | Battery status code + display label; observed pair so far: `normal` / `Normal` |
 | `storages[].last_report` | Epoch seconds for latest battery telemetry |
+| `storages[].battery_mode` | Human-readable battery profile label for the individual storage unit; observed value so far: `Self-Consumption` |
+| `storages[].battery_phase_count` | Number of AC phases exposed for that battery/system view; observed values so far: `1`, `3` |
+| `storages[].is_flex_phase` | Flex-phase capability flag observed on three-phase systems; observed values so far: `false`, `true` |
 | `storages[].battery_soh` | Battery state-of-health percentage string |
 | `included_count` / `excluded_count` | Active vs excluded battery counts in the payload |
+| `supportsMqtt` | Battery settings capability flag indicating MQTT-backed config flows are available; observed value so far: `true` |
+| `pollingInterval` | Suggested BatteryConfig refresh cadence in seconds; observed value so far: `60` |
+| `requestedConfig` / `requestedConfigMqtt` | Pending or echoed config state objects in battery-settings responses; observed values so far: `{}` |
+| `drEventActive` / `drEventMode` | Demand-response event state fields in battery-settings responses; observed values so far: `false` / `""` |
+| `batteryBackupPercentageMin` / `batteryBackupPercentageMax` | Allowed reserve slider bounds from BatteryConfig; observed values so far: `5` / `100` |
+| `previousBatteryBackupPercentage` | Per-profile remembered reserve percentage values |
+| `dtgControl` / `cfgControl` / `rbdControl` | Battery UI feature-capability blocks with visibility, lock, and schedule support flags; observed booleans so far include `show=true`, `showDaySchedule=true`, `enabled=false`, `locked=false`, `scheduleSupported=true` |
+| `systemTask` | Backend task/activity flag that may indicate settings are being managed asynchronously; observed value so far: `false` |
+| `devices.iqEvse.useBatteryFrSelfConsumption` | Indicates IQ EV charger battery participation support in self-consumption mode; observed value so far: `true` |
 | `device-uid` | Stable HEMS device identifier |
 | `device-type` (HEMS) | HEMS device taxonomy values seen in captures: `IQ_ENERGY_ROUTER`, `IQ_GATEWAY`, `SG_READY_GATEWAY`, `ENERGY_METER`, `HEAT_PUMP` |
 | `pairing-status` (HEMS) | Pairing state label (for example `PAIRED`) for router-attached ecosystem devices |

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -30,7 +30,15 @@ def test_parse_battery_settings_payload_maps_mode_and_controls(
                 "veryLowSocMax": 25,
                 "profile": "self-consumption",
                 "batteryBackupPercentage": 20,
+                "batteryBackupPercentageMin": 8,
+                "batteryBackupPercentageMax": 95,
                 "stormGuardState": "enabled",
+                "cfgControl": {
+                    "show": True,
+                    "enabled": True,
+                    "scheduleSupported": True,
+                    "forceScheduleSupported": True,
+                },
                 "devices": {
                     "iqEvse": {
                         "useBatteryFrSelfConsumption": True,
@@ -53,7 +61,13 @@ def test_parse_battery_settings_payload_maps_mode_and_controls(
     assert coord.battery_shutdown_level_available is True
     assert coord.battery_profile == "self-consumption"
     assert coord.battery_effective_backup_percentage == 20
+    assert coord.battery_reserve_min == 8
+    assert coord.battery_reserve_max == 95
     assert coord.storm_guard_state == "enabled"
+    assert coord.battery_cfg_control_show is True
+    assert coord.battery_cfg_control_enabled is True
+    assert coord.battery_cfg_control_schedule_supported is True
+    assert coord.battery_cfg_control_force_schedule_supported is True
     assert coord.battery_use_battery_for_self_consumption is True
 
 
@@ -110,6 +124,7 @@ def test_battery_soc_min_floor_applies_to_reserve_and_shutdown(
 
     coord._battery_profile = "backup_only"  # noqa: SLF001
     assert coord.battery_reserve_min == 100
+    assert coord.battery_reserve_max == 100
 
 
 def test_parse_battery_settings_unknown_grid_mode_uses_none_permissions(
@@ -411,6 +426,20 @@ def test_charge_from_grid_control_honors_cfg_control_false(
     coord._battery_cfg_control_enabled = False  # noqa: SLF001
     coord._battery_hide_charge_from_grid = False  # noqa: SLF001
 
+    assert coord.charge_from_grid_control_available is True
+
+
+def test_charge_from_grid_control_honors_cfg_control_show_false(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord._battery_cfg_control_show = False  # noqa: SLF001
+    coord._battery_cfg_control_enabled = True  # noqa: SLF001
+    coord._battery_hide_charge_from_grid = False  # noqa: SLF001
+
     assert coord.charge_from_grid_control_available is False
 
 
@@ -443,6 +472,38 @@ def test_parse_battery_settings_payload_handles_non_dict_and_bad_disclaimer(
         {"data": {"acceptedItcDisclaimer": BadStr()}}
     )
     assert coord._battery_accepted_itc_disclaimer is None  # noqa: SLF001
+
+
+def test_parse_battery_settings_payload_clears_missing_reserve_bounds(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_backup_percentage_min = 8  # noqa: SLF001
+    coord._battery_backup_percentage_max = 95  # noqa: SLF001
+    coord._battery_very_low_soc_min = 10  # noqa: SLF001
+
+    coord.battery_runtime.parse_battery_settings_payload(
+        {"data": {"batteryBackupPercentage": 20}}
+    )
+
+    assert coord.battery_reserve_min == 10
+    assert coord.battery_reserve_max == 100
+
+
+def test_parse_battery_settings_payload_keeps_reserve_bounds_for_partial_update(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_backup_percentage_min = 8  # noqa: SLF001
+    coord._battery_backup_percentage_max = 95  # noqa: SLF001
+
+    coord.battery_runtime.parse_battery_settings_payload(
+        {"chargeFromGrid": True},
+        clear_missing_reserve_bounds=False,
+    )
+
+    assert coord.battery_reserve_min == 8
+    assert coord.battery_reserve_max == 95
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_number_module.py
+++ b/tests/components/enphase_ev/test_number_module.py
@@ -349,8 +349,13 @@ def test_battery_reserve_number_dynamic_bounds(hass, config_entry) -> None:
     assert number.native_min_value == 5.0
     assert number.native_max_value == 100.0
 
+    coord._battery_backup_percentage_min = 8  # noqa: SLF001
+    coord._battery_backup_percentage_max = 92  # noqa: SLF001
+    assert number.native_min_value == 8.0
+    assert number.native_max_value == 92.0
+
     coord._battery_very_low_soc_min = 12  # noqa: SLF001
-    assert number.native_min_value == 12.0
+    assert number.native_min_value == 8.0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- document the newly observed Enphase battery status and battery settings fields with anonymised observed values
- use `batterySettings.cfgControl` as a fallback source for charge-from-grid capability metadata without treating `cfgControl.enabled` as a hard availability gate
- honor `batteryBackupPercentageMin` and `batteryBackupPercentageMax` for reserve bounds, clear stale bounds on full refresh, and preserve them during partial optimistic battery-settings updates

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_number_module.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/state_models.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
