### PR TITLE
Preserve green mode fallback from live schedule summary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Preserved Green mode from the live EVSE schedule summary when Enphase temporarily omits the scheduler preference, keeping `preferred_mode` and the charge-mode select stable instead of dropping to `null`/`unknown`.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -5102,6 +5102,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 charge_modes.get(sn)
             )
             if charge_mode_pref is None:
+                charge_mode_pref = self._schedule_type_charge_mode_preference(
+                    sch_info0.get("type")
+                )
+            if charge_mode_pref is None:
                 charge_mode_pref = self._cached_charge_mode_preference(sn)
             if charge_mode_pref is None:
                 charge_mode_pref = self._battery_profile_charge_mode_preference(sn)
@@ -7962,6 +7966,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self, sn: str, *, now: float | None = None
     ) -> str | None:
         return self.evse_runtime.cached_charge_mode_preference(sn, now=now)
+
+    @staticmethod
+    def _schedule_type_charge_mode_preference(schedule_type: object) -> str | None:
+        return EvseRuntime.schedule_type_charge_mode_preference(schedule_type)
 
     def _battery_profile_charge_mode_preference(self, sn: str) -> str | None:
         return self.evse_runtime.battery_profile_charge_mode_preference(sn)

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -1389,6 +1389,7 @@ class EvseRuntime:
         candidates: list[str | None] = [
             data.get("charge_mode_pref"),
             data.get("charge_mode"),
+            self.schedule_type_charge_mode_preference(data.get("schedule_type")),
         ]
         cached = self.cached_charge_mode_preference(sn_str)
         if cached is not None:
@@ -1448,6 +1449,21 @@ class EvseRuntime:
         if now - cache_entry[1] >= CHARGE_MODE_CACHE_TTL:
             return None
         return self.normalize_charge_mode_preference(cache_entry[0])
+
+    @staticmethod
+    def schedule_type_charge_mode_preference(schedule_type: object) -> str | None:
+        if schedule_type is None:
+            return None
+        try:
+            normalized = str(schedule_type).strip().upper()
+        except Exception:
+            return None
+        if not normalized:
+            return None
+        compact = normalized.replace("_", "").replace("-", "").replace(" ", "")
+        if compact == "GREENCHARGING":
+            return "GREEN_CHARGING"
+        return None
 
     @staticmethod
     def normalize_charge_mode_preference(value: object) -> str | None:

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -2324,6 +2324,83 @@ async def test_async_update_data_uses_battery_profile_charge_mode_when_scheduler
 
 
 @pytest.mark.asyncio
+async def test_async_update_data_uses_green_schedule_type_when_scheduler_pref_missing(
+    coordinator_factory,
+):
+    coord = coordinator_factory(
+        serials=["EV1"],
+        data={
+            "EV1": {
+                "sn": "EV1",
+                "name": "Garage EV",
+                "charge_mode": "IDLE",
+            }
+        },
+    )
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._scheduler_available = False  # noqa: SLF001
+    coord._scheduler_backoff_active = lambda: False  # type: ignore[assignment]  # noqa: SLF001
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": "EV1",
+                    "name": "Garage EV",
+                    "connectors": [
+                        {
+                            "connectorStatusType": coord_mod.SUSPENDED_EVSE_STATUS,
+                            "connectorStatusReason": "INSUFFICIENT_SOLAR",
+                        }
+                    ],
+                    "sch_d": {"status": 1, "info": [{"type": "greencharging"}]},
+                    "session_d": {},
+                    "charging": False,
+                }
+            ],
+            "ts": 1_700_000_000,
+        }
+    )
+    coord.summary = SimpleNamespace(
+        prepare_refresh=lambda **kwargs: False,
+        async_fetch=AsyncMock(return_value=[]),
+        invalidate=lambda: None,
+    )
+    coord.evse_timeseries.async_refresh = AsyncMock(return_value=None)  # noqa: SLF001
+    coord.evse_timeseries.merge_charger_payloads = MagicMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord.energy._async_refresh_site_energy = AsyncMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord._async_refresh_battery_site_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_status = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_backup_history = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_schedules = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_guard_profile = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_alert = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_grid_control_check = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_devices_inventory = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_dry_contact_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_hems_devices = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_inverters = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_current_power_consumption = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_heatpump_power = AsyncMock()  # noqa: SLF001
+    coord._async_resolve_green_battery_settings = AsyncMock(
+        return_value={}
+    )  # noqa: SLF001
+    coord._async_resolve_auth_settings = AsyncMock(return_value={})  # noqa: SLF001
+    coord._get_charge_mode = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
+    coord._sync_battery_profile_pending_issue = MagicMock()  # noqa: SLF001
+
+    result = await coord._async_update_data()  # noqa: SLF001
+
+    assert result["EV1"]["schedule_type"] == "greencharging"
+    assert result["EV1"]["charge_mode_pref"] == "GREEN_CHARGING"
+    assert result["EV1"]["charge_mode"] == "GREEN_CHARGING"
+
+
+@pytest.mark.asyncio
 async def test_async_update_data_handles_numeric_ts(
     coordinator_factory,
 ):
