### PR TITLE
Add heat pump power diagnostics

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -4514,6 +4514,11 @@ class EnphaseEVClient:
         normalized: dict[str, object] = {
             "heat_pump_consumption": values,
         }
+        device_uid = data.get("device_uid")
+        if device_uid is None:
+            device_uid = data.get("uid")
+        if device_uid is not None:
+            normalized["device_uid"] = device_uid
         start_date = data.get("start_date")
         if start_date is None:
             start_date = data.get("startDate")
@@ -4589,6 +4594,62 @@ class EnphaseEVClient:
 
         return urls
 
+    def _debug_hems_power_timeseries_summary(
+        self,
+        payload: dict[str, object] | None,
+        *,
+        requested_device_uid: str | None = None,
+    ) -> dict[str, object]:
+        """Return a compact debug summary for normalized HEMS power payloads."""
+
+        if not isinstance(payload, dict):
+            return {"payload_type": type(payload).__name__}
+
+        values = payload.get("heat_pump_consumption")
+        bucket_count = 0
+        non_null_bucket_count = 0
+        latest_non_null_index: int | None = None
+        latest_non_null_value: float | None = None
+        if isinstance(values, list):
+            bucket_count = len(values)
+            for index in range(len(values) - 1, -1, -1):
+                numeric = self._coerce_lifetime_energy_value(values[index])
+                if numeric is None:
+                    continue
+                non_null_bucket_count += 1
+                if latest_non_null_index is None:
+                    latest_non_null_index = index
+                    latest_non_null_value = numeric
+
+        interval_minutes = self._coerce_lifetime_energy_value(
+            payload.get("interval_minutes")
+        )
+        response_uid = payload.get("device_uid") or payload.get("uid")
+        return {
+            "requested_device_uid": (
+                self._truncate_debug_identifier(requested_device_uid)
+                if requested_device_uid
+                else None
+            ),
+            "response_device_uid": (
+                self._truncate_debug_identifier(response_uid) if response_uid else None
+            ),
+            "bucket_count": bucket_count,
+            "non_null_bucket_count": non_null_bucket_count,
+            "latest_non_null_index": latest_non_null_index,
+            "latest_non_null_value": (
+                round(float(latest_non_null_value), 3)
+                if latest_non_null_value is not None
+                else None
+            ),
+            "start_date": payload.get("start_date"),
+            "interval_minutes": (
+                round(float(interval_minutes), 3)
+                if interval_minutes is not None
+                else None
+            ),
+        }
+
     async def hems_power_timeseries(
         self,
         device_uid: str | None = None,
@@ -4663,7 +4724,18 @@ class EnphaseEVClient:
                     return None
                 raise
             else:
-                return self._normalize_hems_power_timeseries_payload(data)
+                normalized = self._normalize_hems_power_timeseries_payload(data)
+                if _LOGGER.isEnabledFor(logging.DEBUG):
+                    _LOGGER.debug(
+                        "HEMS power endpoint response summary for site %s: context=%s summary=%s",
+                        redact_site_id(self._site),
+                        debug_context,
+                        self._debug_hems_power_timeseries_summary(
+                            normalized,
+                            requested_device_uid=device_uid,
+                        ),
+                    )
+                return normalized
 
     async def heat_pump_events_json(self, device_uid: str) -> dict | list | None:
         """Return per-device HEMS heat-pump events payload when available."""

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -96,6 +96,26 @@ class HeatpumpRuntime:
     def _debug_truncate_identifier(self, value: object) -> str | None:
         return self.coordinator._debug_truncate_identifier(value)
 
+    def _heatpump_power_redaction_identifiers(
+        self, *extra_identifiers: object
+    ) -> tuple[str, ...]:
+        identifiers: list[str] = []
+        seen: set[str] = set()
+
+        def _add(value: object) -> None:
+            text = coerce_optional_text(value)
+            if not text or text in seen:
+                return
+            seen.add(text)
+            identifiers.append(text)
+
+        for member in self._type_bucket_members("heatpump"):
+            for alias in self._heatpump_member_aliases(member):
+                _add(alias)
+        for value in extra_identifiers:
+            _add(value)
+        return tuple(identifiers)
+
     @staticmethod
     async def _async_call_refreshable_fetcher(
         fetcher, *, force: bool = False
@@ -179,6 +199,7 @@ class HeatpumpRuntime:
             self._heatpump_daily_consumption_backoff_until = None
             self._heatpump_daily_consumption_last_error = None
             self._heatpump_daily_consumption_cache_key = None
+            self._heatpump_power_snapshot = None
             return
 
         now = time.monotonic()
@@ -201,6 +222,18 @@ class HeatpumpRuntime:
                 "Heat pump daily-consumption diagnostics refresh failed for site %s: %s",
                 redact_site_id(self.site_id),
                 redact_text(err, site_ids=(self.site_id,)),
+            )
+        try:
+            await self._async_refresh_heatpump_power(force=force)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Heat pump power diagnostics refresh failed for site %s: %s",
+                redact_site_id(self.site_id),
+                redact_text(
+                    err,
+                    site_ids=(self.site_id,),
+                    identifiers=self._heatpump_power_redaction_identifiers(),
+                ),
             )
 
         self._heatpump_runtime_diagnostics_error = None
