### PR TITLE
[codex] Improve gateway inventory fallback handling

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -3893,6 +3893,34 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 return member
         return None
 
+    def _envoy_member_looks_like_gateway(self, member: dict[str, object]) -> bool:
+        if self._envoy_member_kind(member) in (
+            "production",
+            "consumption",
+            "controller",
+        ):
+            return False
+        if any(
+            member.get(key) is not None
+            for key in (
+                "envoy_sw_version",
+                "ap_mode",
+                "supportsEntrez",
+                "show_connection_details",
+                "ip",
+                "ip_address",
+            )
+        ):
+            return True
+        name = (self._type_member_text(member, "name") or "").lower()
+        return "gateway" in name
+
+    def _envoy_primary_gateway_member(self) -> dict[str, object] | None:
+        for member in self._type_bucket_members("envoy"):
+            if self._envoy_member_looks_like_gateway(member):
+                return member
+        return None
+
     def _heatpump_primary_member(self) -> dict[str, object] | None:
         return self.heatpump_runtime._heatpump_primary_member()
 
@@ -3917,6 +3945,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             return None
         if normalized == "envoy":
             member = self._envoy_system_controller_member()
+            if member is None:
+                member = self._envoy_primary_gateway_member()
             controller_name = self._type_member_text(
                 member,
                 "name",
@@ -3978,6 +4008,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         if normalized == "envoy":
             serial_keys = ("serial_number", "serial", "serialNumber", "device_sn")
             controller = self._envoy_system_controller_member()
+            if controller is None:
+                controller = self._envoy_primary_gateway_member()
             return self._type_member_text(controller, *serial_keys)
         if normalized == "heatpump":
             primary = self._heatpump_primary_member()
@@ -4025,6 +4057,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         )
         if normalized == "envoy":
             controller = self._envoy_system_controller_member()
+            if controller is None:
+                controller = self._envoy_primary_gateway_member()
             model_id = self._type_member_text(controller, *model_id_keys)
         elif normalized == "heatpump":
             primary = self._heatpump_primary_member()
@@ -4070,6 +4104,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         )
         if normalized == "envoy":
             controller = self._envoy_system_controller_member()
+            if controller is None:
+                controller = self._envoy_primary_gateway_member()
             return self._type_member_text(controller, *sw_keys)
         if normalized == "heatpump":
             primary = self._heatpump_primary_member()
@@ -4104,6 +4140,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             return None
         if normalized == "envoy":
             controller = self._envoy_system_controller_member()
