### PR TITLE
Improve HEMS heat pump support

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -1753,6 +1753,12 @@ class EnphaseEVClient:
         headers.update(self._control_headers())
         return headers
 
+    def _hems_auth_context(self) -> tuple[str | None, str | None]:
+        """Return the preferred HEMS bearer token and resolved user id."""
+
+        bearer = self._bearer() or self._eauth
+        return bearer, _jwt_user_id(bearer)
+
     @staticmethod
     def _system_dashboard_is_optional_error(err: Exception) -> bool:
         """Return True when a dashboard route should fall back or soft-fail."""
@@ -1788,7 +1794,12 @@ class EnphaseEVClient:
         """Return headers for HEMS read endpoints."""
 
         headers = dict(self._h)
-        headers.update(self._control_headers())
+        bearer, username = self._hems_auth_context()
+        if bearer:
+            headers["Authorization"] = f"Bearer {bearer}"
+        if username:
+            headers["username"] = username
+        headers["requestId"] = str(uuid.uuid4())
         return headers
 
     def _battery_config_user_id(self) -> str | None:
@@ -4242,9 +4253,13 @@ class EnphaseEVClient:
             else data.get("sg-ready-mode")
         )
         details = cls._heatpump_sg_ready_mode_details(sg_ready_mode_raw)