@@ -943,6 +976,88 @@ class HeatpumpRuntime:
             sample_index,
         )
 
+    def _heatpump_power_debug_candidate_summary(
+        self, uid: str | None
+    ) -> dict[str, object]:
+        member = self._heatpump_member_for_uid(uid) if uid else None
+        return {
+            "requested_device_ref": (
+                self._debug_truncate_identifier(uid) if uid else None
+            ),
+            "member_device_ref": self._debug_truncate_identifier(
+                self._heatpump_member_primary_id(member)
+            ),
+            "member_parent_ref": self._debug_truncate_identifier(
+                self._heatpump_member_parent_id(member)
+            ),
+            "member_device_type": heatpump_member_device_type(member),
+            "pairing_status": heatpump_pairing_status(member),
+            "device_state": heatpump_device_state(member),
+            "status": heatpump_status_text(member),
+            "recommended": self._heatpump_power_candidate_is_recommended(uid),
+        }
+
+    def _heatpump_power_debug_payload_summary(
+        self,
+        payload: dict[str, object],
+        *,
+        requested_uid: str | None,
+        sample: tuple[int, float] | None,
+        selection_key: tuple[int, int, int, int, float, int, int] | None,
+    ) -> dict[str, object]:
+        payload_uid = type_member_text(payload, "device_uid", "uid")
+        resolved_uid = payload_uid or requested_uid
+        member = self._heatpump_member_for_uid(resolved_uid) if resolved_uid else None
+        values = payload.get("heat_pump_consumption")
+        bucket_count = 0
+        non_null_bucket_count = 0
+        sample_tail: list[dict[str, object]] = []
+        if isinstance(values, list):
+            bucket_count = len(values)
+            for index in range(len(values) - 1, -1, -1):
+                numeric = coerce_optional_float(values[index])
+                if numeric is None:
+                    continue
+                non_null_bucket_count += 1
+                if len(sample_tail) < 3:
+                    sample_tail.append(
+                        {
+                            "index": index,
+                            "value_w": round(numeric, 3),
+                        }
+                    )
+        interval_minutes = coerce_optional_float(payload.get("interval_minutes"))
+        return {
+            "requested_device_ref": (
+                self._debug_truncate_identifier(requested_uid)
+                if requested_uid
+                else None
+            ),
+            "payload_device_ref": (
+                self._debug_truncate_identifier(payload_uid) if payload_uid else None
+            ),
+            "resolved_device_ref": (
+                self._debug_truncate_identifier(resolved_uid) if resolved_uid else None
+            ),
+            "member_device_type": heatpump_member_device_type(member),
+            "pairing_status": heatpump_pairing_status(member),
+            "device_state": heatpump_device_state(member),
+            "status": heatpump_status_text(member),
+            "recommended": self._heatpump_power_candidate_is_recommended(resolved_uid),
+            "bucket_count": bucket_count,
+            "non_null_bucket_count": non_null_bucket_count,
+            "sample_tail": sample_tail,
+            "latest_sample_index": sample[0] if sample is not None else None,
+            "latest_sample_w": (
+                round(float(sample[1]), 3) if sample is not None else None
+            ),
+            "start_date": coerce_optional_text(payload.get("start_date")),
+            "interval_minutes": (
+                round(interval_minutes, 3) if interval_minutes is not None else None
+            ),
+            "selection_key": list(selection_key) if selection_key is not None else None,
+        }
+
     async def _async_refresh_heatpump_power(self, *, force: bool = False) -> None:
         now = time.monotonic()
         if not self.has_type("heatpump"):