+            if controller is None:
+                controller = self._envoy_primary_gateway_member()
             return self._type_member_text(
                 controller,
                 "hw_version",

--- a/custom_components/enphase_ev/device_types.py
+++ b/custom_components/enphase_ev/device_types.py
@@ -14,6 +14,8 @@ _TYPE_ALIAS_TOKEN_MAP: dict[str, str] = {
     "meter": "envoy",
     "meters": "envoy",
     "encharge": "encharge",
+    "storage": "encharge",
+    "storages": "encharge",
     "battery": "encharge",
     "batteries": "encharge",
     "enpower": "envoy",

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -691,7 +691,9 @@ Example response shape (anonymized):
           "status": "normal",
           "statusText": "Normal",
           "ip": "192.0.2.10",
+          "ap_mode": true,
           "envoy_sw_version": "D8.X.XXXX",
+          "supportsEntrez": true,
           "last_report": 1770000000,
           "show_connection_details": true,
           "warranty_end_date": "2030-09-18"
@@ -702,11 +704,12 @@ Example response shape (anonymized):
       "type": "encharge",
       "devices": [
         {
-          "name": "IQ Battery 5P",
+          "name": "IQ Battery 5P FlexPhase",
           "serial_number": "BT0000000001",
-          "sku_id": "B05-T02-ROW00-1-2",
+          "sku_id": "IQBATTERY-5P-3P-INT",
           "channel_type": "IQ Battery",
           "status": "normal",
+          "statusText": "Normal",
           "last_report": 1770000010,
           "sw_version": "522-00002-01-vX.Y.Z_rel/31.44",
           "warranty_end_date": "2040-09-18"
@@ -717,11 +720,12 @@ Example response shape (anonymized):
       "type": "enpower",
       "devices": [
         {
-          "name": "IQ System Controller 3",
+          "name": "IQ System Controller 3 INT",
           "serial_number": "SC0000000000",
           "sku_id": "SC100G-M000ROW",
           "channel_type": "IQ System Controller",
           "status": "normal",
+          "statusText": "Normal",
           "last_report": 1770000020,
           "sw_version": "522-00003-01-vX.Y.Z_rel/31.44",
           "warranty_end_date": "2035-09-18"
@@ -767,7 +771,13 @@ Additional observed buckets (anonymized excerpt):
       "type": "hemsDevices",
       "devices": [
         {
-          "gateway": [{ "device-type": "IQ_ENERGY_ROUTER", "device-uid": "<site_id>_IQ_ENERGY_ROUTER_1" }],
+          "gateway": [
+            {
+              "device-type": "IQ_ENERGY_ROUTER",
+              "device-uid": "<site_id>_IQ_ENERGY_ROUTER_1",
+              "ip-address": "192.0.2.11"
+            }
+          ],
           "heat-pump": [{ "device-type": "HEAT_PUMP", "device-uid": "<site_id>_HEAT_PUMP_1" }],
           "evse": [],
           "water-heater": []
@@ -782,8 +792,11 @@ Observed structure:
 - `result[]` is a mixed array containing typed buckets (`{type, devices}`) and metadata objects (for example `curr_date_site`).
 - Each bucket's `type` identifies the device family; `devices[]` may be empty.
 - Common device fields: `name`, `serial_number`, `sku_id`, `status`, `statusText`, `last_report`.
-- Optional fields vary by type (`ip`, `connected`, `envoy_sw_version`, `channel_type`, `sw_version`, `warranty_end_date`, `load_name`, `load_type`, etc.).
+- Observed `type` values include `envoy`, `storage`, `q_relay`, `meter`, `encharge`, `enpower`, `generator`, `wirelessRangeExtender`, `dryContactLoads`, `stringInverters`, `iqCollars`, and `hemsDevices`.
+- Optional fields vary by type (`ip`, `ap_mode`, `connected`, `supportsEntrez`, `envoy_sw_version`, `channel_type`, `sw_version`, `warranty_end_date`, `load_name`, `load_type`, etc.).
 - `channel_type` labels may be localized by site locale (for example French meter labels).
+- Meter examples observed both production and consumption labels via synthetic serial suffixes such as `EIM1` and `EIM2`.
+- `dryContactLoads` entries may expose user-assigned names such as garage/PV load labels.
 - Some sites include a nested `type: "hemsDevices"` bucket in `/devices.json`, reusing the hierarchical HEMS shape documented in `2.17`.
 
 ### 2.9.1 Filtered Site-Device Inventory
@@ -2439,21 +2452,28 @@ Example response shape (anonymized):
             "status": "normal",
             "statusText": "Normal",
             "pairing-status": "PAIRED",
-            "last-report": 1770000000,
+            "last-report": "2026-02-01T10:00:00Z",
             "hems-device-id": "hd_router_001",
             "hems-device-facet-id": "hf_router_001",
             "iqer-uid": "iqer_uid_001",
-            "created-at": "2026-02-01T10:00:00Z"
+            "created-at": "2026-02-01T10:00:00Z",
+            "ip-address": "192.0.2.11"
           },
           {
             "name": "IQ Gateway_1",
             "device-type": "IQ_GATEWAY",
             "device-uid": "<site_id>_IQ_GATEWAY_1",
             "uid": "GW-UID-001",
+            "make": "Enphase",
+            "model": "Envoy-S Metered",
             "status": "normal",
             "statusText": "Normal",
             "pairing-status": "PAIRED",
-            "last-report": 1770000001
+            "last-report": "2026-02-01T10:00:01Z",
+            "created-at": "2026-02-01T09:59:58Z",
+            "hems-device-id": "hd_gateway_001",
+            "hems-device-facet-id": "hf_gateway_001",
+            "iqer-uid": "iqer_uid_001"
           }
         ],
         "heat-pump": [
@@ -2467,7 +2487,11 @@ Example response shape (anonymized):
             "status": "normal",
             "statusText": "Normal",
             "pairing-status": "PAIRED",
-            "last-report": 1770000002
+            "last-report": "2026-02-01T10:00:02Z",
+            "created-at": "2026-02-01T09:58:58Z",
+            "hems-device-id": "hd_sgready_001",
+            "hems-device-facet-id": "hf_sgready_001",
+            "iqer-uid": "iqer_uid_001"
           },
           {
             "name": "Energy Meter_1",
@@ -2480,10 +2504,14 @@ Example response shape (anonymized):
             "status": "normal",
             "statusText": "Normal",
             "pairing-status": "PAIRED",
-            "last-report": 1770000003
+            "last-report": "2026-02-01T10:00:03Z",
+            "created-at": "2026-02-01T09:58:59Z",
+            "hems-device-id": "hd_meter_001",
+            "hems-device-facet-id": "hf_meter_001",
+            "iqer-uid": "iqer_uid_001"
           },
           {
-            "name": "Heat Pump_1",
+            "name": "Waermepumpe",
             "device-type": "HEAT_PUMP",
             "device-uid": "<site_id>_HEAT_PUMP_1",
             "make": "HeatPumpVendor",
@@ -2491,7 +2519,9 @@ Example response shape (anonymized):
             "status": "normal",
             "statusText": "Normal",
             "pairing-status": "PAIRED",
-            "fvt-time": 1770000000
+            "created-at": "2026-02-01T09:59:00.000000000Z",
+            "fvt-time": "2026-02-01T10:00:00.000Z",
+            "iqer-uid": "iqer_uid_001"
           }
         ],
         "evse": [],
@@ -2504,6 +2534,8 @@ Example response shape (anonymized):
 Observed structure:
 - Device grouping is hierarchical (`gateway`, `heat-pump`, `evse`, `water-heater`) rather than the flat `type/devices` shape used by `/app-api/<site_id>/devices.json`.
 - `device-uid` is a stable HEMS identifier reused across timeseries filters and related detail requests.
+- `created-at`, `last-report`, and `fvt-time` were observed as ISO-8601 strings in this capture, not epoch seconds.
+- Router/gateway members may expose network-local metadata such as `ip-address`; redact concrete LAN addresses when documenting captures.
 - For the captured site, device types present were `IQ_ENERGY_ROUTER`, `IQ_GATEWAY`, `SG_READY_GATEWAY`, `ENERGY_METER`, and `HEAT_PUMP`.
 
 ### 2.17.1 HEMS Heat Pump Runtime State (Per Heat Pump UID)
@@ -3798,6 +3830,9 @@ Some sites issue a JWT-like access token via `https://entrez.enphaseenergy.com/a
 | `device-type` (HEMS) | HEMS device taxonomy values seen in captures: `IQ_ENERGY_ROUTER`, `IQ_GATEWAY`, `SG_READY_GATEWAY`, `ENERGY_METER`, `HEAT_PUMP` |
 | `pairing-status` (HEMS) | Pairing state label (for example `PAIRED`) for router-attached ecosystem devices |
 | `hems-device-id` / `hems-device-facet-id` | HEMS backend identifiers present on router/heat-pump stack members in `hems-devices` payloads |
+| `ip` / `ip-address` | Device LAN address fields seen on gateway/router inventory payloads; treat as sensitive in examples |
+| `ap_mode` | Boolean flag on gateway inventory entries indicating the IQ Gateway access-point mode was enabled |
+| `supportsEntrez` | Boolean capability flag observed on gateway inventory entries |
 | `heatpump-status` | App-facing heat-pump runtime state from `/heatpump/<device_uid>/state`; observed values: `IDLE`, `RUNNING` |
 | `sg-ready-mode` | SG Ready operating mode label from `/heatpump/<device_uid>/state`; observed values: `MODE_2` (normal), `MODE_3` (recommended consumption / SG Ready on) |
 | `vpp-sgready-mode-override` | SG Ready override label from `/heatpump/<device_uid>/state`; observed off-state value: `NONE` |

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -312,6 +312,96 @@ def test_type_device_envoy_prefers_system_controller_metadata(
     )  # noqa: SLF001
 
 
+def test_type_device_envoy_falls_back_to_gateway_member_metadata(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "type_label": "Gateway",
+                "count": 3,
+                "devices": [
+                    {
+                        "name": "IQ Gateway",
+                        "serial_number": "GW-123",
+                        "sku_id": "SC100G-M230ROW",
+                        "envoy_sw_version": "D8.3.5167",
+                    },
+                    {
+                        "name": "Consumption Meter",
+                        "channel_type": "consumption_meter",
+                        "serial_number": "CM-123",
+                    },
+                    {
+                        "name": "Production Meter",
+                        "channel_type": "production_meter",
+                        "serial_number": "PM-123",
+                    },
+                ],
+            }
+        },
+        ["envoy"],
+    )
+
+    assert coord.type_device_name("envoy") == "IQ Gateway"
+    assert coord.type_device_model("envoy") == "IQ Gateway"
+    assert coord.type_device_serial_number("envoy") == "GW-123"
+    assert coord.type_device_model_id("envoy") == "SC100G-M230ROW"
+    assert coord.type_device_sw_version("envoy") == "D8.3.5167"
+
+    info = coord.type_device_info("envoy")
+    assert info is not None
+    assert info["name"] == "IQ Gateway"
+    assert info["model"] == "IQ Gateway"
+    assert info["serial_number"] == "GW-123"
+    assert info["model_id"] == "SC100G-M230ROW"
+    assert info["sw_version"] == "D8.3.5167"
+
+
+def test_type_device_envoy_does_not_promote_localized_meters_to_gateway(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "type_label": "Gateway",
+                "count": 2,
+                "devices": [
+                    {
+                        "name": "IQ Envoy",
+                        "serial_number": "GW-EIM1",
+                        "channel_type": "Compteur de production integre Enphase",
+                    },
+                    {
+                        "name": "IQ Envoy",
+                        "serial_number": "GW-EIM2",
+                        "channel_type": "Compteur de consommation integre Enphase",
+                    },
+                ],
+            }
+        },
+        ["envoy"],
+    )
+
+    assert coord.type_device_name("envoy") == "IQ Gateway"
+    assert coord.type_device_model("envoy") == "IQ Gateway"
+    assert coord.type_device_serial_number("envoy") is None
+    assert coord.type_device_model_id("envoy") is None
+    assert coord.type_device_sw_version("envoy") is None
+
+    info = coord.type_device_info("envoy")
+    assert info is not None
+    assert info["name"] == "IQ Gateway"
+    assert info["model"] == "IQ Gateway"
+    assert "serial_number" not in info
+    assert "model_id" not in info
+    assert "sw_version" not in info
+
+
 def test_type_device_summary_helpers_for_battery_and_microinverter(
     hass, monkeypatch
 ) -> None:

--- a/tests/components/enphase_ev/test_device_types.py
+++ b/tests/components/enphase_ev/test_device_types.py
@@ -23,6 +23,8 @@ def test_normalize_type_key_handles_aliases_and_unknown_tokens() -> None:
     assert normalize_type_key("meter") == "envoy"
     assert normalize_type_key("enpower") == "envoy"
     assert normalize_type_key("systemcontroller") == "envoy"
+    assert normalize_type_key("storage") == "encharge"
+    assert normalize_type_key("storages") == "encharge"
     assert normalize_type_key("heat-pump") == "heatpump"
     assert normalize_type_key("heat_pump") == "heatpump"
     assert normalize_type_key("Heat Pump") == "heatpump"
@@ -52,6 +54,7 @@ def test_type_display_label_uses_known_and_title_case_defaults() -> None:
 
 
 def test_is_dry_contact_type_key_handles_relay_aliases() -> None:
+    assert is_dry_contact_type_key(None) is False
     assert is_dry_contact_type_key("dry_contact") is True
     assert is_dry_contact_type_key("Dry Contact 1") is True
     assert is_dry_contact_type_key("Dry Contacts") is True
@@ -213,6 +216,12 @@ def test_active_type_keys_from_inventory_filters_and_orders() -> None:
     )
 
     assert keys == ["envoy", "generator", "wind_turbine"]
+
+
+def test_active_type_keys_from_inventory_maps_storage_to_encharge() -> None:
+    payload = {"result": [{"type": "storage", "devices": [{"serial_number": "BAT-1"}]}]}
+
+    assert active_type_keys_from_inventory(payload) == ["encharge"]
 
 
 def test_active_type_keys_from_inventory_detects_heatpump_in_hems_bucket() -> None:


### PR DESCRIPTION
## Summary
- tighten envoy gateway fallback detection so localized meter records are not promoted into gateway metadata
- map `storage` and `storages` inventory buckets to the battery `encharge` type and add regression coverage
- update the API spec with the newly captured `devices.json` fields and anonymized example values

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/device_types.py custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_device_types.py tests/components/enphase_ev/test_coordinator_behavior.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_device_types.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev/test_device_types.py -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/device_types.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"` (fails in this worktree because the container cannot resolve the external worktree `.git` path referenced by `.git`)