+        endpoint_type = cls._clean_optional_text(payload.get("type"))
+        endpoint_timestamp = payload.get("timestamp")
         normalized: dict[str, object] = {
-            "type": cls._clean_optional_text(payload.get("type")),
-            "timestamp": payload.get("timestamp"),
+            "type": endpoint_type,
+            "timestamp": endpoint_timestamp,
+            "endpoint_type": endpoint_type,
+            "endpoint_timestamp": endpoint_timestamp,
             "device_uid": device_uid,
             "heatpump_status": heatpump_status,
             "sg_ready_mode_raw": sg_ready_mode_raw,
@@ -4316,9 +4331,13 @@ class EnphaseEVClient:
         if not isinstance(data, dict):
             data = payload
 
+        endpoint_type = cls._clean_optional_text(payload.get("type"))
+        endpoint_timestamp = payload.get("timestamp")
         normalized: dict[str, object] = {
-            "type": cls._clean_optional_text(payload.get("type")),
-            "timestamp": payload.get("timestamp"),
+            "type": endpoint_type,
+            "timestamp": endpoint_timestamp,
+            "endpoint_type": endpoint_type,
+            "endpoint_timestamp": endpoint_timestamp,
             "data": {
                 "heat-pump": [],
                 "evse": [],

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -259,6 +259,10 @@ class HeatPumpSgReadyActiveBinarySensor(CoordinatorEntity, BinarySensorEntity):
         )
         return {
             "device_uid": snapshot.get("device_uid"),
+            "member_name": snapshot.get("member_name"),
+            "member_device_type": snapshot.get("member_device_type"),
+            "pairing_status": snapshot.get("pairing_status"),
+            "device_state": snapshot.get("device_state"),
             "heatpump_status_raw": snapshot.get("heatpump_status"),
             "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
             "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
@@ -266,6 +270,8 @@ class HeatPumpSgReadyActiveBinarySensor(CoordinatorEntity, BinarySensorEntity):
             "sg_ready_contact_state": snapshot.get("sg_ready_contact_state"),
             "vpp_sgready_mode_override": snapshot.get("vpp_sgready_mode_override"),
             "last_report_at": snapshot.get("last_report_at"),
+            "runtime_endpoint_type": snapshot.get("endpoint_type"),
+            "runtime_endpoint_timestamp": snapshot.get("endpoint_timestamp"),
             "source": snapshot.get("source"),
             "last_error": getattr(
                 self._coord, "heatpump_runtime_state_last_error", None

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -26,7 +26,9 @@ from .parsing_helpers import (
     coerce_optional_bool,
     coerce_optional_float,
     coerce_optional_text,
+    heatpump_device_state,
     heatpump_member_device_type,
+    heatpump_pairing_status,
     heatpump_status_text,
     parse_inverter_last_report,
     type_member_text,
@@ -305,6 +307,17 @@ class HeatpumpRuntime:
                 return uid
         return None
 
+    def _heatpump_runtime_member(self) -> dict[str, object] | None:
+        runtime_uid = self._heatpump_runtime_device_uid()
+        if runtime_uid:
+            member = self._heatpump_member_for_uid(runtime_uid)
+            if member is not None:
+                return member
+        primary = self._heatpump_primary_member()
+        if primary is not None:
+            return primary
+        return None
+
     async def _async_refresh_heatpump_runtime_state(
         self, *, force: bool = False
     ) -> None:
@@ -376,6 +389,14 @@ class HeatpumpRuntime:
             self._heatpump_runtime_state = None
             return
         snapshot = dict(payload)
+        member = self._heatpump_runtime_member()
+        if isinstance(member, dict):
+            snapshot.setdefault("member_name", type_member_text(member, "name"))
+            snapshot.setdefault(
+                "member_device_type", heatpump_member_device_type(member)
+            )
+            snapshot.setdefault("pairing_status", heatpump_pairing_status(member))
+            snapshot.setdefault("device_state", heatpump_device_state(member))
         snapshot["source"] = f"hems_heatpump_state:{device_uid}"
         self._heatpump_runtime_state = snapshot
 
@@ -393,16 +414,20 @@ class HeatpumpRuntime:
             tz = _tz.utc
         day_key = self._site_local_current_date()
         try:
-            day_start = datetime.combine(
-                datetime.fromisoformat(day_key).date(),
-                dt_time.min,
-                tzinfo=tz,
-            )
+            day_date = datetime.fromisoformat(day_key).date()
         except Exception:
             return None
-        day_end = day_start + timedelta(days=1)
         marker = (day_key, tz_name)
-        return day_start.isoformat(), day_end.isoformat(), tz_name, marker
+        day_start_local = datetime.combine(day_date, dt_time.min, tzinfo=tz)
+        day_end_local = day_start_local + timedelta(days=1) - timedelta(milliseconds=1)
+        day_start = day_start_local.astimezone(_tz.utc)
+        day_end = day_end_local.astimezone(_tz.utc)
+        return (
+            day_start.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+            day_end.isoformat(timespec="milliseconds").replace("+00:00", "Z"),
+            tz_name,
+            marker,
+        )
 
     @staticmethod
     def _sum_optional_values(values: object) -> float | None:
@@ -448,6 +473,10 @@ class HeatpumpRuntime:
         if not isinstance(selected, dict):
             return None
 
+        member = self._heatpump_member_for_uid(selected.get("device_uid"))
+        if member is None:
+            member = self._heatpump_runtime_member()
+
         buckets = selected.get("consumption")
         first_bucket = None
         if isinstance(buckets, list):
@@ -461,6 +490,20 @@ class HeatpumpRuntime:
         return {
             "device_uid": selected.get("device_uid"),
             "device_name": selected.get("device_name"),
+            "member_name": (
+                type_member_text(member, "name") if isinstance(member, dict) else None
+            ),
+            "member_device_type": (
+                heatpump_member_device_type(member)
+                if isinstance(member, dict)
+                else None
+            ),
+            "pairing_status": (
+                heatpump_pairing_status(member) if isinstance(member, dict) else None
+            ),
+            "device_state": (
+                heatpump_device_state(member) if isinstance(member, dict) else None
+            ),
             "daily_energy_wh": self._sum_optional_values(first_bucket.get("details")),
             "daily_solar_wh": coerce_optional_float(first_bucket.get("solar")),
             "daily_battery_wh": coerce_optional_float(first_bucket.get("battery")),
@@ -475,8 +518,16 @@ class HeatpumpRuntime:
                 if selected.get("device_uid")
                 else "hems_energy_consumption"
             ),
-            "endpoint_type": payload.get("type"),
-            "endpoint_timestamp": payload.get("timestamp"),
+            "endpoint_type": (
+                payload.get("endpoint_type")
+                if payload.get("endpoint_type") is not None
+                else payload.get("type")
+            ),
+            "endpoint_timestamp": (
+                payload.get("endpoint_timestamp")
+                if payload.get("endpoint_timestamp") is not None
+                else payload.get("timestamp")
+            ),
         }
 
     async def _async_refresh_heatpump_daily_consumption(
@@ -1031,6 +1082,52 @@ class HeatpumpRuntime:
     async def async_refresh_heatpump_power(self, *, force: bool = False) -> None:
         await self._async_refresh_heatpump_power(force=force)
 
+    @staticmethod
+    def _hems_event_entries(payload: object) -> list[dict[str, object]]:
+        if isinstance(payload, list):
+            return [item for item in payload if isinstance(item, dict)]
+        if not isinstance(payload, dict):
+            return []
+        for key in ("events", "data", "result", "items"):
+            nested = payload.get(key)
+            if isinstance(nested, list):
+                return [item for item in nested if isinstance(item, dict)]
+        return []
+
+    def _heatpump_event_summary(self) -> dict[str, object]:
+        known_event_labels = {
+            "hems_sgready_mode_changed_to_2": "sg_ready_normal",
+            "hems_sgready_mode_changed_to_3": "sg_ready_recommended",
+            "hems_sgready_relay_offline": "sg_ready_relay_offline",
+            "hems_energy_meter_offline": "energy_meter_offline",
+            "hems_iqer_MQTT_offline": "iq_energy_router_mqtt_offline",
+        }
+        event_counts: dict[str, int] = {}
+        unknown_event_keys: set[str] = set()
+        for payload_entry in list(getattr(self, "_heatpump_events_payloads", []) or []):
+            payload = (
+                payload_entry.get("payload")
+                if isinstance(payload_entry, dict)
+                else None
+            )
+            for event in self._hems_event_entries(payload):
+                event_key = coerce_optional_text(
+                    event.get("event_key")
+                    if event.get("event_key") is not None
+                    else event.get("eventKey")
+                )
+                if not event_key:
+                    continue
+                label = known_event_labels.get(event_key)
+                if label is None:
+                    unknown_event_keys.add(event_key)
+                    continue
+                event_counts[label] = event_counts.get(label, 0) + 1
+        return {
+            "known_event_counts": event_counts,
+            "unknown_event_keys": sorted(unknown_event_keys),
+        }
+
     def heatpump_runtime_diagnostics(self) -> dict[str, object]:
         return {
             "runtime_state": self._copy_diagnostics_value(
@@ -1051,6 +1148,7 @@ class HeatpumpRuntime:
             "events_payloads": self._copy_diagnostics_value(
                 list(getattr(self, "_heatpump_events_payloads", []) or [])
             ),
+            "event_summary": self._heatpump_event_summary(),
             "last_error": getattr(self, "_heatpump_runtime_diagnostics_error", None),
         }
 

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -1336,6 +1336,21 @@ class InventoryRuntime:
             return "not_reporting"
         if any(
             token in normalized
+            for token in (
+                "inactive",
+                "unpaired",
+                "not_paired",
+                "notpaired",
+                "deactivated",
+                "decommissioned",
+                "retired",
+            )
+        ):
+            return "not_reporting"
+        if any(token in normalized for token in ("pairing", "pending")):
+            return "warning"
+        if any(
+            token in normalized
             for token in ("normal", "online", "connected", "ok", "recommended")
         ):
             return "normal"

--- a/custom_components/enphase_ev/parsing_helpers.py
+++ b/custom_components/enphase_ev/parsing_helpers.py
@@ -87,7 +87,81 @@ def heatpump_member_device_type(member: dict[str, object] | None) -> str | None:
     return text.upper() if text else None
 
 
-def heatpump_status_text(member: dict[str, object] | None) -> str | None:
+def heatpump_pairing_status(member: dict[str, object] | None) -> str | None:
+    if not isinstance(member, dict):
+        return None
+    return type_member_text(member, "pairing_status", "pairing-status")
+
+
+def heatpump_device_state(member: dict[str, object] | None) -> str | None:
+    if not isinstance(member, dict):
+        return None
+    raw = type_member_text(member, "device_state", "device-state")
+    return raw.upper() if raw else None
+
+
+def _friendly_heatpump_status(value: str | None) -> str | None:
+    if not value:
+        return None
+    return value.replace("_", " ").replace("-", " ").title()
+
+
+def heatpump_status_bucket(value: object) -> str:
+    text = coerce_optional_text(value)
+    if text is None:
+        return "unknown"
+    normalized = text.lower().replace("-", "_").replace(" ", "_")
+    if any(token in normalized for token in ("fault", "error", "critical")):
+        return "error"
+    if "warn" in normalized:
+        return "warning"
+    if any(
+        token in normalized for token in ("not_reporting", "offline", "disconnected")
+    ):
+        return "not_reporting"
+    if any(
+        token in normalized
+        for token in (
+            "inactive",
+            "unpaired",
+            "not_paired",
+            "notpaired",
+            "deactivated",
+            "decommissioned",
+            "retired",
+        )
+    ):
+        return "not_reporting"
+    if any(token in normalized for token in ("pairing", "pending")):
+        return "warning"
+    if any(token in normalized for token in ("normal", "online", "connected", "ok")):
+        return "normal"
+    return "unknown"
+
+
+def _heatpump_status_rank(value: object) -> int:
+    return {
+        "unknown": 0,
+        "normal": 1,
+        "warning": 2,
+        "not_reporting": 3,
+        "error": 4,
+    }.get(heatpump_status_bucket(value), 0)
+
+
+def heatpump_lifecycle_status_text(member: dict[str, object] | None) -> str | None:
+    if not isinstance(member, dict):
+        return None
+    pairing_status = heatpump_pairing_status(member)
+    if pairing_status and pairing_status.upper() != "PAIRED":
+        return _friendly_heatpump_status(pairing_status)
+    device_state = heatpump_device_state(member)
+    if device_state and device_state != "ACTIVE":
+        return _friendly_heatpump_status(device_state)
+    return None
+
+
+def heatpump_operational_status_text(member: dict[str, object] | None) -> str | None:
     if not isinstance(member, dict):
         return None
     status_text = (
@@ -101,7 +175,17 @@ def heatpump_status_text(member: dict[str, object] | None) -> str | None:
     raw = coerce_optional_text(member.get("status"))
     if not raw:
         return None
-    return raw.replace("_", " ").replace("-", " ").title()
+    return _friendly_heatpump_status(raw)
+
+
+def heatpump_status_text(member: dict[str, object] | None) -> str | None:
+    if not isinstance(member, dict):
+        return None
+    operational = heatpump_operational_status_text(member)
+    lifecycle = heatpump_lifecycle_status_text(member)
+    if _heatpump_status_rank(lifecycle) > _heatpump_status_rank(operational):
+        return lifecycle
+    return operational or lifecycle
 
 
 def parse_inverter_last_report(value: object) -> datetime | None:

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -40,6 +40,7 @@ from .device_types import is_dry_contact_type_key, member_is_retired
 from .device_info_helpers import _cloud_device_info
 from .energy import SiteEnergyFlow
 from .entity import EnphaseBaseEntity
+from .parsing_helpers import heatpump_status_text
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
 
 PARALLEL_UPDATES = 0
@@ -489,6 +490,10 @@ async def async_setup_entry(
             "heat_pump_connectivity_status",
             "heat_pump_sg_ready_mode",
             "heat_pump_energy_meter",
+            "heat_pump_daily_energy",
+            "heat_pump_daily_grid_energy",
+            "heat_pump_daily_solar_energy",
+            "heat_pump_daily_battery_energy",
             "heat_pump_last_reported",
             "heat_pump_power",
             "heat_pump_sg_ready_gateway",
@@ -714,8 +719,28 @@ async def async_setup_entry(
                 EnphaseHeatPumpEnergyMeterSensor(coord),
             )
             _add_site_entity(
+                "heat_pump_daily_energy",
+                EnphaseHeatPumpDailyEnergySensor(coord),
+            )
+            _add_site_entity(
+                "heat_pump_daily_grid_energy",
+                EnphaseHeatPumpDailyGridEnergySensor(coord),
+            )
+            _add_site_entity(
+                "heat_pump_daily_solar_energy",
+                EnphaseHeatPumpDailySolarEnergySensor(coord),
+            )
+            _add_site_entity(
+                "heat_pump_daily_battery_energy",
+                EnphaseHeatPumpDailyBatteryEnergySensor(coord),
+            )
+            _add_site_entity(
                 "heat_pump_power",
                 EnphaseHeatPumpPowerSensor(coord),
+            )
+            _add_site_entity(
+                "heat_pump_sg_ready_gateway",
+                EnphaseHeatPumpSgReadyGatewaySensor(coord),
             )
         elif inventory_ready:
             for entity_key in heatpump_site_entity_keys:
@@ -3945,19 +3970,7 @@ def _heatpump_member_device_type(member: dict[str, object] | None) -> str | None
 
 
 def _heatpump_member_status_text(member: dict[str, object] | None) -> str | None:
-    if not isinstance(member, dict):
-        return None
-    status_text = _gateway_clean_text(
-        member.get("statusText")
-        if member.get("statusText") is not None
-        else member.get("status_text")
-    )
-    if status_text:
-        return status_text
-    status_raw = _gateway_clean_text(member.get("status"))
-    if not status_raw:
-        return None
-    return status_raw.replace("_", " ").replace("-", " ").title()
+    return heatpump_status_text(member)
 
 
 def _heatpump_status_counts(members: list[dict[str, object]]) -> dict[str, int]:
@@ -4216,6 +4229,13 @@ def _heatpump_runtime_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
     return {}
 
 
+def _heatpump_daily_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
+    snapshot = getattr(coord, "heatpump_daily_consumption", None)
+    if isinstance(snapshot, dict):
+        return dict(snapshot)
+    return {}
+
+
 def _heatpump_runtime_device_uid(coord: EnphaseCoordinator) -> str | None:
     getter = getattr(coord, "_heatpump_runtime_device_uid", None)
     if callable(getter):
@@ -4232,6 +4252,45 @@ def _heatpump_runtime_last_reported(snapshot: dict[str, object]) -> datetime | N
         if snapshot.get("last_report_at") is not None
         else snapshot.get("last_reported_at")
     )
+
+
+def _heatpump_runtime_common_attrs(
+    coord: EnphaseCoordinator, snapshot: dict[str, object]
+) -> dict[str, object]:
+    last_reported = _heatpump_runtime_last_reported(snapshot)
+    return {
+        "device_uid": snapshot.get("device_uid"),
+        "member_name": snapshot.get("member_name"),
+        "member_device_type": snapshot.get("member_device_type"),
+        "pairing_status": snapshot.get("pairing_status"),
+        "device_state": snapshot.get("device_state"),
+        "runtime_endpoint_type": snapshot.get("endpoint_type"),
+        "runtime_endpoint_timestamp": snapshot.get("endpoint_timestamp"),
+        "last_report_at_utc": (
+            last_reported.isoformat() if last_reported is not None else None
+        ),
+        "source": snapshot.get("source"),
+        "last_error": getattr(coord, "heatpump_runtime_state_last_error", None),
+    }
+
+
+def _heatpump_daily_common_attrs(
+    coord: EnphaseCoordinator, snapshot: dict[str, object]
+) -> dict[str, object]:
+    return {
+        "device_uid": snapshot.get("device_uid"),
+        "device_name": snapshot.get("device_name"),
+        "member_name": snapshot.get("member_name"),
+        "member_device_type": snapshot.get("member_device_type"),
+        "pairing_status": snapshot.get("pairing_status"),
+        "device_state": snapshot.get("device_state"),
+        "daily_endpoint_type": snapshot.get("endpoint_type"),
+        "daily_endpoint_timestamp": snapshot.get("endpoint_timestamp"),
+        "day_key": snapshot.get("day_key"),
+        "timezone": snapshot.get("timezone"),
+        "source": snapshot.get("source"),
+        "last_error": getattr(coord, "heatpump_daily_consumption_last_error", None),
+    }
 
 
 def _title_case_status(value: object) -> str | None:
@@ -5109,6 +5168,14 @@ class EnphaseSiteEnergySensor(_SiteBaseEntity, RestoreSensor):
                     "daily_grid_wh",
                     "device_uid",
                     "device_name",
+                    "member_name",
+                    "member_device_type",
+                    "pairing_status",
+                    "device_state",
+                    "endpoint_type",
+                    "endpoint_timestamp",
+                    "day_key",
+                    "timezone",
                     "source",
                 ):
                     if key not in daily:
@@ -5116,6 +5183,12 @@ class EnphaseSiteEnergySensor(_SiteBaseEntity, RestoreSensor):
                     attr_key = {
                         "device_uid": "daily_device_uid",
                         "device_name": "daily_device_name",
+                        "member_name": "daily_member_name",
+                        "member_device_type": "daily_member_device_type",
+                        "pairing_status": "daily_pairing_status",
+                        "device_state": "daily_device_state",
+                        "endpoint_type": "daily_endpoint_type",
+                        "endpoint_timestamp": "daily_endpoint_timestamp",
                         "source": "daily_source",
                     }.get(key, key)
                     attrs[attr_key] = daily.get(key)
@@ -7009,27 +7082,22 @@ class EnphaseHeatPumpStatusSensor(_SiteBaseEntity):
     @property
     def extra_state_attributes(self):
         snapshot = self._snapshot()
-        last_reported = _heatpump_runtime_last_reported(snapshot)
         sg_ready_details = _heatpump_sg_ready_semantics(
             snapshot.get("sg_ready_mode_label") or snapshot.get("sg_ready_mode_raw")
         )
-        return {
-            "device_uid": snapshot.get("device_uid"),
-            "heatpump_status_raw": snapshot.get("heatpump_status"),
-            "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
-            "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
-            "sg_ready_active": snapshot.get("sg_ready_active"),
-            "sg_ready_contact_state": snapshot.get("sg_ready_contact_state"),
-            "vpp_sgready_mode_override": snapshot.get("vpp_sgready_mode_override"),
-            "last_report_at_utc": (
-                last_reported.isoformat() if last_reported is not None else None
-            ),
-            "source": snapshot.get("source"),
-            "last_error": getattr(
-                self._coord, "heatpump_runtime_state_last_error", None
-            ),
-            **sg_ready_details,
-        }
+        attrs = _heatpump_runtime_common_attrs(self._coord, snapshot)
+        attrs.update(
+            {
+                "heatpump_status_raw": snapshot.get("heatpump_status"),
+                "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
+                "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
+                "sg_ready_active": snapshot.get("sg_ready_active"),
+                "sg_ready_contact_state": snapshot.get("sg_ready_contact_state"),
+                "vpp_sgready_mode_override": snapshot.get("vpp_sgready_mode_override"),
+                **sg_ready_details,
+            }
+        )
+        return attrs
 
 
 class EnphaseHeatPumpConnectivityStatusSensor(_SiteBaseEntity):
@@ -7194,27 +7262,22 @@ class EnphaseHeatPumpSgReadyModeSensor(_SiteBaseEntity):
     @property
     def extra_state_attributes(self):
         snapshot = self._snapshot()
-        last_reported = _heatpump_runtime_last_reported(snapshot)
         details = _heatpump_sg_ready_semantics(
             snapshot.get("sg_ready_mode_label") or snapshot.get("sg_ready_mode_raw")
         )
-        return {
-            "device_uid": snapshot.get("device_uid"),
-            "heatpump_status_raw": snapshot.get("heatpump_status"),
-            "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
-            "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
-            "sg_ready_active": snapshot.get("sg_ready_active"),
-            "sg_ready_contact_state": snapshot.get("sg_ready_contact_state"),
-            "vpp_sgready_mode_override": snapshot.get("vpp_sgready_mode_override"),
-            "last_report_at_utc": (
-                last_reported.isoformat() if last_reported is not None else None
-            ),
-            "source": snapshot.get("source"),
-            "last_error": getattr(
-                self._coord, "heatpump_runtime_state_last_error", None
-            ),
-            **details,
-        }
+        attrs = _heatpump_runtime_common_attrs(self._coord, snapshot)
+        attrs.update(
+            {
+                "heatpump_status_raw": snapshot.get("heatpump_status"),
+                "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
+                "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
+                "sg_ready_active": snapshot.get("sg_ready_active"),
+                "sg_ready_contact_state": snapshot.get("sg_ready_contact_state"),
+                "vpp_sgready_mode_override": snapshot.get("vpp_sgready_mode_override"),
+                **details,
+            }
+        )
+        return attrs
 
 
 class EnphaseHeatPumpEnergyMeterSensor(_EnphaseHeatPumpDeviceTypeSensor):
@@ -7226,6 +7289,19 @@ class EnphaseHeatPumpEnergyMeterSensor(_EnphaseHeatPumpDeviceTypeSensor):
             key="heat_pump_energy_meter",
             name="Heat Pump Energy Meter Status",
             device_type="ENERGY_METER",
+        )
+
+
+class EnphaseHeatPumpSgReadyGatewaySensor(_EnphaseHeatPumpDeviceTypeSensor):
+    _attr_translation_key = "heat_pump_sg_ready_gateway"
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(self, coord: EnphaseCoordinator):
+        super().__init__(
+            coord,
+            key="heat_pump_sg_ready_gateway",
+            name="Heat Pump SG-Ready Gateway Status",
+            device_type="SG_READY_GATEWAY",
         )
 
 
@@ -7264,20 +7340,112 @@ class EnphaseHeatPumpLastReportedSensor(_SiteBaseEntity):
     @property
     def extra_state_attributes(self):
         snapshot = _heatpump_runtime_snapshot(self._coord)
-        last_reported = _heatpump_runtime_last_reported(snapshot)
-        return {
-            "device_uid": snapshot.get("device_uid"),
-            "heatpump_status_raw": snapshot.get("heatpump_status"),
-            "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
-            "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
-            "last_report_at_utc": (
-                last_reported.isoformat() if last_reported is not None else None
-            ),
-            "source": snapshot.get("source"),
-            "last_error": getattr(
-                self._coord, "heatpump_runtime_state_last_error", None
-            ),
-        }
+        attrs = _heatpump_runtime_common_attrs(self._coord, snapshot)
+        attrs.update(
+            {
+                "heatpump_status_raw": snapshot.get("heatpump_status"),
+                "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
+                "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
+            }
+        )
+        return attrs
+
+
+class _EnphaseHeatPumpDailyEnergySensor(_SiteBaseEntity):
+    _attr_device_class = SensorDeviceClass.ENERGY
+    _attr_native_unit_of_measurement = UnitOfEnergy.KILO_WATT_HOUR
+    _attr_state_class = SensorStateClass.TOTAL
+    _attr_suggested_display_precision = 3
+    _daily_key: str
+
+    def __init__(self, coord: EnphaseCoordinator, key: str, name: str) -> None:
+        super().__init__(coord, key, name, type_key="heatpump")
+
+    def _snapshot(self) -> dict[str, object]:
+        return _heatpump_daily_snapshot(self._coord)
+
+    @property
+    def available(self) -> bool:
+        if not super().available:
+            return False
+        snapshot = self._snapshot()
+        return snapshot.get(self._daily_key) is not None
+
+    @property
+    def native_value(self):
+        snapshot = self._snapshot()
+        value = snapshot.get(self._daily_key)
+        if value is None:
+            return None
+        try:
+            return round(float(value) / 1000.0, 3)
+        except Exception:  # noqa: BLE001
+            return None
+
+    @property
+    def extra_state_attributes(self):
+        snapshot = self._snapshot()
+        attrs = _heatpump_daily_common_attrs(self._coord, snapshot)
+        attrs["details"] = (
+            list(snapshot.get("details"))
+            if isinstance(snapshot.get("details"), list)
+            else []
+        )
+        attrs["daily_energy_wh"] = snapshot.get("daily_energy_wh")
+        attrs["daily_grid_wh"] = snapshot.get("daily_grid_wh")
+        attrs["daily_solar_wh"] = snapshot.get("daily_solar_wh")
+        attrs["daily_battery_wh"] = snapshot.get("daily_battery_wh")
+        return attrs
+
+
+class EnphaseHeatPumpDailyEnergySensor(_EnphaseHeatPumpDailyEnergySensor):
+    _attr_translation_key = "heat_pump_daily_energy"
+    _daily_key = "daily_energy_wh"
+
+    def __init__(self, coord: EnphaseCoordinator):
+        super().__init__(coord, "heat_pump_daily_energy", "Heat Pump Daily Energy")
+
+
+class EnphaseHeatPumpDailyGridEnergySensor(_EnphaseHeatPumpDailyEnergySensor):
+    _attr_translation_key = "heat_pump_daily_grid_energy"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+    _daily_key = "daily_grid_wh"
+
+    def __init__(self, coord: EnphaseCoordinator):
+        super().__init__(
+            coord,
+            "heat_pump_daily_grid_energy",
+            "Heat Pump Daily Grid Energy",
+        )
+
+
+class EnphaseHeatPumpDailySolarEnergySensor(_EnphaseHeatPumpDailyEnergySensor):
+    _attr_translation_key = "heat_pump_daily_solar_energy"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+    _daily_key = "daily_solar_wh"
+
+    def __init__(self, coord: EnphaseCoordinator):
+        super().__init__(
+            coord,
+            "heat_pump_daily_solar_energy",
+            "Heat Pump Daily Solar Energy",
+        )
+
+
+class EnphaseHeatPumpDailyBatteryEnergySensor(_EnphaseHeatPumpDailyEnergySensor):
+    _attr_translation_key = "heat_pump_daily_battery_energy"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+    _daily_key = "daily_battery_wh"
+
+    def __init__(self, coord: EnphaseCoordinator):
+        super().__init__(
+            coord,
+            "heat_pump_daily_battery_energy",
+            "Heat Pump Daily Battery Energy",
+        )
 
 
 class EnphaseHeatPumpPowerSensor(_SiteBaseEntity):
@@ -7307,6 +7475,8 @@ class EnphaseHeatPumpPowerSensor(_SiteBaseEntity):
 
     @property
     def extra_state_attributes(self):
+        runtime_snapshot = _heatpump_runtime_snapshot(self._coord)
+        daily_snapshot = _heatpump_daily_snapshot(self._coord)
         attrs: dict[str, object] = {
             "sampled_at_utc": (
                 self._coord.heatpump_power_sample_utc.isoformat()
@@ -7321,6 +7491,36 @@ class EnphaseHeatPumpPowerSensor(_SiteBaseEntity):
             "device_uid": self._coord.heatpump_power_device_uid,
             "source": self._coord.heatpump_power_source,
         }
+        attrs.update(
+            {
+                key: value
+                for key, value in _heatpump_runtime_common_attrs(
+                    self._coord, runtime_snapshot
+                ).items()
+                if key
+                not in {"device_uid", "source", "last_error", "last_report_at_utc"}
+            }
+        )
+        attrs.update(
+            {
+                key: value
+                for key, value in _heatpump_daily_common_attrs(
+                    self._coord, daily_snapshot
+                ).items()
+                if key
+                in {
+                    "device_name",
+                    "member_name",
+                    "member_device_type",
+                    "pairing_status",
+                    "device_state",
+                    "daily_endpoint_type",
+                    "daily_endpoint_timestamp",
+                    "day_key",
+                    "timezone",
+                }
+            }
+        )
         if self._coord.heatpump_power_last_error:
             attrs["last_error"] = self._coord.heatpump_power_last_error
         return attrs

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -932,11 +932,26 @@
       "heat_pump_energy_meter": {
         "name": "Heat Pump Energy Meter Status"
       },
+      "heat_pump_daily_energy": {
+        "name": "Heat Pump Daily Energy"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Heat Pump Daily Grid Energy"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Heat Pump Daily Solar Energy"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Heat Pump Daily Battery Energy"
+      },
       "heat_pump_last_reported": {
         "name": "Heat Pump Runtime Last Reported"
       },
       "heat_pump_power": {
         "name": "Heat Pump Power"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Heat Pump SG-Ready Gateway Status"
       },
       "site_evse_charging": {
         "name": "Site EVSE Charging",

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "SG-Ready Gateway на термопомпата"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Дневна енергия на термопомпата"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Дневна енергия от мрежата на термопомпата"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Дневна слънчева енергия на термопомпата"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Дневна енергия от батерията на термопомпата"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Състояние на SG-Ready шлюза на термопомпата"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "SG-Ready brána tepelného čerpadla"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Denní energie tepelného čerpadla"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Denní síťová energie tepelného čerpadla"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Denní solární energie tepelného čerpadla"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Denní bateriová energie tepelného čerpadla"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Stav brány SG-Ready tepelného čerpadla"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Varmepumpens SG-Ready-gateway"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Daglig energi for varmepumpe"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Daglig netenergi for varmepumpe"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Daglig solenergi for varmepumpe"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Daglig batterienergi for varmepumpe"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Status for SG-Ready-gateway til varmepumpe"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "SG-Ready-Gateway der Wärmepumpe"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Tägliche Energie der Wärmepumpe"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Tägliche Netzenergie der Wärmepumpe"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Tägliche Solarenergie der Wärmepumpe"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Tägliche Batterieenergie der Wärmepumpe"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Status des SG-Ready-Gateways der Wärmepumpe"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Πύλη SG-Ready αντλίας θερμότητας"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Ημερήσια ενέργεια αντλίας θερμότητας"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Ημερήσια ενέργεια δικτύου αντλίας θερμότητας"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Ημερήσια ηλιακή ενέργεια αντλίας θερμότητας"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Ημερήσια ενέργεια μπαταρίας αντλίας θερμότητας"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Κατάσταση πύλης SG-Ready αντλίας θερμότητας"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Heat Pump SG-Ready Mode"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Heat Pump Daily Energy"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Heat Pump Daily Grid Energy"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Heat Pump Daily Solar Energy"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Heat Pump Daily Battery Energy"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Heat Pump SG-Ready Gateway Status"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Heat Pump SG-Ready Mode"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Heat Pump Daily Energy"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Heat Pump Daily Grid Energy"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Heat Pump Daily Solar Energy"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Heat Pump Daily Battery Energy"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Heat Pump SG-Ready Gateway Status"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Heat Pump SG-Ready Mode"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Heat Pump Daily Energy"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Heat Pump Daily Grid Energy"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Heat Pump Daily Solar Energy"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Heat Pump Daily Battery Energy"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Heat Pump SG-Ready Gateway Status"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Heat Pump SG-Ready Mode"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Heat Pump Daily Energy"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Heat Pump Daily Grid Energy"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Heat Pump Daily Solar Energy"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Heat Pump Daily Battery Energy"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Heat Pump SG-Ready Gateway Status"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Heat Pump SG-Ready Mode"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Heat Pump Daily Energy"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Heat Pump Daily Grid Energy"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Heat Pump Daily Solar Energy"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Heat Pump Daily Battery Energy"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Heat Pump SG-Ready Gateway Status"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Heat Pump SG-Ready Mode"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Heat Pump Daily Energy"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Heat Pump Daily Grid Energy"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Heat Pump Daily Solar Energy"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Heat Pump Daily Battery Energy"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Heat Pump SG-Ready Gateway Status"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Gateway SG-Ready de la bomba de calor"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Energía diaria de la bomba de calor"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Energía diaria de red de la bomba de calor"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Energía solar diaria de la bomba de calor"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Energía diaria de batería de la bomba de calor"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Estado de la pasarela SG-Ready de la bomba de calor"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Soojuspumba SG-Ready lüüs"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Soojuspumba päevane energia"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Soojuspumba päevane võrgust saadud energia"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Soojuspumba päevane päikeseenergia"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Soojuspumba päevane akuenergia"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Soojuspumba SG-Ready lüüsi olek"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Lämpöpumpun SG-Ready-yhdyskäytävä"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Lämpöpumpun päivittäinen energia"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Lämpöpumpun päivittäinen verkkenergia"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Lämpöpumpun päivittäinen aurinkoenergia"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Lämpöpumpun päivittäinen akkuenergia"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Lämpöpumpun SG-Ready-yhdyskäytävän tila"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Mode SG-Ready de la pompe à chaleur"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Énergie quotidienne de la pompe à chaleur"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Énergie réseau quotidienne de la pompe à chaleur"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Énergie solaire quotidienne de la pompe à chaleur"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Énergie batterie quotidienne de la pompe à chaleur"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "État de la passerelle SG-Ready de la pompe à chaleur"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Hőszivattyú SG-Ready átjáró"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Hőszivattyú napi energia"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Hőszivattyú napi hálózati energia"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Hőszivattyú napi napenergia"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Hőszivattyú napi akkumulátor-energia"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Hőszivattyú SG-Ready átjáró állapota"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Gateway SG-Ready della pompa di calore"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Energia giornaliera della pompa di calore"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Energia giornaliera dalla rete della pompa di calore"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Energia solare giornaliera della pompa di calore"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Energia giornaliera della batteria della pompa di calore"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Stato del gateway SG-Ready della pompa di calore"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Šilumos siurblio SG-Ready šliuzas"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Šilumos siurblio dienos energija"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Šilumos siurblio dienos tinklo energija"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Šilumos siurblio dienos saulės energija"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Šilumos siurblio dienos akumuliatoriaus energija"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Šilumos siurblio SG-Ready šliuzo būsena"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Siltumsūkņa SG-Ready vārteja"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Siltumsūkņa dienas enerģija"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Siltumsūkņa dienas tīkla enerģija"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Siltumsūkņa dienas saules enerģija"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Siltumsūkņa dienas akumulatora enerģija"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Siltumsūkņa SG-Ready vārtejas statuss"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Varmepumpens SG-Ready-gateway"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Daglig energi for varmepumpe"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Daglig nettenergi for varmepumpe"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Daglig solenergi for varmepumpe"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Daglig batterienergi for varmepumpe"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Status for SG-Ready-gateway for varmepumpe"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "SG-Ready-gateway van de warmtepomp"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Dagelijkse energie van warmtepomp"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Dagelijkse netenergie van warmtepomp"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Dagelijkse zonne-energie van warmtepomp"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Dagelijkse batterij-energie van warmtepomp"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Status van SG-Ready-gateway van warmtepomp"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Bramka SG-Ready pompy ciepła"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Dzienna energia pompy ciepła"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Dzienna energia sieciowa pompy ciepła"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Dzienna energia słoneczna pompy ciepła"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Dzienna energia z baterii pompy ciepła"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Stan bramki SG-Ready pompy ciepła"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Gateway SG-Ready da bomba de calor"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Energia diária da bomba de calor"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Energia diária da rede da bomba de calor"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Energia solar diária da bomba de calor"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Energia diária da bateria da bomba de calor"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Status do gateway SG-Ready da bomba de calor"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Gateway SG-Ready al pompei de căldură"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Energia zilnică a pompei de căldură"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Energia zilnică din rețea a pompei de căldură"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Energia solară zilnică a pompei de căldură"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Energia zilnică din baterie a pompei de căldură"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Starea gateway-ului SG-Ready al pompei de căldură"
       }
     },
     "number": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -984,6 +984,21 @@
       },
       "heat_pump_sg_ready_mode": {
         "name": "Värmepumpens SG-Ready-gateway"
+      },
+      "heat_pump_daily_energy": {
+        "name": "Daglig energi för värmepump"
+      },
+      "heat_pump_daily_grid_energy": {
+        "name": "Daglig nätenergi för värmepump"
+      },
+      "heat_pump_daily_solar_energy": {
+        "name": "Daglig solenergi för värmepump"
+      },
+      "heat_pump_daily_battery_energy": {
+        "name": "Daglig batterienergi för värmepump"
+      },
+      "heat_pump_sg_ready_gateway": {
+        "name": "Status för SG-Ready-gateway för värmepump"
       }
     },
     "number": {

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -98,9 +98,9 @@ Example response (anonymized):
 | Grid eligibility | `GET` | `/app-api/<site_id>/grid_control_check.json` | `e-auth-token` + cookies | Yes |
 | Microinverter inventory | `GET` | `/app-api/<site_id>/inverters.json` | `e-auth-token` + cookies | Yes |
 | Battery status | `GET` | `/pv/settings/<site_id>/battery_status.json` | `e-auth-token` + cookies | Yes |
-| HEMS device inventory | `GET` | `https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/hems-devices` | Enlighten session cookies | No (documented for roadmap) |
-| HEMS heat-pump runtime state | `GET` | `https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/heatpump/<device_uid>/state?timezone=<iana_tz>` | Enlighten session cookies | No (documented from mobile app HAR) |
-| HEMS daily device energy consumption | `GET` | `https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/energy-consumption?from=<iso8601>&to=<iso8601>&timezone=<iana_tz>&step=<period>` | Enlighten session cookies | No (documented from mobile app HAR) |
+| HEMS device inventory | `GET` | `https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/hems-devices[?include-retired=true|refreshData=false]` | Authorization JWT (`Bearer` and bare-token variants observed); cookies optional in web capture | No (documented for roadmap) |
+| HEMS heat-pump runtime state | `GET` | `https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/heatpump/<device_uid>/state?timezone=<iana_tz>` | bearer JWT + Enlighten cookies (`username` and `requestId` also observed) | No (documented from mobile app HAR) |
+| HEMS daily device energy consumption | `GET` | `https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/energy-consumption?from=<iso8601>&to=<iso8601>&timezone=<iana_tz>&step=<period>` | bearer JWT + Enlighten cookies (`username` and `requestId` also observed) | No (documented from mobile app HAR) |
 | HEMS power timeseries | `GET` | `/systems/<site_id>/hems_power_timeseries[?device-uid=<device_uid>]` | `e-auth-token` + cookies | No (documented for roadmap) |
 | HEMS lifetime consumption | `GET` | `/systems/<site_id>/hems_consumption_lifetime` | `e-auth-token` + cookies | No (documented for roadmap) |
 | HEMS live stream toggle | `PUT` | `https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/live-stream/status` | Enlighten session cookies | No (monitoring stream only) |
@@ -2592,119 +2592,130 @@ Observed battery LED legend:
 
 ### 2.F HEMS (IQ Energy Router / Heat Pump Monitoring)
 
-The endpoints below are read-oriented HEMS/IQ Energy Router APIs observed in Enlighten web captures for sites with paired router + heat-pump accessories.
+The endpoints below are read-oriented HEMS/IQ Energy Router APIs observed in Enlighten web and mobile captures for sites with paired router + heat-pump accessories.
 
 ### 2.17 HEMS Device Inventory (Router + Heat Pump Stack)
 ```
 GET https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/hems-devices
+GET https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/hems-devices?include-retired=true
+GET https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/hems-devices?refreshData=false
 Headers:
   Accept: application/json
-  Cookie: ...; XSRF-TOKEN=<token>; ...
+  Authorization: <jwt> or Bearer <jwt>
+  Cookie: ...; XSRF-TOKEN=<token>; ...    # optional in web capture
   Origin: https://enlighten.enphaseenergy.com
+  username: <user_id>                     # observed in Bearer-token variant
+  requestId: <uuid>                       # observed in Bearer-token variant
 ```
 Returns grouped HEMS devices, including IQ Energy Router and connected heat-pump ecosystem devices.
 
 Example response shape (anonymized):
 ```json
 {
-  "status": "success",
-  "result": {
-    "devices": [
-      {
-        "gateway": [
-          {
-            "name": "IQ Energy Router_1",
-            "device-type": "IQ_ENERGY_ROUTER",
-            "device-uid": "<site_id>_IQ_ENERGY_ROUTER_1",
-            "uid": "ROUTER-UID-001",
-            "make": "RouterVendor",
-            "model": "RouterModel",
-            "status": "normal",
-            "statusText": "Normal",
-            "pairing-status": "PAIRED",
-            "last-report": "2026-02-01T10:00:00Z",
-            "hems-device-id": "hd_router_001",
-            "hems-device-facet-id": "hf_router_001",
-            "iqer-uid": "iqer_uid_001",
-            "created-at": "2026-02-01T10:00:00Z",
-            "ip-address": "192.0.2.11"
-          },
-          {
-            "name": "IQ Gateway_1",
-            "device-type": "IQ_GATEWAY",
-            "device-uid": "<site_id>_IQ_GATEWAY_1",
-            "uid": "GW-UID-001",
-            "make": "Enphase",
-            "model": "Envoy-S Metered",
-            "status": "normal",
-            "statusText": "Normal",
-            "pairing-status": "PAIRED",
-            "last-report": "2026-02-01T10:00:01Z",
-            "created-at": "2026-02-01T09:59:58Z",
-            "hems-device-id": "hd_gateway_001",
-            "hems-device-facet-id": "hf_gateway_001",
-            "iqer-uid": "iqer_uid_001"
-          }
-        ],
-        "heat-pump": [
-          {
-            "name": "SG Ready Gateway_1",
-            "device-type": "SG_READY_GATEWAY",
-            "device-uid": "<site_id>_SG_READY_GATEWAY_1",
-            "uid": "SGR-UID-001",
-            "make": "GatewayVendor",
-            "model": "GatewayModel",
-            "status": "normal",
-            "statusText": "Normal",
-            "pairing-status": "PAIRED",
-            "last-report": "2026-02-01T10:00:02Z",
-            "created-at": "2026-02-01T09:58:58Z",
-            "hems-device-id": "hd_sgready_001",
-            "hems-device-facet-id": "hf_sgready_001",
-            "iqer-uid": "iqer_uid_001"
-          },
-          {
-            "name": "Energy Meter_1",
-            "device-type": "ENERGY_METER",
-            "device-uid": "<site_id>_ENERGY_METER_1",
-            "uid": "METER-UID-001",
-            "make": "MeterVendor",
-            "model": "MeterModel",
-            "firmware-version": "X.Y.Z",
-            "status": "normal",
-            "statusText": "Normal",
-            "pairing-status": "PAIRED",
-            "last-report": "2026-02-01T10:00:03Z",
-            "created-at": "2026-02-01T09:58:59Z",
-            "hems-device-id": "hd_meter_001",
-            "hems-device-facet-id": "hf_meter_001",
-            "iqer-uid": "iqer_uid_001"
-          },
-          {
-            "name": "Waermepumpe",
-            "device-type": "HEAT_PUMP",
-            "device-uid": "<site_id>_HEAT_PUMP_1",
-            "make": "HeatPumpVendor",
-            "model": "HeatPumpModel",
-            "status": "normal",
-            "statusText": "Normal",
-            "pairing-status": "PAIRED",
-            "created-at": "2026-02-01T09:59:00.000000000Z",
-            "fvt-time": "2026-02-01T10:00:00.000Z",
-            "iqer-uid": "iqer_uid_001"
-          }
-        ],
-        "evse": [],
-        "water-heater": []
-      }
-    ]
+  "type": "hems-device-details",
+  "timestamp": "2026-03-28T05:17:58.156910991Z",
+  "data": {
+    "hems-devices": {
+      "gateway": [
+        {
+          "name": "IQ Energy Router_1",
+          "device-type": "IQ_ENERGY_ROUTER",
+          "make": "Hive",
+          "model": "Nano Hub 2",
+          "uid": "ROUTER-UID-001",
+          "status": "normal",
+          "statusText": "Normal",
+          "created-at": "2025-08-11T08:11:08Z",
+          "last-report": "2026-03-28T05:16:57Z",
+          "hems-device-id": "hd_router_001",
+          "hems-device-facet-id": "hf_router_001",
+          "pairing-status": "PAIRED",
+          "device-uid": "<site_id>_IQ_ENERGY_ROUTER_1",
+          "device-state": "ACTIVE",
+          "iqer-uid": "<site_id>_IQ_ENERGY_ROUTER_1",
+          "ip-address": "192.0.2.11"
+        },
+        {
+          "name": "IQ Gateway_1",
+          "device-type": "IQ_GATEWAY",
+          "make": "Enphase",
+          "model": "Envoy-S Metered",
+          "uid": "GW-UID-001",
+          "status": "normal",
+          "statusText": "Normal",
+          "created-at": "2025-08-11T09:02:58Z",
+          "last-report": "2025-08-11T09:02:58Z",
+          "hems-device-id": "hd_gateway_001",
+          "hems-device-facet-id": "hf_gateway_001",
+          "pairing-status": "PAIRED",
+          "device-uid": "<site_id>_IQ_GATEWAY_1",
+          "iqer-uid": "<site_id>_IQ_ENERGY_ROUTER_1"
+        }
+      ],
+      "heat-pump": [
+        {
+          "name": "SG Ready Gateway_1",
+          "device-type": "SG_READY_GATEWAY",
+          "make": "Gude",
+          "model": "Expert Net Control 2302",
+          "uid": "SGR-UID-001",
+          "status": "normal",
+          "statusText": "Normal",
+          "created-at": "2025-08-11T09:33:28Z",
+          "last-report": "2026-03-28T05:16:55Z",
+          "hems-device-id": "hd_sgready_001",
+          "hems-device-facet-id": "hf_sgready_001",
+          "pairing-status": "PAIRED",
+          "device-uid": "<site_id>_SG_READY_GATEWAY_1",
+          "iqer-uid": "<site_id>_IQ_ENERGY_ROUTER_1"
+        },
+        {
+          "name": "Energy Meter_1",
+          "device-type": "ENERGY_METER",
+          "make": "Bcontrol",
+          "model": "Energy Manager 420",
+          "firmware-version": "3.3",
+          "uid": "METER-UID-001",
+          "status": "normal",
+          "statusText": "Normal",
+          "created-at": "2025-10-21T10:37:57Z",
+          "last-report": "2026-03-28T05:16:55Z",
+          "hems-device-id": "hd_meter_001",
+          "hems-device-facet-id": "hf_meter_001",
+          "pairing-status": "PAIRED",
+          "device-uid": "<site_id>_ENERGY_METER_1",
+          "iqer-uid": "<site_id>_IQ_ENERGY_ROUTER_1"
+        },
+        {
+          "name": "Waermepumpe",
+          "device-type": "HEAT_PUMP",
+          "make": "Ochsner",
+          "model": "Europa Mini WP",
+          "status": "normal",
+          "statusText": "Normal",
+          "created-at": "2025-10-21T10:38:35.641298069Z",
+          "hems-device-facet-id": "hf_heatpump_001",
+          "pairing-status": "PAIRED",
+          "device-uid": "<site_id>_HEAT_PUMP_1",
+          "iqer-uid": "<site_id>_IQ_ENERGY_ROUTER_1",
+          "fvt-time": "2025-10-21T12:45:52.110Z"
+        }
+      ],
+      "evse": [],
+      "water-heater": []
+    }
   }
 }
 ```
 Observed structure:
+- The top-level inventory envelope in the supplied captures was `type` + `timestamp` + `data["hems-devices"]`; an older `status/result/devices` example should not be assumed.
 - Device grouping is hierarchical (`gateway`, `heat-pump`, `evse`, `water-heater`) rather than the flat `type/devices` shape used by `/app-api/<site_id>/devices.json`.
+- Query variants observed so far are `include-retired=true` and `refreshData=false`; both returned the same `hems-device-details` payload shape.
+- Authorization varied by caller: one web capture succeeded with a bare JWT in the `Authorization` header and no cookies, while another used `Authorization: Bearer <jwt>` together with cookies, `username`, and `requestId`.
 - `device-uid` is a stable HEMS identifier reused across timeseries filters and related detail requests.
 - `created-at`, `last-report`, and `fvt-time` were observed as ISO-8601 strings in this capture, not epoch seconds.
+- `status` / `statusText` were observed as `normal` / `Normal` for all listed devices in these captures; `pairing-status` was `PAIRED`.
+- `device-state` was present on the IQ Energy Router and was observed as `ACTIVE`.
 - Router/gateway members may expose network-local metadata such as `ip-address`; redact concrete LAN addresses when documenting captures.
 - For the captured site, device types present were `IQ_ENERGY_ROUTER`, `IQ_GATEWAY`, `SG_READY_GATEWAY`, `ENERGY_METER`, and `HEAT_PUMP`.
 
@@ -2713,8 +2724,11 @@ Observed structure:
 GET https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/heatpump/<device_uid>/state?timezone=<iana_tz>
 Headers:
   Accept: application/json
+  Authorization: Bearer <jwt>
   Cookie: ...; XSRF-TOKEN=<token>; ...
   Origin: https://enlighten.enphaseenergy.com
+  username: <user_id>
+  requestId: <uuid>
 ```
 Returns app-facing runtime state for a single heat-pump device UID.
 
@@ -2754,6 +2768,7 @@ Observed structure:
 - `sg-ready-mode` and `vpp-sgready-mode-override` appear alongside runtime state and may explain SG Ready behavior independently of health/status reporting.
 - `sg-ready-mode` was observed as `MODE_2` when the app/event history described the heat pump as being in normal mode, and as `MODE_3` when it was heating with recommended-consumption / SG Ready on.
 - `vpp-sgready-mode-override` remained `NONE` in both idle and running captures; other values are still undocumented.
+- Mobile captures also included `username` and `requestId` headers; `timezone` was observed as an IANA name (`Europe/Berlin`).
 - `last-report-at` is an ISO-8601 timestamp and is more precise than the sparse `fvt-time`/`last-report` fields seen on some inventory members.
 
 Inference:
@@ -2764,8 +2779,11 @@ Inference:
 GET https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/energy-consumption?from=<iso8601>&to=<iso8601>&timezone=<iana_tz>&step=P1D
 Headers:
   Accept: application/json
+  Authorization: Bearer <jwt>
   Cookie: ...; XSRF-TOKEN=<token>; ...
   Origin: https://enlighten.enphaseenergy.com
+  username: <user_id>
+  requestId: <uuid>
 ```
 Returns per-device daily energy-consumption buckets for HEMS-managed loads.
 
@@ -2799,7 +2817,9 @@ Observed structure:
 - `type` was `hems-device-details` in the captured responses.
 - Results are grouped by HEMS family (`heat-pump`, `evse`, `water-heater`).
 - The `consumption[]` item exposes source-split totals (`solar`, `battery`, `grid`) plus a `details[]` numeric array.
+- The supplied March 28 capture returned `solar=0`, `battery=0`, `grid=0`, and `details=[987]`; earlier captures used decimal-looking values (`47.0`, `201.0`, `211.0`, `220.0`, `230.0`), so clients should treat these as generic numbers rather than fixed-format floats.
 - In active-heating captures the `details[]` value increased across polls (`201.0`, `211.0`, `220.0`, `230.0`) while `/heatpump/<device_uid>/state` reported `heatpump-status: RUNNING`.
+- Mobile captures also included `username` and `requestId` headers; `step` was observed as `P1D`.
 
 Inference:
 - In the "not running" capture, `details: [47.0]` was still present even though the runtime endpoint reported `heatpump-status: IDLE`, so this endpoint should be treated as daily aggregate consumption, not instantaneous on/off state.
@@ -4173,14 +4193,16 @@ Some sites issue a JWT-like access token via `https://entrez.enphaseenergy.com/a
 | `devices.iqEvse.useBatteryFrSelfConsumption` | Indicates IQ EV charger battery participation support in self-consumption mode; observed value so far: `true` |
 | `device-uid` | Stable HEMS device identifier |
 | `device-type` (HEMS) | HEMS device taxonomy values seen in captures: `IQ_ENERGY_ROUTER`, `IQ_GATEWAY`, `SG_READY_GATEWAY`, `ENERGY_METER`, `HEAT_PUMP` |
+| `status` / `statusText` (HEMS) | HEMS device health code + display label; observed pair so far: `normal` / `Normal` |
 | `pairing-status` (HEMS) | Pairing state label (for example `PAIRED`) for router-attached ecosystem devices |
+| `device-state` (HEMS) | Additional router lifecycle label from `hems-devices`; observed value so far: `ACTIVE` |
 | `hems-device-id` / `hems-device-facet-id` | HEMS backend identifiers present on router/heat-pump stack members in `hems-devices` payloads |
 | `ip` / `ip-address` | Device LAN address fields seen on gateway/router inventory payloads; treat as sensitive in examples |
 | `ap_mode` | Boolean flag on gateway inventory entries indicating the IQ Gateway access-point mode was enabled |
 | `supportsEntrez` | Boolean capability flag observed on gateway inventory entries |
 | `heatpump-status` | App-facing heat-pump runtime state from `/heatpump/<device_uid>/state`; observed values: `IDLE`, `RUNNING` |
 | `sg-ready-mode` | SG Ready operating mode label from `/heatpump/<device_uid>/state`; observed values: `MODE_2` (normal), `MODE_3` (recommended consumption / SG Ready on) |
-| `vpp-sgready-mode-override` | SG Ready override label from `/heatpump/<device_uid>/state`; observed off-state value: `NONE` |
+| `vpp-sgready-mode-override` | SG Ready override label from `/heatpump/<device_uid>/state`; observed value so far: `NONE` |
 | `last-report-at` | ISO-8601 last telemetry timestamp from `/heatpump/<device_uid>/state` |
 
 ---

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3510,8 +3510,9 @@ async def test_hems_consumption_lifetime_uses_control_headers() -> None:
 @pytest.mark.asyncio
 async def test_hems_heatpump_state_normalization_and_headers() -> None:
     client = _make_client()
+    cookie_token = _make_token({"user_id": "user-123"})
     client.update_credentials(
-        cookie="enlighten_manager_token_production=BEAR; XSRF-TOKEN=xsrf",
+        cookie=f"enlighten_manager_token_production={cookie_token}; XSRF-TOKEN=xsrf",
         eauth="EAUTH",
     )
     client._json = AsyncMock(
@@ -3533,6 +3534,8 @@ async def test_hems_heatpump_state_normalization_and_headers() -> None:
     assert payload == {
         "type": "hems-heatpump-details",
         "timestamp": "2026-03-20T08:19:17.945447902Z",
+        "endpoint_type": "hems-heatpump-details",
+        "endpoint_timestamp": "2026-03-20T08:19:17.945447902Z",
         "device_uid": "HP-1",
         "heatpump_status": "RUNNING",
         "sg_ready_mode_raw": "MODE_3",
@@ -3550,9 +3553,11 @@ async def test_hems_heatpump_state_normalization_and_headers() -> None:
     )
     assert callable(kwargs["headers"])
     headers = kwargs["headers"]()
-    assert headers["Authorization"] == "Bearer BEAR"
+    assert headers["Authorization"] == f"Bearer {cookie_token}"
     assert headers["e-auth-token"] == "EAUTH"
     assert headers["X-CSRF-Token"] == "xsrf"
+    assert headers["username"] == "user-123"
+    assert headers["requestId"]
 
 
 def test_hems_heatpump_state_normalizers_cover_edge_cases() -> None:
@@ -3590,6 +3595,8 @@ def test_hems_heatpump_state_normalizers_cover_edge_cases() -> None:
     ) == {
         "type": "hems-heatpump-details",
         "timestamp": None,
+        "endpoint_type": "hems-heatpump-details",
+        "endpoint_timestamp": None,
         "device_uid": "HP-2",
         "heatpump_status": "IDLE",
         "sg_ready_mode_raw": "MODE_2",
@@ -3714,6 +3721,8 @@ def test_hems_energy_consumption_normalizers_cover_edge_cases() -> None:
     ) == {
         "type": "hems-device-details",
         "timestamp": "2026-03-20T07:53:00.739143826Z",
+        "endpoint_type": "hems-device-details",
+        "endpoint_timestamp": "2026-03-20T07:53:00.739143826Z",
         "data": {
             "heat-pump": [
                 {
@@ -3791,6 +3800,8 @@ async def test_hems_energy_consumption_normalization_and_query() -> None:
     assert payload == {
         "type": "hems-device-details",
         "timestamp": "2026-03-20T07:53:00.739143826Z",
+        "endpoint_type": "hems-device-details",
+        "endpoint_timestamp": "2026-03-20T07:53:00.739143826Z",
         "data": {
             "heat-pump": [
                 {
@@ -3823,12 +3834,17 @@ async def test_hems_energy_consumption_normalization_and_query() -> None:
             ],
         },
     }
-    args, _kwargs = client._json.await_args
+    args, kwargs = client._json.await_args
     assert args[0] == "GET"
     assert "from=2026-03-20T00:00:00%2B01:00" in args[1]
     assert "to=2026-03-21T00:00:00%2B01:00" in args[1]
     assert "timezone=Europe/Berlin" in args[1]
     assert "step=P1D" in args[1]
+    assert callable(kwargs["headers"])
+    headers = kwargs["headers"]()
+    assert headers["Authorization"] == "Bearer EAUTH"
+    assert headers["e-auth-token"] == "EAUTH"
+    assert headers["requestId"]
 
 
 @pytest.mark.asyncio
@@ -3919,8 +3935,9 @@ async def test_hems_energy_consumption_optional_and_reraise_variants() -> None:
 @pytest.mark.asyncio
 async def test_hems_devices_uses_dedicated_endpoint_and_headers() -> None:
     client = _make_client()
+    cookie_token = _make_token({"user_id": "user-123"})
     client.update_credentials(
-        cookie="enlighten_manager_token_production=BEAR; XSRF-TOKEN=xsrf",
+        cookie=f"enlighten_manager_token_production={cookie_token}; XSRF-TOKEN=xsrf",
         eauth="EAUTH",
     )
     client._json = AsyncMock(return_value={"data": {"hems-devices": {}}})
@@ -3934,9 +3951,11 @@ async def test_hems_devices_uses_dedicated_endpoint_and_headers() -> None:
     assert args[1].endswith("/api/v1/hems/SITE/hems-devices?refreshData=false")
     assert callable(kwargs["headers"])
     headers = kwargs["headers"]()
-    assert headers["Authorization"] == "Bearer BEAR"
+    assert headers["Authorization"] == f"Bearer {cookie_token}"
     assert headers["e-auth-token"] == "EAUTH"
     assert headers["X-CSRF-Token"] == "xsrf"
+    assert headers["username"] == "user-123"
+    assert headers["requestId"]
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -15,7 +15,12 @@ from custom_components.enphase_ev.parsing_helpers import (
     coerce_optional_bool,
     coerce_optional_float,
     coerce_optional_text,
+    heatpump_device_state,
+    heatpump_lifecycle_status_text,
     heatpump_member_device_type,
+    heatpump_operational_status_text,
+    heatpump_pairing_status,
+    heatpump_status_bucket,
     heatpump_status_text,
     parse_inverter_last_report,
     type_member_text,
@@ -139,8 +144,8 @@ async def test_coordinator_heatpump_runtime_wrapper_delegation(
     runtime._heatpump_primary_device_uid.return_value = "HP-1"
     runtime._heatpump_runtime_device_uid.return_value = "HP-RUNTIME"
     runtime._heatpump_daily_window.return_value = (
-        "2026-03-27T00:00:00+00:00",
-        "2026-03-28T00:00:00+00:00",
+        "2026-03-27T00:00:00.000Z",
+        "2026-03-27T23:59:59.999Z",
         "UTC",
         ("2026-03-27", "UTC"),
     )
@@ -160,7 +165,13 @@ async def test_coordinator_heatpump_runtime_wrapper_delegation(
     runtime.async_refresh_heatpump_runtime_state = AsyncMock()
     runtime.async_refresh_heatpump_daily_consumption = AsyncMock()
     runtime.async_refresh_heatpump_power = AsyncMock()
-    runtime.heatpump_runtime_diagnostics.return_value = {"runtime_state": {}}
+    runtime.heatpump_runtime_diagnostics.return_value = {
+        "runtime_state": {},
+        "event_summary": {
+            "known_event_counts": {},
+            "unknown_event_keys": [],
+        },
+    }
     runtime.heatpump_runtime_state = {"device_uid": "HP-1"}
     runtime.heatpump_runtime_state_last_error = "runtime boom"
     runtime.heatpump_daily_consumption = {"daily_energy_wh": 123.0}
@@ -177,8 +188,8 @@ async def test_coordinator_heatpump_runtime_wrapper_delegation(
     assert coord._heatpump_primary_device_uid() == "HP-1"  # noqa: SLF001
     assert coord._heatpump_runtime_device_uid() == "HP-RUNTIME"  # noqa: SLF001
     assert coord._heatpump_daily_window() == (  # noqa: SLF001
-        "2026-03-27T00:00:00+00:00",
-        "2026-03-28T00:00:00+00:00",
+        "2026-03-27T00:00:00.000Z",
+        "2026-03-27T23:59:59.999Z",
         "UTC",
         ("2026-03-27", "UTC"),
     )
@@ -227,7 +238,11 @@ async def test_coordinator_heatpump_runtime_wrapper_delegation(
     await coord._async_refresh_heatpump_daily_consumption(force=True)  # noqa: SLF001
     await coord._async_refresh_heatpump_power(force=True)  # noqa: SLF001
 
-    assert coord.heatpump_runtime_diagnostics() == {"runtime_state": {}}
+    assert coord.heatpump_runtime_diagnostics()["runtime_state"] == {}
+    assert coord.heatpump_runtime_diagnostics()["event_summary"] == {
+        "known_event_counts": {},
+        "unknown_event_keys": [],
+    }
     assert coord.heatpump_runtime_state == {"device_uid": "HP-1"}
     assert coord.heatpump_runtime_state_last_error == "runtime boom"
     assert coord.heatpump_daily_consumption == {"daily_energy_wh": 123.0}
@@ -530,6 +545,10 @@ async def test_heatpump_runtime_diagnostics_and_refresh_edge_branches(
     assert diagnostics["show_livestream_payload"] == {"live": True}
     assert diagnostics["events_payloads"][0]["payload"] == {"value": "scalar"}
     assert diagnostics["events_payloads"][1]["payload"] == ["list-payload"]
+    assert diagnostics["event_summary"] == {
+        "known_event_counts": {},
+        "unknown_event_keys": [],
+    }
 
     runtime._heatpump_runtime_diagnostics_cache_until = None  # noqa: SLF001
     coord.client.show_livestream = AsyncMock(return_value=None)
@@ -674,8 +693,25 @@ def test_heatpump_runtime_recommended_parent_matching(coordinator_factory) -> No
     )
     assert heatpump_member_device_type({"device-type": "iq_er"}) == "IQ_ER"
     assert heatpump_member_device_type({"device_type": BadString()}) is None
+    assert heatpump_pairing_status(None) is None
+    assert heatpump_device_state(None) is None
+    assert heatpump_device_state({"device-state": "inactive"}) == "INACTIVE"
+    assert parsing_helpers_mod._friendly_heatpump_status(None) is None  # noqa: SLF001
+    assert heatpump_lifecycle_status_text(None) is None
+    assert heatpump_operational_status_text(None) is None
+    assert heatpump_status_bucket("") == "unknown"
+    assert heatpump_status_bucket("unpaired") == "not_reporting"
+    assert heatpump_status_bucket("pending") == "warning"
     assert heatpump_status_text({"statusText": "Running"}) == "Running"
     assert heatpump_status_text({"status": "not_reporting"}) == "Not Reporting"
+    assert (
+        heatpump_status_text({"statusText": "Fault", "pairing-status": "UNPAIRED"})
+        == "Fault"
+    )
+    assert (
+        heatpump_status_text({"statusText": "Normal", "device-state": "INACTIVE"})
+        == "Inactive"
+    )
     assert heatpump_status_text({"status": BadString()}) is None
     assert HeatpumpRuntime._sum_optional_values("bad") is None
     assert HeatpumpRuntime._sum_optional_values([1.0, float("inf"), 2.0]) == 3.0
@@ -694,6 +730,7 @@ def test_heatpump_runtime_type_helpers_cover_guard_paths(coordinator_factory) ->
     }
 
     assert runtime.has_type(None) is False
+    assert runtime._heatpump_runtime_member() is None  # noqa: SLF001
     assert runtime.has_type("heatpump") is False
     assert runtime._type_bucket_members(None) == []  # noqa: SLF001
     assert runtime._type_bucket_members("heatpump") == []  # noqa: SLF001
@@ -796,6 +833,9 @@ async def test_refresh_heatpump_runtime_state_uses_dedicated_heatpump_uid(
                     {
                         "device_type": "HEAT_PUMP",
                         "device_uid": "HP-1",
+                        "name": "Primary Heat Pump",
+                        "pairing_status": "PAIRED",
+                        "device_state": "ACTIVE",
                     },
                 ],
             }
@@ -821,6 +861,10 @@ async def test_refresh_heatpump_runtime_state_uses_dedicated_heatpump_uid(
     coord.client.hems_heatpump_state.assert_awaited_once()
     assert coord.client.hems_heatpump_state.await_args.kwargs["device_uid"] == "HP-1"
     assert coord.heatpump_runtime_state["device_uid"] == "HP-1"
+    assert coord.heatpump_runtime_state["member_name"] == "Primary Heat Pump"
+    assert coord.heatpump_runtime_state["member_device_type"] == "HEAT_PUMP"
+    assert coord.heatpump_runtime_state["pairing_status"] == "PAIRED"
+    assert coord.heatpump_runtime_state["device_state"] == "ACTIVE"
     assert coord.heatpump_runtime_state["source"] == "hems_heatpump_state:HP-1"
 
 
@@ -836,7 +880,15 @@ async def test_refresh_heatpump_runtime_state_covers_cache_and_error_paths(
             "heatpump": {
                 "type_key": "heatpump",
                 "count": 1,
-                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+                "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-1",
+                        "name": "Primary Heat Pump",
+                        "pairing_status": "PAIRED",
+                        "device_state": "ACTIVE",
+                    }
+                ],
             }
         },
         ["heatpump"],
@@ -959,11 +1011,26 @@ async def test_refresh_heatpump_daily_consumption_tracks_site_day(
     kwargs = coord.client.hems_energy_consumption.await_args.kwargs
     assert kwargs["timezone"] == "Europe/Berlin"
     assert kwargs["step"] == "P1D"
-    assert kwargs["start_at"].startswith("2026-03-20T00:00:00")
-    assert kwargs["end_at"].startswith("2026-03-21T00:00:00")
+    assert kwargs["start_at"] == "2026-03-19T23:00:00.000Z"
+    assert kwargs["end_at"] == "2026-03-20T22:59:59.999Z"
     assert coord.heatpump_daily_consumption["daily_energy_wh"] == pytest.approx(230.0)
     assert coord.heatpump_daily_consumption["daily_grid_wh"] == pytest.approx(200.0)
     assert coord.heatpump_daily_consumption["source"] == "hems_energy_consumption:HP-1"
+
+
+def test_heatpump_daily_window_handles_dst_transition_day(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._site_timezone_name = lambda: "Europe/Berlin"  # type: ignore[assignment]  # noqa: SLF001
+    coord._site_local_current_date = lambda: "2026-03-29"  # type: ignore[assignment]  # noqa: SLF001
+
+    assert coord.heatpump_runtime._heatpump_daily_window() == (  # noqa: SLF001
+        "2026-03-28T23:00:00.000Z",
+        "2026-03-29T21:59:59.999Z",
+        "Europe/Berlin",
+        ("2026-03-29", "Europe/Berlin"),
+    )
 
 
 def test_heatpump_daily_helper_and_property_edge_cases(
@@ -1066,6 +1133,10 @@ def test_heatpump_daily_helper_and_property_edge_cases(
     assert snapshot == {
         "device_uid": "HP-2",
         "device_name": "Backup",
+        "member_name": None,
+        "member_device_type": "ENERGY_METER",
+        "pairing_status": None,
+        "device_state": None,
         "daily_energy_wh": pytest.approx(4.0),
         "daily_solar_wh": pytest.approx(1.0),
         "daily_battery_wh": pytest.approx(2.0),
@@ -1081,6 +1152,40 @@ def test_heatpump_daily_helper_and_property_edge_cases(
         )
         is None
     )
+
+
+def test_heatpump_event_summary_classifies_known_event_keys(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord.heatpump_runtime._heatpump_events_payloads = [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "payload": [
+                {"event_key": "hems_sgready_mode_changed_to_3"},
+                {"eventKey": "hems_energy_meter_offline"},
+                {"event_key": "custom_unknown_event"},
+            ],
+        }
+    ]
+
+    assert coord.heatpump_runtime._heatpump_event_summary() == {  # noqa: SLF001
+        "known_event_counts": {
+            "sg_ready_recommended": 1,
+            "energy_meter_offline": 1,
+        },
+        "unknown_event_keys": ["custom_unknown_event"],
+    }
+    assert coord.heatpump_runtime._hems_event_entries(  # noqa: SLF001
+        {"items": [{"event_key": "hems_sgready_mode_changed_to_2"}, "skip-me"]}
+    ) == [{"event_key": "hems_sgready_mode_changed_to_2"}]
+    coord.heatpump_runtime._heatpump_events_payloads = [  # noqa: SLF001
+        {"payload": {"events": [{"event_key": None}, {"eventKey": ""}]}}
+    ]
+    assert coord.heatpump_runtime._heatpump_event_summary() == {  # noqa: SLF001
+        "known_event_counts": {},
+        "unknown_event_keys": [],
+    }
     assert (
         coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
             {"data": {"heat-pump": ["skip-me"]}}
@@ -1435,11 +1540,19 @@ async def test_heatpump_runtime_power_and_diagnostics_paths(
         "optional boom",
         "optional boom",
     ]
+    assert diagnostics["event_summary"] == {
+        "known_event_counts": {},
+        "unknown_event_keys": [],
+    }
 
     runtime._type_device_buckets = {}  # noqa: SLF001
     runtime._type_device_order = []  # noqa: SLF001
     await runtime.async_ensure_heatpump_runtime_diagnostics(force=True)
     assert coord.heatpump_runtime_diagnostics()["events_payloads"] == []
+    assert coord.heatpump_runtime_diagnostics()["event_summary"] == {
+        "known_event_counts": {},
+        "unknown_event_keys": [],
+    }
     assert coord.heatpump_daily_consumption_last_error is None
 
     coord._set_type_device_buckets(

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -55,6 +55,10 @@ def test_inventory_runtime_helper_paths(coordinator_factory) -> None:
         {"index": {}},
     )
     assert runtime._coerce_optional_bool("true") is True  # noqa: SLF001
+    assert (
+        runtime._normalize_inverter_status("unpaired") == "not_reporting"
+    )  # noqa: SLF001
+    assert runtime._normalize_inverter_status("pending") == "warning"  # noqa: SLF001
 
     router_records = runtime._gateway_iq_energy_router_summary_records(  # noqa: SLF001
         [{"name": "Router"}, {"name": "Router"}]
@@ -1178,6 +1182,44 @@ def test_inventory_runtime_merge_heatpump_bucket_uses_worst_status_fallback(
     assert bucket["firmware_summary"] == "1.2.3 x1"
     assert runtime._devices_inventory_ready is False  # noqa: SLF001
     assert refresh_calls == ["refresh"]
+
+
+def test_merge_heatpump_type_bucket_preserves_fault_over_lifecycle_state(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    runtime._hems_devices_payload = {  # noqa: SLF001
+        "data": {
+            "hems-devices": {
+                "heat-pump": [
+                    {
+                        "device-type": "HEAT_PUMP",
+                        "device-uid": "HP-1",
+                        "name": "Primary Heat Pump",
+                        "statusText": "Fault",
+                        "pairing-status": "UNPAIRED",
+                        "device-state": "INACTIVE",
+                    }
+                ]
+            }
+        }
+    }
+
+    runtime._merge_heatpump_type_bucket()  # noqa: SLF001
+
+    bucket = coord.type_bucket("heatpump")
+    assert bucket is not None
+    assert bucket["overall_status_text"] == "Fault"
+    assert bucket["status_counts"] == {
+        "total": 1,
+        "normal": 0,
+        "warning": 0,
+        "error": 1,
+        "not_reporting": 0,
+        "unknown": 0,
+    }
+    assert bucket["latest_reported_device"] is None
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -4741,6 +4741,14 @@ def test_site_heat_pump_energy_sensor_uses_heatpump_device_info(
         "daily_grid_wh": 200.0,
         "device_uid": "HP-1",
         "device_name": "Heat Pump",
+        "member_name": "Primary Heat Pump",
+        "member_device_type": "HEAT_PUMP",
+        "pairing_status": "PAIRED",
+        "device_state": "ACTIVE",
+        "endpoint_type": "hems-device-details",
+        "endpoint_timestamp": "2026-03-20T07:53:00.739143826Z",
+        "day_key": "2026-03-20",
+        "timezone": "Europe/Berlin",
         "source": "hems_energy_consumption:HP-1",
     }
     coord.energy.site_energy = {
@@ -4767,7 +4775,109 @@ def test_site_heat_pump_energy_sensor_uses_heatpump_device_info(
     assert attrs["daily_grid_wh"] == pytest.approx(200.0)
     assert attrs["daily_device_uid"] == "HP-1"
     assert attrs["daily_device_name"] == "Heat Pump"
+    assert attrs["daily_member_name"] == "Primary Heat Pump"
+    assert attrs["daily_member_device_type"] == "HEAT_PUMP"
+    assert attrs["daily_pairing_status"] == "PAIRED"
+    assert attrs["daily_device_state"] == "ACTIVE"
+    assert attrs["daily_endpoint_type"] == "hems-device-details"
+    assert attrs["daily_endpoint_timestamp"] == "2026-03-20T07:53:00.739143826Z"
+    assert attrs["day_key"] == "2026-03-20"
+    assert attrs["timezone"] == "Europe/Berlin"
     assert attrs["daily_source"] == "hems_energy_consumption:HP-1"
+
+
+def test_heat_pump_daily_energy_and_sg_ready_gateway_sensors(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import (
+        EnphaseHeatPumpDailyBatteryEnergySensor,
+        EnphaseHeatPumpDailyEnergySensor,
+        EnphaseHeatPumpDailyGridEnergySensor,
+        EnphaseHeatPumpDailySolarEnergySensor,
+        EnphaseHeatPumpSgReadyGatewaySensor,
+        _heatpump_daily_snapshot,
+    )
+    from homeassistant.components.sensor import SensorStateClass
+
+    coord = coordinator_factory(serials=[])
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 2,
+                "devices": [
+                    {
+                        "device_uid": "HP-1",
+                        "device_type": "HEAT_PUMP",
+                        "name": "Heat Pump",
+                        "pairing_status": "PAIRED",
+                        "device_state": "ACTIVE",
+                    },
+                    {
+                        "device_uid": "HP-SG-1",
+                        "device_type": "SG_READY_GATEWAY",
+                        "name": "SG Ready Gateway",
+                        "statusText": "Normal",
+                    },
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._heatpump_daily_consumption = {  # noqa: SLF001
+        "daily_energy_wh": 230.0,
+        "daily_solar_wh": 10.0,
+        "daily_battery_wh": 20.0,
+        "daily_grid_wh": 200.0,
+        "device_uid": "HP-1",
+        "device_name": "Heat Pump",
+        "member_name": "Heat Pump",
+        "member_device_type": "HEAT_PUMP",
+        "pairing_status": "PAIRED",
+        "device_state": "ACTIVE",
+        "endpoint_type": "hems-device-details",
+        "endpoint_timestamp": "2026-03-20T07:53:00.739143826Z",
+        "day_key": "2026-03-20",
+        "timezone": "Europe/Berlin",
+        "details": [230.0],
+        "source": "hems_energy_consumption:HP-1",
+    }
+
+    daily_sensor = EnphaseHeatPumpDailyEnergySensor(coord)
+    grid_sensor = EnphaseHeatPumpDailyGridEnergySensor(coord)
+    solar_sensor = EnphaseHeatPumpDailySolarEnergySensor(coord)
+    battery_sensor = EnphaseHeatPumpDailyBatteryEnergySensor(coord)
+    gateway_sensor = EnphaseHeatPumpSgReadyGatewaySensor(coord)
+
+    assert daily_sensor.available is True
+    assert daily_sensor.state_class == SensorStateClass.TOTAL
+    assert daily_sensor.native_value == pytest.approx(0.23)
+    assert daily_sensor.extra_state_attributes["daily_endpoint_timestamp"] == (
+        "2026-03-20T07:53:00.739143826Z"
+    )
+    assert grid_sensor.available is True
+    assert grid_sensor.native_value == pytest.approx(0.2)
+    assert grid_sensor.entity_registry_enabled_default is False
+    assert solar_sensor.native_value == pytest.approx(0.01)
+    assert battery_sensor.native_value == pytest.approx(0.02)
+    assert gateway_sensor.available is True
+    assert gateway_sensor.native_value == "Normal"
+    assert gateway_sensor.entity_registry_enabled_default is False
+
+    coord._heatpump_daily_consumption = {"daily_energy_wh": None}  # noqa: SLF001
+    assert daily_sensor.native_value is None
+
+    coord._heatpump_daily_consumption = {"daily_energy_wh": "bad"}  # noqa: SLF001
+    assert daily_sensor.native_value is None
+
+    coord.last_success_utc = None
+    coord.last_update_success = False
+    coord._heatpump_daily_consumption = {"daily_energy_wh": 230.0}  # noqa: SLF001
+    assert daily_sensor.available is False
+    assert (
+        _heatpump_daily_snapshot(SimpleNamespace(heatpump_daily_consumption=[])) == {}
+    )
 
 
 def test_site_heat_pump_energy_sensor_ignores_phantom_heatpump_device_info(


### PR DESCRIPTION
## Summary
- document and normalize the observed HEMS heat pump inventory, runtime, and daily energy payloads
- harden the heat pump runtime/daily selection logic, expose the new daily and SG-Ready sensors, and carry the new HEMS metadata through entity attributes and diagnostics
- fix the follow-up review issues by using timezone-correct UTC daily windows, preserving fault severity over lifecycle hints, and adding DST/inventory regressions plus full touched-file coverage

Thanks to @Hom456 for providing the endpoint data for this uplift.

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/binary_sensor.py custom_components/enphase_ev/heatpump_runtime.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/parsing_helpers.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_inventory_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_inventory_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/binary_sensor.py,custom_components/enphase_ev/heatpump_runtime.py,custom_components/enphase_ev/inventory_runtime.py,custom_components/enphase_ev/parsing_helpers.py,custom_components/enphase_ev/sensor.py --fail-under=100"`
- `git diff --check`