@@ -951,6 +1066,7 @@ class HeatpumpRuntime:
             self._heatpump_power_start_utc = None
             self._heatpump_power_device_uid = None
             self._heatpump_power_source = None
+            self._heatpump_power_snapshot = None
             self._heatpump_power_cache_until = None
             self._heatpump_power_backoff_until = None
             self._heatpump_power_last_error = None
@@ -970,6 +1086,11 @@ class HeatpumpRuntime:
             self._heatpump_power_start_utc = None
             self._heatpump_power_device_uid = None
             self._heatpump_power_source = None
+            self._heatpump_power_snapshot = {
+                "site_date": self._site_local_current_date(),
+                "force": force,
+                "outcome": "unsupported_site",
+            }
             self._heatpump_power_cache_until = now + HEATPUMP_POWER_CACHE_TTL
             self._heatpump_power_backoff_until = None
             self._heatpump_power_last_error = None
@@ -978,10 +1099,46 @@ class HeatpumpRuntime:
 
         fetcher = getattr(self.client, "hems_power_timeseries", None)
         if not callable(fetcher):
+            self._heatpump_power_snapshot = {
+                "site_date": self._site_local_current_date(),
+                "force": force,
+                "outcome": "fetcher_unavailable",
+            }
             return
 
         site_date = self._site_local_current_date()
-        candidate_uids, _compare_all, marker = self._heatpump_power_fetch_plan()
+        candidate_uids, compare_all, marker = self._heatpump_power_fetch_plan()
+        candidate_summaries = [
+            self._heatpump_power_debug_candidate_summary(candidate_uid)
+            for candidate_uid in candidate_uids
+        ]
+        power_snapshot: dict[str, object] = {
+            "site_date": site_date,
+            "force": force,
+            "compare_all": compare_all,
+            "previous_device_ref": self._debug_truncate_identifier(
+                self._heatpump_power_device_uid
+            ),
+            "candidates": candidate_summaries,
+            "attempts": [],
+            "selected_payload": None,
+            "selected_source": None,
+            "selected_sample_at_utc": None,
+            "last_error": None,
+            "outcome": "pending",
+        }
+        self._heatpump_power_snapshot = power_snapshot
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(
+                "Heat pump power fetch plan for site %s: site_date=%s force=%s compare_all=%s previous_device_uid=%s candidates=%s",
+                redact_site_id(self.site_id),
+                site_date,
+                force,
+                compare_all,
+                self._debug_truncate_identifier(self._heatpump_power_device_uid)
+                or "[redacted]",
+                candidate_summaries,
+            )
         payload: dict[str, object] | None = None
         sample: tuple[int, float] | None = None
         requested_uid: str | None = None
@@ -995,13 +1152,51 @@ class HeatpumpRuntime:
                 )
             except Exception as err:  # noqa: BLE001
                 last_error = err
+                redacted_error = (
+                    redact_text(
+                        err,
+                        site_ids=(self.site_id,),
+                        identifiers=self._heatpump_power_redaction_identifiers(
+                            candidate_uid
+                        ),
+                    )
+                    or err.__class__.__name__
+                )
+                attempts = power_snapshot.setdefault("attempts", [])
+                if isinstance(attempts, list):
+                    attempts.append(
+                        {
+                            "requested_device_ref": self._debug_truncate_identifier(
+                                candidate_uid
+                            ),
+                            "error": redacted_error,
+                        }
+                    )
                 _LOGGER.debug(
                     "Heat pump power fetch failed (requested_device_uid=%s): %s",
                     self._debug_truncate_identifier(candidate_uid) or "[redacted]",
-                    err,
+                    redacted_error,
                 )
                 continue
             if not isinstance(current_payload, dict):
