### PR TITLE
[codex] Document EV firmware details endpoint capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🔄 Other changes
-- None
+- Refreshed the API reference for the EV firmware-details endpoint with a redacted browser capture, observed request/auth notes, and the latest payload structure.
 
 ## v2.6.0 - 2026-03-28
 

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -321,6 +321,16 @@ GET /service/evse_management/fwDetails/<site_id>
 Returns site-scoped EV charger firmware rollout details as an array keyed by `serialNumber`.
 Unlike summary v2, the path variable is the site identifier, not the charger serial number.
 
+Observed request fields:
+- Method: `GET`.
+- Path parameter `site_id`: numeric Enlighten site identifier in the URL path.
+- Query/body: none observed.
+- `Accept: */*`.
+- `Content-Type: application/json`.
+- `X-Requested-With: XMLHttpRequest`.
+- `Referer`: `/web/<site_id>/today/graph/hours?v=3.4.0?osv=1`.
+- Browser capture authenticated with the normal Enlighten session cookie jar; the observed `e-auth-token` header value was the literal string `null`.
+
 Example response (anonymized capture):
 ```json
 [
@@ -338,6 +348,11 @@ Example response (anonymized capture):
 ]
 ```
 
+Observed structure:
+- The response is a bare JSON array with no top-level `meta`, `data`, or `error` envelope.
+- Each array item represents one charger at the site and can be joined to runtime/summary payloads via `serialNumber`.
+- Timestamp fields use extended ISO-8601 strings with fractional seconds plus a bracketed zone suffix such as `Z[UTC]`.
+
 Observed fields:
 - `serialNumber`: charger serial number used to join the record to summary/runtime data.
 - `siteId`: numeric site identifier echoed by the service.
@@ -348,6 +363,10 @@ Observed fields:
 - `lastUpdatedAt`: service timestamp for the current firmware-details record.
 - `statusDetail`: optional additional upgrade-state detail; often `null`.
 - `isAutoOta`: whether automatic OTA behavior is enabled for the charger.
+
+Notes:
+- The captured browser request succeeded with session cookies even though `e-auth-token` was `null`. Whether non-browser clients can omit `e-auth-token` for this endpoint remains unverified, so preserve standard session headers when scripting against it.
+- The original trace contained live cookies, XSRF tokens, JWT-bearing cookie values with account identifiers, a real site ID, a real charger serial number, and a client-facing proxy address. Those values are intentionally replaced with placeholders here.
 
 ### 2.2.3 EV Feature Flags
 ```


### PR DESCRIPTION
## Summary
- document the EV firmware-details endpoint with the newly captured request/response shape
- note the observed browser auth behavior where the captured request sent `e-auth-token: null`
- explicitly document that site IDs, serial numbers, cookies, tokens, and proxy address data were redacted from the captured example

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml build ha-dev` *(failed: insufficient free space in `/var/cache/apt/archives/` while building the pinned Docker image, so the required Docker-based lint/test checks could not be run in this environment)*
