### PR TITLE
Fix IQ Battery schedule helper availability

### DIFF
--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -37,6 +37,24 @@ def _battery_write_access_confirmed(coord: EnphaseCoordinator) -> bool:
     return owner is True or installer is True
 
 
+def _cfg_schedule_edit_available(coord: EnphaseCoordinator) -> bool:
+    if getattr(coord, "charge_from_grid_schedule_available", False):
+        return True
+    if not getattr(coord, "charge_from_grid_control_available", False):
+        return False
+    if not getattr(coord, "charge_from_grid_schedule_supported", False):
+        return False
+    if getattr(coord, "_battery_cfg_schedule_id", None) is not None:
+        start_time = getattr(coord, "battery_charge_from_grid_start_time", None)
+        end_time = getattr(coord, "battery_charge_from_grid_end_time", None)
+        if start_time is not None and end_time is not None:
+            return True
+        begin = getattr(coord, "_battery_charge_begin_time", None)
+        end = getattr(coord, "_battery_charge_end_time", None)
+        return begin is not None and end is not None
+    return False
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: EnphaseConfigEntry,
@@ -289,7 +307,7 @@ class BatteryCfgScheduleLimitNumber(CoordinatorEntity, NumberEntity):
         return (
             _type_available(self._coord, "encharge")
             and _battery_write_access_confirmed(self._coord)
-            and self._coord.charge_from_grid_force_schedule_available
+            and _cfg_schedule_edit_available(self._coord)
             and self._coord.battery_cfg_schedule_limit is not None
         )
 
@@ -306,7 +324,11 @@ class BatteryCfgScheduleLimitNumber(CoordinatorEntity, NumberEntity):
         return float(level) if level is not None else 0.0
 
     async def async_set_native_value(self, value: float) -> None:
-        await self._coord.async_set_cfg_schedule_limit(int(value))
+        limit = int(value)
+        if self._coord.charge_from_grid_force_schedule_available:
+            await self._coord.async_set_cfg_schedule_limit(limit)
+            return
+        await self._coord.async_update_cfg_schedule(limit=limit)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -7800,22 +7800,47 @@ class EnphaseBatteryModeSensor(_SiteBaseEntity):
     def __init__(self, coord: EnphaseCoordinator):
         super().__init__(coord, "battery_mode", "Battery Mode", type_key="encharge")
 
+    def _mode_raw(self) -> str | None:
+        raw_mode = getattr(self._coord, "battery_grid_mode", None)
+        if raw_mode is not None:
+            return raw_mode
+        payload = getattr(self._coord, "battery_status_payload", None)
+        if isinstance(payload, dict):
+            storages = payload.get("storages")
+            if isinstance(storages, list):
+                for storage in storages:
+                    if not isinstance(storage, dict):
+                        continue
+                    raw_mode = storage.get("battery_mode")
+                    if raw_mode is None:
+                        continue
+                    try:
+                        text = str(raw_mode).strip()
+                    except Exception:  # noqa: BLE001
+                        continue
+                    if text:
+                        return text
+        return None
+
     @property
     def available(self) -> bool:
         if not super().available:
             return False
-        return self._coord.battery_grid_mode is not None
+        return self.native_value is not None
 
     @property
     def native_value(self):