+                attempts = power_snapshot.setdefault("attempts", [])
+                if isinstance(attempts, list):
+                    attempts.append(
+                        {
+                            "requested_device_ref": self._debug_truncate_identifier(
+                                candidate_uid
+                            ),
+                            "payload_type": type(current_payload).__name__,
+                            "usable_payload": False,
+                        }
+                    )
+                if _LOGGER.isEnabledFor(logging.DEBUG):
+                    _LOGGER.debug(
+                        "Heat pump power fetch returned unusable payload for site %s: requested_device_uid=%s payload_type=%s",
+                        redact_site_id(self.site_id),
+                        self._debug_truncate_identifier(candidate_uid) or "[redacted]",
+                        type(current_payload).__name__,
+                    )
                 continue
             current_sample = self._heatpump_latest_power_sample(current_payload)
             current_key = self._heatpump_power_selection_key(
@@ -1009,6 +1204,21 @@ class HeatpumpRuntime:
                 requested_uid=candidate_uid,
                 sample=current_sample,
             )
+            current_summary = self._heatpump_power_debug_payload_summary(
+                current_payload,
+                requested_uid=candidate_uid,
+                sample=current_sample,
+                selection_key=current_key,
+            )
+            attempts = power_snapshot.setdefault("attempts", [])
+            if isinstance(attempts, list):
+                attempts.append(current_summary)
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug(
+                    "Heat pump power candidate payload for site %s: %s",
+                    redact_site_id(self.site_id),
+                    current_summary,
+                )
             if selected_key is None or current_key > selected_key:
                 payload = current_payload
                 requested_uid = candidate_uid
@@ -1016,10 +1226,19 @@ class HeatpumpRuntime:
                 selected_key = current_key
 
         if payload is None and last_error is not None:
-            self._heatpump_power_last_error = (
-                redact_text(last_error, site_ids=(self.site_id,))
+            last_error_text = (
+                redact_text(
+                    last_error,
+                    site_ids=(self.site_id,),
+                    identifiers=self._heatpump_power_redaction_identifiers(
+                        requested_uid
+                    ),
+                )
                 or last_error.__class__.__name__
             )
+            self._heatpump_power_last_error = last_error_text
+            power_snapshot["last_error"] = last_error_text
+            power_snapshot["outcome"] = "fetch_error"
             self._heatpump_power_backoff_until = now + HEATPUMP_POWER_FAILURE_BACKOFF_S
             self._heatpump_power_cache_until = None
             return
@@ -1036,6 +1255,14 @@ class HeatpumpRuntime:
         self._heatpump_power_source = "hems_power_timeseries"
 
         if not isinstance(payload, dict):
+            power_snapshot["outcome"] = "no_usable_payload"
+            if _LOGGER.isEnabledFor(logging.DEBUG):
+                _LOGGER.debug(
+                    "Heat pump power refresh found no usable payload for site %s: site_date=%s candidates=%s",
+                    redact_site_id(self.site_id),
+                    site_date,
+                    candidate_summaries,
+                )
             return
 
         payload_uid = type_member_text(payload, "device_uid", "uid")
@@ -1045,10 +1272,32 @@ class HeatpumpRuntime:
             self._heatpump_power_source = (
                 f"hems_power_timeseries:{self._heatpump_power_device_uid}"
             )
+        selected_summary = self._heatpump_power_debug_payload_summary(
+            payload,
+            requested_uid=requested_uid,
+            sample=sample,
+            selection_key=selected_key,
+        )
+        power_snapshot["selected_payload"] = selected_summary
+        if self._heatpump_power_device_uid:
+            power_snapshot["selected_source"] = (
+                "hems_power_timeseries:"
+                f"{self._debug_truncate_identifier(self._heatpump_power_device_uid)}"
+            )
+        else:
+            power_snapshot["selected_source"] = self._heatpump_power_source
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(
+                "Heat pump power selected payload for site %s: %s",
+                redact_site_id(self.site_id),
+                selected_summary,
+            )
         if sample is None:
+            power_snapshot["outcome"] = "no_usable_sample"
             return
         sample_index, sample_value = sample
         self._heatpump_power_w = sample_value
+        power_snapshot["outcome"] = "selected_sample"
 
         start_utc = parse_inverter_last_report(payload.get("start_date"))
         self._heatpump_power_start_utc = start_utc
@@ -1078,6 +1327,11 @@ class HeatpumpRuntime:
                 self._heatpump_power_sample_utc = None
         elif sample_index is not None:
             self._heatpump_power_sample_utc = dt_util.utcnow()
+        power_snapshot["selected_sample_at_utc"] = (
+            self._heatpump_power_sample_utc.isoformat()
+            if self._heatpump_power_sample_utc is not None
+            else None
+        )
 
     async def async_refresh_heatpump_power(self, *, force: bool = False) -> None:
         await self._async_refresh_heatpump_power(force=force)
@@ -1147,6 +1401,9 @@ class HeatpumpRuntime:
             ),
             "events_payloads": self._copy_diagnostics_value(
                 list(getattr(self, "_heatpump_events_payloads", []) or [])
+            ),
+            "power_snapshot": self._copy_diagnostics_value(
+                getattr(self, "_heatpump_power_snapshot", None)
             ),
             "event_summary": self._heatpump_event_summary(),
             "last_error": getattr(self, "_heatpump_runtime_diagnostics_error", None),

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -4728,6 +4728,7 @@ async def test_hems_power_timeseries_normalization() -> None:
     client = _make_client()
     client._json = AsyncMock(
         return_value={
+            "device_uid": "HP-1",
             "heat_pump_consumption": [None, "1200.5", "bad", 900],
             "startDate": "2026-02-27T00:00:00Z",
             "interval": "5",
@@ -4737,6 +4738,7 @@ async def test_hems_power_timeseries_normalization() -> None:
     payload = await client.hems_power_timeseries(device_uid="HP-1")
 
     assert payload == {
+        "device_uid": "HP-1",
         "heat_pump_consumption": [None, 1200.5, None, 900.0],
         "start_date": "2026-02-27T00:00:00Z",
         "interval_minutes": 5.0,
@@ -5116,6 +5118,41 @@ async def test_hems_power_timeseries_optional_invalid_payload_logs_redacted_summ
     assert "[redacted]" in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_hems_power_timeseries_success_logs_redacted_response_summary(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        return_value={
+            "device_uid": "DEVICE-UID-123456789",
+            "heat_pump_consumption": [None, "550.5", 0],
+            "startDate": "2026-02-27T00:00:00Z",
+            "intervalMinutes": "5",
+        }
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        payload = await client.hems_power_timeseries(
+            device_uid="DEVICE-UID-123456789",
+            site_date="2026-03-13",
+        )
+
+    assert payload == {
+        "device_uid": "DEVICE-UID-123456789",
+        "heat_pump_consumption": [None, 550.5, 0.0],
+        "start_date": "2026-02-27T00:00:00Z",
+        "interval_minutes": 5.0,
+    }
+    assert "HEMS power endpoint response summary for site [site]" in caplog.text
+    assert "DEVICE-UID-123456789" not in caplog.text
+    assert "/systems/SITE/hems_power_timeseries" not in caplog.text
+    assert "DEVI...6789" in caplog.text
+    assert "/systems/[site]/hems_power_timeseries" in caplog.text
+    assert "'bucket_count': 3" in caplog.text
+    assert "'latest_non_null_value': 0.0" in caplog.text
+
+
 def test_is_hems_invalid_date_error_handles_unstringable_message() -> None:
     class _BadString:
         def __str__(self) -> str:
@@ -5165,12 +5202,14 @@ def test_normalize_hems_power_timeseries_payload_accepts_alias_keys() -> None:
     assert client._normalize_hems_power_timeseries_payload(  # noqa: SLF001
         {
             "data": {
+                "uid": "HP-1",
                 "heatpump_consumption": [None, "550.5", "bad"],
                 "startDate": "2026-02-27T00:00:00Z",
                 "intervalMinutes": "5",
             }
         }
     ) == {
+        "device_uid": "HP-1",
         "heat_pump_consumption": [None, 550.5, None],
         "start_date": "2026-02-27T00:00:00Z",
         "interval_minutes": 5.0,
@@ -5210,6 +5249,14 @@ def test_normalize_hems_power_timeseries_payload_skips_non_list_alias_values() -
         "heat_pump_consumption": [None, 525.0],
         "start_date": "2026-03-01T00:00:00Z",
         "interval_minutes": 5.0,
+    }
+
+
+def test_debug_hems_power_timeseries_summary_handles_non_dict_payload() -> None:
+    client = _make_client()
+
+    assert client._debug_hems_power_timeseries_summary(None) == {  # noqa: SLF001
+        "payload_type": "NoneType"
     }
 
 

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -448,6 +448,38 @@ class DummyCoordinator(SimpleNamespace):
                 "payload": [{"statusText": "Recommended"}],
             }
         ]
+        self._heatpump_power_snapshot = {
+            "site_date": "2026-03-01",
+            "force": True,
+            "compare_all": True,
+            "previous_device_ref": "H...1",
+            "candidates": [
+                {
+                    "requested_device_ref": "H...1",
+                    "member_device_ref": "H...1",
+                    "member_device_type": "HEAT_PUMP",
+                    "status": "Normal",
+                    "recommended": False,
+                }
+            ],
+            "attempts": [
+                {
+                    "requested_device_ref": "H...1",
+                    "resolved_device_ref": "H...1",
+                    "bucket_count": 3,
+                    "non_null_bucket_count": 1,
+                    "latest_sample_w": 550.0,
+                }
+            ],
+            "selected_payload": {
+                "resolved_device_ref": "H...1",
+                "latest_sample_w": 550.0,
+            },
+            "selected_source": "hems_power_timeseries:H...1",
+            "selected_sample_at_utc": "2026-03-01T00:05:00+00:00",
+            "last_error": None,
+            "outcome": "selected_sample",
+        }
         self._heatpump_runtime_diagnostics_error = None
 
     def collect_site_metrics(self):
@@ -538,6 +570,7 @@ class DummyCoordinator(SimpleNamespace):
             "daily_consumption_last_error": self._heatpump_daily_consumption_last_error,
             "show_livestream_payload": self._show_livestream_payload,
             "events_payloads": self._heatpump_events_payloads,
+            "power_snapshot": self._heatpump_power_snapshot,
             "last_error": self._heatpump_runtime_diagnostics_error,
         }
 
@@ -705,6 +738,22 @@ async def test_config_entry_diagnostics_includes_coordinator(
             "statusText"
         ]
         == "Recommended"
+    )
+    assert (
+        diag["coordinator"]["heatpump_runtime"]["power_snapshot"]["candidates"][0][
+            "requested_device_ref"
+        ]
+        == "H...1"
+    )
+    assert (
+        diag["coordinator"]["heatpump_runtime"]["power_snapshot"]["selected_payload"][
+            "latest_sample_w"
+        ]
+        == 550.0
+    )
+    assert (
+        diag["coordinator"]["heatpump_runtime"]["power_snapshot"]["selected_source"]
+        == "hems_power_timeseries:H...1"
     )
     assert diag["coordinator"]["battery_config"]["devices_inventory_payload"] == {
         "result": [{"type": "encharge"}]
@@ -1223,6 +1272,16 @@ async def test_device_diagnostics_heatpump_includes_runtime_payloads(
     assert (
         result["heatpump_runtime"]["events_payloads"][0]["payload"][0]["statusText"]
         == "Recommended"
+    )
+    assert (
+        result["heatpump_runtime"]["power_snapshot"]["selected_payload"][
+            "resolved_device_ref"
+        ]
+        == "H...1"
+    )
+    assert (
+        result["heatpump_runtime"]["power_snapshot"]["selected_source"]
+        == "hems_power_timeseries:H...1"
     )
 
 

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -98,6 +98,56 @@ async def test_heatpump_runtime_public_async_wrappers(
 
 
 @pytest.mark.asyncio
+async def test_heatpump_runtime_diagnostics_refreshes_power_snapshot(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._type_device_buckets = {  # noqa: SLF001
+        "heatpump": {"type_key": "heatpump", "count": 1, "devices": [{}]}
+    }
+    runtime._async_refresh_heatpump_runtime_state = AsyncMock()  # type: ignore[assignment]  # noqa: SLF001
+    runtime._async_refresh_heatpump_daily_consumption = AsyncMock()  # type: ignore[assignment]  # noqa: SLF001
+    runtime._async_refresh_heatpump_power = AsyncMock()  # type: ignore[assignment]  # noqa: SLF001
+
+    await runtime.async_ensure_heatpump_runtime_diagnostics(force=True)
+
+    runtime._async_refresh_heatpump_runtime_state.assert_awaited_once_with(  # noqa: SLF001
+        force=True
+    )
+    runtime._async_refresh_heatpump_daily_consumption.assert_awaited_once_with(  # noqa: SLF001
+        force=True
+    )
+    runtime._async_refresh_heatpump_power.assert_awaited_once_with(  # noqa: SLF001
+        force=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_heatpump_runtime_diagnostics_logs_power_refresh_failures(
+    coordinator_factory, caplog
+) -> None:
+    raw_uid = "DEVICE-UID-123456789"
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._type_device_buckets = {  # noqa: SLF001
+        "heatpump": {
+            "type_key": "heatpump",
+            "count": 1,
+            "devices": [{"device_uid": raw_uid}],
+        }
+    }
+    runtime._async_refresh_heatpump_runtime_state = AsyncMock()  # type: ignore[assignment]  # noqa: SLF001
+    runtime._async_refresh_heatpump_daily_consumption = AsyncMock()  # type: ignore[assignment]  # noqa: SLF001
+    runtime._async_refresh_heatpump_power = AsyncMock(side_effect=RuntimeError(f"power {raw_uid}"))  # type: ignore[assignment]  # noqa: SLF001
+
+    with caplog.at_level(logging.DEBUG):
+        await runtime.async_ensure_heatpump_runtime_diagnostics(force=True)
+
+    assert "Heat pump power diagnostics refresh failed for site" in caplog.text
+    assert raw_uid not in caplog.text
+    assert "DEVI...6789" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_heatpump_runtime_power_failure_logs_truncated_device_uid(
     coordinator_factory, caplog
 ) -> None:
@@ -132,6 +182,208 @@ async def test_heatpump_runtime_power_failure_logs_truncated_device_uid(
     assert "Heat pump power fetch failed" in caplog.text
     assert "DEVICE-UID-123456789" not in caplog.text
     assert "DEVI...6789" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_heatpump_runtime_power_logs_fetch_plan_and_selection_summary(
+    coordinator_factory, caplog
+) -> None:
+    primary_uid = "DEVICE-UID-123456789"
+    meter_uid = "METER-UID-987654321"
+    coord = coordinator_factory(serials=[])
+    coord._devices_inventory_payload = {"curr_date_site": "2026-03-13"}  # noqa: SLF001
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 2,
+                "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": primary_uid,
+                        "statusText": "Normal",
+                    },
+                    {
+                        "device_type": "ENERGY_METER",
+                        "device_uid": meter_uid,
+                        "statusText": "Recommended",
+                    },
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    coord.client.hems_power_timeseries = AsyncMock(
+        side_effect=[
+            {
+                "device_uid": primary_uid,
+                "heat_pump_consumption": [None, 25.0],
+                "start_date": "2026-03-13T00:00:00Z",
+                "interval_minutes": 5,
+            },
+            {
+                "device_uid": meter_uid,
+                "heat_pump_consumption": [None, 550.0],
+                "start_date": "2026-03-13T00:00:00Z",
+                "interval_minutes": 5,
+            },
+            "bad",
+        ]
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        await coord.heatpump_runtime._async_refresh_heatpump_power(  # noqa: SLF001
+            force=True
+        )
+
+    assert "Heat pump power fetch plan for site" in caplog.text
+    assert "Heat pump power candidate payload for site" in caplog.text
+    assert "Heat pump power selected payload for site" in caplog.text
+    assert "Heat pump power fetch returned unusable payload for site" in caplog.text
+    assert primary_uid not in caplog.text
+    assert meter_uid not in caplog.text
+    assert "DEVI...6789" in caplog.text
+    assert "METE...4321" in caplog.text
+    assert "'latest_sample_w': 550.0" in caplog.text
+    assert coord.heatpump_power_device_uid == meter_uid
+    power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
+        "power_snapshot"
+    ]
+    assert power_snapshot["compare_all"] is True
+    assert power_snapshot["previous_device_ref"] is None
+    assert power_snapshot["outcome"] == "selected_sample"
+    assert power_snapshot["selected_source"] == "hems_power_timeseries:METE...4321"
+    assert power_snapshot["selected_payload"]["resolved_device_ref"] == "METE...4321"
+    assert power_snapshot["selected_payload"]["latest_sample_w"] == pytest.approx(550.0)
+    assert power_snapshot["selected_sample_at_utc"] is not None
+    assert len(power_snapshot["attempts"]) == 3
+
+
+@pytest.mark.asyncio
+async def test_heatpump_runtime_power_logs_when_no_candidate_payload_is_usable(
+    coordinator_factory, caplog
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._devices_inventory_payload = {"curr_date_site": "2026-03-13"}  # noqa: SLF001
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    coord.client.hems_power_timeseries = AsyncMock(return_value="bad")
+
+    with caplog.at_level(logging.DEBUG):
+        await coord.heatpump_runtime._async_refresh_heatpump_power(  # noqa: SLF001
+            force=True
+        )
+
+    assert "Heat pump power refresh found no usable payload for site" in caplog.text
+    assert coord.heatpump_power_w is None
+    power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
+        "power_snapshot"
+    ]
+    assert power_snapshot["outcome"] == "no_usable_payload"
+    assert power_snapshot["attempts"] == [
+        {
+            "requested_device_ref": "H...1",
+            "payload_type": "str",
+            "usable_payload": False,
+        },
+        {
+            "requested_device_ref": None,
+            "payload_type": "str",
+            "usable_payload": False,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_heatpump_runtime_power_snapshot_handles_selected_payload_without_uid(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._devices_inventory_payload = {"curr_date_site": "2026-03-13"}  # noqa: SLF001
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "statusText": "Normal"}],
+            }
+        },
+        ["heatpump"],
+    )
+    coord.client.hems_power_timeseries = AsyncMock(
+        return_value={
+            "heat_pump_consumption": [125.0],
+            "start_date": "2026-03-13T00:00:00Z",
+            "interval_minutes": 5,
+        }
+    )
+
+    await coord.heatpump_runtime._async_refresh_heatpump_power(
+        force=True
+    )  # noqa: SLF001
+
+    assert coord.heatpump_power_w == pytest.approx(125.0)
+    assert coord.heatpump_power_device_uid is None
+    assert coord.heatpump_power_source == "hems_power_timeseries"
+    power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
+        "power_snapshot"
+    ]
+    assert power_snapshot["selected_source"] == "hems_power_timeseries"
+
+
+@pytest.mark.asyncio
+async def test_heatpump_runtime_power_snapshot_redacts_identifier_bearing_errors(
+    coordinator_factory,
+) -> None:
+    raw_uid = "DEVICE-UID-123456789"
+    coord = coordinator_factory(serials=[])
+    coord._devices_inventory_payload = {"curr_date_site": "2026-03-13"}  # noqa: SLF001
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": raw_uid,
+                        "serial_number": "SERIAL-123456",
+                    }
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+
+    async def _raise_fetch_error(*, device_uid=None, site_date=None):
+        raise RuntimeError(f"fetch failed for {raw_uid} serial SERIAL-123456")
+
+    coord.client.hems_power_timeseries = _raise_fetch_error  # type: ignore[method-assign]
+    coord.heatpump_runtime._async_refresh_hems_support_preflight = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
+
+    await coord.heatpump_runtime._async_refresh_heatpump_power(
+        force=True
+    )  # noqa: SLF001
+
+    power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
+        "power_snapshot"
+    ]
+    assert power_snapshot["outcome"] == "fetch_error"
+    attempt_error = power_snapshot["attempts"][0]["error"]
+    assert raw_uid not in attempt_error
+    assert "SERIAL-123456" not in attempt_error
+    assert "DEVI...6789" in attempt_error
+    assert "SERI...3456" in attempt_error
+    assert raw_uid not in power_snapshot["last_error"]
+    assert "DEVI...6789" in power_snapshot["last_error"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add targeted debug logging around HEMS heat-pump live power fetch and selection
- export a diagnostics-safe heat-pump power snapshot showing candidates, attempts, selected payload, and outcome
- refresh the power snapshot during diagnostics capture and redact known heat-pump identifiers from stored power-fetch errors

Related issue: https://github.com/barneyonline/ha-enphase-energy/issues/443

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_diagnostics.py tests/components/enphase_ev/test_heatpump_runtime.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/api.py custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_diagnostics.py tests/components/enphase_ev/test_heatpump_runtime.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_heatpump_runtime.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_diagnostics.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q -k 'not test_async_update_data_success_enriches_payload' && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/heatpump_runtime.py --fail-under=100"`
- `git diff --check`

## Notes
- The branch excludes unrelated local edits already present in this worktree.
- `tests/components/enphase_ev/test_coordinator_additional_coverage.py::test_async_update_data_success_enriches_payload` is an existing unrelated failure and was excluded from the coverage sweep above.