@@ -2510,6 +2587,9 @@ def test_charge_mode_preference_helpers(coordinator_factory):
     coord.data[sn]["charge_mode"] = "IDLE"
     assert coord._resolve_charge_mode_pref(sn) is None
 
+    coord.data[sn]["schedule_type"] = "greencharging"
+    assert coord._resolve_charge_mode_pref(sn) == "GREEN_CHARGING"
+
 
 def test_resolve_charge_mode_pref_handles_errors(coordinator_factory):
     coord = coordinator_factory(serials=["EV1"])
@@ -2539,6 +2619,7 @@ def test_charge_mode_normalizers_handle_invalid_values(coordinator_factory):
     assert coord._normalize_effective_charge_mode(BadStr()) is None  # noqa: SLF001
     assert coord._normalize_effective_charge_mode("   ") is None  # noqa: SLF001
     assert coord._normalize_effective_charge_mode("custom") is None  # noqa: SLF001
+    assert coord._schedule_type_charge_mode_preference(BadStr()) is None  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -138,6 +138,28 @@ def test_evse_runtime_battery_profile_charge_mode_preference_error_paths() -> No
     assert runtime.battery_profile_charge_mode_preference("EV1") is None
 
 
+def test_evse_runtime_schedule_type_charge_mode_preference_paths(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory().evse_runtime
+
+    class BadStr:
+        def __str__(self):
+            raise ValueError("boom")
+
+    assert (
+        runtime.schedule_type_charge_mode_preference("greencharging")
+        == "GREEN_CHARGING"
+    )
+    assert (
+        runtime.schedule_type_charge_mode_preference("GREEN_CHARGING")
+        == "GREEN_CHARGING"
+    )
+    assert runtime.schedule_type_charge_mode_preference("   ") is None
+    assert runtime.schedule_type_charge_mode_preference("CUSTOM") is None
+    assert runtime.schedule_type_charge_mode_preference(BadStr()) is None
+
+
 @pytest.mark.asyncio
 async def test_evse_runtime_resolvers_use_runtime_methods(
     coordinator_factory,

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -246,6 +246,9 @@ def test_charge_mode_select_current_option_paths(coordinator_factory):
     coord._charge_mode_cache.clear()  # noqa: SLF001
     assert sel.current_option is None
 
+    coord.data[RANDOM_SERIAL]["schedule_type"] = "greencharging"
+    assert sel.current_option == "Green"
+
 
 def test_charge_mode_select_uses_smart_label_for_smart_mode(coordinator_factory):
     from custom_components.enphase_ev.select import ChargeModeSelect


### PR DESCRIPTION
## Summary
- preserve Green mode when Enphase temporarily omits the scheduler preference
- use the live EVSE schedule summary as a fallback when the status payload still reports `greencharging`
- keep `preferred_mode` and the charge mode select stable instead of dropping to `null` or `unknown`
- addresses issue #424: https://github.com/barneyonline/ha-enphase-energy/issues/424

## Root Cause
The scheduler preference can intermittently return no mode while the live EVSE status still reports a green-charging schedule summary. Without a fallback from that live schedule summary, the integration can temporarily clear the preferred charge mode and expose `unknown` state to automations.

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/evse_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_select_charge_mode.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/evse_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_select_charge_mode.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_select_charge_mode.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/evse_runtime.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"`
