### PR TITLE
Harden battery capability write gating

### DIFF
--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -38,6 +38,7 @@ from .const import (
 from .device_types import member_is_retired, sanitize_member
 from .log_redaction import redact_identifier, redact_site_id, redact_text
 from .service_validation import raise_translated_service_validation
+from .state_models import BatteryControlCapability
 
 if TYPE_CHECKING:  # pragma: no cover
     from .coordinator import EnphaseCoordinator
@@ -758,22 +759,120 @@ class BatteryRuntime:
             return 100
         return max(0, min(100, int(value)))
 
-    def _apply_cfg_control_state(self, cfg_control: object) -> None:
+    def _parse_battery_control_capability(
+        self, raw_control: object
+    ) -> BatteryControlCapability | None:
+        if not isinstance(raw_control, dict):
+            return None
+        return BatteryControlCapability(
+            show=self._coerce_optional_bool(raw_control.get("show")),
+            enabled=self._coerce_optional_bool(raw_control.get("enabled")),
+            locked=self._coerce_optional_bool(raw_control.get("locked")),
+            show_day_schedule=self._coerce_optional_bool(
+                raw_control.get("showDaySchedule")
+            ),
+            schedule_supported=self._coerce_optional_bool(
+                raw_control.get("scheduleSupported")
+            ),
+            force_schedule_supported=self._coerce_optional_bool(
+                raw_control.get("forceScheduleSupported")
+            ),
+            force_schedule_opted=self._coerce_optional_bool(
+                raw_control.get("forceScheduleOpted")
+            ),
+        )
+
+    def _apply_battery_control_state(
+        self, attr_name: str, raw_control: object
+    ) -> BatteryControlCapability | None:
         state = self.battery_state
-        if not isinstance(cfg_control, dict):
+        control = self._parse_battery_control_capability(raw_control)
+        setattr(state, attr_name, control)
+        if attr_name == "_battery_cfg_control":
+            if control is None:
+                state._battery_cfg_control_show = None
+                state._battery_cfg_control_enabled = None
+                state._battery_cfg_control_schedule_supported = None
+                state._battery_cfg_control_force_schedule_supported = None
+            else:
+                state._battery_cfg_control_show = control.show
+                state._battery_cfg_control_enabled = control.enabled
+                state._battery_cfg_control_schedule_supported = (
+                    control.schedule_supported
+                )
+                state._battery_cfg_control_force_schedule_supported = (
+                    control.force_schedule_supported
+                )
+        return control
+
+    def _apply_battery_capability_blocks(self, data: dict[str, object]) -> None:
+        state = self.battery_state
+        if "dtgControl" in data:
+            self._apply_battery_control_state(
+                "_battery_dtg_control", data.get("dtgControl")
+            )
+        if "cfgControl" in data:
+            self._apply_battery_control_state(
+                "_battery_cfg_control", data.get("cfgControl")
+            )
+        if "rbdControl" in data:
+            self._apply_battery_control_state(
+                "_battery_rbd_control", data.get("rbdControl")
+            )
+        if "systemTask" in data:
+            state._battery_system_task = self._coerce_optional_bool(
+                data.get("systemTask")
+            )
+
+    def _apply_battery_user_details(self, user_details: object) -> None:
+        if not isinstance(user_details, dict):
             return
-        state._battery_cfg_control_show = self._coerce_optional_bool(
-            cfg_control.get("show")
-        )
-        state._battery_cfg_control_enabled = self._coerce_optional_bool(
-            cfg_control.get("enabled")
-        )
-        state._battery_cfg_control_schedule_supported = self._coerce_optional_bool(
-            cfg_control.get("scheduleSupported")
-        )
-        state._battery_cfg_control_force_schedule_supported = (
-            self._coerce_optional_bool(cfg_control.get("forceScheduleSupported"))
-        )
+        state = self.battery_state
+        owner = self._coerce_optional_bool(user_details.get("isOwner"))
+        installer = self._coerce_optional_bool(user_details.get("isInstaller"))
+        if owner is not None:
+            state._battery_user_is_owner = owner
+        if installer is not None:
+            state._battery_user_is_installer = installer
+
+    def _apply_battery_permission_payload(self, payload: object) -> None:
+        if not isinstance(payload, dict):
+            return
+        data = payload.get("data")
+        if not isinstance(data, dict):
+            data = payload
+        self._apply_battery_capability_blocks(data)
+        self._apply_battery_user_details(data.get("userDetails"))
+
+    def _assert_battery_system_not_busy(
+        self, unavailable_message: str = "Battery updates are unavailable."
+    ) -> None:
+        if self.coordinator.battery_system_task is True:
+            raise ServiceValidationError(unavailable_message)
+
+    def _assert_battery_profile_feature_writable(
+        self, unavailable_message: str
+    ) -> None:
+        coord = self.coordinator
+        self._assert_battery_system_not_busy(unavailable_message)
+        owner = coord.battery_user_is_owner
+        installer = coord.battery_user_is_installer
+        if owner is False and installer is False:
+            raise ServiceValidationError(
+                "Battery profile updates are not permitted for this account."
+            )
+
+    def _assert_battery_settings_feature_writable(
+        self, unavailable_message: str
+    ) -> None:
+        coord = self.coordinator
+        self._assert_battery_system_not_busy(unavailable_message)
+        owner = coord.battery_user_is_owner
+        installer = coord.battery_user_is_installer
+        if owner is False and installer is False:
+            raise ServiceValidationError(
+                "Battery settings updates are not permitted for this account."
+            )
 
     def assert_battery_profile_write_allowed(self) -> None:
         coord = self.coordinator
@@ -789,6 +888,7 @@ class BatteryRuntime:
             raise ServiceValidationError(
                 "Battery profile updates are not permitted for this account."
             )
+        self._assert_battery_system_not_busy("Battery profile updates are unavailable.")
 
         now = time.monotonic()
         last = getattr(state, "_battery_profile_last_write_mono", None)
@@ -829,20 +929,7 @@ class BatteryRuntime:
                     state._battery_site_settings_payload = redacted_payload
                 else:
                     state._battery_site_settings_payload = {"value": redacted_payload}
-                if isinstance(payload, dict):
-                    data = payload.get("data")
-                    if not isinstance(data, dict):
-                        data = payload
-                    user_details = data.get("userDetails")
-                    if isinstance(user_details, dict):
-                        owner = self._coerce_optional_bool(user_details.get("isOwner"))
-                        installer = self._coerce_optional_bool(
-                            user_details.get("isInstaller")
-                        )
-                        if owner is not None:
-                            state._battery_user_is_owner = owner
-                        if installer is not None:
-                            state._battery_user_is_installer = installer
+                self._apply_battery_permission_payload(payload)
         if coord.battery_write_access_confirmed:
             return
         owner = coord.battery_user_is_owner
@@ -856,6 +943,7 @@ class BatteryRuntime:
     async def async_assert_battery_profile_write_allowed(self) -> None:
         self.assert_battery_profile_write_allowed()
         await self.async_ensure_battery_write_access_confirmed()
+        self.assert_battery_profile_write_allowed()
 
     def assert_battery_settings_write_allowed(self) -> None:
         coord = self.coordinator
@@ -871,6 +959,9 @@ class BatteryRuntime:
             raise ServiceValidationError(
                 "Battery settings updates are not permitted for this account."
             )
+        self._assert_battery_system_not_busy(
+            "Battery settings updates are unavailable."
+        )
         now = time.monotonic()
         last = getattr(state, "_battery_settings_last_write_mono", None)
         if (
@@ -885,6 +976,7 @@ class BatteryRuntime:
     async def async_assert_battery_settings_write_allowed(self) -> None:
         self.assert_battery_settings_write_allowed()
         await self.async_ensure_battery_write_access_confirmed()
+        self.assert_battery_settings_write_allowed()
 
     def current_charge_from_grid_schedule_window(self) -> tuple[int, int]:
         state = self.battery_state
@@ -1124,7 +1216,7 @@ class BatteryRuntime:
         supports_mqtt = self._coerce_optional_bool(data.get("supportsMqtt"))
         evse_storm_enabled = self._coerce_optional_bool(data.get("evseStormEnabled"))
         storm_state = self.normalize_storm_guard_state(data.get("stormGuardState"))
-        self._apply_cfg_control_state(data.get("cfgControl"))
+        self._apply_battery_capability_blocks(data)
         devices: list[dict[str, object]] = []
         profile_evse_device: dict[str, object] | None = None
         raw_devices = data.get("devices")
@@ -1435,14 +1527,8 @@ class BatteryRuntime:
                 if isinstance(value, (str, int, float)):
                     feature_details[key_text] = value
         state._battery_feature_details = feature_details
-        user_details = data.get("userDetails")
-        if isinstance(user_details, dict):
-            owner = self._coerce_optional_bool(user_details.get("isOwner"))
-            installer = self._coerce_optional_bool(user_details.get("isInstaller"))
-            if owner is not None:
-                state._battery_user_is_owner = owner
-            if installer is not None:
-                state._battery_user_is_installer = installer
+        self._apply_battery_capability_blocks(data)
+        self._apply_battery_user_details(data.get("userDetails"))
         site_status = data.get("siteStatus")
         if isinstance(site_status, dict):
             state._battery_site_status_code = _as_text(site_status.get("code"))
@@ -1554,7 +1640,7 @@ class BatteryRuntime:
         if storm_state is not None:
             state._storm_guard_state = storm_state
         self.sync_storm_guard_pending(storm_state)
-        self._apply_cfg_control_state(data.get("cfgControl"))
+        self._apply_battery_capability_blocks(data)
         raw_devices = data.get("devices")
         if isinstance(raw_devices, dict):
             iq_evse = raw_devices.get("iqEvse")
@@ -2484,6 +2570,9 @@ class BatteryRuntime:
             raise ServiceValidationError("Battery profile is unavailable.")
         if profile == "backup_only":
             raise ServiceValidationError("Full Backup reserve is fixed at 100%.")
+        self._assert_battery_profile_feature_writable("Battery reserve is unavailable.")
+        if not coord.battery_reserve_editable:
+            raise ServiceValidationError("Battery reserve is unavailable.")
         normalized = self.normalize_battery_reserve_for_profile(profile, reserve)
         sub_type = self.target_operation_mode_sub_type(profile)
         await self.async_apply_battery_profile(
@@ -2497,6 +2586,11 @@ class BatteryRuntime:
         profile = coord.battery_selected_profile
         if profile != "cost_savings":
             raise ServiceValidationError("Savings profile must be active.")
+        self._assert_battery_profile_feature_writable(
+            "Savings profile settings are unavailable."
+        )
+        if not coord.savings_use_battery_switch_available:
+            raise ServiceValidationError("Savings profile settings are unavailable.")
         reserve = coord.battery_selected_backup_percentage
         if reserve is None:
             reserve = self.target_reserve_for_profile("cost_savings")
@@ -2514,6 +2608,7 @@ class BatteryRuntime:
             raise ServiceValidationError("Battery profile is unavailable.")
         if profile not in coord.battery_profile_option_keys:
             raise ServiceValidationError("Selected battery profile is not supported.")
+        self._assert_battery_profile_feature_writable("Battery profile is unavailable.")
         reserve = self.target_reserve_for_profile(profile)
         sub_type = self.target_operation_mode_sub_type(profile)
         await self.async_apply_battery_profile(
@@ -2540,6 +2635,9 @@ class BatteryRuntime:
 
     async def async_set_charge_from_grid(self, enabled: bool) -> None:
         coord = self.coordinator
+        self._assert_battery_settings_feature_writable(
+            "Charge from grid setting is unavailable."
+        )
         if not coord.charge_from_grid_control_available:
             raise ServiceValidationError("Charge from grid setting is unavailable.")
         payload: dict[str, object] = {"chargeFromGrid": bool(enabled)}
@@ -2555,7 +2653,10 @@ class BatteryRuntime:
 
     async def async_set_charge_from_grid_schedule_enabled(self, enabled: bool) -> None:
         coord = self.coordinator
-        if not coord.charge_from_grid_schedule_supported:
+        self._assert_battery_settings_feature_writable(
+            "Charge from grid schedule is unavailable."
+        )
+        if not coord.charge_from_grid_force_schedule_supported:
             raise ServiceValidationError("Charge from grid schedule is unavailable.")
         if coord.battery_charge_from_grid_enabled is not True:
             raise ServiceValidationError("Charge from grid must be enabled first.")
@@ -2581,6 +2682,9 @@ class BatteryRuntime:
     ) -> None:
         coord = self.coordinator
         state = self.battery_state
+        self._assert_battery_settings_feature_writable(
+            "Charge from grid schedule is unavailable."
+        )
         if not coord.charge_from_grid_schedule_supported:
             raise ServiceValidationError("Charge from grid schedule is unavailable.")
         if coord.battery_charge_from_grid_enabled is not True:
@@ -2683,6 +2787,11 @@ class BatteryRuntime:
     async def async_set_cfg_schedule_limit(self, limit: int) -> None:
         coord = self.coordinator
         state = self.battery_state
+        self._assert_battery_settings_feature_writable(
+            "Charge from grid schedule is unavailable."
+        )
+        if coord.battery_cfg_control_force_schedule_supported is False:
+            raise ServiceValidationError("Charge from grid schedule is unavailable.")
         if not hasattr(coord.client, "update_battery_schedule"):
             raise ServiceValidationError(
                 "Schedule API not available on this client version."
@@ -2738,6 +2847,9 @@ class BatteryRuntime:
     ) -> None:
         coord = self.coordinator
         state = self.battery_state
+        self._assert_battery_settings_feature_writable(
+            "Charge from grid schedule is unavailable."
+        )
         if not hasattr(coord.client, "update_battery_schedule"):
             raise ServiceValidationError(
                 "Schedule API not available on this client version."
@@ -2979,6 +3091,9 @@ class BatteryRuntime:
 
     async def async_set_battery_shutdown_level(self, level: int) -> None:
         coord = self.coordinator
+        self._assert_battery_settings_feature_writable(
+            "Battery shutdown level is unavailable."
+        )
         if not coord.battery_shutdown_level_available:
             raise ServiceValidationError("Battery shutdown level is unavailable.")
         try:

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -121,6 +121,7 @@ from .refresh_plan import (
 )
 from .service_validation import raise_translated_service_validation
 from .state_models import (
+    BatteryControlCapability,
     BatteryState,
     DiscoveryState,
     EVSEState,
@@ -6408,6 +6409,30 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         installer = self.battery_user_is_installer
         return owner is True or installer is True
 
+    @staticmethod
+    def _battery_control_to_dict(
+        value: BatteryControlCapability | None,
+    ) -> dict[str, bool | None] | None:
+        if value is None:
+            return None
+        return {
+            "show": value.show,
+            "enabled": value.enabled,
+            "locked": value.locked,
+            "show_day_schedule": value.show_day_schedule,
+            "schedule_supported": value.schedule_supported,
+            "force_schedule_supported": value.force_schedule_supported,
+            "force_schedule_opted": value.force_schedule_opted,
+        }
+
+    @staticmethod
+    def _battery_control_field(
+        value: BatteryControlCapability | None, field_name: str
+    ) -> bool | None:
+        if value is None:
+            return None
+        return getattr(value, field_name)
+
     @property
     def battery_site_status_code(self) -> str | None:
         return getattr(self, "_battery_site_status_code", None)
@@ -6519,6 +6544,20 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return bool(self.battery_profile_option_keys)
 
     @property
+    def battery_system_task(self) -> bool | None:
+        return getattr(self, "_battery_system_task", None)
+
+    @property
+    def battery_profile_selection_available(self) -> bool:
+        if not self.battery_controls_available:
+            return False
+        if self.battery_system_task is True:
+            return False
+        owner = self.battery_user_is_owner
+        installer = self.battery_user_is_installer
+        return not (owner is False and installer is False)
+
+    @property
     def savings_use_battery_after_peak(self) -> bool | None:
         profile = self.battery_selected_profile
         if profile != "cost_savings":
@@ -6530,11 +6569,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @property
     def savings_use_battery_switch_available(self) -> bool:
-        if not self.battery_controls_available:
-            return False
-        owner = self.battery_user_is_owner
-        installer = self.battery_user_is_installer
-        if owner is False and installer is False:
+        if not self.battery_profile_selection_available:
             return False
         if getattr(self, "_battery_show_savings_mode", None) is False:
             return False
@@ -6542,17 +6577,16 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @property
     def battery_reserve_editable(self) -> bool:
-        if not self.battery_controls_available:
+        if not self.battery_profile_selection_available:
             return False
-        cfg_show = getattr(self, "_battery_cfg_control_show", None)
-        if cfg_show is not None:
-            if cfg_show is False:
+        rbd_control = getattr(self, "_battery_rbd_control", None)
+        rbd_show = self._battery_control_field(rbd_control, "show")
+        if rbd_show is not None:
+            if rbd_show is False:
                 return False
         elif getattr(self, "_battery_show_battery_backup_percentage", None) is False:
             return False
-        owner = self.battery_user_is_owner
-        installer = self.battery_user_is_installer
-        if owner is False and installer is False:
+        if self._battery_control_field(rbd_control, "locked") is True:
             return False
         profile = self.battery_selected_profile
         if profile is None:
@@ -6611,18 +6645,22 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def charge_from_grid_control_available(self) -> bool:
         if getattr(self, "_battery_has_encharge", None) is False:
             return False
+        if self.battery_system_task is True:
+            return False
         # Prefer cfgControl.show (used by Enlighten app) over the
         # legacy hideChargeFromGrid flag which is unreliable on EMEA
         # sites. cfgControl.enabled appears to reflect current toggle
         # state on some homeowner payloads, so it is not authoritative
         # for control availability.
-        cfg_show = getattr(self, "_battery_cfg_control_show", None)
+        cfg_show = self.battery_cfg_control_show
         if cfg_show is not None:
             if cfg_show is False:
                 return False
         else:
             if getattr(self, "_battery_hide_charge_from_grid", None) is True:
                 return False
+        if self.battery_cfg_control_locked is True:
+            return False
         owner = self.battery_user_is_owner
         installer = self.battery_user_is_installer
         if owner is False and installer is False:
@@ -6641,6 +6679,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def charge_from_grid_schedule_supported(self) -> bool:
         if not self.charge_from_grid_control_available:
             return False
+        show_day_schedule = self.battery_cfg_control_show_day_schedule
+        if show_day_schedule is False:
+            return False
+        schedule_supported = self.battery_cfg_control_schedule_supported
+        if schedule_supported is not None:
+            return schedule_supported
         begin = getattr(self, "_battery_charge_begin_time", None)
         end = getattr(self, "_battery_charge_end_time", None)
         return begin is not None and end is not None
@@ -6648,6 +6692,30 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     @property
     def charge_from_grid_schedule_available(self) -> bool:
         if not self.charge_from_grid_schedule_supported:
+            return False
+        return self.battery_charge_from_grid_enabled is True
+
+    @property
+    def charge_from_grid_force_schedule_supported(self) -> bool:
+        if not self.charge_from_grid_control_available:
+            return False
+        force_schedule_supported = self.battery_cfg_control_force_schedule_supported
+        if force_schedule_supported is not None:
+            return force_schedule_supported
+        if getattr(self, "_battery_cfg_schedule_limit", None) is not None:
+            return True
+        if getattr(self, "_battery_cfg_schedule_id", None) is not None:
+            return True
+        if (
+            getattr(self, "_battery_charge_from_grid_schedule_enabled", None)
+            is not None
+        ):
+            return True
+        return True
+
+    @property
+    def charge_from_grid_force_schedule_available(self) -> bool:
+        if not self.charge_from_grid_force_schedule_supported:
             return False
         return self.battery_charge_from_grid_enabled is True
 
@@ -7069,20 +7137,66 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return None
 
     @property
+    def battery_dtg_control(self) -> dict[str, bool | None] | None:
+        value = getattr(self, "_battery_dtg_control", None)
+        return self._battery_control_to_dict(value)
+
+    @property
+    def battery_cfg_control(self) -> dict[str, bool | None] | None:
+        value = getattr(self, "_battery_cfg_control", None)
+        return self._battery_control_to_dict(value)
+
+    @property
+    def battery_rbd_control(self) -> dict[str, bool | None] | None:
+        value = getattr(self, "_battery_rbd_control", None)
+        return self._battery_control_to_dict(value)
+
+    @property
     def battery_cfg_control_show(self) -> bool | None:
+        value = getattr(self, "_battery_cfg_control", None)
+        field = self._battery_control_field(value, "show")
+        if field is not None:
+            return field
         return getattr(self, "_battery_cfg_control_show", None)
 
     @property
     def battery_cfg_control_enabled(self) -> bool | None:
+        value = getattr(self, "_battery_cfg_control", None)
+        field = self._battery_control_field(value, "enabled")
+        if field is not None:
+            return field
         return getattr(self, "_battery_cfg_control_enabled", None)
 
     @property
+    def battery_cfg_control_locked(self) -> bool | None:
+        value = getattr(self, "_battery_cfg_control", None)
+        return self._battery_control_field(value, "locked")
+
+    @property
+    def battery_cfg_control_show_day_schedule(self) -> bool | None:
+        value = getattr(self, "_battery_cfg_control", None)
+        return self._battery_control_field(value, "show_day_schedule")
+
+    @property
     def battery_cfg_control_schedule_supported(self) -> bool | None:
+        value = getattr(self, "_battery_cfg_control", None)
+        field = self._battery_control_field(value, "schedule_supported")
+        if field is not None:
+            return field
         return getattr(self, "_battery_cfg_control_schedule_supported", None)
 
     @property
     def battery_cfg_control_force_schedule_supported(self) -> bool | None:
+        value = getattr(self, "_battery_cfg_control", None)
+        field = self._battery_control_field(value, "force_schedule_supported")
+        if field is not None:
+            return field
         return getattr(self, "_battery_cfg_control_force_schedule_supported", None)
+
+    @property
+    def battery_cfg_control_force_schedule_opted(self) -> bool | None:
+        value = getattr(self, "_battery_cfg_control", None)
+        return self._battery_control_field(value, "force_schedule_opted")
 
     @property
     def battery_use_battery_for_self_consumption(self) -> bool | None:

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -282,6 +282,10 @@ class CoordinatorDiagnostics:
                 getattr(coord, "_battery_profile_write_lock", None)
                 and coord._battery_profile_write_lock.locked()
             ),
+            "battery_dtg_control": coord.battery_dtg_control,
+            "battery_cfg_control": coord.battery_cfg_control,
+            "battery_rbd_control": coord.battery_rbd_control,
+            "battery_system_task": coord.battery_system_task,
             "battery_grid_mode": getattr(coord, "_battery_grid_mode", None),
             "battery_mode_display": coord.battery_mode_display,
             "battery_charge_from_grid_allowed": coord.battery_charge_from_grid_allowed,

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -289,7 +289,7 @@ class BatteryCfgScheduleLimitNumber(CoordinatorEntity, NumberEntity):
         return (
             _type_available(self._coord, "encharge")
             and _battery_write_access_confirmed(self._coord)
-            and self._coord.charge_from_grid_control_available
+            and self._coord.charge_from_grid_force_schedule_available
             and self._coord.battery_cfg_schedule_limit is not None
         )
 

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -165,13 +165,21 @@ class SystemProfileSelect(CoordinatorEntity, SelectEntity):
     def available(self) -> bool:  # type: ignore[override]
         if not super().available:
             return False
+        if not _type_available(self._coord, "envoy"):
+            return False
+        available = getattr(self._coord, "battery_profile_selection_available", None)
+        if available is None:
+            if not getattr(self._coord, "battery_controls_available", False):
+                return False
+            owner = getattr(self._coord, "battery_user_is_owner", None)
+            installer = getattr(self._coord, "battery_user_is_installer", None)
+            if owner is False and installer is False:
+                return False
+        elif not available:
+            return False
         if not _battery_write_access_confirmed(self._coord):
             return False
-        return (
-            _type_available(self._coord, "envoy")
-            and self._coord.battery_controls_available
-            and bool(self.options)
-        )
+        return bool(self.options)
 
     @property
     def current_option(self) -> str | None:

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -8046,6 +8046,19 @@ class EnphaseSystemProfileStatusSensor(_SiteBaseEntity):
         attrs["cfg_control_force_schedule_supported"] = getattr(
             self._coord, "battery_cfg_control_force_schedule_supported", None
         )
+        attrs["cfg_control_locked"] = getattr(
+            self._coord, "battery_cfg_control_locked", None
+        )
+        attrs["cfg_control_show_day_schedule"] = getattr(
+            self._coord, "battery_cfg_control_show_day_schedule", None
+        )
+        attrs["cfg_control_force_schedule_opted"] = getattr(
+            self._coord, "battery_cfg_control_force_schedule_opted", None
+        )
+        attrs["dtg_control"] = getattr(self._coord, "battery_dtg_control", None)
+        attrs["cfg_control"] = getattr(self._coord, "battery_cfg_control", None)
+        attrs["rbd_control"] = getattr(self._coord, "battery_rbd_control", None)
+        attrs["battery_system_task"] = getattr(self._coord, "battery_system_task", None)
         attrs["site_show_production"] = getattr(
             self._coord, "battery_show_production", None
         )

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -48,6 +48,17 @@ class DiscoveryState:
     _debug_summary_log_cache: dict[str, object] = field(default_factory=dict)
 
 
+@dataclass(frozen=True, slots=True)
+class BatteryControlCapability:
+    show: bool | None = None
+    enabled: bool | None = None
+    locked: bool | None = None
+    show_day_schedule: bool | None = None
+    schedule_supported: bool | None = None
+    force_schedule_supported: bool | None = None
+    force_schedule_opted: bool | None = None
+
+
 @dataclass(slots=True)
 class RefreshHealthState:
     last_set_amps: dict[str, int] = field(default_factory=dict)
@@ -278,10 +289,14 @@ class BatteryState:
     _battery_operation_mode_sub_type: str | None = None
     _battery_supports_mqtt: bool | None = None
     _battery_polling_interval_s: int | None = None
+    _battery_dtg_control: BatteryControlCapability | None = None
     _battery_cfg_control_show: bool | None = None
     _battery_cfg_control_enabled: bool | None = None
     _battery_cfg_control_schedule_supported: bool | None = None
     _battery_cfg_control_force_schedule_supported: bool | None = None
+    _battery_cfg_control: BatteryControlCapability | None = None
+    _battery_rbd_control: BatteryControlCapability | None = None
+    _battery_system_task: bool | None = None
     _battery_profile_evse_device: dict[str, object] | None = None
     _battery_use_battery_for_self_consumption: bool | None = None
     _battery_profile_devices: list[dict[str, object]] = field(default_factory=list)

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -399,7 +399,7 @@ class ChargeFromGridScheduleSwitch(CoordinatorEntity, SwitchEntity):
         return (
             _type_available(self._coord, "encharge")
             and _battery_write_access_confirmed(self._coord)
-            and self._coord.charge_from_grid_schedule_available
+            and self._coord.charge_from_grid_force_schedule_available
         )
 
     @property

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock
 import aiohttp
 import pytest
 
+from custom_components.enphase_ev.state_models import BatteryControlCapability
+
 
 def test_parse_battery_settings_payload_maps_mode_and_controls(
     coordinator_factory,
@@ -36,14 +38,28 @@ def test_parse_battery_settings_payload_maps_mode_and_controls(
                 "cfgControl": {
                     "show": True,
                     "enabled": True,
+                    "locked": False,
+                    "showDaySchedule": True,
                     "scheduleSupported": True,
                     "forceScheduleSupported": True,
+                    "forceScheduleOpted": True,
+                },
+                "dtgControl": {
+                    "show": True,
+                    "enabled": False,
+                    "locked": True,
+                },
+                "rbdControl": {
+                    "show": True,
+                    "enabled": True,
+                    "locked": False,
                 },
                 "devices": {
                     "iqEvse": {
                         "useBatteryFrSelfConsumption": True,
                     }
                 },
+                "systemTask": False,
             }
         }
     )
@@ -68,6 +84,28 @@ def test_parse_battery_settings_payload_maps_mode_and_controls(
     assert coord.battery_cfg_control_enabled is True
     assert coord.battery_cfg_control_schedule_supported is True
     assert coord.battery_cfg_control_force_schedule_supported is True
+    assert coord.battery_cfg_control_locked is False
+    assert coord.battery_cfg_control_show_day_schedule is True
+    assert coord.battery_cfg_control_force_schedule_opted is True
+    assert coord.battery_dtg_control == {
+        "show": True,
+        "enabled": False,
+        "locked": True,
+        "show_day_schedule": None,
+        "schedule_supported": None,
+        "force_schedule_supported": None,
+        "force_schedule_opted": None,
+    }
+    assert coord.battery_rbd_control == {
+        "show": True,
+        "enabled": True,
+        "locked": False,
+        "show_day_schedule": None,
+        "schedule_supported": None,
+        "force_schedule_supported": None,
+        "force_schedule_opted": None,
+    }
+    assert coord.battery_system_task is False
     assert coord.battery_use_battery_for_self_consumption is True
 
 
@@ -443,6 +481,84 @@ def test_charge_from_grid_control_honors_cfg_control_show_false(
     assert coord.charge_from_grid_control_available is False
 
 
+def test_charge_from_grid_control_honors_cfg_control_locked(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_cfg_control = BatteryControlCapability(  # noqa: SLF001
+        show=True,
+        enabled=False,
+        locked=True,
+    )
+
+    assert coord.charge_from_grid_control_available is False
+
+
+def test_charge_from_grid_schedule_supported_uses_capability_flags(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_cfg_control = BatteryControlCapability(  # noqa: SLF001
+        show=True,
+        enabled=False,
+        locked=False,
+        show_day_schedule=False,
+        schedule_supported=True,
+        force_schedule_supported=True,
+    )
+    coord._battery_charge_begin_time = 120  # noqa: SLF001
+    coord._battery_charge_end_time = 300  # noqa: SLF001
+
+    assert coord.charge_from_grid_schedule_supported is False
+
+    coord._battery_cfg_control = BatteryControlCapability(  # noqa: SLF001
+        show=True,
+        enabled=False,
+        locked=False,
+        show_day_schedule=True,
+        schedule_supported=True,
+        force_schedule_supported=False,
+    )
+    assert coord.charge_from_grid_schedule_supported is True
+    assert coord.charge_from_grid_force_schedule_supported is False
+
+    coord._battery_cfg_control = BatteryControlCapability(  # noqa: SLF001
+        show=True,
+        enabled=False,
+        locked=False,
+        show_day_schedule=True,
+        schedule_supported=True,
+        force_schedule_supported=True,
+    )
+    assert coord.charge_from_grid_schedule_supported is True
+    assert coord.charge_from_grid_force_schedule_supported is True
+
+
+def test_charge_from_grid_schedule_supported_uses_capability_without_times(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_cfg_control = BatteryControlCapability(  # noqa: SLF001
+        show=True,
+        enabled=False,
+        locked=False,
+        show_day_schedule=True,
+        schedule_supported=True,
+        force_schedule_supported=False,
+    )
+    coord._battery_charge_begin_time = None  # noqa: SLF001
+    coord._battery_charge_end_time = None  # noqa: SLF001
+
+    assert coord.charge_from_grid_schedule_supported is True
+    assert coord.charge_from_grid_force_schedule_supported is False
+
+
 def test_charge_from_grid_control_falls_back_to_legacy_hide_when_cfg_control_absent(
     coordinator_factory,
 ) -> None:
@@ -455,6 +571,45 @@ def test_charge_from_grid_control_falls_back_to_legacy_hide_when_cfg_control_abs
     coord._battery_hide_charge_from_grid = True  # noqa: SLF001
 
     assert coord.charge_from_grid_control_available is False
+
+
+def test_charge_from_grid_control_enabled_state_does_not_hide_writable_control(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_cfg_control = BatteryControlCapability(  # noqa: SLF001
+        show=True,
+        enabled=False,
+        locked=False,
+    )
+
+    assert coord.charge_from_grid_control_available is True
+
+
+def test_battery_control_capability_helpers_cover_none_inputs(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.battery_runtime
+    coord._battery_cfg_control_show = True  # noqa: SLF001
+    coord._battery_cfg_control_enabled = True  # noqa: SLF001
+    coord._battery_cfg_control_schedule_supported = True  # noqa: SLF001
+    coord._battery_cfg_control_force_schedule_supported = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+
+    assert runtime._parse_battery_control_capability(None) is None  # noqa: SLF001
+    assert (
+        runtime._apply_battery_control_state("_battery_cfg_control", None) is None
+    )  # noqa: SLF001
+    assert coord._battery_cfg_control_show is None  # noqa: SLF001
+    assert coord._battery_cfg_control_enabled is None  # noqa: SLF001
+    assert coord._battery_cfg_control_schedule_supported is None  # noqa: SLF001
+    assert coord._battery_cfg_control_force_schedule_supported is None  # noqa: SLF001
+
+    runtime._apply_battery_permission_payload(["bad"])  # noqa: SLF001
+    assert coord.battery_user_is_owner is True
 
 
 def test_parse_battery_settings_payload_handles_non_dict_and_bad_disclaimer(
@@ -590,6 +745,133 @@ async def test_battery_settings_forbidden_read_only_user_translates_to_permissio
             {"chargeFromGrid": False}
         )
     coord.client.set_battery_settings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_battery_settings_write_blocked_when_system_task_active(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_system_task = True  # noqa: SLF001
+    coord.client.set_battery_settings = AsyncMock()
+
+    with pytest.raises(
+        ServiceValidationError, match="Battery settings updates are unavailable"
+    ):
+        await coord.battery_runtime.async_apply_battery_settings(
+            {"chargeFromGrid": False}
+        )
+    coord.client.set_battery_settings.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_battery_settings_write_blocked_when_refresh_discovers_system_task(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_user_is_owner = None  # noqa: SLF001
+    coord._battery_user_is_installer = None  # noqa: SLF001
+    coord.client.battery_site_settings = AsyncMock(
+        return_value={
+            "data": {
+                "userDetails": {"isOwner": True, "isInstaller": False},
+                "systemTask": True,
+            }
+        }
+    )
+    coord.client.set_battery_settings = AsyncMock()
+
+    with pytest.raises(
+        ServiceValidationError, match="Battery settings updates are unavailable"
+    ):
+        await coord.battery_runtime.async_apply_battery_settings(
+            {"chargeFromGrid": False}
+        )
+    coord.client.set_battery_settings.assert_not_awaited()
+
+
+def test_battery_settings_feature_writable_rejects_read_only_user(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_user_is_owner = False  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Battery settings updates are not permitted for this account",
+    ):
+        coord.battery_runtime._assert_battery_settings_feature_writable(  # noqa: SLF001
+            "Charge from grid setting is unavailable."
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_battery_reserve_rejects_when_reserve_not_editable(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_rbd_control = BatteryControlCapability(  # noqa: SLF001
+        show=True,
+        locked=True,
+    )
+
+    with pytest.raises(ServiceValidationError, match="Battery reserve is unavailable"):
+        await coord.async_set_battery_reserve(25)
+
+
+@pytest.mark.asyncio
+async def test_set_savings_use_battery_after_peak_rejects_when_switch_unavailable(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_profile = "cost_savings"  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_show_savings_mode = False  # noqa: SLF001
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Savings profile settings are unavailable",
+    ):
+        await coord.async_set_savings_use_battery_after_peak(True)
+
+
+@pytest.mark.asyncio
+async def test_set_charge_from_grid_schedule_enabled_rejects_without_force_support(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_charge_begin_time = 120  # noqa: SLF001
+    coord._battery_charge_end_time = 300  # noqa: SLF001
+    coord._battery_cfg_control = BatteryControlCapability(  # noqa: SLF001
+        show=True,
+        locked=False,
+        show_day_schedule=True,
+        schedule_supported=True,
+        force_schedule_supported=False,
+    )
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Charge from grid schedule is unavailable",
+    ):
+        await coord.async_set_charge_from_grid_schedule_enabled(True)
 
 
 @pytest.mark.asyncio
@@ -1096,6 +1378,27 @@ async def test_cfg_schedule_limit_rejects_without_schedule_api(
     coord.client = MagicMock(spec=())
 
     with pytest.raises(ServiceValidationError, match="Schedule API not available"):
+        await coord.battery_runtime.async_set_cfg_schedule_limit(90)
+
+
+@pytest.mark.asyncio
+async def test_cfg_schedule_limit_rejects_when_force_schedule_explicitly_unsupported(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_cfg_control = BatteryControlCapability(  # noqa: SLF001
+        show=True,
+        locked=False,
+        force_schedule_supported=False,
+    )
+    coord.client.update_battery_schedule = AsyncMock()
+
+    with pytest.raises(
+        ServiceValidationError,
+        match="Charge from grid schedule is unavailable",
+    ):
         await coord.battery_runtime.async_set_cfg_schedule_limit(90)
 
 

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -7,6 +7,8 @@ from unittest.mock import AsyncMock, MagicMock
 import aiohttp
 import pytest
 
+from custom_components.enphase_ev.state_models import BatteryControlCapability
+
 
 def _profile_payload(
     *,
@@ -615,30 +617,108 @@ def test_battery_profile_property_helpers_cover_branches(coordinator_factory) ->
     assert coord.savings_use_battery_switch_available is False
 
 
-def test_battery_reserve_editable_uses_cfg_control_when_present(
+def test_battery_reserve_editable_uses_rbd_control_when_present(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
     coord._battery_profile = "self-consumption"  # noqa: SLF001
     coord._battery_user_is_owner = True  # noqa: SLF001
     coord._battery_user_is_installer = False  # noqa: SLF001
-    coord._battery_cfg_control_show = True  # noqa: SLF001
+    coord._battery_rbd_control = BatteryControlCapability(
+        show=True, locked=False
+    )  # noqa: SLF001
     coord._battery_show_battery_backup_percentage = False  # noqa: SLF001
 
     assert coord.battery_reserve_editable is True
 
 
-def test_battery_reserve_editable_honors_cfg_control_false(
+def test_battery_reserve_editable_honors_rbd_control_false(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
     coord._battery_profile = "self-consumption"  # noqa: SLF001
     coord._battery_user_is_owner = True  # noqa: SLF001
     coord._battery_user_is_installer = False  # noqa: SLF001
-    coord._battery_cfg_control_show = False  # noqa: SLF001
+    coord._battery_rbd_control = BatteryControlCapability(
+        show=False, locked=False
+    )  # noqa: SLF001
     coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
 
     assert coord.battery_reserve_editable is False
+
+
+def test_battery_reserve_editable_honors_rbd_control_locked(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord._battery_rbd_control = BatteryControlCapability(
+        show=True, locked=True
+    )  # noqa: SLF001
+
+    assert coord.battery_reserve_editable is False
+
+
+def test_battery_profile_selection_available_false_when_system_task_active(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_system_task = True  # noqa: SLF001
+
+    assert coord.battery_profile_selection_available is False
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_write_blocked_when_system_task_active(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_system_task = True  # noqa: SLF001
+    coord.client.set_battery_profile = AsyncMock()
+
+    with pytest.raises(
+        ServiceValidationError, match="Battery profile updates are unavailable"
+    ):
+        await coord.battery_runtime.async_apply_battery_profile(
+            profile="self-consumption",
+            reserve=20,
+        )
+    coord.client.set_battery_profile.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_write_blocked_when_refresh_discovers_system_task(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_user_is_owner = None  # noqa: SLF001
+    coord._battery_user_is_installer = None  # noqa: SLF001
+    coord.client.battery_site_settings = AsyncMock(
+        return_value={
+            "data": {
+                "userDetails": {"isOwner": True, "isInstaller": False},
+                "systemTask": True,
+            }
+        }
+    )
+    coord.client.set_battery_profile = AsyncMock()
+
+    with pytest.raises(
+        ServiceValidationError, match="Battery profile updates are unavailable"
+    ):
+        await coord.battery_runtime.async_apply_battery_profile(
+            profile="self-consumption",
+            reserve=20,
+        )
+    coord.client.set_battery_profile.assert_not_awaited()
 
 
 def test_battery_write_access_confirmed_requires_explicit_role(
@@ -655,6 +735,60 @@ def test_battery_write_access_confirmed_requires_explicit_role(
     coord._battery_user_is_owner = None  # noqa: SLF001
     coord._battery_user_is_installer = True  # noqa: SLF001
     assert coord.battery_write_access_confirmed is True
+
+
+def test_charge_from_grid_control_unavailable_when_system_task_active(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_system_task = True  # noqa: SLF001
+
+    assert coord.charge_from_grid_control_available is False
+
+
+def test_charge_from_grid_schedule_supported_honors_schedule_supported_false(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_cfg_control = BatteryControlCapability(  # noqa: SLF001
+        show=True,
+        locked=False,
+        show_day_schedule=True,
+        schedule_supported=False,
+        force_schedule_supported=True,
+    )
+    coord._battery_charge_begin_time = 120  # noqa: SLF001
+    coord._battery_charge_end_time = 300  # noqa: SLF001
+
+    assert coord.charge_from_grid_schedule_supported is False
+
+
+def test_battery_cfg_control_enabled_falls_back_to_legacy_scalar(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_cfg_control = BatteryControlCapability(  # noqa: SLF001
+        show=True,
+        enabled=None,
+    )
+    coord._battery_cfg_control_enabled = False  # noqa: SLF001
+
+    assert coord.battery_cfg_control_enabled is False
+
+
+def test_charge_from_grid_force_schedule_supported_falls_back_to_schedule_id(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_cfg_schedule_id = "cfg-1"  # noqa: SLF001
+
+    assert coord.charge_from_grid_force_schedule_supported is True
 
 
 def test_battery_pending_age_handles_datetime_failures(

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -199,6 +199,34 @@ class DummyCoordinator(SimpleNamespace):
             "per_battery_status": {"BT0001": "normal"},
             "worst_storage_key": "BT0001",
         }
+        self.battery_dtg_control = {
+            "show": True,
+            "enabled": False,
+            "locked": True,
+            "show_day_schedule": None,
+            "schedule_supported": None,
+            "force_schedule_supported": None,
+            "force_schedule_opted": None,
+        }
+        self.battery_cfg_control = {
+            "show": True,
+            "enabled": True,
+            "locked": False,
+            "show_day_schedule": True,
+            "schedule_supported": True,
+            "force_schedule_supported": True,
+            "force_schedule_opted": True,
+        }
+        self.battery_rbd_control = {
+            "show": True,
+            "enabled": True,
+            "locked": False,
+            "show_day_schedule": None,
+            "schedule_supported": None,
+            "force_schedule_supported": None,
+            "force_schedule_opted": None,
+        }
+        self.battery_system_task = False
         self._grid_control_check_payload = {
             "disableGridControl": False,
             "activeDownload": False,
@@ -440,6 +468,10 @@ class DummyCoordinator(SimpleNamespace):
             "dry_contact_settings_unmatched_count": 0,
             "dry_contact_settings_fetch_failures": 0,
             "dry_contact_settings_data_stale": False,
+            "battery_dtg_control": self.battery_dtg_control,
+            "battery_cfg_control": self.battery_cfg_control,
+            "battery_rbd_control": self.battery_rbd_control,
+            "battery_system_task": self.battery_system_task,
         }
 
     def charge_mode_cache_snapshot(self):
@@ -631,6 +663,9 @@ async def test_config_entry_diagnostics_includes_coordinator(
         diag["coordinator"]["battery_config"]["backup_history_payload"]["total_records"]
         == 1
     )
+    assert diag["coordinator"]["site_metrics"]["battery_cfg_control"]["locked"] is False
+    assert diag["coordinator"]["site_metrics"]["battery_dtg_control"]["locked"] is True
+    assert diag["coordinator"]["site_metrics"]["battery_system_task"] is False
     assert (
         diag["coordinator"]["battery_config"]["hems_devices_payload"]["data"][
             "hems-devices"

--- a/tests/components/enphase_ev/test_number_module.py
+++ b/tests/components/enphase_ev/test_number_module.py
@@ -569,6 +569,29 @@ def test_battery_cfg_schedule_limit_number_unavailable_without_schedule(
     assert number.native_value is None
 
 
+def test_battery_cfg_schedule_limit_number_unavailable_without_force_support(
+    hass, config_entry
+) -> None:
+    coord = _make_coordinator(hass, config_entry, {RANDOM_SERIAL: {}})
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_cfg_schedule_limit = 80  # noqa: SLF001
+    coord._battery_cfg_control = (
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {
+                "show": True,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "forceScheduleSupported": False,
+            }
+        )
+    )
+
+    assert BatteryCfgScheduleLimitNumber(coord).available is False
+
+
 def test_battery_cfg_schedule_limit_number_super_unavailable_and_device_info_fallback(
     hass, config_entry
 ) -> None:

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -1353,6 +1353,13 @@ def test_system_profile_status_sensor_states():
         battery_cfg_control_enabled=True,
         battery_cfg_control_schedule_supported=True,
         battery_cfg_control_force_schedule_supported=False,
+        battery_cfg_control_locked=False,
+        battery_cfg_control_show_day_schedule=True,
+        battery_cfg_control_force_schedule_opted=True,
+        battery_dtg_control={"show": True, "locked": False},
+        battery_cfg_control={"show": True, "locked": False},
+        battery_rbd_control={"show": True, "locked": False},
+        battery_system_task=False,
         battery_show_production=True,
         battery_show_consumption=True,
         battery_show_storm_guard=True,
@@ -1393,6 +1400,12 @@ def test_system_profile_status_sensor_states():
     assert attrs["requested_profile_label"] == "AI Optimisation"
     assert attrs["supports_mqtt"] is True
     assert attrs["cfg_control_show"] is True
+    assert attrs["cfg_control_locked"] is False
+    assert attrs["cfg_control_show_day_schedule"] is True
+    assert attrs["cfg_control_force_schedule_opted"] is True
+    assert attrs["cfg_control"]["locked"] is False
+    assert attrs["rbd_control"]["show"] is True
+    assert attrs["battery_system_task"] is False
     assert attrs["site_country_code"] == "US"
     assert attrs["feature_details"] == {"HEMS_EV_Custom_Schedule": True}
     assert attrs["evse_profile"]["uuid"] == "evse-1"

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -1365,6 +1365,31 @@ def test_charge_from_grid_schedule_switch_availability(coordinator_factory) -> N
     assert sw.is_on is True
 
 
+def test_charge_from_grid_schedule_switch_unavailable_without_force_support(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_charge_begin_time = 120  # noqa: SLF001
+    coord._battery_charge_end_time = 300  # noqa: SLF001
+    coord._battery_charge_from_grid_schedule_enabled = True  # noqa: SLF001
+    coord._battery_cfg_control = (
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {
+                "show": True,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "forceScheduleSupported": False,
+            }
+        )
+    )
+
+    assert ChargeFromGridScheduleSwitch(coord).available is False
+
+
 def test_charge_from_grid_schedule_switch_suggested_object_id(
     coordinator_factory,
 ) -> None:

--- a/tests/components/enphase_ev/test_time_module.py
+++ b/tests/components/enphase_ev/test_time_module.py
@@ -429,6 +429,35 @@ async def test_charge_from_grid_time_entity_availability_and_values(
     assert end.available is False
 
 
+@pytest.mark.asyncio
+async def test_charge_from_grid_time_entity_available_from_capability_without_times(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_charge_begin_time = None  # noqa: SLF001
+    coord._battery_charge_end_time = None  # noqa: SLF001
+    coord._battery_cfg_control = (
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {
+                "show": True,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "forceScheduleSupported": False,
+            }
+        )
+    )
+
+    start = ChargeFromGridStartTimeEntity(coord)
+    end = ChargeFromGridEndTimeEntity(coord)
+
+    assert start.available is True
+    assert end.available is True
+    assert start.native_value is None
+    assert end.native_value is None
+
+
 def test_charge_from_grid_time_entity_unavailable_when_coordinator_down(
     coordinator_factory,
 ) -> None:

--- a/tests/components/enphase_ev/test_type_device_entity_fallbacks.py
+++ b/tests/components/enphase_ev/test_type_device_entity_fallbacks.py
@@ -174,6 +174,36 @@ def test_site_entities_fall_back_to_role_checks_without_property_or_type_helpers
     assert StormGuardSwitch(coord).available is True
 
 
+def test_system_profile_select_fallback_unavailable_without_battery_controls() -> None:
+    coord = SimpleNamespace(
+        site_id="site-4",
+        last_update_success=True,
+        battery_user_is_owner=True,
+        battery_user_is_installer=False,
+        battery_controls_available=False,
+        battery_profile_option_labels={"self-consumption": "Self-Consumption"},
+        battery_profile_option_keys=["self-consumption"],
+        battery_selected_profile="self-consumption",
+    )
+
+    assert SystemProfileSelect(coord).available is False
+
+
+def test_system_profile_select_fallback_unavailable_for_read_only_user() -> None:
+    coord = SimpleNamespace(
+        site_id="site-5",
+        last_update_success=True,
+        battery_user_is_owner=False,
+        battery_user_is_installer=False,
+        battery_controls_available=True,
+        battery_profile_option_labels={"self-consumption": "Self-Consumption"},
+        battery_profile_option_keys=["self-consumption"],
+        battery_selected_profile="self-consumption",
+    )
+
+    assert SystemProfileSelect(coord).available is False
+
+
 def test_base_entity_device_info_sets_via_device_from_type_identifier() -> None:
     class DummyEntity(EnphaseBaseEntity):
         pass


### PR DESCRIPTION
## Summary
- normalize battery capability blocks into typed coordinator state and expose them in diagnostics and sensor attributes
- harden battery write gating around capability flags, `systemTask`, and post-refresh revalidation
- split base charge-from-grid schedule support from force-schedule support so time-window controls and force-schedule controls are gated correctly

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/number.py custom_components/enphase_ev/switch.py custom_components/enphase_ev/select.py custom_components/enphase_ev/coordinator_diagnostics.py custom_components/enphase_ev/sensor.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_coordinator_battery_profile.py tests/components/enphase_ev/test_diagnostics.py tests/components/enphase_ev/test_sensors.py tests/components/enphase_ev/test_type_device_entity_fallbacks.py tests/components/enphase_ev/test_switch_module.py tests/components/enphase_ev/test_number_module.py tests/components/enphase_ev/test_time_module.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_coordinator_battery_profile.py tests/components/enphase_ev/test_switch_module.py tests/components/enphase_ev/test_number_module.py tests/components/enphase_ev/test_time_module.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/number.py,custom_components/enphase_ev/switch.py,custom_components/enphase_ev/select.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/state_models.py --fail-under=100"`