-        return self._coord.battery_mode_display
+        display = getattr(self._coord, "battery_mode_display", None)
+        if display is not None:
+            return display
+        return self._mode_raw()
 
     @property
     def extra_state_attributes(self):
         start_time = getattr(self._coord, "battery_charge_from_grid_start_time", None)
         end_time = getattr(self._coord, "battery_charge_from_grid_end_time", None)
         return {
-            "mode_raw": self._coord.battery_grid_mode,
+            "mode_raw": self._mode_raw(),
             "charge_from_grid_allowed": self._coord.battery_charge_from_grid_allowed,
             "discharge_to_grid_allowed": self._coord.battery_discharge_to_grid_allowed,
             "charge_from_grid_enabled": getattr(

--- a/custom_components/enphase_ev/time.py
+++ b/custom_components/enphase_ev/time.py
@@ -76,6 +76,24 @@ def _type_available(coord: EnphaseCoordinator, type_key: str) -> bool:
     return bool(has_type(type_key)) if callable(has_type) else True
 
 
+def _cfg_schedule_edit_available(coord: EnphaseCoordinator) -> bool:
+    if getattr(coord, "charge_from_grid_schedule_available", False):
+        return True
+    if not getattr(coord, "charge_from_grid_control_available", False):
+        return False
+    if not getattr(coord, "charge_from_grid_schedule_supported", False):
+        return False
+    if getattr(coord, "_battery_cfg_schedule_id", None) is None:
+        return False
+    start_time = getattr(coord, "battery_charge_from_grid_start_time", None)
+    end_time = getattr(coord, "battery_charge_from_grid_end_time", None)
+    if start_time is not None and end_time is not None:
+        return True
+    begin = getattr(coord, "_battery_charge_begin_time", None)
+    end = getattr(coord, "_battery_charge_end_time", None)
+    return begin is not None and end is not None
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: EnphaseConfigEntry,
@@ -141,10 +159,9 @@ class _BaseChargeFromGridTimeEntity(CoordinatorEntity, TimeEntity):
     def available(self) -> bool:  # type: ignore[override]
         if not super().available:
             return False
-        return (
-            _type_available(self._coord, "encharge")
-            and self._coord.charge_from_grid_schedule_available
-        )
+        return _type_available(
+            self._coord, "encharge"
+        ) and _cfg_schedule_edit_available(self._coord)
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -173,7 +190,10 @@ class ChargeFromGridStartTimeEntity(_BaseChargeFromGridTimeEntity):
         return self._coord.battery_charge_from_grid_start_time
 
     async def async_set_value(self, value: dt_time) -> None:
-        await self._coord.async_set_charge_from_grid_schedule_time(start=value)
+        if self._coord.charge_from_grid_schedule_available:
+            await self._coord.async_set_charge_from_grid_schedule_time(start=value)
+            return
+        await self._coord.async_update_cfg_schedule(start=value)
 
 
 class ChargeFromGridEndTimeEntity(_BaseChargeFromGridTimeEntity):
@@ -191,4 +211,7 @@ class ChargeFromGridEndTimeEntity(_BaseChargeFromGridTimeEntity):
         return self._coord.battery_charge_from_grid_end_time
 
     async def async_set_value(self, value: dt_time) -> None:
-        await self._coord.async_set_charge_from_grid_schedule_time(end=value)
+        if self._coord.charge_from_grid_schedule_available:
+            await self._coord.async_set_charge_from_grid_schedule_time(end=value)
+            return
+        await self._coord.async_update_cfg_schedule(end=value)

--- a/tests/components/enphase_ev/test_number_module.py
+++ b/tests/components/enphase_ev/test_number_module.py
@@ -16,6 +16,56 @@ from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
 
 
+def test_cfg_schedule_edit_available_uses_schedule_id_and_public_times() -> None:
+    from custom_components.enphase_ev import number as number_mod
+
+    coord = SimpleNamespace(
+        charge_from_grid_schedule_available=False,
+        charge_from_grid_control_available=True,
+        charge_from_grid_schedule_supported=True,
+        battery_cfg_schedule_limit=None,
+        _battery_cfg_schedule_id="sched-1",
+        battery_charge_from_grid_start_time=1,
+        battery_charge_from_grid_end_time=2,
+        _battery_charge_begin_time=None,
+        _battery_charge_end_time=None,
+    )
+
+    assert number_mod._cfg_schedule_edit_available(coord) is True
+
+    coord.battery_charge_from_grid_start_time = None
+    coord.battery_charge_from_grid_end_time = None
+    coord._battery_charge_begin_time = 60
+    coord._battery_charge_end_time = 120
+
+    assert number_mod._cfg_schedule_edit_available(coord) is True
+
+    coord._battery_cfg_schedule_id = None
+    coord.battery_charge_from_grid_start_time = 1
+    coord.battery_charge_from_grid_end_time = 2
+    coord._battery_charge_begin_time = None
+    coord._battery_charge_end_time = None
+
+    assert number_mod._cfg_schedule_edit_available(coord) is False
+
+
+def test_cfg_schedule_edit_available_rejects_when_control_unavailable() -> None:
+    from custom_components.enphase_ev import number as number_mod
+
+    coord = SimpleNamespace(
+        charge_from_grid_schedule_available=False,
+        charge_from_grid_control_available=False,
+        charge_from_grid_schedule_supported=True,
+        _battery_cfg_schedule_id="sched-1",
+        battery_charge_from_grid_start_time=1,
+        battery_charge_from_grid_end_time=2,
+        _battery_charge_begin_time=60,
+        _battery_charge_end_time=120,
+    )
+
+    assert number_mod._cfg_schedule_edit_available(coord) is False
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_syncs_new_serials(hass, config_entry) -> None:
     coord = SimpleNamespace()
@@ -529,6 +579,9 @@ def test_battery_cfg_schedule_limit_number_bounds_and_availability(
     coord._battery_charge_from_grid = True  # noqa: SLF001
     coord._battery_cfg_schedule_limit = 80  # noqa: SLF001
     coord._battery_very_low_soc = 12  # noqa: SLF001
+    coord._battery_cfg_schedule_id = "sched-1"  # noqa: SLF001
+    coord._battery_charge_begin_time = 120  # noqa: SLF001
+    coord._battery_charge_end_time = 300  # noqa: SLF001
 
     number = BatteryCfgScheduleLimitNumber(coord)
 
@@ -589,7 +642,40 @@ def test_battery_cfg_schedule_limit_number_unavailable_without_force_support(
         )
     )
 
-    assert BatteryCfgScheduleLimitNumber(coord).available is False
+    assert BatteryCfgScheduleLimitNumber(coord).available is True
+
+
+@pytest.mark.asyncio
+async def test_battery_cfg_schedule_limit_number_updates_existing_schedule_when_force_toggle_unavailable(
+    hass, config_entry
+) -> None:
+    coord = _make_coordinator(hass, config_entry, {RANDOM_SERIAL: {}})
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_charge_from_grid = False  # noqa: SLF001
+    coord._battery_cfg_schedule_limit = 80  # noqa: SLF001
+    coord._battery_cfg_schedule_id = "sched-1"  # noqa: SLF001
+    coord._battery_charge_begin_time = 180  # noqa: SLF001
+    coord._battery_charge_end_time = 960  # noqa: SLF001
+    coord._battery_cfg_control = (
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {
+                "show": True,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "forceScheduleSupported": False,
+            }
+        )
+    )
+    coord.async_update_cfg_schedule = AsyncMock()
+
+    number = BatteryCfgScheduleLimitNumber(coord)
+
+    assert number.available is True
+    await number.async_set_native_value(95)
+
+    coord.async_update_cfg_schedule.assert_awaited_once_with(limit=95)
 
 
 def test_battery_cfg_schedule_limit_number_super_unavailable_and_device_info_fallback(

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -1007,6 +1007,7 @@ def test_battery_mode_sensor_states():
     assert attrs["use_battery_for_self_consumption"] is True
 
     coord.battery_grid_mode = None
+    coord.battery_mode_display = None
     assert sensor.available is False
 
 
@@ -1033,6 +1034,102 @@ def test_battery_mode_sensor_unavailable_when_coordinator_unavailable():
     )
 
     assert EnphaseBatteryModeSensor(coord).available is False
+
+
+def test_battery_mode_sensor_falls_back_to_status_payload():
+    from types import SimpleNamespace
+
+    from custom_components.enphase_ev.sensor import EnphaseBatteryModeSensor
+
+    coord = SimpleNamespace(
+        site_id="site",
+        battery_grid_mode=None,
+        battery_mode_display=None,
+        battery_charge_from_grid_allowed=None,
+        battery_discharge_to_grid_allowed=None,
+        battery_charge_from_grid_enabled=False,
+        battery_charge_from_grid_schedule_enabled=True,
+        battery_charge_from_grid_start_time=dt_time(3, 0),
+        battery_charge_from_grid_end_time=dt_time(16, 0),
+        battery_shutdown_level=None,
+        battery_shutdown_level_min=5,
+        battery_shutdown_level_max=100,
+        battery_use_battery_for_self_consumption=None,
+        battery_status_payload={
+            "storages": [
+                {
+                    "battery_mode": "Self-Consumption",
+                }
+            ]
+        },
+        _battery_hide_charge_from_grid=True,
+        _battery_envoy_supports_vls=True,
+        last_success_utc=None,
+        last_failure_utc=None,
+        last_failure_status=None,
+        last_failure_description=None,
+        last_failure_source=None,
+        last_failure_response=None,
+        backoff_ends_utc=None,
+        latency_ms=None,
+        last_update_success=True,
+    )
+
+    sensor = EnphaseBatteryModeSensor(coord)
+
+    assert sensor.available is True
+    assert sensor.native_value == "Self-Consumption"
+    assert sensor.extra_state_attributes["mode_raw"] == "Self-Consumption"
+
+
+def test_battery_mode_sensor_skips_invalid_status_payload_entries():
+    from types import SimpleNamespace
+
+    from custom_components.enphase_ev.sensor import EnphaseBatteryModeSensor
+
+    class BadStr:
+        def __str__(self):
+            raise ValueError("boom")
+
+    coord = SimpleNamespace(
+        site_id="site",
+        battery_grid_mode=None,
+        battery_mode_display=None,
+        battery_charge_from_grid_allowed=None,
+        battery_discharge_to_grid_allowed=None,
+        battery_charge_from_grid_enabled=False,
+        battery_charge_from_grid_schedule_enabled=False,
+        battery_charge_from_grid_start_time=None,
+        battery_charge_from_grid_end_time=None,
+        battery_shutdown_level=None,
+        battery_shutdown_level_min=5,
+        battery_shutdown_level_max=100,
+        battery_use_battery_for_self_consumption=None,
+        battery_status_payload={
+            "storages": [
+                None,
+                {},
+                {"battery_mode": BadStr()},
+                {"battery_mode": "Backup"},
+            ]
+        },
+        _battery_hide_charge_from_grid=False,
+        _battery_envoy_supports_vls=True,
+        last_success_utc=None,
+        last_failure_utc=None,
+        last_failure_status=None,
+        last_failure_description=None,
+        last_failure_source=None,
+        last_failure_response=None,
+        backoff_ends_utc=None,
+        latency_ms=None,
+        last_update_success=True,
+    )
+
+    sensor = EnphaseBatteryModeSensor(coord)
+
+    assert sensor.available is True
+    assert sensor.native_value == "Backup"
 
 
 def test_grid_control_status_sensor_states_and_attributes():

--- a/tests/components/enphase_ev/test_time_module.py
+++ b/tests/components/enphase_ev/test_time_module.py
@@ -26,6 +26,40 @@ def test_time_type_available_falls_back_to_has_type() -> None:
     assert time_mod._type_available(coord_no_helpers, "encharge") is True
 
 
+def test_cfg_schedule_edit_available_handles_supported_and_existing_windows() -> None:
+    from custom_components.enphase_ev import time as time_mod
+
+    coord = SimpleNamespace(
+        charge_from_grid_schedule_available=False,
+        charge_from_grid_control_available=False,
+        charge_from_grid_schedule_supported=False,
+        _battery_cfg_schedule_id=None,
+        battery_charge_from_grid_start_time=None,
+        battery_charge_from_grid_end_time=None,
+        _battery_charge_begin_time=None,
+        _battery_charge_end_time=None,
+    )
+
+    assert time_mod._cfg_schedule_edit_available(coord) is False
+
+    coord.charge_from_grid_control_available = True
+    assert time_mod._cfg_schedule_edit_available(coord) is False
+
+    coord.charge_from_grid_schedule_supported = True
+    coord.battery_charge_from_grid_start_time = dt_time(1, 0)
+    coord.battery_charge_from_grid_end_time = dt_time(2, 0)
+
+    assert time_mod._cfg_schedule_edit_available(coord) is False
+
+    coord._battery_cfg_schedule_id = "sched-1"
+    coord.battery_charge_from_grid_start_time = None
+    coord.battery_charge_from_grid_end_time = None
+    coord._battery_charge_begin_time = 60
+    coord._battery_charge_end_time = 120
+
+    assert time_mod._cfg_schedule_edit_available(coord) is True
+
+
 def test_migrated_time_entity_id_handles_strong_migration_and_auto_suffix() -> None:
     assert (
         _migrated_time_entity_id(
@@ -425,8 +459,9 @@ async def test_charge_from_grid_time_entity_availability_and_values(
     assert end.native_value == dt_time(5, 0)
 
     coord._battery_charge_from_grid = False  # noqa: SLF001
-    assert start.available is False
-    assert end.available is False
+    coord._battery_cfg_schedule_id = "sched-1"  # noqa: SLF001
+    assert start.available is True
+    assert end.available is True
 
 
 @pytest.mark.asyncio
@@ -505,3 +540,39 @@ async def test_charge_from_grid_time_entity_sets_value(coordinator_factory) -> N
     coord.async_set_charge_from_grid_schedule_time.assert_awaited_with(
         end=dt_time(4, 45)
     )
+
+
+@pytest.mark.asyncio
+async def test_charge_from_grid_time_entity_updates_existing_schedule_when_cfg_disabled(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_hide_charge_from_grid = False  # noqa: SLF001
+    coord._battery_charge_from_grid = False  # noqa: SLF001
+    coord._battery_charge_begin_time = 180  # noqa: SLF001
+    coord._battery_charge_end_time = 960  # noqa: SLF001
+    coord._battery_cfg_schedule_id = "sched-1"  # noqa: SLF001
+    coord._battery_cfg_control = (
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {
+                "show": True,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "forceScheduleSupported": False,
+            }
+        )
+    )
+    coord.async_update_cfg_schedule = AsyncMock()
+
+    start = ChargeFromGridStartTimeEntity(coord)
+    end = ChargeFromGridEndTimeEntity(coord)
+
+    assert start.available is True
+    assert end.available is True
+
+    await start.async_set_value(dt_time(1, 30))
+    coord.async_update_cfg_schedule.assert_awaited_with(start=dt_time(1, 30))
+
+    await end.async_set_value(dt_time(4, 45))
+    coord.async_update_cfg_schedule.assert_awaited_with(end=dt_time(4, 45))


### PR DESCRIPTION
## Summary
- keep the IQ Battery mode sensor available when Enphase omits `batteryGridMode` but still reports `battery_mode` in battery status payloads
- allow existing charge-from-grid schedule time and limit helpers to stay available when grid charging is off, but only when an existing CFG schedule can actually be updated
- keep helper availability aligned with write-path validation so Home Assistant does not show editable entities that fail immediately on write

## Root Cause
Issue #444 exposed two payload mismatches on affected IQ Battery sites. The homeowner payload could omit `batteryGridMode` even though battery status still reported the mode, and existing CFG schedules could remain editable through the schedule API while `chargeFromGrid` itself was off. The previous helper gating either hid valid entities or, after the initial fix, risked exposing helpers in states the runtime would still reject.

## Issue
- Related: https://github.com/barneyonline/ha-enphase-energy/issues/444

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_number_module.py tests/components/enphase_ev/test_time_module.py tests/components/enphase_ev/test_sensors.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/number.py custom_components/enphase_ev/time.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_number_module.py tests/components/enphase_ev/test_time_module.py tests/components/enphase_ev/test_sensors.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/number.py,custom_components/enphase_ev/time.py,custom_components/enphase_ev/sensor.py --fail-under=100"`
