### PR TITLE
Decouple runtime helpers from coordinator internals

### DIFF
--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -37,6 +37,12 @@ from .const import (
 )
 from .device_types import member_is_retired, sanitize_member
 from .log_redaction import redact_identifier, redact_site_id, redact_text
+from .parsing_helpers import (
+    coerce_optional_bool,
+    coerce_optional_float,
+    coerce_optional_text,
+)
+from .runtime_helpers import coerce_int, coerce_optional_int
 from .service_validation import raise_translated_service_validation
 from .state_models import BatteryControlCapability
 
@@ -79,63 +85,19 @@ class BatteryRuntime:
             func()
 
     def _coerce_int(self, value: object, *, default: int = 0) -> int:
-        coord = self.coordinator
-        func = getattr(coord, "coerce_int", None)
-        if callable(func):
-            return func(value, default=default)
-        func = getattr(coord, "_coerce_int", None)
-        if callable(func):
-            return func(value, default=default)
-        try:
-            return int(value)
-        except Exception:
-            return default
+        return coerce_int(value, default=default)
 
     def _coerce_optional_bool(self, value: object) -> bool | None:
-        coord = self.coordinator
-        func = getattr(coord, "coerce_optional_bool", None)
-        if callable(func):
-            return func(value)
-        func = getattr(coord, "_coerce_optional_bool", None)
-        if callable(func):
-            return func(value)
-        return None
+        return coerce_optional_bool(value)
 
     def _coerce_optional_text(self, value: object) -> str | None:
-        coord = self.coordinator
-        func = getattr(coord, "coerce_optional_text", None)
-        if callable(func):
-            return func(value)
-        func = getattr(coord, "_coerce_optional_text", None)
-        if callable(func):
-            return func(value)
-        if value is None:
-            return None
-        try:
-            text = str(value).strip()
-        except Exception:
-            return None
-        return text or None
+        return coerce_optional_text(value)
 
     def _coerce_optional_int(self, value: object) -> int | None:
-        coord = self.coordinator
-        func = getattr(coord, "coerce_optional_int", None)
-        if callable(func):
-            return func(value)
-        func = getattr(coord, "_coerce_optional_int", None)
-        if callable(func):
-            return func(value)
-        return None
+        return coerce_optional_int(value)
 
     def _coerce_optional_float(self, value: object) -> float | None:
-        coord = self.coordinator
-        func = getattr(coord, "coerce_optional_float", None)
-        if callable(func):
-            return func(value)
-        func = getattr(coord, "_coerce_optional_float", None)
-        if callable(func):
-            return func(value)
-        return None
+        return coerce_optional_float(value)
 
     def _coerce_optional_kwh(self, value: object) -> float | None:
         func = getattr(self.coordinator, "_coerce_optional_kwh", None)

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -102,6 +102,16 @@ from .parsing_helpers import (
     parse_inverter_last_report,
     type_member_text,
 )
+from .runtime_helpers import (
+    coerce_int as helper_coerce_int,
+    coerce_optional_int as helper_coerce_optional_int,
+    copy_diagnostics_value,
+    normalize_iso_date,
+    redact_battery_payload,
+    resolve_inverter_start_date,
+    resolve_site_local_current_date,
+    resolve_site_timezone_name,
+)
 from .session_history import (
     MIN_SESSION_HISTORY_CACHE_TTL,
     SESSION_HISTORY_CACHE_DAY_RETENTION,
@@ -110,6 +120,7 @@ from .session_history import (
     SessionHistoryManager,
 )
 from .summary import SummaryStore
+from . import system_dashboard_helpers as sd_helpers
 from .refresh_plan import (
     FOLLOWUP_PLAN,
     HEATPUMP_FOLLOWUP_PLAN,
@@ -652,19 +663,63 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return self.inventory_runtime.topology_snapshot()
 
     def gateway_inventory_summary(self) -> dict[str, object]:
-        return self.inventory_runtime.gateway_inventory_summary()
+        source = self._gateway_inventory_summary_marker()
+        summary = getattr(self, "_gateway_inventory_summary_cache", {}) or {}
+        if not summary or source != self._gateway_inventory_summary_source:
+            summary = self._build_gateway_inventory_summary()
+            self._gateway_inventory_summary_cache = summary
+            self._gateway_inventory_summary_source = source
+        return dict(summary)
 
     def microinverter_inventory_summary(self) -> dict[str, object]:
-        return self.inventory_runtime.microinverter_inventory_summary()
+        source = self._microinverter_inventory_summary_marker()
+        summary = getattr(self, "_microinverter_inventory_summary_cache", {}) or {}
+        if not summary or source != self._microinverter_inventory_summary_source:
+            summary = self._build_microinverter_inventory_summary()
+            self._microinverter_inventory_summary_cache = summary
+            self._microinverter_inventory_summary_source = source
+        return dict(summary)
 
     def heatpump_inventory_summary(self) -> dict[str, object]:
-        return self.inventory_runtime.heatpump_inventory_summary()
+        source = self._heatpump_inventory_summary_marker()
+        summary = getattr(self, "_heatpump_inventory_summary_cache", {}) or {}
+        if not summary or source != self._heatpump_inventory_summary_source:
+            summary = self._build_heatpump_inventory_summary()
+            self._heatpump_inventory_summary_cache = summary
+            self._heatpump_inventory_summary_source = source
+        return dict(summary)
 
     def heatpump_type_summary(self, device_type: str) -> dict[str, object]:
-        return self.inventory_runtime.heatpump_type_summary(device_type)
+        try:
+            normalized = str(device_type).strip().upper()
+        except Exception:  # noqa: BLE001
+            normalized = ""
+        source = self._heatpump_inventory_summary_marker()
+        summaries = getattr(self, "_heatpump_type_summaries_cache", {}) or {}
+        if source != self._heatpump_type_summaries_source or (
+            normalized and normalized not in summaries
+        ):
+            summaries = self._build_heatpump_type_summaries()
+            self._heatpump_type_summaries_cache = summaries
+            self._heatpump_type_summaries_source = source
+        summary = summaries.get(normalized, {})
+        return dict(summary) if isinstance(summary, dict) else {}
 
     def gateway_iq_energy_router_summary_records(self) -> list[dict[str, object]]:
-        return self.inventory_runtime.gateway_iq_energy_router_summary_records()
+        source = self._gateway_iq_energy_router_records_marker()
+        records = getattr(self, "_gateway_iq_energy_router_records_cache", [])
+        if not records or source != self._gateway_iq_energy_router_records_source:
+            records = self._gateway_iq_energy_router_summary_records(
+                self.gateway_iq_energy_router_records()
+            )
+            self._gateway_iq_energy_router_records_cache = records
+            self._gateway_iq_energy_router_records_source = source
+            self._gateway_iq_energy_router_records_by_key_cache = {
+                record["key"]: record
+                for record in records
+                if isinstance(record, dict) and isinstance(record.get("key"), str)
+            }
+        return [dict(record) for record in records if isinstance(record, dict)]
 
     @staticmethod
     def _router_record_key(record: object) -> str | None:
@@ -682,7 +737,17 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def gateway_iq_energy_router_record(
         self, router_key: object
     ) -> dict[str, object] | None:
-        return self.inventory_runtime.gateway_iq_energy_router_record(router_key)
+        try:
+            key = str(router_key).strip()
+        except Exception:  # noqa: BLE001
+            return None
+        if not key:
+            return None
+        self.gateway_iq_energy_router_summary_records()
+        record = getattr(
+            self, "_gateway_iq_energy_router_records_by_key_cache", {}
+        ).get(key)
+        return dict(record) if isinstance(record, dict) else None
 
     def _current_topology_snapshot(self) -> CoordinatorTopologySnapshot:
         return self.inventory_runtime._current_topology_snapshot()
@@ -934,14 +999,18 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         inverter_order = snapshot.get("inverter_order")
         inverter_data = snapshot.get("inverter_data")
         if isinstance(inverter_order, list) and isinstance(inverter_data, dict):
-            self._inverter_order = [
+            restored_inverter_order = [
                 str(item).strip() for item in inverter_order if str(item).strip()
             ]
-            self._inverter_data = {
+            restored_inverter_data = {
                 str(key).strip(): dict(value)
                 for key, value in inverter_data.items()
                 if str(key).strip() and isinstance(value, dict)
             }
+            self.inventory_runtime._update_shared_state(
+                _inverter_order=restored_inverter_order,
+                _inverter_data=restored_inverter_data,
+            )
 
         has_encharge = self._snapshot_bool(snapshot.get("battery_has_encharge"))
         if has_encharge is not None:
@@ -1424,47 +1493,19 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return InventoryRuntime._summary_identity(value)
 
     def _summary_type_bucket_source(self, type_key: object) -> dict[str, object] | None:
-        normalized = normalize_type_key(type_key)
-        if not normalized:
-            return None
-        buckets = getattr(self, "_type_device_buckets", None)
-        if not isinstance(buckets, dict):
-            return None
-        bucket = buckets.get(normalized)
-        return bucket if isinstance(bucket, dict) else None
+        return self.inventory_runtime._summary_type_bucket_source(type_key)
 
     def _gateway_inventory_summary_marker(self) -> tuple[object, ...]:
-        dashboard_payloads = getattr(
-            self, "_system_dashboard_devices_details_raw", None
-        )
-        dashboard_envoy = (
-            dashboard_payloads.get("envoy")
-            if isinstance(dashboard_payloads, dict)
-            else None
-        )
-        return (
-            id(self._summary_type_bucket_source("envoy")),
-            id(dashboard_envoy),
-        )
+        return self.inventory_runtime._gateway_inventory_summary_marker()
 
     def _microinverter_inventory_summary_marker(self) -> tuple[object, ...]:
-        return (id(self._summary_type_bucket_source("microinverter")),)
+        return self.inventory_runtime._microinverter_inventory_summary_marker()
 
     def _heatpump_inventory_summary_marker(self) -> tuple[object, ...]:
-        return (
-            id(self._summary_type_bucket_source("heatpump")),
-            id(getattr(self, "_hems_devices_payload", None)),
-            bool(getattr(self, "_hems_devices_using_stale", False)),
-            getattr(self, "_hems_devices_last_success_utc", None),
-            getattr(self, "_hems_devices_last_success_mono", None),
-        )
+        return self.inventory_runtime._heatpump_inventory_summary_marker()
 
     def _gateway_iq_energy_router_records_marker(self) -> tuple[object, ...]:
-        return (
-            id(getattr(self, "_hems_devices_payload", None)),
-            id(getattr(self, "_devices_inventory_payload", None)),
-            id(getattr(self, "_restored_gateway_iq_energy_router_records", None)),
-        )
+        return self.inventory_runtime._gateway_iq_energy_router_records_marker()
 
     @staticmethod
     def _heatpump_status_text(member: dict[str, object] | None) -> str | None:
@@ -1657,355 +1698,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         }
 
     def _build_microinverter_inventory_summary(self) -> dict[str, object]:
-        bucket = self.type_bucket("microinverter") or {}
-        members = bucket.get("devices")
-        safe_members = (
-            [dict(item) for item in members if isinstance(item, dict)]
-            if isinstance(members, list)
-            else []
-        )
-        status_counts_raw = bucket.get("status_counts")
-        status_counts: dict[str, int] = {}
-        has_status_counts = isinstance(status_counts_raw, dict)
-        if isinstance(status_counts_raw, dict):
-            for key in (
-                "total",
-                "normal",
-                "warning",
-                "error",
-                "not_reporting",
-                "unknown",
-            ):
-                try:
-                    status_counts[key] = int(status_counts_raw.get(key, 0) or 0)
-                except Exception:
-                    status_counts[key] = 0
-        try:
-            total_inverters = int(bucket.get("count", len(safe_members)) or 0)
-        except Exception:
-            total_inverters = len(safe_members)
-        if status_counts.get("total", 0) > 0:
-            total_inverters = max(total_inverters, int(status_counts.get("total", 0)))
-        not_reporting = max(0, int(status_counts.get("not_reporting", 0)))
-        unknown = max(0, int(status_counts.get("unknown", 0)))
-        if not has_status_counts:
-            unknown = total_inverters
-        elif (
-            total_inverters > 0
-            and int(status_counts.get("total", 0) or 0) <= 0
-            and max(
-                0,
-                int(status_counts.get("normal", 0) or 0)
-                + int(status_counts.get("warning", 0) or 0)
-                + int(status_counts.get("error", 0) or 0)
-                + not_reporting
-                + unknown,
-            )
-            == 0
-        ):
-            unknown = total_inverters
-        known_status_total = not_reporting + unknown
-        if known_status_total > total_inverters:
-            unknown = max(0, unknown - (known_status_total - total_inverters))
-        reporting = max(0, total_inverters - not_reporting - unknown)
-        latest_reported = self._parse_inverter_last_report(
-            bucket.get("latest_reported_utc")
-            if bucket.get("latest_reported_utc") is not None
-            else bucket.get("latest_reported")
-        )
-        latest_reported_device = (
-            dict(bucket.get("latest_reported_device"))
-            if isinstance(bucket.get("latest_reported_device"), dict)
-            else None
-        )
-        if latest_reported is None:
-            for member in safe_members:
-                parsed_last = self._parse_inverter_last_report(
-                    member.get("last_report")
-                )
-                if parsed_last is None:
-                    continue
-                if latest_reported is None or parsed_last > latest_reported:
-                    latest_reported = parsed_last
-                    latest_reported_device = {
-                        "serial_number": self._summary_text(
-                            member.get("serial_number")
-                        ),
-                        "name": self._summary_text(member.get("name")),
-                        "status": self._summary_text(
-                            member.get("statusText")
-                            if member.get("statusText") is not None
-                            else member.get("status")
-                        ),
-                    }
-        snapshot: dict[str, object] = {
-            "total_inverters": total_inverters,
-            "reporting_inverters": reporting,
-            "not_reporting_inverters": not_reporting,
-            "unknown_inverters": unknown,
-            "status_counts": status_counts,
-            "status_summary": bucket.get("status_summary"),
-            "model_summary": bucket.get("model_summary"),
-            "firmware_summary": bucket.get("firmware_summary"),
-            "array_summary": bucket.get("array_summary"),
-            "panel_info": (
-                dict(bucket.get("panel_info"))
-                if isinstance(bucket.get("panel_info"), dict)
-                else None
-            ),
-            "status_type_counts": (
-                dict(bucket.get("status_type_counts"))
-                if isinstance(bucket.get("status_type_counts"), dict)
-                else None
-            ),
-            "latest_reported": latest_reported,
-            "latest_reported_utc": (
-                latest_reported.isoformat() if latest_reported is not None else None
-            ),
-            "latest_reported_device": latest_reported_device,
-            "production_start_date": bucket.get("production_start_date"),
-            "production_end_date": bucket.get("production_end_date"),
-        }
-        connectivity_state = bucket.get("connectivity_state")
-        if not isinstance(connectivity_state, str) or not connectivity_state.strip():
-            connectivity_state = "degraded"
-            if total_inverters <= 0:
-                connectivity_state = None
-            elif reporting >= total_inverters:
-                connectivity_state = "online"
-            elif reporting == 0 and not_reporting > 0:
-                connectivity_state = "offline"
-            elif reporting > 0 and reporting < total_inverters:
-                connectivity_state = "degraded"
-            elif unknown >= total_inverters:
-                connectivity_state = "unknown"
-        snapshot["connectivity_state"] = connectivity_state
-        return snapshot
+        return self.inventory_runtime._build_microinverter_inventory_summary()
 
     def _build_heatpump_inventory_summary(self) -> dict[str, object]:
-        bucket = self.type_bucket("heatpump") or {}
-        members = bucket.get("devices")
-        safe_members = (
-            [dict(item) for item in members if isinstance(item, dict)]
-            if isinstance(members, list)
-            else []
-        )
-        status_counts_raw = bucket.get("status_counts")
-        status_counts: dict[str, int] | None = None
-        if isinstance(status_counts_raw, dict):
-            parsed_counts = {
-                "total": 0,
-                "normal": 0,
-                "warning": 0,
-                "error": 0,
-                "not_reporting": 0,
-                "unknown": 0,
-            }
-            try:
-                for key in parsed_counts:
-                    parsed_counts[key] = int(status_counts_raw.get(key, 0) or 0)
-                status_counts = parsed_counts
-            except Exception:
-                status_counts = None
-        if status_counts is None:
-            status_counts = {
-                "total": len(safe_members),
-                "normal": 0,
-                "warning": 0,
-                "error": 0,
-                "not_reporting": 0,
-                "unknown": 0,
-            }
-            for member in safe_members:
-                status_key = self._normalize_inverter_status(
-                    self._heatpump_status_text(member)
-                )
-                status_counts[status_key] = int(status_counts.get(status_key, 0)) + 1
-        try:
-            total_devices = int(bucket.get("count", len(safe_members)) or 0)
-        except Exception:
-            total_devices = len(safe_members)
-        total_devices = max(total_devices, len(safe_members))
-        status_counts["total"] = max(
-            int(status_counts.get("total", 0) or 0), total_devices
-        )
-        latest_reported = self._parse_inverter_last_report(
-            bucket.get("latest_reported_utc")
-            if bucket.get("latest_reported_utc") is not None
-            else bucket.get("latest_reported")
-        )
-        latest_reported_device = (
-            dict(bucket.get("latest_reported_device"))
-            if isinstance(bucket.get("latest_reported_device"), dict)
-            else None
-        )
-        without_last_report_count = 0
-        if latest_reported is None:
-            for member in safe_members:
-                member_last = None
-                for key in (
-                    "last_report",
-                    "last_reported",
-                    "last_reported_at",
-                    "last-report",
-                ):
-                    member_last = self._parse_inverter_last_report(member.get(key))
-                    if member_last is not None:
-                        break
-                if member_last is None:
-                    without_last_report_count += 1
-                    continue
-                if latest_reported is None or member_last > latest_reported:
-                    latest_reported = member_last
-                    latest_reported_device = {
-                        "device_type": self._heatpump_member_device_type(member),
-                        "name": self._summary_text(member.get("name")),
-                        "device_uid": self._type_member_text(
-                            member, "device_uid", "device-uid", "uid"
-                        ),
-                        "status": self._heatpump_status_text(member),
-                    }
-        overall_status_text = self._summary_text(bucket.get("overall_status_text"))
-        if not overall_status_text:
-            for member in safe_members:
-                if self._heatpump_member_device_type(member) != "HEAT_PUMP":
-                    continue
-                overall_status_text = self._heatpump_status_text(member)
-                if overall_status_text:
-                    break
-        if not overall_status_text:
-            overall_status_text = self._heatpump_worst_status_text(status_counts)
-        device_type_counts: dict[str, int] = {}
-        if isinstance(bucket.get("device_type_counts"), dict):
-            for key, value in bucket.get("device_type_counts", {}).items():
-                if key is None:
-                    continue
-                try:
-                    count = int(value)
-                except Exception:
-                    continue
-                if count > 0:
-                    device_type_counts[str(key)] = count
-        else:
-            for member in safe_members:
-                device_type = self._heatpump_member_device_type(member) or "UNKNOWN"
-                device_type_counts[device_type] = (
-                    device_type_counts.get(device_type, 0) + 1
-                )
-        status_summary = bucket.get("status_summary")
-        if not isinstance(status_summary, str) or not status_summary.strip():
-            status_summary = self._format_inverter_status_summary(status_counts)
-        hems_last_success_utc = getattr(self, "_hems_devices_last_success_utc", None)
-        if not isinstance(hems_last_success_utc, datetime):
-            hems_last_success_utc = None
-        hems_last_success_mono = getattr(self, "_hems_devices_last_success_mono", None)
-        hems_last_success_age_s: float | None = None
-        if isinstance(hems_last_success_mono, (int, float)):
-            age = time.monotonic() - float(hems_last_success_mono)
-            if age >= 0:
-                hems_last_success_age_s = round(age, 1)
-        return {
-            "total_devices": total_devices,
-            "members": safe_members,
-            "status_counts": status_counts,
-            "status_summary": status_summary,
-            "device_type_counts": device_type_counts,
-            "model_summary": bucket.get("model_summary"),
-            "firmware_summary": bucket.get("firmware_summary"),
-            "latest_reported": latest_reported,
-            "latest_reported_utc": (
-                latest_reported.isoformat() if latest_reported is not None else None
-            ),
-            "latest_reported_device": latest_reported_device,
-            "without_last_report_count": without_last_report_count,
-            "overall_status_text": overall_status_text,
-            "hems_data_stale": bool(getattr(self, "_hems_devices_using_stale", False)),
-            "hems_last_success_utc": (
-                hems_last_success_utc.isoformat()
-                if hems_last_success_utc is not None
-                else None
-            ),
-            "hems_last_success_age_s": hems_last_success_age_s,
-        }
+        return self.inventory_runtime._build_heatpump_inventory_summary()
 
     def _build_heatpump_type_summaries(self) -> dict[str, dict[str, object]]:
-        snapshot = self._build_heatpump_inventory_summary()
-        members = [
-            member for member in snapshot.get("members", []) if isinstance(member, dict)
-        ]
-        summaries: dict[str, dict[str, object]] = {}
-        for device_type in sorted(
-            {
-                self._heatpump_member_device_type(member)
-                for member in members
-                if self._heatpump_member_device_type(member)
-            }
-        ):
-            type_members = [
-                member
-                for member in members
-                if self._heatpump_member_device_type(member) == device_type
-            ]
-            counts = {
-                "total": len(type_members),
-                "normal": 0,
-                "warning": 0,
-                "error": 0,
-                "not_reporting": 0,
-                "unknown": 0,
-            }
-            latest_reported: datetime | None = None
-            latest_device: dict[str, object] | None = None
-            status_texts: list[str] = []
-            for member in type_members:
-                status_text = self._heatpump_status_text(member)
-                if status_text:
-                    status_texts.append(status_text)
-                status_key = self._normalize_inverter_status(status_text)
-                counts[status_key] = int(counts.get(status_key, 0)) + 1
-                parsed_last = None
-                for key in (
-                    "last_report",
-                    "last_reported",
-                    "last_reported_at",
-                    "last-report",
-                ):
-                    parsed_last = self._parse_inverter_last_report(member.get(key))
-                    if parsed_last is not None:
-                        break
-                if parsed_last is not None and (
-                    latest_reported is None or parsed_last > latest_reported
-                ):
-                    latest_reported = parsed_last
-                    latest_device = {
-                        "name": self._summary_text(member.get("name")),
-                        "device_uid": self._type_member_text(
-                            member, "device_uid", "device-uid", "uid"
-                        ),
-                        "status": status_text,
-                    }
-            unique_statuses = list(dict.fromkeys(status_texts))
-            if len(unique_statuses) == 1:
-                native_status = unique_statuses[0]
-            else:
-                native_status = self._heatpump_worst_status_text(counts)
-            summaries[device_type] = {
-                "device_type": device_type,
-                "members": type_members,
-                "member_count": len(type_members),
-                "status_counts": counts,
-                "status_summary": self._format_inverter_status_summary(counts),
-                "native_status": native_status,
-                "latest_reported": latest_reported,
-                "latest_reported_utc": (
-                    latest_reported.isoformat() if latest_reported is not None else None
-                ),
-                "latest_reported_device": latest_device,
-                "hems_data_stale": snapshot.get("hems_data_stale"),
-                "hems_last_success_utc": snapshot.get("hems_last_success_utc"),
-                "hems_last_success_age_s": snapshot.get("hems_last_success_age_s"),
-            }
-        return summaries
+        return self.inventory_runtime._build_heatpump_type_summaries()
 
     @callback
     def _rebuild_inventory_summary_caches(self) -> None:
@@ -2019,14 +1718,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @staticmethod
     def _copy_diagnostics_value(value: object) -> object:
-        if isinstance(value, dict):
-            return {
-                key: EnphaseCoordinator._copy_diagnostics_value(item)
-                for key, item in value.items()
-            }
-        if isinstance(value, list):
-            return [EnphaseCoordinator._copy_diagnostics_value(item) for item in value]
-        return value
+        return copy_diagnostics_value(value)
 
     @staticmethod
     def _debug_truncate_identifier(value: object) -> str | None:
@@ -2121,85 +1813,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         grouped: dict[str, dict[str, object]],
         ordered_keys: list[str],
     ) -> dict[str, object]:
-        """Return a sanitized summary of device inventory discovery."""
-
-        types: dict[str, dict[str, object]] = {}
-        for type_key in ordered_keys:
-            bucket = grouped.get(type_key)
-            if not isinstance(bucket, dict):
-                continue
-            members = bucket.get("devices")
-            count = self._coerce_int(bucket.get("count"), default=0)
-            summary: dict[str, object] = {
-                "count": max(
-                    count,
-                    len(members) if isinstance(members, list) else 0,
-                ),
-                "field_keys": self._debug_field_keys(members),
-            }
-            status_counts = bucket.get("status_counts")
-            if isinstance(status_counts, dict) and status_counts:
-                summary["status_counts"] = {
-                    str(key): self._coerce_int(value, default=0)
-                    for key, value in status_counts.items()
-                }
-            device_type_counts = bucket.get("device_type_counts")
-            if isinstance(device_type_counts, dict) and device_type_counts:
-                summary["device_type_counts"] = {
-                    str(key): self._coerce_int(value, default=0)
-                    for key, value in device_type_counts.items()
-                }
-            types[type_key] = summary
-        return {
-            "ordered_type_keys": list(ordered_keys),
-            "type_count": len(types),
-            "types": types,
-        }
+        return self.inventory_runtime._debug_devices_inventory_summary(
+            grouped, ordered_keys
+        )
 
     def _debug_hems_inventory_summary(self) -> dict[str, object]:
-        """Return a sanitized summary of HEMS discovery data."""
-
-        grouped_devices = self._hems_grouped_devices()
-        group_keys: set[str] = set()
-        for grouped in grouped_devices:
-            if not isinstance(grouped, dict):
-                continue
-            for key, value in grouped.items():
-                if isinstance(value, list):
-                    try:
-                        key_text = str(key).strip()
-                    except Exception:  # noqa: BLE001
-                        continue
-                    if key_text:
-                        group_keys.add(key_text)
-
-        gateway_members = self._hems_group_members("gateway")
-        heatpump_members = self._hems_group_members(
-            "heat-pump", "heat_pump", "heatpump"
-        )
-        heatpump_summary = self._build_heatpump_inventory_summary()
-        router_records = self.gateway_iq_energy_router_summary_records()
-        device_type_counts = heatpump_summary.get("device_type_counts")
-        status_counts = heatpump_summary.get("status_counts")
-
-        return {
-            "site_supported": getattr(self.client, "hems_site_supported", None),
-            "using_stale": bool(getattr(self, "_hems_devices_using_stale", False)),
-            "group_keys": sorted(group_keys),
-            "gateway_member_count": len(gateway_members),
-            "gateway_field_keys": self._debug_field_keys(gateway_members),
-            "heatpump_member_count": self._coerce_int(
-                heatpump_summary.get("total_devices"), default=len(heatpump_members)
-            ),
-            "heatpump_field_keys": self._debug_field_keys(heatpump_members),
-            "heatpump_device_type_counts": (
-                dict(device_type_counts) if isinstance(device_type_counts, dict) else {}
-            ),
-            "heatpump_status_counts": (
-                dict(status_counts) if isinstance(status_counts, dict) else {}
-            ),
-            "router_count": len(router_records),
-        }
+        return self.inventory_runtime._debug_hems_inventory_summary()
 
     def _debug_system_dashboard_summary(
         self,
@@ -2208,57 +1827,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         type_summaries: dict[str, dict[str, object]],
         hierarchy_summary: dict[str, object],
     ) -> dict[str, object]:
-        """Return a sanitized summary of system dashboard discovery."""
-
-        types: dict[str, dict[str, object]] = {}
-        for canonical_type, payloads_by_source in details_payloads.items():
-            records = self._system_dashboard_detail_records(
-                payloads_by_source, *sorted(payloads_by_source)
-            )
-            raw_type_summary = type_summaries.get(canonical_type, {})
-            type_summary = (
-                raw_type_summary if isinstance(raw_type_summary, dict) else {}
-            )
-            summary: dict[str, object] = {
-                "sources": sorted(payloads_by_source),
-                "record_count": len(records),
-                "field_keys": self._debug_field_keys(records),
-            }
-            hierarchy = type_summary.get("hierarchy")
-            if isinstance(hierarchy, dict):
-                summary["hierarchy_count"] = self._coerce_int(
-                    hierarchy.get("count"), default=0
-                )
-            counts = type_summary.get("counts_by_type")
-            if isinstance(counts, dict) and counts:
-                summary["counts_by_type"] = {
-                    str(key): self._coerce_int(value, default=0)
-                    for key, value in counts.items()
-                }
-            status_counts = type_summary.get("status_counts")
-            if isinstance(status_counts, dict) and status_counts:
-                summary["status_counts"] = {
-                    str(key): self._coerce_int(value, default=0)
-                    for key, value in status_counts.items()
-                }
-            types[canonical_type] = summary
-
-        hierarchy_counts = hierarchy_summary.get("counts_by_type")
-        return {
-            "tree_keys": self._debug_sorted_keys(tree_payload),
-            "hierarchy_total_nodes": self._coerce_int(
-                hierarchy_summary.get("total_nodes"), default=0
-            ),
-            "hierarchy_counts_by_type": (
-                {
-                    str(key): self._coerce_int(value, default=0)
-                    for key, value in hierarchy_counts.items()
-                }
-                if isinstance(hierarchy_counts, dict)
-                else {}
-            ),
-            "types": types,
-        }
+        return self.inventory_runtime._debug_system_dashboard_summary(
+            tree_payload,
+            details_payloads,
+            type_summaries,
+            hierarchy_summary,
+        )
 
     def _debug_evse_feature_flag_summary(self) -> dict[str, object]:
         """Return a sanitized summary of EVSE feature-flag discovery."""
@@ -2286,107 +1860,39 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def _debug_topology_summary(
         self, snapshot: CoordinatorTopologySnapshot
     ) -> dict[str, object]:
-        """Return a sanitized summary of active discovery-driven topology."""
-
-        return {
-            "inventory_ready": bool(snapshot.inventory_ready),
-            "charger_count": len(snapshot.charger_serials),
-            "battery_count": len(snapshot.battery_serials),
-            "inverter_count": len(snapshot.inverter_serials),
-            "active_type_keys": list(snapshot.active_type_keys),
-            "gateway_iq_router_count": len(snapshot.gateway_iq_router_keys),
-            "site_energy_channels": sorted(self._live_site_energy_channels()),
-        }
+        return self.inventory_runtime._debug_topology_summary(snapshot)
 
     @staticmethod
     def _dashboard_key_token(key: object) -> str:
-        text = EnphaseCoordinator._coerce_optional_text(key)
-        if not text:
-            return ""
-        return "".join(ch if ch.isalnum() else "_" for ch in text.lower()).strip("_")
+        return sd_helpers.dashboard_key_token(key)
 
     @classmethod
     def _dashboard_key_matches(cls, key: object, *candidates: str) -> bool:
-        token = cls._dashboard_key_token(key)
-        if not token:
-            return False
-        candidate_tokens = {
-            cls._dashboard_key_token(candidate) for candidate in candidates if candidate
-        }
-        if token in candidate_tokens:
-            return True
-        return any(
-            token.startswith(candidate)
-            or token.endswith(candidate)
-            or candidate in token
-            for candidate in candidate_tokens
-            if candidate and len(candidate) >= 3
-        )
+        return sd_helpers.dashboard_key_matches(key, *candidates)
 
     @staticmethod
     def _dashboard_simple_value(value: object) -> object | None:
-        if value is None:
-            return None
-        if isinstance(value, bool):
-            return value
-        if isinstance(value, (int, float)):
-            return value
-        if isinstance(value, str):
-            return value.strip() or None
-        if isinstance(value, dict):
-            out: dict[str, object] = {}
-            for key, item in value.items():
-                simplified = EnphaseCoordinator._dashboard_simple_value(item)
-                if simplified is not None:
-                    out[str(key)] = simplified
-            return out or None
-        if isinstance(value, list):
-            out = [
-                simplified
-                for item in value
-                if (simplified := EnphaseCoordinator._dashboard_simple_value(item))
-                is not None
-            ]
-            return out or None
-        return EnphaseCoordinator._coerce_optional_text(value)
+        return sd_helpers.dashboard_simple_value(value)
 
     @classmethod
     def _iter_dashboard_mappings(cls, value: object) -> Iterable[dict[str, object]]:
-        if isinstance(value, dict):
-            yield value
-            for item in value.values():
-                yield from cls._iter_dashboard_mappings(item)
-            return
-        if isinstance(value, list):
-            for item in value:
-                yield from cls._iter_dashboard_mappings(item)
+        yield from sd_helpers.iter_dashboard_mappings(value)
 
     @classmethod
     def _dashboard_first_value(cls, payload: object, *keys: str) -> object | None:
-        for mapping in cls._iter_dashboard_mappings(payload):
-            for key, value in mapping.items():
-                if cls._dashboard_key_matches(key, *keys):
-                    return value
-        return None
+        return sd_helpers.dashboard_first_value(payload, *keys)
 
     @classmethod
     def _dashboard_first_mapping(
         cls, payload: object, *keys: str
     ) -> dict[str, object] | None:
-        value = cls._dashboard_first_value(payload, *keys)
-        if isinstance(value, dict):
-            return dict(value)
-        return None
+        return sd_helpers.dashboard_first_mapping(payload, *keys)
 
     @classmethod
     def _dashboard_field(
         cls, payload: object, *keys: str, default: object | None = None
     ) -> object | None:
-        value = cls._dashboard_first_value(payload, *keys)
-        simplified = cls._dashboard_simple_value(value)
-        if simplified is None:
-            return default
-        return simplified
+        return sd_helpers.dashboard_field(payload, *keys, default=default)
 
     @classmethod
     def _dashboard_field_map(
@@ -2394,104 +1900,29 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         payload: object,
         fields: dict[str, tuple[str, ...]],
     ) -> dict[str, object]:
-        out: dict[str, object] = {}
-        for output_key, candidate_keys in fields.items():
-            value = cls._dashboard_field(payload, *candidate_keys)
-            if value is not None:
-                out[output_key] = value
-        return out
+        return sd_helpers.dashboard_field_map(payload, fields)
 
     @classmethod
     def _dashboard_aliases(cls, payload: dict[str, object]) -> list[str]:
-        aliases: list[str] = []
-        seen: set[str] = set()
-        for key in (
-            "device_uid",
-            "device-uid",
-            "uid",
-            "iqer_uid",
-            "iqer-uid",
-            "hems_device_id",
-            "hems-device-id",
-            "serial_number",
-            "serialNumber",
-            "serial",
-            "device_id",
-            "deviceId",
-            "id",
-        ):
-            value = cls._coerce_optional_text(payload.get(key))
-            if not value or value in seen:
-                continue
-            seen.add(value)
-            aliases.append(value)
-        return aliases
+        return sd_helpers.dashboard_aliases(payload)
 
     @classmethod
     def _dashboard_primary_id(cls, payload: dict[str, object]) -> str | None:
-        for key in (
-            "device_uid",
-            "device-uid",
-            "uid",
-            "iqer_uid",
-            "iqer-uid",
-            "hems_device_id",
-            "hems-device-id",
-            "serial_number",
-            "serialNumber",
-            "serial",
-            "device_id",
-            "deviceId",
-            "id",
-        ):
-            value = cls._coerce_optional_text(payload.get(key))
-            if value:
-                return value
-        return None
+        return sd_helpers.dashboard_primary_id(payload)
 
     @classmethod
     def _dashboard_parent_id(cls, payload: dict[str, object]) -> str | None:
-        for key in (
-            "parent_uid",
-            "parentUid",
-            "parent_device_uid",
-            "parentDeviceUid",
-            "parent_id",
-            "parentId",
-            "parent",
-        ):
-            value = cls._coerce_optional_text(payload.get(key))
-            if value:
-                return value
-        return None
+        return sd_helpers.dashboard_parent_id(payload)
 
     @classmethod
     def _dashboard_raw_type(
         cls, payload: dict[str, object], fallback_type: str | None = None
     ) -> str | None:
-        for key in (
-            "type",
-            "device_type",
-            "deviceType",
-            "channel_type",
-            "channelType",
-            "meter_type",
-        ):
-            value = cls._coerce_optional_text(payload.get(key))
-            if value:
-                return value
-        return fallback_type
+        return sd_helpers.dashboard_raw_type(payload, fallback_type)
 
     @classmethod
     def _system_dashboard_type_key(cls, raw_type: object) -> str | None:
-        text = cls._coerce_optional_text(raw_type)
-        if text:
-            token = "".join(ch if ch.isalnum() else "_" for ch in text.lower()).strip(
-                "_"
-            )
-            if token in SYSTEM_DASHBOARD_TYPE_KEY_MAP:
-                return SYSTEM_DASHBOARD_TYPE_KEY_MAP[token]
-        return normalize_type_key(raw_type)
+        return sd_helpers.system_dashboard_type_key(raw_type)
 
     @classmethod
     def _system_dashboard_detail_records(
@@ -2499,110 +1930,18 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         payloads: dict[str, object],
         *source_types: str,
     ) -> list[dict[str, object]]:
-        records: list[dict[str, object]] = []
-        seen: set[tuple[str | None, str | None, str | None]] = set()
-        for source_type in source_types:
-            payload = payloads.get(source_type)
-            if not isinstance(payload, dict):
-                continue
-            items = payload.get(source_type)
-            if isinstance(items, list):
-                source_items = items
-            elif isinstance(items, dict):
-                nested_items = (
-                    items.get("devices")
-                    if isinstance(items.get("devices"), list)
-                    else (
-                        items.get("members")
-                        if isinstance(items.get("members"), list)
-                        else (
-                            items.get("items")
-                            if isinstance(items.get("items"), list)
-                            else None
-                        )
-                    )
-                )
-                source_items = (
-                    nested_items if isinstance(nested_items, list) else [items]
-                )
-            else:
-                nested_items = (
-                    payload.get("devices")
-                    if isinstance(payload.get("devices"), list)
-                    else (
-                        payload.get("members")
-                        if isinstance(payload.get("members"), list)
-                        else (
-                            payload.get("items")
-                            if isinstance(payload.get("items"), list)
-                            else None
-                        )
-                    )
-                )
-                source_items = (
-                    nested_items if isinstance(nested_items, list) else [payload]
-                )
-            for item in source_items:
-                if not isinstance(item, dict):
-                    continue
-                record = dict(item)
-                dedupe_key = (
-                    cls._coerce_optional_text(record.get("serial_number")),
-                    cls._coerce_optional_text(record.get("device_uid")),
-                    cls._coerce_optional_text(record.get("id")),
-                )
-                if dedupe_key in seen:
-                    continue
-                seen.add(dedupe_key)
-                records.append(record)
-        return records
+        return sd_helpers.system_dashboard_detail_records(payloads, *source_types)
 
     @classmethod
     def _system_dashboard_meter_kind(cls, payload: dict[str, object]) -> str | None:
-        for value in (
-            payload.get("meter_type"),
-            payload.get("config_type"),
-            payload.get("channel_type"),
-            payload.get("name"),
-        ):
-            text = cls._coerce_optional_text(value)
-            if not text:
-                continue
-            normalized = "".join(ch if ch.isalnum() else "_" for ch in text.lower())
-            if "production" in normalized or normalized in ("prod", "pv", "solar"):
-                return "production"
-            if "consumption" in normalized or normalized in (
-                "cons",
-                "load",
-                "site_load",
-            ):
-                return "consumption"
-        return None
+        return sd_helpers.system_dashboard_meter_kind(payload)
 
     @classmethod
     def _system_dashboard_battery_detail_subset(
         cls,
         payload: dict[str, object] | None,
     ) -> dict[str, object]:
-        if not isinstance(payload, dict):
-            return {}
-        allowed = (
-            "phase",
-            "operation_mode",
-            "app_version",
-            "sw_version",
-            "rssi_subghz",
-            "rssi_24ghz",
-            "rssi_dbm",
-            "led_status",
-            "alarm_id",
-        )
-        out: dict[str, object] = {}
-        for key in allowed:
-            value = payload.get(key)
-            if value is not None:
-                out[key] = value
-        return out
+        return sd_helpers.system_dashboard_battery_detail_subset(payload)
 
     @classmethod
     def _dashboard_node_entry(
@@ -2612,71 +1951,17 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         fallback_type: str | None = None,
         parent_uid: str | None = None,
     ) -> dict[str, object] | None:
-        device_uid = cls._dashboard_primary_id(payload)
-        if not device_uid:
-            return None
-        raw_type = cls._dashboard_raw_type(payload, fallback_type)
-        type_key = cls._system_dashboard_type_key(raw_type)
-        entry: dict[str, object] = {"device_uid": device_uid}
-        if type_key:
-            entry["type_key"] = type_key
-        if raw_type:
-            entry["source_type"] = raw_type
-        parent = cls._dashboard_parent_id(payload) or parent_uid
-        if parent:
-            entry["parent_uid"] = parent
-        name = cls._coerce_optional_text(
-            payload.get("name")
-            if payload.get("name") is not None
-            else payload.get("display_name")
+        return sd_helpers.dashboard_node_entry(
+            payload,
+            fallback_type=fallback_type,
+            parent_uid=parent_uid,
         )
-        if name:
-            entry["name"] = name
-        serial = cls._coerce_optional_text(
-            payload.get("serial_number")
-            if payload.get("serial_number") is not None
-            else (
-                payload.get("serialNumber")
-                if payload.get("serialNumber") is not None
-                else payload.get("serial")
-            )
-        )
-        if serial:
-            entry["serial_number"] = serial
-        return entry
 
     @classmethod
     def _dashboard_child_containers(
         cls, payload: dict[str, object]
     ) -> list[tuple[object, str | None]]:
-        out: list[tuple[object, str | None]] = []
-        next_type = cls._dashboard_raw_type(payload)
-        for key, value in payload.items():
-            if cls._dashboard_key_matches(
-                key,
-                "children",
-                "child_nodes",
-                "devices",
-                "members",
-                "items",
-                "nodes",
-                "result",
-                "data",
-                "envoy",
-                "envoys",
-                "meter",
-                "meters",
-                "enpower",
-                "enpowers",
-                "encharge",
-                "encharges",
-                "modem",
-                "modems",
-                "inverter",
-                "inverters",
-            ) and isinstance(value, (dict, list)):
-                out.append((value, next_type))
-        return out
+        return sd_helpers.dashboard_child_containers(payload)
 
     @classmethod
     def _index_dashboard_nodes(
@@ -2688,59 +1973,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         index: dict[str, dict[str, object]] | None = None,
         alias_index: dict[str, str] | None = None,
     ) -> dict[str, dict[str, object]]:
-        out = index if isinstance(index, dict) else {}
-        aliases = alias_index if isinstance(alias_index, dict) else {}
-        if isinstance(payload, list):
-            for item in payload:
-                cls._index_dashboard_nodes(
-                    item,
-                    fallback_type=fallback_type,
-                    parent_uid=parent_uid,
-                    index=out,
-                    alias_index=aliases,
-                )
-            return out
-        if not isinstance(payload, dict):
-            return out
-
-        entry = cls._dashboard_node_entry(
+        return sd_helpers.index_dashboard_nodes(
             payload,
             fallback_type=fallback_type,
             parent_uid=parent_uid,
+            index=index,
+            alias_index=alias_index,
         )
-        next_parent = parent_uid
-        next_type = fallback_type
-        if entry is not None:
-            entry_aliases = cls._dashboard_aliases(payload)
-            device_uid = next(
-                (
-                    canonical_uid
-                    for alias in entry_aliases
-                    if (canonical_uid := aliases.get(alias)) is not None
-                ),
-                str(entry["device_uid"]),
-            )
-            existing = out.get(device_uid, {"device_uid": device_uid})
-            for key, value in entry.items():
-                if value is None:
-                    continue
-                existing[key] = value
-            existing["device_uid"] = device_uid
-            out[device_uid] = existing
-            for alias in entry_aliases:
-                aliases[alias] = device_uid
-            next_parent = device_uid
-            next_type = cls._coerce_optional_text(entry.get("source_type")) or next_type
-
-        for child_payload, child_type in cls._dashboard_child_containers(payload):
-            cls._index_dashboard_nodes(
-                child_payload,
-                fallback_type=child_type or next_type,
-                parent_uid=next_parent,
-                index=out,
-                alias_index=aliases,
-            )
-        return out
 
     @classmethod
     def _system_dashboard_hierarchy_summary_from_index(
@@ -2748,47 +1987,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         index: dict[str, dict[str, object]],
         alias_index: dict[str, str] | None = None,
     ) -> dict[str, object]:
-        counts_by_type: dict[str, int] = {}
-        child_counts: dict[str, int] = {}
-        relationships: list[dict[str, object]] = []
-        aliases = alias_index if isinstance(alias_index, dict) else {}
-        for device_uid, entry in index.items():
-            type_key = cls._coerce_optional_text(entry.get("type_key"))
-            if type_key:
-                counts_by_type[type_key] = counts_by_type.get(type_key, 0) + 1
-            parent_uid = cls._coerce_optional_text(entry.get("parent_uid"))
-            if parent_uid:
-                parent_uid = aliases.get(parent_uid, parent_uid)
-            if parent_uid:
-                child_counts[parent_uid] = child_counts.get(parent_uid, 0) + 1
-            relationships.append(
-                {
-                    "device_uid": device_uid,
-                    "parent_uid": parent_uid,
-                    "type_key": type_key,
-                    "source_type": cls._coerce_optional_text(entry.get("source_type")),
-                    "name": cls._coerce_optional_text(entry.get("name")),
-                    "serial_number": cls._coerce_optional_text(
-                        entry.get("serial_number")
-                    ),
-                }
-            )
-        for relationship in relationships:
-            relationship["child_count"] = child_counts.get(
-                str(relationship["device_uid"]), 0
-            )
-        relationships.sort(
-            key=lambda item: (
-                str(item.get("type_key") or ""),
-                str(item.get("name") or ""),
-                str(item.get("device_uid") or ""),
-            )
+        return sd_helpers.system_dashboard_hierarchy_summary_from_index(
+            index, alias_index
         )
-        return {
-            "total_nodes": len(index),
-            "counts_by_type": counts_by_type,
-            "relationships": relationships,
-        }
 
     @classmethod
     def _system_dashboard_type_hierarchy(
@@ -2797,92 +1998,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         index: dict[str, dict[str, object]],
         alias_index: dict[str, str] | None = None,
     ) -> dict[str, object]:
-        aliases = alias_index if isinstance(alias_index, dict) else {}
-        relationships = [
-            {
-                "device_uid": device_uid,
-                "parent_uid": (
-                    aliases.get(parent_uid, parent_uid)
-                    if (
-                        parent_uid := cls._coerce_optional_text(entry.get("parent_uid"))
-                    )
-                    else None
-                ),
-                "name": cls._coerce_optional_text(entry.get("name")),
-                "serial_number": cls._coerce_optional_text(entry.get("serial_number")),
-                "source_type": cls._coerce_optional_text(entry.get("source_type")),
-                "child_count": sum(
-                    1
-                    for candidate in index.values()
-                    if cls._coerce_optional_text(candidate.get("parent_uid"))
-                    == device_uid
-                ),
-            }
-            for device_uid, entry in index.items()
-            if cls._coerce_optional_text(entry.get("type_key")) == type_key
-        ]
-        relationships.sort(
-            key=lambda item: (
-                str(item.get("name") or ""),
-                str(item.get("device_uid") or ""),
-            )
-        )
-        return {"count": len(relationships), "relationships": relationships}
+        return sd_helpers.system_dashboard_type_hierarchy(type_key, index, alias_index)
 
     @classmethod
     def _system_dashboard_meter_summaries(
         cls, payloads: dict[str, object]
     ) -> list[dict[str, object]]:
-        meters: list[dict[str, object]] = []
-        seen: set[tuple[str | None, str | None]] = set()
-        for record in cls._system_dashboard_detail_records(payloads, "meters", "meter"):
-            name = cls._coerce_optional_text(record.get("name"))
-            meter_kind = cls._system_dashboard_meter_kind(record)
-            meter_type = (
-                cls._coerce_optional_text(record.get("meter_type")) or meter_kind
-            )
-            dedupe_key = (name, meter_type)
-            if dedupe_key in seen:
-                continue
-            seen.add(dedupe_key)
-            meter_summary = {
-                "name": name,
-                "meter_type": meter_type,
-                "status": cls._dashboard_field(record, "status", "status_text"),
-                "meter_state": cls._coerce_optional_text(record.get("meter_state")),
-                "config_type": cls._coerce_optional_text(record.get("config_type")),
-            }
-            config_payload = cls._dashboard_first_mapping(
-                record,
-                "configuration",
-                "meter_config",
-                "meter_configuration",
-            )
-            if isinstance(config_payload, dict):
-                config = cls._dashboard_field_map(
-                    config_payload,
-                    {
-                        "phase": ("phase", "phase_mode", "phase_configuration"),
-                        "wiring": ("wiring", "wiring_type"),
-                        "mode": ("mode", "config_mode", "meter_mode"),
-                        "role": ("role", "measurement", "measurement_type"),
-                        "enabled": ("enabled", "is_enabled"),
-                    },
-                )
-                if config:
-                    meter_summary["config"] = config
-            cleaned = {
-                key: value for key, value in meter_summary.items() if value is not None
-            }
-            if cleaned:
-                meters.append(cleaned)
-        meters.sort(
-            key=lambda item: (
-                str(item.get("name") or ""),
-                str(item.get("meter_type") or ""),
-            )
-        )
-        return meters
+        return sd_helpers.system_dashboard_meter_summaries(payloads)
 
     @classmethod
     def _system_dashboard_envoy_summary(
@@ -2891,99 +2013,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         index: dict[str, dict[str, object]],
         alias_index: dict[str, str] | None = None,
     ) -> dict[str, object]:
-        modem_records = cls._system_dashboard_detail_records(
-            payloads, "modems", "modem"
-        )
-        modem_source = (
-            modem_records[0]
-            if modem_records
-            else cls._dashboard_first_mapping(payloads, "modem", "cellular", "sim")
-        )
-        envoy_records = cls._system_dashboard_detail_records(
-            payloads, "envoys", "envoy"
-        )
-        envoy_source = envoy_records[0] if envoy_records else payloads
-        network_source = cls._dashboard_first_mapping(
-            envoy_source,
-            "network",
-            "network_config",
-            "gateway_network",
-            "gateway_config",
-        )
-        tunnel_source = cls._dashboard_first_mapping(envoy_source, "tunnel", "vpn")
-        controller_records = cls._system_dashboard_detail_records(
-            payloads, "enpowers", "enpower"
-        )
-        controller_source = (
-            controller_records[0]
-            if controller_records
-            else cls._dashboard_first_mapping(
-                payloads,
-                "controller",
-                "system_controller",
-                "enpower",
-            )
-        )
-        summary = {
-            "modem": cls._dashboard_field_map(
-                modem_source or payloads,
-                {
-                    "signal": (
-                        "signal",
-                        "signal_strength",
-                        "signal_level",
-                        "sig_str",
-                    ),
-                    "rssi": ("rssi",),
-                    "sim_plan_expiry": (
-                        "sim_plan_expiry",
-                        "plan_expiry",
-                        "plan_expiry_date",
-                        "plan_end",
-                        "sim_expiry",
-                    ),
-                },
-            ),
-            "network": cls._dashboard_field_map(
-                network_source or envoy_source,
-                {
-                    "status": ("status", "state", "link_state"),
-                    "mode": ("mode", "network_mode", "config_mode"),
-                    "type": ("type", "network_type", "connection_type"),
-                    "dhcp": ("dhcp", "is_dhcp"),
-                    "enabled": ("enabled", "is_enabled"),
-                },
-            ),
-            "tunnel": cls._dashboard_field_map(
-                tunnel_source or payloads,
-                {
-                    "status": ("status", "state"),
-                    "type": ("type", "tunnel_type"),
-                    "enabled": ("enabled", "is_enabled"),
-                    "connected": ("connected", "is_connected"),
-                    "healthy": ("healthy", "is_healthy"),
-                },
-            ),
-            "controller": cls._dashboard_field_map(
-                controller_source or payloads,
-                {
-                    "earth_type": (
-                        "earth_type",
-                        "earthType",
-                        "system_earth_type",
-                    ),
-                    "status": ("status", "state"),
-                    "operation_mode": ("operation_mode", "mode"),
-                },
-            ),
-            "meters": cls._system_dashboard_meter_summaries(payloads),
-            "hierarchy": cls._system_dashboard_type_hierarchy(
-                "envoy", index, alias_index
-            ),
-        }
-        return {
-            key: value for key, value in summary.items() if value not in ({}, [], None)
-        }
+        return sd_helpers.system_dashboard_envoy_summary(payloads, index, alias_index)
 
     @classmethod
     def _system_dashboard_encharge_summary(
@@ -2992,89 +2022,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         index: dict[str, dict[str, object]],
         alias_index: dict[str, str] | None = None,
     ) -> dict[str, object]:
-        records = cls._system_dashboard_detail_records(
-            payloads, "encharges", "encharge"
+        return sd_helpers.system_dashboard_encharge_summary(
+            payloads, index, alias_index
         )
-        first_record = records[0] if records else payloads
-        connectivity_source = cls._dashboard_first_mapping(
-            first_record,
-            "connectivity",
-            "network",
-            "wireless",
-        )
-        software_source = cls._dashboard_first_mapping(
-            first_record,
-            "software",
-            "app",
-            "application",
-        )
-        operation_source = cls._dashboard_first_mapping(
-            first_record,
-            "operation_mode",
-            "operation",
-            "mode",
-        )
-        summary = {
-            "connectivity": cls._dashboard_field_map(
-                connectivity_source or first_record,
-                {
-                    "signal": (
-                        "signal",
-                        "signal_strength",
-                        "signal_level",
-                        "sig_str",
-                    ),
-                    "rssi": ("rssi",),
-                    "rssi_subghz": ("rssi_subghz",),
-                    "rssi_24ghz": ("rssi_24ghz",),
-                    "rssi_dbm": ("rssi_dbm",),
-                    "status": ("status", "state"),
-                },
-            ),
-            "software": cls._dashboard_field_map(
-                software_source or first_record,
-                {
-                    "app_version": ("app_version", "appVersion", "version"),
-                    "firmware": ("firmware", "fw_version", "sw_version"),
-                    "sw_version": ("sw_version",),
-                },
-            ),
-            "operation_mode": cls._dashboard_field_map(
-                operation_source or first_record,
-                {
-                    "mode": ("operation_mode", "operationMode", "mode"),
-                    "state": ("status", "state"),
-                },
-            ),
-            "batteries": [
-                cls._system_dashboard_battery_detail_subset(record)
-                | {
-                    key: value
-                    for key, value in {
-                        "name": cls._coerce_optional_text(record.get("name")),
-                        "serial_number": cls._coerce_optional_text(
-                            record.get("serial_number")
-                        ),
-                        "status": cls._coerce_optional_text(record.get("status")),
-                        "status_text": cls._coerce_optional_text(
-                            record.get("statusText")
-                        ),
-                        "soc": cls._coerce_optional_text(record.get("soc")),
-                    }.items()
-                    if value is not None
-                }
-                for record in records
-                if cls._system_dashboard_battery_detail_subset(record)
-                or cls._coerce_optional_text(record.get("serial_number"))
-                or cls._coerce_optional_text(record.get("name"))
-            ],
-            "hierarchy": cls._system_dashboard_type_hierarchy(
-                "encharge", index, alias_index
-            ),
-        }
-        return {
-            key: value for key, value in summary.items() if value not in ({}, [], None)
-        }
 
     @classmethod
     def _system_dashboard_microinverter_summary(
@@ -3083,53 +2033,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         index: dict[str, dict[str, object]],
         alias_index: dict[str, str] | None = None,
     ) -> dict[str, object]:
-        summary_payload = (
-            cls._dashboard_first_mapping(payloads, "inverters", "inverter") or {}
+        return sd_helpers.system_dashboard_microinverter_summary(
+            payloads, index, alias_index
         )
-        if not isinstance(summary_payload, dict):
-            return {}
-        nested_payload = summary_payload.get("inverters")
-        if isinstance(nested_payload, dict):
-            summary_payload = nested_payload
-        total = cls._coerce_optional_int(summary_payload.get("total"))
-        not_reporting = cls._coerce_optional_int(summary_payload.get("not_reporting"))
-        plc_comm = cls._coerce_optional_int(summary_payload.get("plc_comm"))
-        items = summary_payload.get("items")
-        if isinstance(items, list):
-            model_counts = {
-                cls._coerce_optional_text(item.get("name"))
-                or f"item_{index}": (cls._coerce_optional_int(item.get("count")) or 0)
-                for index, item in enumerate(items, start=1)
-                if isinstance(item, dict)
-            }
-        else:
-            model_counts = {}
-        reporting = None
-        if total is not None:
-            reporting = max(0, total - int(not_reporting or 0))
-        connectivity = None
-        if total is not None:
-            if int(total) <= 0:
-                connectivity = None
-            elif int(not_reporting or 0) <= 0:
-                connectivity = "online"
-            elif int(not_reporting or 0) >= int(total):
-                connectivity = "offline"
-            else:
-                connectivity = "degraded"
-        summary = {
-            "total_inverters": total,
-            "reporting_inverters": reporting,
-            "not_reporting_inverters": not_reporting,
-            "plc_comm_inverters": plc_comm,
-            "model_counts": model_counts or None,
-            "model_summary": cls._format_inverter_model_summary(model_counts),
-            "connectivity": connectivity,
-            "hierarchy": cls._system_dashboard_type_hierarchy(
-                "microinverter", index, alias_index
-            ),
-        }
-        return {key: value for key, value in summary.items() if value is not None}
 
     def _build_system_dashboard_summaries(
         self,
@@ -3138,66 +2044,17 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     ) -> tuple[
         dict[str, dict[str, object]], dict[str, object], dict[str, dict[str, object]]
     ]:
-        hierarchy_index: dict[str, dict[str, object]] = {}
-        hierarchy_aliases: dict[str, str] = {}
-        if isinstance(tree_payload, dict):
-            hierarchy_index = self._index_dashboard_nodes(
-                tree_payload, alias_index=hierarchy_aliases
-            )
-        for type_key, payloads_by_source in details_payloads.items():
-            for source_type, payload in payloads_by_source.items():
-                self._index_dashboard_nodes(
-                    payload,
-                    fallback_type=source_type or type_key,
-                    index=hierarchy_index,
-                    alias_index=hierarchy_aliases,
-                )
-        hierarchy_summary = self._system_dashboard_hierarchy_summary_from_index(
-            hierarchy_index,
-            hierarchy_aliases,
+        return sd_helpers.build_system_dashboard_summaries(
+            tree_payload,
+            details_payloads,
         )
-        type_summaries: dict[str, dict[str, object]] = {}
-        envoy_payloads: dict[str, object] = {}
-        for key in ("envoy", "modem"):
-            payloads = details_payloads.get(key, {})
-            if isinstance(payloads, dict):
-                envoy_payloads.update(payloads)
-        if envoy_summary := self._system_dashboard_envoy_summary(
-            envoy_payloads,
-            hierarchy_index,
-            hierarchy_aliases,
-        ):
-            type_summaries["envoy"] = envoy_summary
-        if encharge_summary := self._system_dashboard_encharge_summary(
-            details_payloads.get("encharge", {}),
-            hierarchy_index,
-            hierarchy_aliases,
-        ):
-            type_summaries["encharge"] = encharge_summary
-        if microinverter_summary := self._system_dashboard_microinverter_summary(
-            details_payloads.get("microinverter", {}),
-            hierarchy_index,
-            hierarchy_aliases,
-        ):
-            type_summaries["microinverter"] = microinverter_summary
-        return type_summaries, hierarchy_summary, hierarchy_index
 
     async def _async_refresh_system_dashboard(self, *, force: bool = False) -> None:
         await self.inventory_runtime._async_refresh_system_dashboard(force=force)
 
     @staticmethod
     def _coerce_int(value: object, *, default: int = 0) -> int:
-        if value is None:
-            return default
-        if isinstance(value, bool):
-            return int(value)
-        try:
-            return int(value)
-        except (TypeError, ValueError):
-            try:
-                return int(float(str(value).strip()))
-            except (TypeError, ValueError):
-                return default
+        return helper_coerce_int(value, default=default)
 
     @staticmethod
     def coerce_int(value: object, *, default: int = 0) -> int:
@@ -3205,86 +2062,23 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @staticmethod
     def _normalize_iso_date(value: object) -> str | None:
-        """Normalize a YYYY-MM-DD date string."""
-        if value is None:
-            return None
-        try:
-            cleaned = str(value).strip()
-        except Exception:
-            return None
-        if not cleaned:
-            return None
-        try:
-            return datetime.strptime(cleaned, "%Y-%m-%d").date().isoformat()
-        except Exception:
-            return None
+        return normalize_iso_date(value)
 
     def _inverter_start_date(self) -> str | None:
-        """Return query start date for inverter lifetime totals."""
-        start_date: str | None = None
         energy = getattr(self, "energy", None)
-        if energy is not None:
-            meta = getattr(energy, "_site_energy_meta", None)
-            if isinstance(meta, dict):
-                start_date = self._normalize_iso_date(meta.get("start_date"))
-        if start_date:
-            return start_date
-
-        existing_starts: list[str] = []
-        existing = getattr(self, "_inverter_data", None)
-        if isinstance(existing, dict):
-            for payload in existing.values():
-                if not isinstance(payload, dict):
-                    continue
-                normalized = self._normalize_iso_date(
-                    payload.get("lifetime_query_start_date")
-                )
-                if normalized:
-                    existing_starts.append(normalized)
-        if existing_starts:
-            return min(existing_starts)
-        return None
+        return resolve_inverter_start_date(
+            getattr(energy, "_site_energy_meta", None),
+            getattr(self, "_inverter_data", None),
+        )
 
     def _site_local_current_date(self) -> str:
-        """Return current date in site-local timezone when available."""
-        inventory_payload = getattr(self, "_devices_inventory_payload", None)
-        if isinstance(inventory_payload, dict):
-            direct = self._normalize_iso_date(inventory_payload.get("curr_date_site"))
-            if direct:
-                return direct
-            result = inventory_payload.get("result")
-            if isinstance(result, list):
-                for item in result:
-                    if not isinstance(item, dict):
-                        continue
-                    candidate = self._normalize_iso_date(item.get("curr_date_site"))
-                    if candidate:
-                        return candidate
-
-        tz_name = getattr(self, "_battery_timezone", None)
-        if isinstance(tz_name, str) and tz_name.strip():
-            try:
-                return datetime.now(ZoneInfo(tz_name.strip())).date().isoformat()
-            except Exception:
-                pass
-
-        try:
-            return dt_util.now().date().isoformat()
-        except Exception:
-            return datetime.now(tz=_tz.utc).date().isoformat()
+        return resolve_site_local_current_date(
+            getattr(self, "_devices_inventory_payload", None),
+            getattr(self, "_battery_timezone", None),
+        )
 
     def _site_timezone_name(self) -> str:
-        """Return the site timezone name when available."""
-
-        tz_name = getattr(self, "_battery_timezone", None)
-        if isinstance(tz_name, str) and tz_name.strip():
-            try:
-                ZoneInfo(tz_name.strip())
-            except Exception:
-                pass
-            else:
-                return tz_name.strip()
-        return "UTC"
+        return resolve_site_timezone_name(getattr(self, "_battery_timezone", None))
 
     @staticmethod
     def _format_inverter_model_summary(model_counts: dict[str, int]) -> str | None:
@@ -3307,136 +2101,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return parse_inverter_last_report(value)
 
     def _merge_microinverter_type_bucket(self) -> None:
-        """Merge inverter summary/details into the type-device buckets."""
-        ready_before = bool(getattr(self, "_devices_inventory_ready", False))
-        buckets = dict(getattr(self, "_type_device_buckets", {}) or {})
-        ordered = list(getattr(self, "_type_device_order", []) or [])
-        key = "microinverter"
-
-        devices_out: list[dict[str, object]] = []
-        for serial in self.iter_inverter_serials():
-            payload = self.inverter_data(serial)
-            if not isinstance(payload, dict):
-                continue
-            devices_out.append(
-                {
-                    "name": payload.get("name"),
-                    "serial_number": payload.get("serial_number"),
-                    "sku_id": payload.get("sku_id"),
-                    "status": payload.get("status"),
-                    "statusText": payload.get("status_text"),
-                    "last_report": payload.get("last_report"),
-                    "array_name": payload.get("array_name"),
-                    "warranty_end_date": payload.get("warranty_end_date"),
-                    "device_id": payload.get("device_id"),
-                    "inverter_id": payload.get("inverter_id"),
-                    "fw1": payload.get("fw1"),
-                    "fw2": payload.get("fw2"),
-                }
-            )
-
-        if devices_out:
-            model_counts = dict(self._inverter_model_counts)
-            model_summary = self._format_inverter_model_summary(model_counts)
-            summary_counts = dict(self._inverter_summary_counts)
-            status_counts = {
-                "total": int(summary_counts.get("total", len(devices_out))),
-                "normal": int(summary_counts.get("normal", 0)),
-                "warning": int(summary_counts.get("warning", 0)),
-                "error": int(summary_counts.get("error", 0)),
-                "not_reporting": int(summary_counts.get("not_reporting", 0)),
-                "unknown": int(summary_counts.get("unknown", 0)),
-            }
-            latest_reported: datetime | None = None
-            latest_reported_device: dict[str, object] | None = None
-            array_counts: dict[str, int] = {}
-            firmware_counts: dict[str, int] = {}
-            for member in devices_out:
-                parsed_last = self._parse_inverter_last_report(
-                    member.get("last_report")
-                )
-                if parsed_last is not None and (
-                    latest_reported is None or parsed_last > latest_reported
-                ):
-                    latest_reported = parsed_last
-                    latest_reported_device = {
-                        "serial_number": member.get("serial_number"),
-                        "name": member.get("name"),
-                        "status": (
-                            member.get("statusText")
-                            if member.get("statusText") is not None
-                            else member.get("status")
-                        ),
-                    }
-                raw_array = member.get("array_name")
-                if raw_array is not None:
-                    try:
-                        array_name = str(raw_array).strip()
-                    except Exception:
-                        array_name = ""
-                    if array_name:
-                        array_counts[array_name] = array_counts.get(array_name, 0) + 1
-                raw_firmware = member.get("fw1") or member.get("fw2")
-                if raw_firmware is not None:
-                    try:
-                        firmware = str(raw_firmware).strip()
-                    except Exception:
-                        firmware = ""
-                    if firmware:
-                        firmware_counts[firmware] = firmware_counts.get(firmware, 0) + 1
-            array_summary = self._format_inverter_model_summary(array_counts)
-            firmware_summary = self._format_inverter_model_summary(firmware_counts)
-            buckets[key] = {
-                "type_key": key,
-                "type_label": "Microinverters",
-                "count": len(devices_out),
-                "devices": devices_out,
-                "model_counts": model_counts,
-                "model_summary": model_summary or "Microinverters",
-                "status_counts": status_counts,
-                "status_summary": self._format_inverter_status_summary(summary_counts),
-                "connectivity_state": self._inverter_connectivity_state(status_counts),
-                "reporting_count": max(
-                    0,
-                    int(status_counts.get("total", len(devices_out)))
-                    - int(status_counts.get("not_reporting", 0))
-                    - int(status_counts.get("unknown", 0)),
-                ),
-                "latest_reported_utc": (
-                    latest_reported.isoformat() if latest_reported is not None else None
-                ),
-                "latest_reported_device": latest_reported_device,
-                "array_counts": array_counts,
-                "array_summary": array_summary,
-                "firmware_counts": firmware_counts,
-                "firmware_summary": firmware_summary,
-            }
-            panel_info = getattr(self, "_inverter_panel_info", None)
-            if isinstance(panel_info, dict):
-                buckets[key]["panel_info"] = dict(panel_info)
-            production_payload = getattr(self, "_inverter_production_payload", None)
-            if isinstance(production_payload, dict):
-                start_date = self._normalize_iso_date(
-                    production_payload.get("start_date")
-                )
-                end_date = self._normalize_iso_date(production_payload.get("end_date"))
-                if start_date:
-                    buckets[key]["production_start_date"] = start_date
-                if end_date:
-                    buckets[key]["production_end_date"] = end_date
-            status_type_counts = getattr(self, "_inverter_status_type_counts", None)
-            if isinstance(status_type_counts, dict) and status_type_counts:
-                buckets[key]["status_type_counts"] = dict(status_type_counts)
-            if key not in ordered:
-                ordered.append(key)
-        else:
-            buckets.pop(key, None)
-            ordered = [item for item in ordered if item != key]
-
-        self._set_type_device_buckets(buckets, ordered)
-        if not ready_before:
-            # Preserve unknown-inventory behavior for non-inverter type gating.
-            self._devices_inventory_ready = False
+        self.inventory_runtime._merge_microinverter_type_bucket()
 
     async def _async_refresh_inverters(self) -> None:
         await self.inventory_runtime._async_refresh_inverters()
@@ -6132,12 +4797,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @staticmethod
     def _coerce_optional_int(value: object) -> int | None:
-        if value is None:
-            return None
-        try:
-            return int(str(value).strip())
-        except Exception:  # noqa: BLE001
-            return None
+        return helper_coerce_optional_int(value)
 
     @staticmethod
     def coerce_optional_int(value: object) -> int | None:
@@ -6243,40 +4903,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @staticmethod
     def _redact_battery_payload(value: object) -> object:
-        """Return a diagnostics-safe copy of BatteryConfig payloads."""
-
-        sensitive = {
-            "email",
-            "authorization",
-            "cookie",
-            "token",
-            "access_token",
-            "refresh_token",
-            "xsrf_token",
-            "x_xsrf_token",
-            "session_id",
-            "userid",
-            "user_id",
-            "username",
-            "device_link",
-            "interface_ip",
-            "ip_addr",
-            "gateway_ip_addr",
-            "default_route",
-            "mac_addr",
-        }
-        if isinstance(value, dict):
-            out: dict[str, object] = {}
-            for key, item in value.items():
-                key_text = str(key)
-                if key_text.strip().lower().replace("-", "_") in sensitive:
-                    out[key_text] = "[redacted]"
-                else:
-                    out[key_text] = EnphaseCoordinator._redact_battery_payload(item)
-            return out
-        if isinstance(value, list):
-            return [EnphaseCoordinator._redact_battery_payload(item) for item in value]
-        return value
+        return redact_battery_payload(value)
 
     def redact_battery_payload(self, value: object) -> object:
         return self._redact_battery_payload(value)

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -21,7 +21,7 @@ from .const import (
     HEATPUMP_RUNTIME_STATE_FAILURE_BACKOFF_S,
 )
 from .device_types import normalize_type_key
-from .log_redaction import redact_site_id, redact_text
+from .log_redaction import redact_site_id, redact_text, truncate_identifier
 from .parsing_helpers import (
     coerce_optional_bool,
     coerce_optional_float,
@@ -32,6 +32,12 @@ from .parsing_helpers import (
     heatpump_status_text,
     parse_inverter_last_report,
     type_member_text,
+)
+from .runtime_helpers import (
+    copy_diagnostics_value,
+    redact_battery_payload,
+    resolve_site_local_current_date,
+    resolve_site_timezone_name,
 )
 from .state_models import install_state_descriptors
 
@@ -82,19 +88,24 @@ class HeatpumpRuntime:
         return [dict(item) for item in members if isinstance(item, dict)]
 
     def _site_timezone_name(self) -> str:
-        return self.coordinator._site_timezone_name()
+        return resolve_site_timezone_name(
+            getattr(self.coordinator, "_battery_timezone", None)
+        )
 
     def _site_local_current_date(self) -> str:
-        return self.coordinator._site_local_current_date()
+        return resolve_site_local_current_date(
+            getattr(self, "_devices_inventory_payload", None),
+            getattr(self.coordinator, "_battery_timezone", None),
+        )
 
     def _copy_diagnostics_value(self, value: object) -> object:
-        return self.coordinator._copy_diagnostics_value(value)
+        return copy_diagnostics_value(value)
 
     def _redact_battery_payload(self, payload: object) -> object:
-        return self.coordinator._redact_battery_payload(payload)
+        return redact_battery_payload(payload)
 
     def _debug_truncate_identifier(self, value: object) -> str | None:
-        return self.coordinator._debug_truncate_identifier(value)
+        return truncate_identifier(value)
 
     def _heatpump_power_redaction_identifiers(
         self, *extra_identifiers: object

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import inspect
+import json
 import logging
 import re
 import time
@@ -26,7 +27,22 @@ from .parsing_helpers import (
     parse_inverter_last_report,
     type_member_text,
 )
+from .runtime_helpers import (
+    coerce_int,
+    copy_diagnostics_value,
+    normalize_iso_date,
+    redact_battery_payload,
+    resolve_inverter_start_date,
+    resolve_site_local_current_date,
+)
 from .state_models import install_state_descriptors
+from .system_dashboard_helpers import (
+    build_system_dashboard_summaries,
+    system_dashboard_battery_detail_subset,
+    system_dashboard_detail_records,
+    system_dashboard_meter_kind,
+    system_dashboard_type_key,
+)
 
 if TYPE_CHECKING:  # pragma: no cover
     from .coordinator import EnphaseCoordinator
@@ -66,6 +82,19 @@ class InventoryRuntime:
         self.inventory_state = coordinator.inventory_state
         self.heatpump_state = coordinator.heatpump_state
 
+    def _set_shared_state_attr(self, name: str, value: object) -> None:
+        object.__setattr__(self, name, value)
+        setattr(self.coordinator, name, value)
+
+    def _update_shared_state(self, **values: object) -> None:
+        for name, value in values.items():
+            self._set_shared_state_attr(name, value)
+
+    def _coordinator_backed_attr(self, name: str, default: object = None) -> object:
+        if name in self.__dict__:
+            return self.__dict__[name]
+        return getattr(self.coordinator, name, default)
+
     @property
     def client(self):
         return self.coordinator.client
@@ -103,34 +132,146 @@ class InventoryRuntime:
         return coerce_optional_bool(value)
 
     def _coerce_int(self, value: object, *, default: int = 0) -> int:
-        return self.coordinator._coerce_int(value, default=default)
+        return coerce_int(value, default=default)
 
     def _copy_diagnostics_value(self, value: object) -> object:
-        return self.coordinator._copy_diagnostics_value(value)
+        return copy_diagnostics_value(value)
 
     def _normalize_iso_date(self, value: object) -> str | None:
-        return self.coordinator._normalize_iso_date(value)
+        return normalize_iso_date(value)
 
     def _site_local_current_date(self) -> str:
-        return self.coordinator._site_local_current_date()
+        return resolve_site_local_current_date(
+            getattr(self, "_devices_inventory_payload", None),
+            getattr(self.coordinator, "_battery_timezone", None),
+        )
 
     def _redact_battery_payload(self, payload: object) -> object:
-        return self.coordinator._redact_battery_payload(payload)
+        return redact_battery_payload(payload)
+
+    @staticmethod
+    def _debug_sorted_keys(value: object) -> list[str]:
+        if not isinstance(value, dict):
+            return []
+        keys: set[str] = set()
+        for key in value:
+            try:
+                key_text = str(key).strip()
+            except Exception:  # noqa: BLE001
+                continue
+            if key_text:
+                keys.add(key_text)
+        return sorted(keys)
+
+    @classmethod
+    def _debug_field_keys(cls, members: object) -> list[str]:
+        if not isinstance(members, list):
+            return []
+        keys: set[str] = set()
+        for member in members:
+            if not isinstance(member, dict):
+                continue
+            keys.update(cls._debug_sorted_keys(member))
+        return sorted(keys)
+
+    @staticmethod
+    def _debug_render_summary(summary: object) -> str:
+        try:
+            return json.dumps(summary, sort_keys=True, ensure_ascii=True)
+        except Exception:  # noqa: BLE001
+            return str(summary)
 
     def _debug_log_summary_if_changed(
         self, summary_key: str, log_label: str, summary: object
     ) -> None:
-        self.coordinator._debug_log_summary_if_changed(summary_key, log_label, summary)
+        if not _LOGGER.isEnabledFor(logging.DEBUG):
+            return
+        cached = self._debug_summary_log_cache.get(summary_key)
+        if cached == summary:
+            return
+        self._debug_summary_log_cache[summary_key] = self._copy_diagnostics_value(
+            summary
+        )
+        _LOGGER.debug("%s: %s", log_label, self._debug_render_summary(summary))
 
     def _debug_devices_inventory_summary(
         self,
         grouped: dict[str, dict[str, object]],
         ordered_keys: list[str],
     ) -> dict[str, object]:
-        return self.coordinator._debug_devices_inventory_summary(grouped, ordered_keys)
+        types: dict[str, dict[str, object]] = {}
+        for type_key in ordered_keys:
+            bucket = grouped.get(type_key)
+            if not isinstance(bucket, dict):
+                continue
+            members = bucket.get("devices")
+            count = self._coerce_int(bucket.get("count"), default=0)
+            summary: dict[str, object] = {
+                "count": max(count, len(members) if isinstance(members, list) else 0),
+                "field_keys": self._debug_field_keys(members),
+            }
+            status_counts = bucket.get("status_counts")
+            if isinstance(status_counts, dict) and status_counts:
+                summary["status_counts"] = {
+                    str(key): self._coerce_int(value, default=0)
+                    for key, value in status_counts.items()
+                }
+            device_type_counts = bucket.get("device_type_counts")
+            if isinstance(device_type_counts, dict) and device_type_counts:
+                summary["device_type_counts"] = {
+                    str(key): self._coerce_int(value, default=0)
+                    for key, value in device_type_counts.items()
+                }
+            types[type_key] = summary
+        return {
+            "ordered_type_keys": list(ordered_keys),
+            "type_count": len(types),
+            "types": types,
+        }
 
     def _debug_hems_inventory_summary(self) -> dict[str, object]:
-        return self.coordinator._debug_hems_inventory_summary()
+        grouped_devices = self._hems_grouped_devices()
+        group_keys: set[str] = set()
+        for grouped in grouped_devices:
+            if not isinstance(grouped, dict):
+                continue
+            for key, value in grouped.items():
+                if isinstance(value, list):
+                    try:
+                        key_text = str(key).strip()
+                    except Exception:  # noqa: BLE001
+                        continue
+                    if key_text:
+                        group_keys.add(key_text)
+
+        gateway_members = self._hems_group_members("gateway")
+        heatpump_members = self._hems_group_members(
+            "heat-pump", "heat_pump", "heatpump"
+        )
+        heatpump_summary = self._build_heatpump_inventory_summary()
+        router_records = self.gateway_iq_energy_router_summary_records()
+        device_type_counts = heatpump_summary.get("device_type_counts")
+        status_counts = heatpump_summary.get("status_counts")
+
+        return {
+            "site_supported": getattr(self.client, "hems_site_supported", None),
+            "using_stale": bool(getattr(self, "_hems_devices_using_stale", False)),
+            "group_keys": sorted(group_keys),
+            "gateway_member_count": len(gateway_members),
+            "gateway_field_keys": self._debug_field_keys(gateway_members),
+            "heatpump_member_count": self._coerce_int(
+                heatpump_summary.get("total_devices"),
+                default=len(heatpump_members),
+            ),
+            "heatpump_field_keys": self._debug_field_keys(heatpump_members),
+            "heatpump_device_type_counts": (
+                dict(device_type_counts) if isinstance(device_type_counts, dict) else {}
+            ),
+            "heatpump_status_counts": (
+                dict(status_counts) if isinstance(status_counts, dict) else {}
+            ),
+            "router_count": len(router_records),
+        }
 
     def _debug_system_dashboard_summary(
         self,
@@ -139,17 +280,113 @@ class InventoryRuntime:
         type_summaries: dict[str, dict[str, object]],
         hierarchy_summary: dict[str, object],
     ) -> dict[str, object]:
-        return self.coordinator._debug_system_dashboard_summary(
-            tree_payload,
-            details_payloads,
-            type_summaries,
-            hierarchy_summary,
-        )
+        types: dict[str, dict[str, object]] = {}
+        for canonical_type, payloads_by_source in details_payloads.items():
+            records = self._system_dashboard_detail_records(
+                payloads_by_source, *sorted(payloads_by_source)
+            )
+            raw_type_summary = type_summaries.get(canonical_type, {})
+            type_summary = (
+                raw_type_summary if isinstance(raw_type_summary, dict) else {}
+            )
+            summary: dict[str, object] = {
+                "sources": sorted(payloads_by_source),
+                "record_count": len(records),
+                "field_keys": self._debug_field_keys(records),
+            }
+            hierarchy = type_summary.get("hierarchy")
+            if isinstance(hierarchy, dict):
+                summary["hierarchy_count"] = self._coerce_int(
+                    hierarchy.get("count"), default=0
+                )
+            counts = type_summary.get("counts_by_type")
+            if isinstance(counts, dict) and counts:
+                summary["counts_by_type"] = {
+                    str(key): self._coerce_int(value, default=0)
+                    for key, value in counts.items()
+                }
+            status_counts = type_summary.get("status_counts")
+            if isinstance(status_counts, dict) and status_counts:
+                summary["status_counts"] = {
+                    str(key): self._coerce_int(value, default=0)
+                    for key, value in status_counts.items()
+                }
+            types[canonical_type] = summary
+
+        hierarchy_counts = hierarchy_summary.get("counts_by_type")
+        return {
+            "tree_keys": self._debug_sorted_keys(tree_payload),
+            "hierarchy_total_nodes": self._coerce_int(
+                hierarchy_summary.get("total_nodes"), default=0
+            ),
+            "hierarchy_counts_by_type": (
+                {
+                    str(key): self._coerce_int(value, default=0)
+                    for key, value in hierarchy_counts.items()
+                }
+                if isinstance(hierarchy_counts, dict)
+                else {}
+            ),
+            "types": types,
+        }
+
+    def _live_site_energy_channels(self) -> set[str]:
+        channels: set[str] = set()
+        energy = getattr(self.coordinator, "energy", None)
+        if energy is None:
+            return channels
+        flows = getattr(energy, "site_energy", None)
+        if isinstance(flows, dict):
+            for key in flows:
+                try:
+                    key_text = str(key).strip()
+                except Exception:  # noqa: BLE001
+                    continue
+                if key_text:
+                    channels.add(key_text)
+        meta = getattr(energy, "site_energy_meta", None)
+        if isinstance(meta, dict):
+            bucket_lengths = meta.get("bucket_lengths")
+            if isinstance(bucket_lengths, dict):
+                for key, value in bucket_lengths.items():
+                    try:
+                        key_text = str(key).strip()
+                    except Exception:  # noqa: BLE001
+                        continue
+                    if not key_text:
+                        continue
+                    try:
+                        if int(value) <= 0:
+                            continue
+                    except Exception:  # noqa: BLE001
+                        if not value:
+                            continue
+                    mapped = {
+                        "heatpump": "heat_pump",
+                        "water_heater": "water_heater",
+                        "evse": "evse_charging",
+                        "solar_production": "solar_production",
+                        "consumption": "consumption",
+                        "grid_import": "grid_import",
+                        "grid_export": "grid_export",
+                        "battery_charge": "battery_charge",
+                        "battery_discharge": "battery_discharge",
+                    }.get(key_text, key_text)
+                    channels.add(mapped)
+        return channels
 
     def _debug_topology_summary(
         self, snapshot: CoordinatorTopologySnapshot
     ) -> dict[str, object]:
-        return self.coordinator._debug_topology_summary(snapshot)
+        return {
+            "inventory_ready": bool(snapshot.inventory_ready),
+            "charger_count": len(snapshot.charger_serials),
+            "battery_count": len(snapshot.battery_serials),
+            "inverter_count": len(snapshot.inverter_serials),
+            "active_type_keys": list(snapshot.active_type_keys),
+            "gateway_iq_router_count": len(snapshot.gateway_iq_router_keys),
+            "site_energy_channels": sorted(self._live_site_energy_channels()),
+        }
 
     def _build_system_dashboard_summaries(
         self,
@@ -160,12 +397,10 @@ class InventoryRuntime:
         dict[str, object],
         dict[str, dict[str, object]],
     ]:
-        return self.coordinator._build_system_dashboard_summaries(
-            tree_payload, details_payloads
-        )
+        return build_system_dashboard_summaries(tree_payload, details_payloads)
 
     def _system_dashboard_type_key(self, raw_type: object) -> str | None:
-        return self.coordinator._system_dashboard_type_key(raw_type)
+        return system_dashboard_type_key(raw_type)
 
     def topology_snapshot(self) -> CoordinatorTopologySnapshot:
         """Return the latest cached topology snapshot."""
@@ -547,14 +782,15 @@ class InventoryRuntime:
             and isinstance(grouped[key].get("devices"), list)
             and int(grouped[key].get("count", 0)) > 0
         ]
-        self._type_device_buckets = {
+        buckets_out = {
             key: value
             for key, value in grouped.items()
             if int(value.get("count", 0)) > 0
         }
-        self._type_device_order = normalized_order
+        self._set_shared_state_attr("_type_device_buckets", buckets_out)
+        self._set_shared_state_attr("_type_device_order", normalized_order)
         if authoritative:
-            self._devices_inventory_ready = True
+            self._set_shared_state_attr("_devices_inventory_ready", True)
 
     @staticmethod
     def _devices_inventory_buckets(payload: object) -> list[dict[str, object]]:
@@ -889,19 +1125,51 @@ class InventoryRuntime:
         return normalized or None
 
     def _summary_type_bucket_source(self, type_key: object) -> dict[str, object] | None:
-        return self.coordinator._summary_type_bucket_source(type_key)
+        normalized = normalize_type_key(type_key)
+        if not normalized:
+            return None
+        buckets = getattr(self, "_type_device_buckets", None)
+        if not isinstance(buckets, dict):
+            return None
+        bucket = buckets.get(normalized)
+        return bucket if isinstance(bucket, dict) else None
 
     def _gateway_inventory_summary_marker(self) -> tuple[object, ...]:
-        return self.coordinator._gateway_inventory_summary_marker()
+        dashboard_payloads = getattr(
+            self, "_system_dashboard_devices_details_raw", None
+        )
+        dashboard_envoy = (
+            dashboard_payloads.get("envoy")
+            if isinstance(dashboard_payloads, dict)
+            else None
+        )
+        return (
+            id(self._summary_type_bucket_source("envoy")),
+            id(dashboard_envoy),
+        )
 
     def _microinverter_inventory_summary_marker(self) -> tuple[object, ...]:
-        return self.coordinator._microinverter_inventory_summary_marker()
+        return (id(self._summary_type_bucket_source("microinverter")),)
 
     def _heatpump_inventory_summary_marker(self) -> tuple[object, ...]:
-        return self.coordinator._heatpump_inventory_summary_marker()
+        return (
+            id(self._summary_type_bucket_source("heatpump")),
+            id(getattr(self, "_hems_devices_payload", None)),
+            bool(getattr(self, "_hems_devices_using_stale", False)),
+            getattr(self, "_hems_devices_last_success_utc", None),
+            getattr(self, "_hems_devices_last_success_mono", None),
+        )
 
     def _gateway_iq_energy_router_records_marker(self) -> tuple[object, ...]:
-        return self.coordinator._gateway_iq_energy_router_records_marker()
+        return (
+            id(getattr(self, "_hems_devices_payload", None)),
+            id(getattr(self, "_devices_inventory_payload", None)),
+            id(
+                self._coordinator_backed_attr(
+                    "_restored_gateway_iq_energy_router_records"
+                )
+            ),
+        )
 
     @staticmethod
     def _heatpump_status_text(member: dict[str, object] | None) -> str | None:
@@ -941,16 +1209,508 @@ class InventoryRuntime:
         return records
 
     def _build_gateway_inventory_summary(self) -> dict[str, object]:
-        return self.coordinator._build_gateway_inventory_summary()
+        bucket = self.type_bucket("envoy") or {}
+        members_raw = bucket.get("devices")
+        members = (
+            [item for item in members_raw if isinstance(item, dict)]
+            if isinstance(members_raw, list)
+            else []
+        )
+        dashboard_envoy = self.system_dashboard_envoy_detail()
+        if not members and isinstance(dashboard_envoy, dict):
+            members = [dict(dashboard_envoy)]
+        try:
+            total_devices = int(bucket.get("count", len(members)) or 0)
+        except Exception:
+            total_devices = len(members)
+        total_devices = max(total_devices, len(members))
+        status_counts: dict[str, int] = {
+            "normal": 0,
+            "warning": 0,
+            "error": 0,
+            "not_reporting": 0,
+            "unknown": 0,
+        }
+        model_counts: dict[str, int] = {}
+        firmware_counts: dict[str, int] = {}
+        property_keys: set[str] = set()
+        connected_devices = 0
+        disconnected_devices = 0
+        latest_reported: datetime | None = None
+        latest_reported_device: dict[str, object] | None = None
+        without_last_report_count = 0
+
+        for member in members:
+            property_keys.update(str(key) for key in member.keys())
+            status_source = None
+            for key in ("statusText", "status_text", "status"):
+                if member.get(key) is not None:
+                    status_source = member.get(key)
+                    break
+            status = self._normalize_inverter_status(status_source)
+            status_counts[status] = status_counts.get(status, 0) + 1
+
+            connected = member.get("connected")
+            if isinstance(connected, str):
+                normalized_connected = connected.strip().lower()
+                if normalized_connected in {"true", "1", "yes", "y"}:
+                    connected = True
+                elif normalized_connected in {"false", "0", "no", "n"}:
+                    connected = False
+                else:
+                    connected = None
+            elif isinstance(connected, (int, float)):
+                connected = connected != 0
+            elif not isinstance(connected, bool):
+                connected = None
+            if connected is None:
+                if status == "normal":
+                    connected = True
+                elif status == "not_reporting":
+                    connected = False
+            if connected is True:
+                connected_devices += 1
+            elif connected is False:
+                disconnected_devices += 1
+
+            model_name = self._type_member_text(
+                member, "model", "model_name", "part_number", "device_type"
+            )
+            if model_name:
+                model_counts[model_name] = model_counts.get(model_name, 0) + 1
+            firmware_version = self._type_member_text(
+                member, "firmware_version", "sw_version", "software_version"
+            )
+            if firmware_version:
+                firmware_counts[firmware_version] = (
+                    firmware_counts.get(firmware_version, 0) + 1
+                )
+
+            parsed_last_report = None
+            for key in (
+                "last_report",
+                "last_reported",
+                "last_reported_at",
+                "last-report",
+            ):
+                parsed_last_report = self._parse_inverter_last_report(member.get(key))
+                if parsed_last_report is not None:
+                    break
+            if parsed_last_report is None:
+                without_last_report_count += 1
+                continue
+            if latest_reported is None or parsed_last_report > latest_reported:
+                latest_reported = parsed_last_report
+                latest_reported_device = {
+                    "name": self._summary_text(member.get("name")),
+                    "serial_number": self._summary_text(member.get("serial_number")),
+                    "status": self._summary_text(status_source),
+                }
+
+        unknown_connection_devices = max(
+            0, total_devices - connected_devices - disconnected_devices
+        )
+        status_summary = (
+            f"Normal {status_counts.get('normal', 0)} | "
+            f"Warning {status_counts.get('warning', 0)} | "
+            f"Error {status_counts.get('error', 0)} | "
+            f"Not Reporting {status_counts.get('not_reporting', 0)} | "
+            f"Unknown {status_counts.get('unknown', 0)}"
+            if total_devices > 0
+            else None
+        )
+        if latest_reported is None and isinstance(dashboard_envoy, dict):
+            fallback_last = None
+            for key in ("last_report", "last_interval_end_date"):
+                fallback_last = self._parse_inverter_last_report(
+                    dashboard_envoy.get(key)
+                )
+                if fallback_last is not None:
+                    break
+            if fallback_last is not None:
+                latest_reported = fallback_last
+                latest_reported_device = {
+                    "name": self._summary_text(dashboard_envoy.get("name"))
+                    or "IQ Gateway",
+                    "serial_number": self._summary_text(
+                        dashboard_envoy.get("serial_number")
+                    ),
+                    "status": self._summary_text(
+                        dashboard_envoy.get("statusText")
+                        if dashboard_envoy.get("statusText") is not None
+                        else dashboard_envoy.get("status")
+                    ),
+                }
+        return {
+            "total_devices": total_devices,
+            "connected_devices": connected_devices,
+            "disconnected_devices": disconnected_devices,
+            "unknown_connection_devices": unknown_connection_devices,
+            "without_last_report_count": without_last_report_count,
+            "status_counts": status_counts,
+            "status_summary": status_summary,
+            "model_counts": model_counts,
+            "model_summary": self._format_inverter_model_summary(model_counts),
+            "firmware_counts": firmware_counts,
+            "firmware_summary": self._format_inverter_model_summary(firmware_counts),
+            "latest_reported": latest_reported,
+            "latest_reported_utc": (
+                latest_reported.isoformat() if latest_reported is not None else None
+            ),
+            "latest_reported_device": latest_reported_device,
+            "property_keys": sorted(property_keys),
+        }
 
     def _build_microinverter_inventory_summary(self) -> dict[str, object]:
-        return self.coordinator._build_microinverter_inventory_summary()
+        bucket = self.type_bucket("microinverter") or {}
+        members = bucket.get("devices")
+        safe_members = (
+            [dict(item) for item in members if isinstance(item, dict)]
+            if isinstance(members, list)
+            else []
+        )
+        status_counts_raw = bucket.get("status_counts")
+        status_counts: dict[str, int] = {}
+        has_status_counts = isinstance(status_counts_raw, dict)
+        if isinstance(status_counts_raw, dict):
+            for key in (
+                "total",
+                "normal",
+                "warning",
+                "error",
+                "not_reporting",
+                "unknown",
+            ):
+                try:
+                    status_counts[key] = int(status_counts_raw.get(key, 0) or 0)
+                except Exception:
+                    status_counts[key] = 0
+        try:
+            total_inverters = int(bucket.get("count", len(safe_members)) or 0)
+        except Exception:
+            total_inverters = len(safe_members)
+        if status_counts.get("total", 0) > 0:
+            total_inverters = max(total_inverters, int(status_counts.get("total", 0)))
+        not_reporting = max(0, int(status_counts.get("not_reporting", 0)))
+        unknown = max(0, int(status_counts.get("unknown", 0)))
+        if not has_status_counts:
+            unknown = total_inverters
+        elif (
+            total_inverters > 0
+            and int(status_counts.get("total", 0) or 0) <= 0
+            and max(
+                0,
+                int(status_counts.get("normal", 0) or 0)
+                + int(status_counts.get("warning", 0) or 0)
+                + int(status_counts.get("error", 0) or 0)
+                + not_reporting
+                + unknown,
+            )
+            == 0
+        ):
+            unknown = total_inverters
+        known_status_total = not_reporting + unknown
+        if known_status_total > total_inverters:
+            unknown = max(0, unknown - (known_status_total - total_inverters))
+        reporting = max(0, total_inverters - not_reporting - unknown)
+        latest_reported = self._parse_inverter_last_report(
+            bucket.get("latest_reported_utc")
+            if bucket.get("latest_reported_utc") is not None
+            else bucket.get("latest_reported")
+        )
+        latest_reported_device = (
+            dict(bucket.get("latest_reported_device"))
+            if isinstance(bucket.get("latest_reported_device"), dict)
+            else None
+        )
+        if latest_reported is None:
+            for member in safe_members:
+                parsed_last = self._parse_inverter_last_report(
+                    member.get("last_report")
+                )
+                if parsed_last is None:
+                    continue
+                if latest_reported is None or parsed_last > latest_reported:
+                    latest_reported = parsed_last
+                    latest_reported_device = {
+                        "serial_number": self._summary_text(
+                            member.get("serial_number")
+                        ),
+                        "name": self._summary_text(member.get("name")),
+                        "status": self._summary_text(
+                            member.get("statusText")
+                            if member.get("statusText") is not None
+                            else member.get("status")
+                        ),
+                    }
+        snapshot: dict[str, object] = {
+            "total_inverters": total_inverters,
+            "reporting_inverters": reporting,
+            "not_reporting_inverters": not_reporting,
+            "unknown_inverters": unknown,
+            "status_counts": status_counts,
+            "status_summary": bucket.get("status_summary"),
+            "model_summary": bucket.get("model_summary"),
+            "firmware_summary": bucket.get("firmware_summary"),
+            "array_summary": bucket.get("array_summary"),
+            "panel_info": (
+                dict(bucket.get("panel_info"))
+                if isinstance(bucket.get("panel_info"), dict)
+                else None
+            ),
+            "status_type_counts": (
+                dict(bucket.get("status_type_counts"))
+                if isinstance(bucket.get("status_type_counts"), dict)
+                else None
+            ),
+            "latest_reported": latest_reported,
+            "latest_reported_utc": (
+                latest_reported.isoformat() if latest_reported is not None else None
+            ),
+            "latest_reported_device": latest_reported_device,
+            "production_start_date": bucket.get("production_start_date"),
+            "production_end_date": bucket.get("production_end_date"),
+        }
+        connectivity_state = bucket.get("connectivity_state")
+        if not isinstance(connectivity_state, str) or not connectivity_state.strip():
+            connectivity_state = "degraded"
+            if total_inverters <= 0:
+                connectivity_state = None
+            elif reporting >= total_inverters:
+                connectivity_state = "online"
+            elif reporting == 0 and not_reporting > 0:
+                connectivity_state = "offline"
+            elif reporting > 0 and reporting < total_inverters:
+                connectivity_state = "degraded"
+            elif unknown >= total_inverters:
+                connectivity_state = "unknown"
+        snapshot["connectivity_state"] = connectivity_state
+        return snapshot
 
     def _build_heatpump_inventory_summary(self) -> dict[str, object]:
-        return self.coordinator._build_heatpump_inventory_summary()
+        bucket = self.type_bucket("heatpump") or {}
+        members = bucket.get("devices")
+        safe_members = (
+            [dict(item) for item in members if isinstance(item, dict)]
+            if isinstance(members, list)
+            else []
+        )
+        status_counts_raw = bucket.get("status_counts")
+        status_counts: dict[str, int] | None = None
+        if isinstance(status_counts_raw, dict):
+            parsed_counts = {
+                "total": 0,
+                "normal": 0,
+                "warning": 0,
+                "error": 0,
+                "not_reporting": 0,
+                "unknown": 0,
+            }
+            try:
+                for key in parsed_counts:
+                    parsed_counts[key] = int(status_counts_raw.get(key, 0) or 0)
+                status_counts = parsed_counts
+            except Exception:
+                status_counts = None
+        if status_counts is None:
+            status_counts = {
+                "total": len(safe_members),
+                "normal": 0,
+                "warning": 0,
+                "error": 0,
+                "not_reporting": 0,
+                "unknown": 0,
+            }
+            for member in safe_members:
+                status_key = self._normalize_inverter_status(
+                    self._heatpump_status_text(member)
+                )
+                status_counts[status_key] = int(status_counts.get(status_key, 0)) + 1
+        try:
+            total_devices = int(bucket.get("count", len(safe_members)) or 0)
+        except Exception:
+            total_devices = len(safe_members)
+        total_devices = max(total_devices, len(safe_members))
+        status_counts["total"] = max(
+            int(status_counts.get("total", 0) or 0), total_devices
+        )
+        latest_reported = self._parse_inverter_last_report(
+            bucket.get("latest_reported_utc")
+            if bucket.get("latest_reported_utc") is not None
+            else bucket.get("latest_reported")
+        )
+        latest_reported_device = (
+            dict(bucket.get("latest_reported_device"))
+            if isinstance(bucket.get("latest_reported_device"), dict)
+            else None
+        )
+        without_last_report_count = 0
+        if latest_reported is None:
+            for member in safe_members:
+                member_last = None
+                for key in (
+                    "last_report",
+                    "last_reported",
+                    "last_reported_at",
+                    "last-report",
+                ):
+                    member_last = self._parse_inverter_last_report(member.get(key))
+                    if member_last is not None:
+                        break
+                if member_last is None:
+                    without_last_report_count += 1
+                    continue
+                if latest_reported is None or member_last > latest_reported:
+                    latest_reported = member_last
+                    latest_reported_device = {
+                        "device_type": self._heatpump_member_device_type(member),
+                        "name": self._summary_text(member.get("name")),
+                        "device_uid": self._type_member_text(
+                            member, "device_uid", "device-uid", "uid"
+                        ),
+                        "status": self._heatpump_status_text(member),
+                    }
+        overall_status_text = self._summary_text(bucket.get("overall_status_text"))
+        if not overall_status_text:
+            for member in safe_members:
+                if self._heatpump_member_device_type(member) != "HEAT_PUMP":
+                    continue
+                overall_status_text = self._heatpump_status_text(member)
+                if overall_status_text:
+                    break
+        if not overall_status_text:
+            overall_status_text = self._heatpump_worst_status_text(status_counts)
+        device_type_counts: dict[str, int] = {}
+        if isinstance(bucket.get("device_type_counts"), dict):
+            for key, value in bucket.get("device_type_counts", {}).items():
+                if key is None:
+                    continue
+                try:
+                    count = int(value)
+                except Exception:
+                    continue
+                if count > 0:
+                    device_type_counts[str(key)] = count
+        else:
+            for member in safe_members:
+                device_type = self._heatpump_member_device_type(member) or "UNKNOWN"
+                device_type_counts[device_type] = (
+                    device_type_counts.get(device_type, 0) + 1
+                )
+        status_summary = bucket.get("status_summary")
+        if not isinstance(status_summary, str) or not status_summary.strip():
+            status_summary = self._format_inverter_status_summary(status_counts)
+        hems_last_success_utc = getattr(self, "_hems_devices_last_success_utc", None)
+        if not isinstance(hems_last_success_utc, datetime):
+            hems_last_success_utc = None
+        hems_last_success_mono = getattr(self, "_hems_devices_last_success_mono", None)
+        hems_last_success_age_s: float | None = None
+        if isinstance(hems_last_success_mono, (int, float)):
+            age = time.monotonic() - float(hems_last_success_mono)
+            if age >= 0:
+                hems_last_success_age_s = round(age, 1)
+        return {
+            "total_devices": total_devices,
+            "members": safe_members,
+            "status_counts": status_counts,
+            "status_summary": status_summary,
+            "device_type_counts": device_type_counts,
+            "model_summary": bucket.get("model_summary"),
+            "firmware_summary": bucket.get("firmware_summary"),
+            "latest_reported": latest_reported,
+            "latest_reported_utc": (
+                latest_reported.isoformat() if latest_reported is not None else None
+            ),
+            "latest_reported_device": latest_reported_device,
+            "without_last_report_count": without_last_report_count,
+            "overall_status_text": overall_status_text,
+            "hems_data_stale": bool(getattr(self, "_hems_devices_using_stale", False)),
+            "hems_last_success_utc": (
+                hems_last_success_utc.isoformat()
+                if hems_last_success_utc is not None
+                else None
+            ),
+            "hems_last_success_age_s": hems_last_success_age_s,
+        }
 
     def _build_heatpump_type_summaries(self) -> dict[str, dict[str, object]]:
-        return self.coordinator._build_heatpump_type_summaries()
+        snapshot = self._build_heatpump_inventory_summary()
+        members = [
+            member for member in snapshot.get("members", []) if isinstance(member, dict)
+        ]
+        summaries: dict[str, dict[str, object]] = {}
+        for device_type in sorted(
+            {
+                self._heatpump_member_device_type(member)
+                for member in members
+                if self._heatpump_member_device_type(member)
+            }
+        ):
+            type_members = [
+                member
+                for member in members
+                if self._heatpump_member_device_type(member) == device_type
+            ]
+            counts = {
+                "total": len(type_members),
+                "normal": 0,
+                "warning": 0,
+                "error": 0,
+                "not_reporting": 0,
+                "unknown": 0,
+            }
+            latest_reported: datetime | None = None
+            latest_device: dict[str, object] | None = None
+            status_texts: list[str] = []
+            for member in type_members:
+                status_text = self._heatpump_status_text(member)
+                if status_text:
+                    status_texts.append(status_text)
+                status_key = self._normalize_inverter_status(status_text)
+                counts[status_key] = int(counts.get(status_key, 0)) + 1
+                parsed_last = None
+                for key in (
+                    "last_report",
+                    "last_reported",
+                    "last_reported_at",
+                    "last-report",
+                ):
+                    parsed_last = self._parse_inverter_last_report(member.get(key))
+                    if parsed_last is not None:
+                        break
+                if parsed_last is not None and (
+                    latest_reported is None or parsed_last > latest_reported
+                ):
+                    latest_reported = parsed_last
+                    latest_device = {
+                        "name": self._summary_text(member.get("name")),
+                        "device_uid": self._type_member_text(
+                            member, "device_uid", "device-uid", "uid"
+                        ),
+                        "status": status_text,
+                    }
+            unique_statuses = list(dict.fromkeys(status_texts))
+            if len(unique_statuses) == 1:
+                native_status = unique_statuses[0]
+            else:
+                native_status = self._heatpump_worst_status_text(counts)
+            summaries[device_type] = {
+                "device_type": device_type,
+                "members": type_members,
+                "member_count": len(type_members),
+                "status_counts": counts,
+                "status_summary": self._format_inverter_status_summary(counts),
+                "native_status": native_status,
+                "latest_reported": latest_reported,
+                "latest_reported_utc": (
+                    latest_reported.isoformat() if latest_reported is not None else None
+                ),
+                "latest_reported_device": latest_device,
+                "hems_data_stale": snapshot.get("hems_data_stale"),
+                "hems_last_success_utc": snapshot.get("hems_last_success_utc"),
+                "hems_last_success_age_s": snapshot.get("hems_last_success_age_s"),
+            }
+        return summaries
 
     @callback
     def _rebuild_inventory_summary_caches(self) -> None:
@@ -965,21 +1725,24 @@ class InventoryRuntime:
         router_records = self._gateway_iq_energy_router_summary_records(
             self.gateway_iq_energy_router_records()
         )
-        self._gateway_inventory_summary_cache = gateway_summary
-        self._gateway_inventory_summary_source = gateway_source
-        self._microinverter_inventory_summary_cache = micro_summary
-        self._microinverter_inventory_summary_source = micro_source
-        self._heatpump_inventory_summary_cache = heatpump_summary
-        self._heatpump_inventory_summary_source = heatpump_source
-        self._heatpump_type_summaries_cache = heatpump_type_summaries
-        self._heatpump_type_summaries_source = heatpump_source
-        self._gateway_iq_energy_router_records_cache = router_records
-        self._gateway_iq_energy_router_records_source = router_source
-        self._gateway_iq_energy_router_records_by_key_cache = {
+        router_by_key = {
             record["key"]: record
             for record in router_records
             if isinstance(record, dict) and isinstance(record.get("key"), str)
         }
+        self._update_shared_state(
+            _gateway_inventory_summary_cache=gateway_summary,
+            _gateway_inventory_summary_source=gateway_source,
+            _microinverter_inventory_summary_cache=micro_summary,
+            _microinverter_inventory_summary_source=micro_source,
+            _heatpump_inventory_summary_cache=heatpump_summary,
+            _heatpump_inventory_summary_source=heatpump_source,
+            _heatpump_type_summaries_cache=heatpump_type_summaries,
+            _heatpump_type_summaries_source=heatpump_source,
+            _gateway_iq_energy_router_records_cache=router_records,
+            _gateway_iq_energy_router_records_source=router_source,
+            _gateway_iq_energy_router_records_by_key_cache=router_by_key,
+        )
 
     async def _async_refresh_devices_inventory(self, *, force: bool = False) -> None:
         now = time.monotonic()
@@ -1036,11 +1799,15 @@ class InventoryRuntime:
         self._set_type_device_buckets(grouped, ordered)
         redacted_payload = self._redact_battery_payload(payload)
         if isinstance(redacted_payload, dict):
-            self._devices_inventory_payload = redacted_payload
+            self._set_shared_state_attr("_devices_inventory_payload", redacted_payload)
         else:
-            self._devices_inventory_payload = {"value": redacted_payload}
+            self._set_shared_state_attr(
+                "_devices_inventory_payload", {"value": redacted_payload}
+            )
         self._merge_heatpump_type_bucket()
-        self._devices_inventory_cache_until = now + DEVICES_INVENTORY_CACHE_TTL
+        self._set_shared_state_attr(
+            "_devices_inventory_cache_until", now + DEVICES_INVENTORY_CACHE_TTL
+        )
         self._debug_log_summary_if_changed(
             "devices_inventory",
             "Device inventory discovery summary",
@@ -1052,13 +1819,19 @@ class InventoryRuntime:
         if not force and self._hems_devices_cache_until:
             if now < self._hems_devices_cache_until:
                 return
-        await self.coordinator._async_refresh_hems_support_preflight(force=force)
+        await self.coordinator.heatpump_runtime.async_refresh_hems_support_preflight(
+            force=force
+        )
         if getattr(self.client, "hems_site_supported", None) is False:
-            self._hems_devices_payload = None
-            self._hems_devices_using_stale = False
-            self._hems_inventory_ready = True
+            self._update_shared_state(
+                _hems_devices_payload=None,
+                _hems_devices_using_stale=False,
+                _hems_inventory_ready=True,
+            )
             self._merge_heatpump_type_bucket()
-            self._hems_devices_cache_until = now + HEMS_DEVICES_CACHE_TTL
+            self._set_shared_state_attr(
+                "_hems_devices_cache_until", now + HEMS_DEVICES_CACHE_TTL
+            )
             self._debug_log_summary_if_changed(
                 "hems_inventory",
                 "HEMS discovery summary",
@@ -1084,20 +1857,26 @@ class InventoryRuntime:
                 redact_text(err, site_ids=(self.site_id,)),
             )
             if getattr(self.client, "hems_site_supported", None) is False:
-                self._hems_devices_payload = None
-                self._hems_devices_using_stale = False
-                self._hems_inventory_ready = True
-                self._hems_devices_cache_until = now + HEMS_DEVICES_CACHE_TTL
+                self._update_shared_state(
+                    _hems_devices_payload=None,
+                    _hems_devices_using_stale=False,
+                    _hems_inventory_ready=True,
+                    _hems_devices_cache_until=now + HEMS_DEVICES_CACHE_TTL,
+                )
             elif stale_allowed:
-                self._hems_devices_payload = previous_payload
-                self._hems_devices_using_stale = True
-                self._hems_inventory_ready = True
-                self._hems_devices_cache_until = now + HEMS_DEVICES_CACHE_TTL
+                self._update_shared_state(
+                    _hems_devices_payload=previous_payload,
+                    _hems_devices_using_stale=True,
+                    _hems_inventory_ready=True,
+                    _hems_devices_cache_until=now + HEMS_DEVICES_CACHE_TTL,
+                )
             else:
-                self._hems_devices_payload = None
-                self._hems_devices_using_stale = False
-                self._hems_inventory_ready = False
-                self._hems_devices_cache_until = now + HEMS_DEVICES_CACHE_TTL
+                self._update_shared_state(
+                    _hems_devices_payload=None,
+                    _hems_devices_using_stale=False,
+                    _hems_inventory_ready=False,
+                    _hems_devices_cache_until=now + HEMS_DEVICES_CACHE_TTL,
+                )
             self._merge_heatpump_type_bucket()
             self._debug_log_summary_if_changed(
                 "hems_inventory",
@@ -1108,11 +1887,15 @@ class InventoryRuntime:
 
         if not isinstance(payload, dict):
             if getattr(self.client, "hems_site_supported", None) is False:
-                self._hems_devices_payload = None
-                self._hems_devices_using_stale = False
-                self._hems_inventory_ready = True
+                self._update_shared_state(
+                    _hems_devices_payload=None,
+                    _hems_devices_using_stale=False,
+                    _hems_inventory_ready=True,
+                )
                 self._merge_heatpump_type_bucket()
-                self._hems_devices_cache_until = now + HEMS_DEVICES_CACHE_TTL
+                self._set_shared_state_attr(
+                    "_hems_devices_cache_until", now + HEMS_DEVICES_CACHE_TTL
+                )
                 self._debug_log_summary_if_changed(
                     "hems_inventory",
                     "HEMS discovery summary",
@@ -1120,22 +1903,30 @@ class InventoryRuntime:
                 )
                 return
             if stale_allowed:
-                self._hems_devices_payload = previous_payload
-                self._hems_devices_using_stale = True
-                self._hems_inventory_ready = True
+                self._update_shared_state(
+                    _hems_devices_payload=previous_payload,
+                    _hems_devices_using_stale=True,
+                    _hems_inventory_ready=True,
+                )
                 self._merge_heatpump_type_bucket()
-                self._hems_devices_cache_until = now + HEMS_DEVICES_CACHE_TTL
+                self._set_shared_state_attr(
+                    "_hems_devices_cache_until", now + HEMS_DEVICES_CACHE_TTL
+                )
                 self._debug_log_summary_if_changed(
                     "hems_inventory",
                     "HEMS discovery summary",
                     self._debug_hems_inventory_summary(),
                 )
                 return
-            self._hems_devices_payload = None
-            self._hems_devices_using_stale = False
-            self._hems_inventory_ready = False
+            self._update_shared_state(
+                _hems_devices_payload=None,
+                _hems_devices_using_stale=False,
+                _hems_inventory_ready=False,
+            )
             self._merge_heatpump_type_bucket()
-            self._hems_devices_cache_until = now + HEMS_DEVICES_CACHE_TTL
+            self._set_shared_state_attr(
+                "_hems_devices_cache_until", now + HEMS_DEVICES_CACHE_TTL
+            )
             self._debug_log_summary_if_changed(
                 "hems_inventory",
                 "HEMS discovery summary",
@@ -1145,15 +1936,21 @@ class InventoryRuntime:
 
         redacted_payload = self._redact_battery_payload(payload)
         if isinstance(redacted_payload, dict):
-            self._hems_devices_payload = redacted_payload
+            self._set_shared_state_attr("_hems_devices_payload", redacted_payload)
         else:
-            self._hems_devices_payload = {"value": redacted_payload}
-        self._hems_devices_last_success_mono = now
-        self._hems_devices_last_success_utc = dt_util.utcnow()
-        self._hems_devices_using_stale = False
-        self._hems_inventory_ready = True
+            self._set_shared_state_attr(
+                "_hems_devices_payload", {"value": redacted_payload}
+            )
+        self._update_shared_state(
+            _hems_devices_last_success_mono=now,
+            _hems_devices_last_success_utc=dt_util.utcnow(),
+            _hems_devices_using_stale=False,
+            _hems_inventory_ready=True,
+        )
         self._merge_heatpump_type_bucket()
-        self._hems_devices_cache_until = now + HEMS_DEVICES_CACHE_TTL
+        self._set_shared_state_attr(
+            "_hems_devices_cache_until", now + HEMS_DEVICES_CACHE_TTL
+        )
         self._debug_log_summary_if_changed(
             "hems_inventory",
             "HEMS discovery summary",
@@ -1165,19 +1962,16 @@ class InventoryRuntime:
         payloads: dict[str, object],
         *source_types: str,
     ) -> list[dict[str, object]]:
-        return self.coordinator._system_dashboard_detail_records(
-            payloads,
-            *source_types,
-        )
+        return system_dashboard_detail_records(payloads, *source_types)
 
     def _system_dashboard_meter_kind(self, payload: dict[str, object]) -> str | None:
-        return self.coordinator._system_dashboard_meter_kind(payload)
+        return system_dashboard_meter_kind(payload)
 
     def _system_dashboard_battery_detail_subset(
         self,
         payload: dict[str, object] | None,
     ) -> dict[str, object]:
-        return self.coordinator._system_dashboard_battery_detail_subset(payload)
+        return system_dashboard_battery_detail_subset(payload)
 
     async def _async_refresh_system_dashboard(self, *, force: bool = False) -> None:
         now = time.monotonic()
@@ -1229,10 +2023,8 @@ class InventoryRuntime:
             hierarchy_summary,
             hierarchy_index,
         ) = self._build_system_dashboard_summaries(tree_payload, details_payloads)
-        self._system_dashboard_devices_tree_raw = (
-            tree_payload if isinstance(tree_payload, dict) else None
-        )
-        self._system_dashboard_devices_details_raw = {
+        tree_raw = tree_payload if isinstance(tree_payload, dict) else None
+        details_raw = {
             canonical_type: {
                 str(source_type): dict(payload)
                 for source_type, payload in payloads.items()
@@ -1241,32 +2033,37 @@ class InventoryRuntime:
             for canonical_type, payloads in details_payloads.items()
             if isinstance(payloads, dict)
         }
-        if isinstance(self._system_dashboard_devices_tree_raw, dict):
-            redacted_tree = self._redact_battery_payload(
-                self._system_dashboard_devices_tree_raw
-            )
-            self._system_dashboard_devices_tree_payload = (
+        self._update_shared_state(
+            _system_dashboard_devices_tree_raw=tree_raw,
+            _system_dashboard_devices_details_raw=details_raw,
+        )
+        if isinstance(tree_raw, dict):
+            redacted_tree = self._redact_battery_payload(tree_raw)
+            tree_payload_out = (
                 redacted_tree if isinstance(redacted_tree, dict) else None
             )
         else:
-            self._system_dashboard_devices_tree_payload = None
+            tree_payload_out = None
 
         redacted_details: dict[str, dict[str, object]] = {}
         for (
             canonical_type,
             payloads_by_source,
-        ) in self._system_dashboard_devices_details_raw.items():
+        ) in details_raw.items():
             merged: dict[str, object] = {}
             for source_type, payload in payloads_by_source.items():
                 redacted = self._redact_battery_payload(payload)
                 if isinstance(redacted, dict):
                     merged[source_type] = redacted
             redacted_details[canonical_type] = merged
-        self._system_dashboard_devices_details_payloads = redacted_details
-        self._system_dashboard_type_summaries = type_summaries
-        self._system_dashboard_hierarchy_summary = hierarchy_summary
-        self._system_dashboard_hierarchy_index = hierarchy_index
-        self._system_dashboard_cache_until = now + DEVICES_INVENTORY_CACHE_TTL
+        self._update_shared_state(
+            _system_dashboard_devices_tree_payload=tree_payload_out,
+            _system_dashboard_devices_details_payloads=redacted_details,
+            _system_dashboard_type_summaries=type_summaries,
+            _system_dashboard_hierarchy_summary=hierarchy_summary,
+            _system_dashboard_hierarchy_index=hierarchy_index,
+            _system_dashboard_cache_until=now + DEVICES_INVENTORY_CACHE_TTL,
+        )
         self._debug_log_summary_if_changed(
             "system_dashboard",
             "System dashboard discovery summary",
@@ -1279,7 +2076,12 @@ class InventoryRuntime:
         )
 
     def _inverter_start_date(self) -> str | None:
-        return self.coordinator._inverter_start_date()
+        energy = getattr(self.coordinator, "energy", None)
+        site_energy_meta = getattr(energy, "_site_energy_meta", None)
+        return resolve_inverter_start_date(
+            site_energy_meta,
+            self._coordinator_backed_attr("_inverter_data"),
+        )
 
     @staticmethod
     def _format_inverter_model_summary(model_counts: dict[str, int]) -> str | None:
@@ -1377,26 +2179,155 @@ class InventoryRuntime:
         return parse_inverter_last_report(value)
 
     def _merge_microinverter_type_bucket(self) -> None:
-        self.coordinator._merge_microinverter_type_bucket()
+        ready_before = bool(getattr(self, "_devices_inventory_ready", False))
+        buckets = dict(getattr(self, "_type_device_buckets", {}) or {})
+        ordered = list(getattr(self, "_type_device_order", []) or [])
+        key = "microinverter"
+
+        devices_out: list[dict[str, object]] = []
+        for serial in self.iter_inverter_serials():
+            payload = self.inverter_data(serial)
+            if not isinstance(payload, dict):
+                continue
+            devices_out.append(
+                {
+                    "name": payload.get("name"),
+                    "serial_number": payload.get("serial_number"),
+                    "sku_id": payload.get("sku_id"),
+                    "status": payload.get("status"),
+                    "statusText": payload.get("status_text"),
+                    "last_report": payload.get("last_report"),
+                    "array_name": payload.get("array_name"),
+                    "warranty_end_date": payload.get("warranty_end_date"),
+                    "device_id": payload.get("device_id"),
+                    "inverter_id": payload.get("inverter_id"),
+                    "fw1": payload.get("fw1"),
+                    "fw2": payload.get("fw2"),
+                }
+            )
+
+        if devices_out:
+            model_counts = dict(self._inverter_model_counts)
+            model_summary = self._format_inverter_model_summary(model_counts)
+            summary_counts = dict(self._inverter_summary_counts)
+            status_counts = {
+                "total": int(summary_counts.get("total", len(devices_out))),
+                "normal": int(summary_counts.get("normal", 0)),
+                "warning": int(summary_counts.get("warning", 0)),
+                "error": int(summary_counts.get("error", 0)),
+                "not_reporting": int(summary_counts.get("not_reporting", 0)),
+                "unknown": int(summary_counts.get("unknown", 0)),
+            }
+            latest_reported: datetime | None = None
+            latest_reported_device: dict[str, object] | None = None
+            array_counts: dict[str, int] = {}
+            firmware_counts: dict[str, int] = {}
+            for member in devices_out:
+                parsed_last = self._parse_inverter_last_report(
+                    member.get("last_report")
+                )
+                if parsed_last is not None and (
+                    latest_reported is None or parsed_last > latest_reported
+                ):
+                    latest_reported = parsed_last
+                    latest_reported_device = {
+                        "serial_number": member.get("serial_number"),
+                        "name": member.get("name"),
+                        "status": (
+                            member.get("statusText")
+                            if member.get("statusText") is not None
+                            else member.get("status")
+                        ),
+                    }
+                raw_array = member.get("array_name")
+                if raw_array is not None:
+                    try:
+                        array_name = str(raw_array).strip()
+                    except Exception:
+                        array_name = ""
+                    if array_name:
+                        array_counts[array_name] = array_counts.get(array_name, 0) + 1
+                raw_firmware = member.get("fw1") or member.get("fw2")
+                if raw_firmware is not None:
+                    try:
+                        firmware = str(raw_firmware).strip()
+                    except Exception:
+                        firmware = ""
+                    if firmware:
+                        firmware_counts[firmware] = firmware_counts.get(firmware, 0) + 1
+            array_summary = self._format_inverter_model_summary(array_counts)
+            firmware_summary = self._format_inverter_model_summary(firmware_counts)
+            buckets[key] = {
+                "type_key": key,
+                "type_label": "Microinverters",
+                "count": len(devices_out),
+                "devices": devices_out,
+                "model_counts": model_counts,
+                "model_summary": model_summary or "Microinverters",
+                "status_counts": status_counts,
+                "status_summary": self._format_inverter_status_summary(summary_counts),
+                "connectivity_state": self._inverter_connectivity_state(status_counts),
+                "reporting_count": max(
+                    0,
+                    int(status_counts.get("total", len(devices_out)))
+                    - int(status_counts.get("not_reporting", 0))
+                    - int(status_counts.get("unknown", 0)),
+                ),
+                "latest_reported_utc": (
+                    latest_reported.isoformat() if latest_reported is not None else None
+                ),
+                "latest_reported_device": latest_reported_device,
+                "array_counts": array_counts,
+                "array_summary": array_summary,
+                "firmware_counts": firmware_counts,
+                "firmware_summary": firmware_summary,
+            }
+            panel_info = getattr(self, "_inverter_panel_info", None)
+            if isinstance(panel_info, dict):
+                buckets[key]["panel_info"] = dict(panel_info)
+            production_payload = getattr(self, "_inverter_production_payload", None)
+            if isinstance(production_payload, dict):
+                start_date = self._normalize_iso_date(
+                    production_payload.get("start_date")
+                )
+                end_date = self._normalize_iso_date(production_payload.get("end_date"))
+                if start_date:
+                    buckets[key]["production_start_date"] = start_date
+                if end_date:
+                    buckets[key]["production_end_date"] = end_date
+            status_type_counts = getattr(self, "_inverter_status_type_counts", None)
+            if isinstance(status_type_counts, dict) and status_type_counts:
+                buckets[key]["status_type_counts"] = dict(status_type_counts)
+            if key not in ordered:
+                ordered.append(key)
+        else:
+            buckets.pop(key, None)
+            ordered = [item for item in ordered if item != key]
+
+        self._set_type_device_buckets(buckets, ordered)
+        if not ready_before:
+            self._devices_inventory_ready = False
 
     async def _async_refresh_inverters(self) -> None:
         """Refresh inverter metadata/status/production and build serial snapshots."""
         if not self.include_inverters:
-            self._inverters_inventory_payload = None
-            self._inverter_status_payload = None
-            self._inverter_production_payload = None
-            self._inverter_data = {}
-            self._inverter_order = []
-            self._inverter_panel_info = None
-            self._inverter_status_type_counts = {}
-            self._inverter_model_counts = {}
-            self._inverter_summary_counts = {
-                "total": 0,
-                "normal": 0,
-                "warning": 0,
-                "error": 0,
-                "not_reporting": 0,
-            }
+            self._update_shared_state(
+                _inverters_inventory_payload=None,
+                _inverter_status_payload=None,
+                _inverter_production_payload=None,
+                _inverter_data={},
+                _inverter_order=[],
+                _inverter_panel_info=None,
+                _inverter_status_type_counts={},
+                _inverter_model_counts={},
+                _inverter_summary_counts={
+                    "total": 0,
+                    "normal": 0,
+                    "warning": 0,
+                    "error": 0,
+                    "not_reporting": 0,
+                },
+            )
             self._merge_microinverter_type_bucket()
             self._merge_heatpump_type_bucket()
             return
@@ -1514,7 +2445,7 @@ class InventoryRuntime:
             item["inverter_id"] = str(inverter_id)
             status_by_serial[serial] = item
 
-        previous_data = getattr(self, "_inverter_data", None)
+        previous_data = self._coordinator_backed_attr("_inverter_data")
         if not isinstance(previous_data, dict):
             previous_data = {}
 
@@ -1703,22 +2634,24 @@ class InventoryRuntime:
             if not panel_info_out:
                 panel_info_out = None
 
-        self._inverters_inventory_payload = inventory_payload
-        self._inverter_status_payload = status_payload
-        self._inverter_production_payload = production_payload
-        self._inverter_data = inverter_data
-        self._inverter_order = inverter_order
-        self._inverter_panel_info = panel_info_out
-        self._inverter_status_type_counts = status_type_counts
-        self._inverter_model_counts = model_counts
-        self._inverter_summary_counts = summary_counts
+        self._update_shared_state(
+            _inverters_inventory_payload=inventory_payload,
+            _inverter_status_payload=status_payload,
+            _inverter_production_payload=production_payload,
+            _inverter_data=inverter_data,
+            _inverter_order=inverter_order,
+            _inverter_panel_info=panel_info_out,
+            _inverter_status_type_counts=status_type_counts,
+            _inverter_model_counts=model_counts,
+            _inverter_summary_counts=summary_counts,
+        )
         self._merge_microinverter_type_bucket()
         self._merge_heatpump_type_bucket()
 
     def iter_inverter_serials(self) -> list[str]:
         """Return currently active inverter serials in a stable order."""
-        order = getattr(self, "_inverter_order", None) or []
-        data = getattr(self, "_inverter_data", None)
+        order = self._coordinator_backed_attr("_inverter_order", []) or []
+        data = self._coordinator_backed_attr("_inverter_data")
         if not isinstance(data, dict):
             return []
         serials = [str(sn) for sn in order if sn in data]
@@ -1727,7 +2660,7 @@ class InventoryRuntime:
 
     def inverter_data(self, serial: str) -> dict[str, object] | None:
         """Return normalized inverter snapshot for a serial."""
-        data = getattr(self, "_inverter_data", None)
+        data = self._coordinator_backed_attr("_inverter_data")
         if not isinstance(data, dict):
             return None
         try:

--- a/custom_components/enphase_ev/runtime_helpers.py
+++ b/custom_components/enphase_ev/runtime_helpers.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone as _tz
+from zoneinfo import ZoneInfo
+
+from homeassistant.util import dt as dt_util
+
+
+def coerce_int(value: object, *, default: int = 0) -> int:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return int(value)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        try:
+            return int(float(str(value).strip()))
+        except (TypeError, ValueError):
+            return default
+
+
+def coerce_optional_int(value: object) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(str(value).strip())
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def copy_diagnostics_value(value: object) -> object:
+    if isinstance(value, dict):
+        return {key: copy_diagnostics_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [copy_diagnostics_value(item) for item in value]
+    return value
+
+
+def normalize_iso_date(value: object) -> str | None:
+    if value is None:
+        return None
+    try:
+        cleaned = str(value).strip()
+    except Exception:  # noqa: BLE001
+        return None
+    if not cleaned:
+        return None
+    try:
+        return datetime.strptime(cleaned, "%Y-%m-%d").date().isoformat()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def resolve_inverter_start_date(
+    site_energy_meta: object,
+    inverter_data: object,
+) -> str | None:
+    start_date: str | None = None
+    if isinstance(site_energy_meta, dict):
+        start_date = normalize_iso_date(site_energy_meta.get("start_date"))
+    if start_date:
+        return start_date
+
+    existing_starts: list[str] = []
+    if isinstance(inverter_data, dict):
+        for payload in inverter_data.values():
+            if not isinstance(payload, dict):
+                continue
+            normalized = normalize_iso_date(payload.get("lifetime_query_start_date"))
+            if normalized:
+                existing_starts.append(normalized)
+    if existing_starts:
+        return min(existing_starts)
+    return None
+
+
+def resolve_site_timezone_name(battery_timezone: object) -> str:
+    tz_name = battery_timezone
+    if isinstance(tz_name, str) and tz_name.strip():
+        try:
+            ZoneInfo(tz_name.strip())
+        except Exception:  # noqa: BLE001
+            pass
+        else:
+            return tz_name.strip()
+    return "UTC"
+
+
+def resolve_site_local_current_date(
+    devices_inventory_payload: object,
+    battery_timezone: object,
+) -> str:
+    inventory_payload = (
+        devices_inventory_payload
+        if isinstance(devices_inventory_payload, dict)
+        else None
+    )
+    if inventory_payload is not None:
+        direct = normalize_iso_date(inventory_payload.get("curr_date_site"))
+        if direct:
+            return direct
+        result = inventory_payload.get("result")
+        if isinstance(result, list):
+            for item in result:
+                if not isinstance(item, dict):
+                    continue
+                candidate = normalize_iso_date(item.get("curr_date_site"))
+                if candidate:
+                    return candidate
+
+    tz_name = battery_timezone
+    if isinstance(tz_name, str) and tz_name.strip():
+        try:
+            return datetime.now(ZoneInfo(tz_name.strip())).date().isoformat()
+        except Exception:  # noqa: BLE001
+            pass
+
+    try:
+        return dt_util.now().date().isoformat()
+    except Exception:  # noqa: BLE001
+        return datetime.now(tz=_tz.utc).date().isoformat()
+
+
+def redact_battery_payload(value: object) -> object:
+    sensitive = {
+        "email",
+        "authorization",
+        "cookie",
+        "token",
+        "access_token",
+        "refresh_token",
+        "xsrf_token",
+        "x_xsrf_token",
+        "session_id",
+        "userid",
+        "user_id",
+        "username",
+        "device_link",
+        "interface_ip",
+        "ip_addr",
+        "gateway_ip_addr",
+        "default_route",
+        "mac_addr",
+    }
+    if isinstance(value, dict):
+        out: dict[str, object] = {}
+        for key, item in value.items():
+            key_text = str(key)
+            if key_text.strip().lower().replace("-", "_") in sensitive:
+                out[key_text] = "[redacted]"
+            else:
+                out[key_text] = redact_battery_payload(item)
+        return out
+    if isinstance(value, list):
+        return [redact_battery_payload(item) for item in value]
+    return value

--- a/custom_components/enphase_ev/system_dashboard_helpers.py
+++ b/custom_components/enphase_ev/system_dashboard_helpers.py
@@ -1,0 +1,844 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .device_types import normalize_type_key
+from .parsing_helpers import coerce_optional_text
+from .runtime_helpers import coerce_optional_int
+
+SYSTEM_DASHBOARD_TYPE_KEY_MAP: dict[str, str] = {
+    "envoys": "envoy",
+    "meters": "envoy",
+    "enpowers": "envoy",
+    "encharges": "encharge",
+    "inverters": "microinverter",
+    "modems": "modem",
+}
+
+
+def _format_inverter_model_summary(model_counts: dict[str, int]) -> str | None:
+    clean: dict[str, int] = {}
+    for model, count in (model_counts or {}).items():
+        name = str(model).strip()
+        if not name:
+            continue
+        try:
+            count_int = int(count)
+        except (TypeError, ValueError):
+            continue
+        if count_int <= 0:
+            continue
+        clean[name] = count_int
+    if not clean:
+        return None
+    ordered = sorted(clean.items(), key=lambda item: (-item[1], item[0]))
+    return ", ".join(f"{name} x{count}" for name, count in ordered)
+
+
+def dashboard_key_token(key: object) -> str:
+    text = coerce_optional_text(key)
+    if not text:
+        return ""
+    return "".join(ch if ch.isalnum() else "_" for ch in text.lower()).strip("_")
+
+
+def dashboard_key_matches(key: object, *candidates: str) -> bool:
+    token = dashboard_key_token(key)
+    if not token:
+        return False
+    candidate_tokens = {
+        dashboard_key_token(candidate) for candidate in candidates if candidate
+    }
+    if token in candidate_tokens:
+        return True
+    return any(
+        token.startswith(candidate) or token.endswith(candidate) or candidate in token
+        for candidate in candidate_tokens
+        if candidate and len(candidate) >= 3
+    )
+
+
+def dashboard_simple_value(value: object) -> object | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        return value.strip() or None
+    if isinstance(value, dict):
+        out: dict[str, object] = {}
+        for key, item in value.items():
+            simplified = dashboard_simple_value(item)
+            if simplified is not None:
+                out[str(key)] = simplified
+        return out or None
+    if isinstance(value, list):
+        out = [
+            simplified
+            for item in value
+            if (simplified := dashboard_simple_value(item)) is not None
+        ]
+        return out or None
+    return coerce_optional_text(value)
+
+
+def iter_dashboard_mappings(value: object) -> Iterable[dict[str, object]]:
+    if isinstance(value, dict):
+        yield value
+        for item in value.values():
+            yield from iter_dashboard_mappings(item)
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from iter_dashboard_mappings(item)
+
+
+def dashboard_first_value(payload: object, *keys: str) -> object | None:
+    for mapping in iter_dashboard_mappings(payload):
+        for key, value in mapping.items():
+            if dashboard_key_matches(key, *keys):
+                return value
+    return None
+
+
+def dashboard_first_mapping(payload: object, *keys: str) -> dict[str, object] | None:
+    value = dashboard_first_value(payload, *keys)
+    if isinstance(value, dict):
+        return dict(value)
+    return None
+
+
+def dashboard_field(
+    payload: object,
+    *keys: str,
+    default: object | None = None,
+) -> object | None:
+    value = dashboard_first_value(payload, *keys)
+    simplified = dashboard_simple_value(value)
+    if simplified is None:
+        return default
+    return simplified
+
+
+def dashboard_field_map(
+    payload: object,
+    fields: dict[str, tuple[str, ...]],
+) -> dict[str, object]:
+    out: dict[str, object] = {}
+    for output_key, candidate_keys in fields.items():
+        value = dashboard_field(payload, *candidate_keys)
+        if value is not None:
+            out[output_key] = value
+    return out
+
+
+def dashboard_aliases(payload: dict[str, object]) -> list[str]:
+    aliases: list[str] = []
+    seen: set[str] = set()
+    for key in (
+        "device_uid",
+        "device-uid",
+        "uid",
+        "iqer_uid",
+        "iqer-uid",
+        "hems_device_id",
+        "hems-device-id",
+        "serial_number",
+        "serialNumber",
+        "serial",
+        "device_id",
+        "deviceId",
+        "id",
+    ):
+        value = coerce_optional_text(payload.get(key))
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        aliases.append(value)
+    return aliases
+
+
+def dashboard_primary_id(payload: dict[str, object]) -> str | None:
+    for key in (
+        "device_uid",
+        "device-uid",
+        "uid",
+        "iqer_uid",
+        "iqer-uid",
+        "hems_device_id",
+        "hems-device-id",
+        "serial_number",
+        "serialNumber",
+        "serial",
+        "device_id",
+        "deviceId",
+        "id",
+    ):
+        value = coerce_optional_text(payload.get(key))
+        if value:
+            return value
+    return None
+
+
+def dashboard_parent_id(payload: dict[str, object]) -> str | None:
+    for key in (
+        "parent_uid",
+        "parentUid",
+        "parent_device_uid",
+        "parentDeviceUid",
+        "parent_id",
+        "parentId",
+        "parent",
+    ):
+        value = coerce_optional_text(payload.get(key))
+        if value:
+            return value
+    return None
+
+
+def dashboard_raw_type(
+    payload: dict[str, object],
+    fallback_type: str | None = None,
+) -> str | None:
+    for key in (
+        "type",
+        "device_type",
+        "deviceType",
+        "channel_type",
+        "channelType",
+        "meter_type",
+    ):
+        value = coerce_optional_text(payload.get(key))
+        if value:
+            return value
+    return fallback_type
+
+
+def system_dashboard_type_key(raw_type: object) -> str | None:
+    text = coerce_optional_text(raw_type)
+    if text:
+        token = "".join(ch if ch.isalnum() else "_" for ch in text.lower()).strip("_")
+        if token in SYSTEM_DASHBOARD_TYPE_KEY_MAP:
+            return SYSTEM_DASHBOARD_TYPE_KEY_MAP[token]
+    return normalize_type_key(raw_type)
+
+
+def system_dashboard_detail_records(
+    payloads: dict[str, object],
+    *source_types: str,
+) -> list[dict[str, object]]:
+    records: list[dict[str, object]] = []
+    seen: set[tuple[str | None, str | None, str | None]] = set()
+    for source_type in source_types:
+        payload = payloads.get(source_type)
+        if not isinstance(payload, dict):
+            continue
+        items = payload.get(source_type)
+        if isinstance(items, list):
+            source_items = items
+        elif isinstance(items, dict):
+            nested_items = (
+                items.get("devices")
+                if isinstance(items.get("devices"), list)
+                else (
+                    items.get("members")
+                    if isinstance(items.get("members"), list)
+                    else (
+                        items.get("items")
+                        if isinstance(items.get("items"), list)
+                        else None
+                    )
+                )
+            )
+            source_items = nested_items if isinstance(nested_items, list) else [items]
+        else:
+            nested_items = (
+                payload.get("devices")
+                if isinstance(payload.get("devices"), list)
+                else (
+                    payload.get("members")
+                    if isinstance(payload.get("members"), list)
+                    else (
+                        payload.get("items")
+                        if isinstance(payload.get("items"), list)
+                        else None
+                    )
+                )
+            )
+            source_items = nested_items if isinstance(nested_items, list) else [payload]
+        for item in source_items:
+            if not isinstance(item, dict):
+                continue
+            record = dict(item)
+            dedupe_key = (
+                coerce_optional_text(record.get("serial_number")),
+                coerce_optional_text(record.get("device_uid")),
+                coerce_optional_text(record.get("id")),
+            )
+            if dedupe_key in seen:
+                continue
+            seen.add(dedupe_key)
+            records.append(record)
+    return records
+
+
+def system_dashboard_meter_kind(payload: dict[str, object]) -> str | None:
+    for value in (
+        payload.get("meter_type"),
+        payload.get("config_type"),
+        payload.get("channel_type"),
+        payload.get("name"),
+    ):
+        text = coerce_optional_text(value)
+        if not text:
+            continue
+        normalized = "".join(ch if ch.isalnum() else "_" for ch in text.lower())
+        if "production" in normalized or normalized in ("prod", "pv", "solar"):
+            return "production"
+        if "consumption" in normalized or normalized in ("cons", "load", "site_load"):
+            return "consumption"
+    return None
+
+
+def system_dashboard_battery_detail_subset(
+    payload: dict[str, object] | None,
+) -> dict[str, object]:
+    if not isinstance(payload, dict):
+        return {}
+    allowed = (
+        "phase",
+        "operation_mode",
+        "app_version",
+        "sw_version",
+        "rssi_subghz",
+        "rssi_24ghz",
+        "rssi_dbm",
+        "led_status",
+        "alarm_id",
+    )
+    out: dict[str, object] = {}
+    for key in allowed:
+        value = payload.get(key)
+        if value is not None:
+            out[key] = value
+    return out
+
+
+def dashboard_node_entry(
+    payload: dict[str, object],
+    *,
+    fallback_type: str | None = None,
+    parent_uid: str | None = None,
+) -> dict[str, object] | None:
+    device_uid = dashboard_primary_id(payload)
+    if not device_uid:
+        return None
+    raw_type = dashboard_raw_type(payload, fallback_type)
+    type_key = system_dashboard_type_key(raw_type)
+    entry: dict[str, object] = {"device_uid": device_uid}
+    if type_key:
+        entry["type_key"] = type_key
+    if raw_type:
+        entry["source_type"] = raw_type
+    parent = dashboard_parent_id(payload) or parent_uid
+    if parent:
+        entry["parent_uid"] = parent
+    name = coerce_optional_text(
+        payload.get("name")
+        if payload.get("name") is not None
+        else payload.get("display_name")
+    )
+    if name:
+        entry["name"] = name
+    serial = coerce_optional_text(
+        payload.get("serial_number")
+        if payload.get("serial_number") is not None
+        else (
+            payload.get("serialNumber")
+            if payload.get("serialNumber") is not None
+            else payload.get("serial")
+        )
+    )
+    if serial:
+        entry["serial_number"] = serial
+    return entry
+
+
+def dashboard_child_containers(
+    payload: dict[str, object],
+) -> list[tuple[object, str | None]]:
+    out: list[tuple[object, str | None]] = []
+    next_type = dashboard_raw_type(payload)
+    for key, value in payload.items():
+        if dashboard_key_matches(
+            key,
+            "children",
+            "child_nodes",
+            "devices",
+            "members",
+            "items",
+            "nodes",
+            "result",
+            "data",
+            "envoy",
+            "envoys",
+            "meter",
+            "meters",
+            "enpower",
+            "enpowers",
+            "encharge",
+            "encharges",
+            "modem",
+            "modems",
+            "inverter",
+            "inverters",
+        ) and isinstance(value, (dict, list)):
+            out.append((value, next_type))
+    return out
+
+
+def index_dashboard_nodes(
+    payload: object,
+    *,
+    fallback_type: str | None = None,
+    parent_uid: str | None = None,
+    index: dict[str, dict[str, object]] | None = None,
+    alias_index: dict[str, str] | None = None,
+) -> dict[str, dict[str, object]]:
+    out = index if isinstance(index, dict) else {}
+    aliases = alias_index if isinstance(alias_index, dict) else {}
+    if isinstance(payload, list):
+        for item in payload:
+            index_dashboard_nodes(
+                item,
+                fallback_type=fallback_type,
+                parent_uid=parent_uid,
+                index=out,
+                alias_index=aliases,
+            )
+        return out
+    if not isinstance(payload, dict):
+        return out
+
+    entry = dashboard_node_entry(
+        payload,
+        fallback_type=fallback_type,
+        parent_uid=parent_uid,
+    )
+    next_parent = parent_uid
+    next_type = fallback_type
+    if entry is not None:
+        entry_aliases = dashboard_aliases(payload)
+        device_uid = next(
+            (
+                canonical_uid
+                for alias in entry_aliases
+                if (canonical_uid := aliases.get(alias)) is not None
+            ),
+            str(entry["device_uid"]),
+        )
+        existing = out.get(device_uid, {"device_uid": device_uid})
+        for key, value in entry.items():
+            if value is None:
+                continue
+            existing[key] = value
+        existing["device_uid"] = device_uid
+        out[device_uid] = existing
+        for alias in entry_aliases:
+            aliases[alias] = device_uid
+        next_parent = device_uid
+        next_type = coerce_optional_text(entry.get("source_type")) or next_type
+
+    for child_payload, child_type in dashboard_child_containers(payload):
+        index_dashboard_nodes(
+            child_payload,
+            fallback_type=child_type or next_type,
+            parent_uid=next_parent,
+            index=out,
+            alias_index=aliases,
+        )
+    return out
+
+
+def system_dashboard_hierarchy_summary_from_index(
+    index: dict[str, dict[str, object]],
+    alias_index: dict[str, str] | None = None,
+) -> dict[str, object]:
+    counts_by_type: dict[str, int] = {}
+    child_counts: dict[str, int] = {}
+    relationships: list[dict[str, object]] = []
+    aliases = alias_index if isinstance(alias_index, dict) else {}
+    for device_uid, entry in index.items():
+        type_key = coerce_optional_text(entry.get("type_key"))
+        if type_key:
+            counts_by_type[type_key] = counts_by_type.get(type_key, 0) + 1
+        parent_uid = coerce_optional_text(entry.get("parent_uid"))
+        if parent_uid:
+            parent_uid = aliases.get(parent_uid, parent_uid)
+        if parent_uid:
+            child_counts[parent_uid] = child_counts.get(parent_uid, 0) + 1
+        relationships.append(
+            {
+                "device_uid": device_uid,
+                "parent_uid": parent_uid,
+                "type_key": type_key,
+                "source_type": coerce_optional_text(entry.get("source_type")),
+                "name": coerce_optional_text(entry.get("name")),
+                "serial_number": coerce_optional_text(entry.get("serial_number")),
+            }
+        )
+    for relationship in relationships:
+        relationship["child_count"] = child_counts.get(
+            str(relationship.get("device_uid")), 0
+        )
+    relationships.sort(
+        key=lambda item: (
+            str(item.get("type_key") or ""),
+            str(item.get("name") or ""),
+            str(item.get("device_uid") or ""),
+        )
+    )
+    return {
+        "total_nodes": len(index),
+        "counts_by_type": counts_by_type,
+        "relationships": relationships,
+    }
+
+
+def system_dashboard_type_hierarchy(
+    type_key: str,
+    index: dict[str, dict[str, object]],
+    alias_index: dict[str, str] | None = None,
+) -> dict[str, object]:
+    aliases = alias_index if isinstance(alias_index, dict) else {}
+    relationships = [
+        {
+            "device_uid": device_uid,
+            "parent_uid": (
+                aliases.get(parent_uid, parent_uid)
+                if (parent_uid := coerce_optional_text(entry.get("parent_uid")))
+                else None
+            ),
+            "name": coerce_optional_text(entry.get("name")),
+            "serial_number": coerce_optional_text(entry.get("serial_number")),
+            "source_type": coerce_optional_text(entry.get("source_type")),
+            "child_count": sum(
+                1
+                for candidate in index.values()
+                if coerce_optional_text(candidate.get("parent_uid")) == device_uid
+            ),
+        }
+        for device_uid, entry in index.items()
+        if coerce_optional_text(entry.get("type_key")) == type_key
+    ]
+    relationships.sort(
+        key=lambda item: (
+            str(item.get("name") or ""),
+            str(item.get("device_uid") or ""),
+        )
+    )
+    return {"count": len(relationships), "relationships": relationships}
+
+
+def system_dashboard_meter_summaries(
+    payloads: dict[str, object],
+) -> list[dict[str, object]]:
+    meters: list[dict[str, object]] = []
+    seen: set[tuple[str | None, str | None]] = set()
+    for record in system_dashboard_detail_records(payloads, "meters", "meter"):
+        name = coerce_optional_text(record.get("name"))
+        meter_kind = system_dashboard_meter_kind(record)
+        meter_type = coerce_optional_text(record.get("meter_type")) or meter_kind
+        dedupe_key = (name, meter_type)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        meter_summary = {
+            "name": name,
+            "meter_type": meter_type,
+            "status": dashboard_field(record, "status", "status_text"),
+            "meter_state": coerce_optional_text(record.get("meter_state")),
+            "config_type": coerce_optional_text(record.get("config_type")),
+        }
+        config_payload = dashboard_first_mapping(
+            record,
+            "configuration",
+            "meter_config",
+            "meter_configuration",
+        )
+        if isinstance(config_payload, dict):
+            config = dashboard_field_map(
+                config_payload,
+                {
+                    "phase": ("phase", "phase_mode", "phase_configuration"),
+                    "wiring": ("wiring", "wiring_type"),
+                    "mode": ("mode", "config_mode", "meter_mode"),
+                    "role": ("role", "measurement", "measurement_type"),
+                    "enabled": ("enabled", "is_enabled"),
+                },
+            )
+            if config:
+                meter_summary["config"] = config
+        cleaned = {
+            key: value for key, value in meter_summary.items() if value is not None
+        }
+        if cleaned:
+            meters.append(cleaned)
+    meters.sort(
+        key=lambda item: (
+            str(item.get("name") or ""),
+            str(item.get("meter_type") or ""),
+        )
+    )
+    return meters
+
+
+def system_dashboard_envoy_summary(
+    payloads: dict[str, object],
+    index: dict[str, dict[str, object]],
+    alias_index: dict[str, str] | None = None,
+) -> dict[str, object]:
+    modem_records = system_dashboard_detail_records(payloads, "modems", "modem")
+    modem_source = (
+        modem_records[0]
+        if modem_records
+        else dashboard_first_mapping(payloads, "modem", "cellular", "sim")
+    )
+    envoy_records = system_dashboard_detail_records(payloads, "envoys", "envoy")
+    envoy_source = envoy_records[0] if envoy_records else payloads
+    network_source = dashboard_first_mapping(
+        envoy_source,
+        "network",
+        "network_config",
+        "gateway_network",
+        "gateway_config",
+    )
+    tunnel_source = dashboard_first_mapping(envoy_source, "tunnel", "vpn")
+    controller_records = system_dashboard_detail_records(
+        payloads, "enpowers", "enpower"
+    )
+    controller_source = (
+        controller_records[0]
+        if controller_records
+        else dashboard_first_mapping(
+            payloads, "controller", "system_controller", "enpower"
+        )
+    )
+    summary = {
+        "modem": dashboard_field_map(
+            modem_source or payloads,
+            {
+                "signal": ("signal", "signal_strength", "signal_level", "sig_str"),
+                "rssi": ("rssi",),
+                "sim_plan_expiry": (
+                    "sim_plan_expiry",
+                    "plan_expiry",
+                    "plan_expiry_date",
+                    "plan_end",
+                    "sim_expiry",
+                ),
+            },
+        ),
+        "network": dashboard_field_map(
+            network_source or envoy_source,
+            {
+                "status": ("status", "state", "link_state"),
+                "mode": ("mode", "network_mode", "config_mode"),
+                "type": ("type", "network_type", "connection_type"),
+                "dhcp": ("dhcp", "is_dhcp"),
+                "enabled": ("enabled", "is_enabled"),
+            },
+        ),
+        "tunnel": dashboard_field_map(
+            tunnel_source or payloads,
+            {
+                "status": ("status", "state"),
+                "type": ("type", "tunnel_type"),
+                "enabled": ("enabled", "is_enabled"),
+                "connected": ("connected", "is_connected"),
+                "healthy": ("healthy", "is_healthy"),
+            },
+        ),
+        "controller": dashboard_field_map(
+            controller_source or payloads,
+            {
+                "earth_type": ("earth_type", "earthType", "system_earth_type"),
+                "status": ("status", "state"),
+                "operation_mode": ("operation_mode", "mode"),
+            },
+        ),
+        "meters": system_dashboard_meter_summaries(payloads),
+        "hierarchy": system_dashboard_type_hierarchy("envoy", index, alias_index),
+    }
+    return {key: value for key, value in summary.items() if value not in ({}, [], None)}
+
+
+def system_dashboard_encharge_summary(
+    payloads: dict[str, object],
+    index: dict[str, dict[str, object]],
+    alias_index: dict[str, str] | None = None,
+) -> dict[str, object]:
+    records = system_dashboard_detail_records(payloads, "encharges", "encharge")
+    first_record = records[0] if records else payloads
+    connectivity_source = dashboard_first_mapping(
+        first_record, "connectivity", "network", "wireless"
+    )
+    software_source = dashboard_first_mapping(
+        first_record, "software", "app", "application"
+    )
+    operation_source = dashboard_first_mapping(
+        first_record, "operation_mode", "operation", "mode"
+    )
+    summary = {
+        "connectivity": dashboard_field_map(
+            connectivity_source or first_record,
+            {
+                "signal": ("signal", "signal_strength", "signal_level", "sig_str"),
+                "rssi": ("rssi",),
+                "rssi_subghz": ("rssi_subghz",),
+                "rssi_24ghz": ("rssi_24ghz",),
+                "rssi_dbm": ("rssi_dbm",),
+                "status": ("status", "state"),
+            },
+        ),
+        "software": dashboard_field_map(
+            software_source or first_record,
+            {
+                "app_version": ("app_version", "appVersion", "version"),
+                "firmware": ("firmware", "fw_version", "sw_version"),
+                "sw_version": ("sw_version",),
+            },
+        ),
+        "operation_mode": dashboard_field_map(
+            operation_source or first_record,
+            {
+                "mode": ("operation_mode", "operationMode", "mode"),
+                "state": ("status", "state"),
+            },
+        ),
+        "batteries": [
+            system_dashboard_battery_detail_subset(record)
+            | {
+                key: value
+                for key, value in {
+                    "name": coerce_optional_text(record.get("name")),
+                    "serial_number": coerce_optional_text(record.get("serial_number")),
+                    "status": coerce_optional_text(record.get("status")),
+                    "status_text": coerce_optional_text(record.get("statusText")),
+                    "soc": coerce_optional_text(record.get("soc")),
+                }.items()
+                if value is not None
+            }
+            for record in records
+            if system_dashboard_battery_detail_subset(record)
+            or coerce_optional_text(record.get("serial_number"))
+            or coerce_optional_text(record.get("name"))
+        ],
+        "hierarchy": system_dashboard_type_hierarchy("encharge", index, alias_index),
+    }
+    return {key: value for key, value in summary.items() if value not in ({}, [], None)}
+
+
+def system_dashboard_microinverter_summary(
+    payloads: dict[str, object],
+    index: dict[str, dict[str, object]],
+    alias_index: dict[str, str] | None = None,
+) -> dict[str, object]:
+    summary_payload = dashboard_first_mapping(payloads, "inverters", "inverter") or {}
+    if not isinstance(summary_payload, dict):
+        return {}
+    nested_payload = summary_payload.get("inverters")
+    if isinstance(nested_payload, dict):
+        summary_payload = nested_payload
+    total = coerce_optional_int(summary_payload.get("total"))
+    not_reporting = coerce_optional_int(summary_payload.get("not_reporting"))
+    plc_comm = coerce_optional_int(summary_payload.get("plc_comm"))
+    items = summary_payload.get("items")
+    if isinstance(items, list):
+        model_counts = {
+            coerce_optional_text(item.get("name"))
+            or f"item_{index}": (coerce_optional_int(item.get("count")) or 0)
+            for index, item in enumerate(items, start=1)
+            if isinstance(item, dict)
+        }
+    else:
+        model_counts = {}
+    reporting = None
+    if total is not None:
+        reporting = max(0, total - int(not_reporting or 0))
+    connectivity = None
+    if total is not None:
+        if int(total) <= 0:
+            connectivity = None
+        elif int(not_reporting or 0) <= 0:
+            connectivity = "online"
+        elif int(not_reporting or 0) >= int(total):
+            connectivity = "offline"
+        else:
+            connectivity = "degraded"
+    summary = {
+        "total_inverters": total,
+        "reporting_inverters": reporting,
+        "not_reporting_inverters": not_reporting,
+        "plc_comm_inverters": plc_comm,
+        "model_counts": model_counts or None,
+        "model_summary": _format_inverter_model_summary(model_counts),
+        "connectivity": connectivity,
+        "hierarchy": system_dashboard_type_hierarchy(
+            "microinverter", index, alias_index
+        ),
+    }
+    return {key: value for key, value in summary.items() if value is not None}
+
+
+def build_system_dashboard_summaries(
+    tree_payload: dict[str, object] | None,
+    details_payloads: dict[str, dict[str, object]],
+) -> tuple[
+    dict[str, dict[str, object]], dict[str, object], dict[str, dict[str, object]]
+]:
+    hierarchy_index: dict[str, dict[str, object]] = {}
+    hierarchy_aliases: dict[str, str] = {}
+    if isinstance(tree_payload, dict):
+        hierarchy_index = index_dashboard_nodes(
+            tree_payload, alias_index=hierarchy_aliases
+        )
+    for type_key, payloads_by_source in details_payloads.items():
+        for source_type, payload in payloads_by_source.items():
+            index_dashboard_nodes(
+                payload,
+                fallback_type=source_type or type_key,
+                index=hierarchy_index,
+                alias_index=hierarchy_aliases,
+            )
+    hierarchy_summary = system_dashboard_hierarchy_summary_from_index(
+        hierarchy_index,
+        hierarchy_aliases,
+    )
+    type_summaries: dict[str, dict[str, object]] = {}
+    envoy_payloads: dict[str, object] = {}
+    for key in ("envoy", "modem"):
+        payloads = details_payloads.get(key, {})
+        if isinstance(payloads, dict):
+            envoy_payloads.update(payloads)
+    if envoy_summary := system_dashboard_envoy_summary(
+        envoy_payloads,
+        hierarchy_index,
+        hierarchy_aliases,
+    ):
+        type_summaries["envoy"] = envoy_summary
+    if encharge_summary := system_dashboard_encharge_summary(
+        details_payloads.get("encharge", {}),
+        hierarchy_index,
+        hierarchy_aliases,
+    ):
+        type_summaries["encharge"] = encharge_summary
+    if microinverter_summary := system_dashboard_microinverter_summary(
+        details_payloads.get("microinverter", {}),
+        hierarchy_index,
+        hierarchy_aliases,
+    ):
+        type_summaries["microinverter"] = microinverter_summary
+    return type_summaries, hierarchy_summary, hierarchy_index

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -168,9 +168,6 @@ def test_battery_runtime_transition_helpers_cover_private_and_fallback_paths() -
     coordinator = SimpleNamespace(
         _normalize_battery_sub_type=lambda value: f"private:{value}",
         _sync_battery_profile_pending_issue=private_sync,
-        _coerce_int=lambda value, default=0: 41 if value == "41" else default,
-        _coerce_optional_bool=lambda value: True if value == "yes" else None,
-        _coerce_optional_text=lambda value: str(value).strip().upper(),
         _current_charge_from_grid_schedule_window=lambda: (11, 22),
         _raise_grid_validation=private_raise,
     )
@@ -181,7 +178,7 @@ def test_battery_runtime_transition_helpers_cover_private_and_fallback_paths() -
     private_sync.assert_called_once_with()
     assert runtime._coerce_int("41", default=-1) == 41
     assert runtime._coerce_optional_bool("yes") is True
-    assert runtime._coerce_optional_text(" a ") == "A"
+    assert runtime._coerce_optional_text(" a ") == "a"
     assert runtime._current_schedule_window_from_coordinator() == (11, 22)
 
     runtime.raise_grid_validation("grid_control_unavailable")
@@ -198,10 +195,6 @@ def test_battery_runtime_transition_helpers_cover_public_paths() -> None:
     coordinator = SimpleNamespace(
         normalize_battery_sub_type=lambda value: f"public:{value}",
         sync_battery_profile_pending_issue=public_sync,
-        coerce_int=lambda value, default=0: 52 if value == "52" else default,
-        coerce_optional_float=lambda value: 2.5 if value == "2.5" else None,
-        coerce_optional_bool=lambda value: False if value == "no" else None,
-        coerce_optional_text=lambda value: str(value).strip().lower(),
         current_charge_from_grid_schedule_window=lambda: (33, 44),
         raise_grid_validation=public_raise,
     )
@@ -213,7 +206,7 @@ def test_battery_runtime_transition_helpers_cover_public_paths() -> None:
     assert runtime._coerce_int("52", default=-1) == 52
     assert runtime._coerce_optional_float("2.5") == pytest.approx(2.5)
     assert runtime._coerce_optional_bool("no") is False
-    assert runtime._coerce_optional_text(" A ") == "a"
+    assert runtime._coerce_optional_text(" A ") == "A"
     assert runtime._current_schedule_window_from_coordinator() == (33, 44)
 
     runtime.raise_grid_validation("grid_control_unavailable")
@@ -295,8 +288,8 @@ def test_battery_runtime_top_level_helper_passthroughs_cover_fallback_paths() ->
     runtime = BatteryRuntime(SimpleNamespace())
     source = {"id": 1, "nested": {"value": 2}, "items": [{"x": 1}]}
 
-    assert runtime._coerce_optional_int("7") is None
-    assert runtime._coerce_optional_float("1.5") is None
+    assert runtime._coerce_optional_int("7") == 7
+    assert runtime._coerce_optional_float("1.5") == pytest.approx(1.5)
     assert runtime._coerce_optional_kwh("2.5") is None
     assert runtime._parse_percent_value("55") is None
     assert runtime._normalize_battery_status_text("Normal") is None

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -669,9 +669,8 @@ def test_system_dashboard_helper_branches(coordinator_factory, monkeypatch) -> N
     )
     with monkeypatch.context() as nested_patch:
         nested_patch.setattr(
-            type(coord),
-            "_dashboard_first_mapping",
-            classmethod(lambda cls, payload, *keys: "bad"),
+            "custom_components.enphase_ev.system_dashboard_helpers.dashboard_first_mapping",
+            lambda payload, *keys: "bad",
         )
         assert (
             coord._system_dashboard_microinverter_summary({}, {}, None) == {}
@@ -1302,6 +1301,152 @@ def test_summary_compat_shims(coordinator_factory):
     coord._session_history_cache_ttl = 120
     assert coord.session_history.cache_ttl == 120
     assert coord._session_history_cache_ttl == 120
+
+
+def test_runtime_and_dashboard_delegate_shims(coordinator_factory) -> None:
+    coord = coordinator_factory(serials=[])
+
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "count": 3,
+                "devices": [
+                    {"name": "Gateway A", "status": "normal", "connected": "yes"},
+                    {"name": "Gateway B", "status": "warning", "connected": "no"},
+                    {"name": "Gateway C", "status": "normal", "connected": "maybe"},
+                ],
+            }
+        },
+        ["envoy"],
+    )
+    gateway_summary = coord._build_gateway_inventory_summary()  # noqa: SLF001
+    assert gateway_summary["connected_devices"] == 2
+    assert gateway_summary["disconnected_devices"] == 1
+
+    assert (
+        coord._heatpump_member_device_type({"device_type": "heat_pump"}) == "HEAT_PUMP"
+    )  # noqa: SLF001
+    assert (
+        coord._heatpump_worst_status_text({"not_reporting": 1}) == "Not Reporting"
+    )  # noqa: SLF001
+    assert coord._debug_truncate_identifier("ABCDEFGHIJKL") is not None  # noqa: SLF001
+    assert (
+        coord._debug_topology_summary(  # noqa: SLF001
+            coord.inventory_runtime.topology_snapshot()
+        )["charger_count"]
+        == 0
+    )
+    assert (
+        coord._dashboard_first_value(  # noqa: SLF001
+            {"wrapper": {"meter_type": "consumption"}},
+            "meter_type",
+        )
+        == "consumption"
+    )
+    assert coord._dashboard_first_mapping(  # noqa: SLF001
+        {"wrapper": {"network": {"mode": "dhcp"}}},
+        "network",
+    ) == {"mode": "dhcp"}
+    assert (
+        coord._dashboard_field(  # noqa: SLF001
+            {"wrapper": {"meter_type": "consumption"}},
+            "meter_type",
+        )
+        == "consumption"
+    )
+    assert coord._dashboard_field_map(  # noqa: SLF001
+        {"serialNumber": "GW-1"},
+        {"serial": ("serial_number", "serialNumber")},
+    ) == {"serial": "GW-1"}
+    assert coord._dashboard_aliases(
+        {"serialNumber": "GW-1", "id": "node-1"}
+    ) == [  # noqa: SLF001
+        "GW-1",
+        "node-1",
+    ]
+    assert coord._dashboard_primary_id({"id": "node-1"}) == "node-1"  # noqa: SLF001
+    assert (
+        coord._dashboard_raw_type({"device_type": "envoy"}) == "envoy"
+    )  # noqa: SLF001
+    assert coord._dashboard_child_containers(  # noqa: SLF001
+        {"type": "envoy", "children": [{"id": "child-1"}]}
+    ) == [([{"id": "child-1"}], "envoy")]
+
+    payloads = {
+        "envoys": {"envoys": [{"device_uid": "GW-1", "network": {"mode": "dhcp"}}]},
+        "encharges": {
+            "encharges": [
+                {
+                    "device_uid": "BAT-1",
+                    "serial_number": "BAT-1",
+                    "app_version": "1.2.3",
+                }
+            ]
+        },
+    }
+    envoy_index = coord._index_dashboard_nodes(
+        [{"device_uid": "GW-1", "type": "envoy"}]
+    )  # noqa: SLF001
+    encharge_index = coord._index_dashboard_nodes(  # noqa: SLF001
+        [{"device_uid": "BAT-1", "type": "encharge"}]
+    )
+    assert (
+        coord._system_dashboard_type_hierarchy("envoy", envoy_index, None)["count"] == 1
+    )  # noqa: SLF001
+    assert (
+        coord._system_dashboard_envoy_summary(  # noqa: SLF001
+            payloads,
+            envoy_index,
+            None,
+        )["network"]["mode"]
+        == "dhcp"
+    )
+    assert (
+        coord._system_dashboard_encharge_summary(  # noqa: SLF001
+            payloads,
+            encharge_index,
+            None,
+        )["batteries"][0]["serial_number"]
+        == "BAT-1"
+    )
+
+    tree_payload = {
+        "devices": [
+            {
+                "device_uid": "GW-1",
+                "type": "envoy",
+                "children": [
+                    {"device_uid": "BAT-1", "type": "encharge", "name": "Battery"}
+                ],
+            }
+        ]
+    }
+    details_payloads = {
+        "envoy": {"envoys": {"envoys": [{"device_uid": "GW-1"}]}},
+        "encharge": {
+            "encharges": {
+                "encharges": [{"device_uid": "BAT-1", "serial_number": "BAT-1"}]
+            }
+        },
+    }
+    type_summaries, hierarchy_summary, hierarchy_index = (
+        coord._build_system_dashboard_summaries(  # noqa: SLF001
+            tree_payload,
+            details_payloads,
+        )
+    )
+    assert hierarchy_summary["total_nodes"] == 2
+    assert hierarchy_index["GW-1"]["device_uid"] == "GW-1"
+    assert type_summaries["envoy"]["hierarchy"]["count"] == 1
+    assert coord._coerce_int("7") == 7  # noqa: SLF001
+    assert coord.coerce_int("bad", default=4) == 4
+    assert (
+        coord._inverter_connectivity_state(  # noqa: SLF001
+            {"total": 1, "not_reporting": 1, "unknown": 0}
+        )
+        == "offline"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2634,6 +2634,8 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
     assert set_buckets.call_args.kwargs["authoritative"] is False
     assert coord._battery_storage_order == ["BAT-1"]  # noqa: SLF001
     assert coord._inverter_order == ["INV-1"]  # noqa: SLF001
+    assert coord.inventory_runtime.iter_inverter_serials() == ["INV-1"]
+    assert coord.inventory_runtime.inverter_data("INV-1") == {"name": "Inverter"}
     assert coord._restored_site_energy_channels == {"heat_pump"}  # noqa: SLF001
     assert coord._restored_gateway_iq_energy_router_records == [  # noqa: SLF001
         {"device-uid": "REST-1"}

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -172,7 +172,7 @@ async def test_heatpump_runtime_power_failure_logs_truncated_device_uid(
     )
     coord.heatpump_runtime._async_refresh_hems_support_preflight = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
     coord.heatpump_runtime._heatpump_power_fetch_plan = lambda: (["DEVICE-UID-123456789"], False, ())  # type: ignore[assignment]  # noqa: SLF001
-    coord._site_local_current_date = lambda: "2026-03-13"  # type: ignore[assignment]  # noqa: SLF001
+    coord._devices_inventory_payload = {"curr_date_site": "2026-03-13"}  # noqa: SLF001
 
     with caplog.at_level(logging.DEBUG):
         await coord.heatpump_runtime._async_refresh_heatpump_power(
@@ -789,7 +789,7 @@ async def test_heatpump_runtime_diagnostics_and_refresh_edge_branches(
             return None
         return payload
 
-    monkeypatch.setattr(coord, "_redact_battery_payload", _redact)
+    monkeypatch.setattr(heatpump_runtime_mod, "redact_battery_payload", _redact)
 
     await runtime.async_ensure_heatpump_runtime_diagnostics(force=True)
 
@@ -1274,8 +1274,8 @@ def test_heatpump_daily_window_handles_dst_transition_day(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory(serials=[])
-    coord._site_timezone_name = lambda: "Europe/Berlin"  # type: ignore[assignment]  # noqa: SLF001
-    coord._site_local_current_date = lambda: "2026-03-29"  # type: ignore[assignment]  # noqa: SLF001
+    coord._battery_timezone = "Europe/Berlin"  # noqa: SLF001
+    coord._devices_inventory_payload = {"curr_date_site": "2026-03-29"}  # noqa: SLF001
 
     assert coord.heatpump_runtime._heatpump_daily_window() == (  # noqa: SLF001
         "2026-03-28T23:00:00.000Z",
@@ -1291,9 +1291,19 @@ def test_heatpump_daily_helper_and_property_edge_cases(
     coord = coordinator_factory(serials=[])
     coord._battery_timezone = "Not/A-Timezone"  # noqa: SLF001
     assert coord._site_timezone_name() == "UTC"  # noqa: SLF001
-    coord._site_timezone_name = lambda: "Not/A-Timezone"  # type: ignore[assignment]  # noqa: SLF001
-    coord._site_local_current_date = lambda: "bad-date"  # type: ignore[assignment]  # noqa: SLF001
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        heatpump_runtime_mod,
+        "resolve_site_timezone_name",
+        lambda _value: "Not/A-Timezone",
+    )
+    monkeypatch.setattr(
+        heatpump_runtime_mod,
+        "resolve_site_local_current_date",
+        lambda _payload, _timezone: "bad-date",
+    )
     assert coord.heatpump_runtime._heatpump_daily_window() is None  # noqa: SLF001
+    monkeypatch.undo()
 
     assert coord._sum_optional_values("bad") is None  # noqa: SLF001
     assert (
@@ -1769,7 +1779,7 @@ async def test_heatpump_runtime_power_and_diagnostics_paths(
             return "event-redacted"
         return None if payload == "EVENT_NONE" else payload
 
-    monkeypatch.setattr(coord, "_redact_battery_payload", _redact)
+    monkeypatch.setattr(heatpump_runtime_mod, "redact_battery_payload", _redact)
     coord.client.show_livestream = AsyncMock(return_value="SHOW_SCALAR")
     coord.client.heat_pump_events_json = AsyncMock(
         side_effect=lambda uid: "EVENT_NONE" if uid == "HP-CTRL" else "EVENT_SCALAR"

--- a/tests/components/enphase_ev/test_helper_modules.py
+++ b/tests/components/enphase_ev/test_helper_modules.py
@@ -14,6 +14,7 @@ from multidict import CIMultiDict, CIMultiDictProxy
 from yarl import URL
 
 from custom_components.enphase_ev import session_history as sh_mod
+from custom_components.enphase_ev import runtime_helpers, system_dashboard_helpers
 from custom_components.enphase_ev.api import (
     InvalidPayloadError,
     SessionHistoryUnavailable,
@@ -30,6 +31,215 @@ from custom_components.enphase_ev.summary import (
     SUMMARY_ACTIVE_MIN_TTL,
     SUMMARY_IDLE_TTL,
 )
+
+
+def test_runtime_helpers_cover_parsing_dates_and_redaction(monkeypatch) -> None:
+    class BadStr:
+        def __str__(self) -> str:
+            raise ValueError("bad")
+
+    assert runtime_helpers.coerce_int(True) == 1
+    assert runtime_helpers.coerce_int(" 7 ") == 7
+    assert runtime_helpers.coerce_int("bad", default=9) == 9
+    assert runtime_helpers.coerce_optional_int(" 5 ") == 5
+    assert runtime_helpers.coerce_optional_int(BadStr()) is None
+    assert runtime_helpers.normalize_iso_date("2026-03-29") == "2026-03-29"
+    assert runtime_helpers.normalize_iso_date(BadStr()) is None
+    assert (
+        runtime_helpers.resolve_inverter_start_date(
+            {"start_date": "2022-08-10"},
+            {},
+        )
+        == "2022-08-10"
+    )
+    assert (
+        runtime_helpers.resolve_inverter_start_date(
+            {},
+            {
+                "INV-B": {"lifetime_query_start_date": "2023-01-01"},
+                "INV-A": {"lifetime_query_start_date": "2022-08-10"},
+            },
+        )
+        == "2022-08-10"
+    )
+    assert runtime_helpers.resolve_inverter_start_date({}, {"INV-A": "bad"}) is None
+
+    assert (
+        runtime_helpers.resolve_site_timezone_name("Europe/Berlin") == "Europe/Berlin"
+    )
+    assert runtime_helpers.resolve_site_timezone_name("Bad/Zone") == "UTC"
+    assert (
+        runtime_helpers.resolve_site_local_current_date(
+            {"curr_date_site": "2026-03-29"},
+            None,
+        )
+        == "2026-03-29"
+    )
+    assert (
+        runtime_helpers.resolve_site_local_current_date(
+            {"result": [{"curr_date_site": "2026-03-28"}]},
+            None,
+        )
+        == "2026-03-28"
+    )
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.runtime_helpers.dt_util.now",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    fallback_date = runtime_helpers.resolve_site_local_current_date({}, "Bad/Zone")
+    assert fallback_date == datetime.now(timezone.utc).date().isoformat()
+
+    original = {"a": [1, {"b": 2}], "token": "secret"}
+    copied = runtime_helpers.copy_diagnostics_value(original)
+    assert copied == original
+    assert copied is not original
+    assert copied["a"] is not original["a"]
+    assert runtime_helpers.redact_battery_payload(original) == {
+        "a": [1, {"b": 2}],
+        "token": "[redacted]",
+    }
+
+
+def test_system_dashboard_helpers_cover_core_paths(monkeypatch) -> None:
+    assert (
+        system_dashboard_helpers.dashboard_key_token("System Controller")
+        == "system_controller"
+    )
+    assert system_dashboard_helpers.dashboard_key_matches("meter_type", "meter")
+    assert system_dashboard_helpers.dashboard_simple_value({"a": [1, "x", None]}) == {
+        "a": [1, "x"]
+    }
+    assert list(
+        system_dashboard_helpers.iter_dashboard_mappings(
+            [{"status": "ok"}, {"nested": {"mode": "dhcp"}}]
+        )
+    ) == [{"status": "ok"}, {"nested": {"mode": "dhcp"}}, {"mode": "dhcp"}]
+    assert (
+        system_dashboard_helpers.dashboard_parent_id({"parentId": "PARENT"}) == "PARENT"
+    )
+    assert system_dashboard_helpers.system_dashboard_type_key("meters") == "envoy"
+    assert (
+        system_dashboard_helpers.system_dashboard_type_key("inverters")
+        == "microinverter"
+    )
+    assert system_dashboard_helpers.system_dashboard_battery_detail_subset(None) == {}
+    assert (
+        system_dashboard_helpers.system_dashboard_meter_kind({"meter_type": " "})
+        is None
+    )
+    assert system_dashboard_helpers.system_dashboard_detail_records(
+        {"envoys": {"envoys": {"devices": [{"id": "dup"}, {"id": "dup"}]}}},
+        "envoys",
+    ) == [{"id": "dup"}]
+
+    with monkeypatch.context() as nested:
+        nested.setattr(
+            "custom_components.enphase_ev.system_dashboard_helpers.dashboard_first_mapping",
+            lambda payload, *keys: "bad",
+        )
+        assert (
+            system_dashboard_helpers.system_dashboard_microinverter_summary(
+                {}, {}, None
+            )
+            == {}
+        )
+
+    tree_payload = {
+        "devices": [
+            {
+                "device_uid": "GW-1",
+                "type": "envoy",
+                "name": "Gateway",
+                "serial_number": "GW-1",
+                "children": [
+                    {"device_uid": "BAT-1", "type": "encharge", "name": "Battery"}
+                ],
+            }
+        ]
+    }
+    details_payloads = {
+        "envoy": {
+            "envoys": {
+                "envoys": [
+                    {
+                        "device_uid": "GW-1",
+                        "status": "online",
+                        "network": {"mode": "dhcp"},
+                    }
+                ]
+            },
+            "meters": {
+                "meters": [{"id": "1", "name": "M1", "meter_type": "consumption"}]
+            },
+        },
+        "encharge": {
+            "encharges": {
+                "encharges": [
+                    {
+                        "device_uid": "BAT-1",
+                        "serial_number": "BAT-1",
+                        "app_version": "1.2.3",
+                        "status": "ok",
+                    }
+                ]
+            }
+        },
+        "microinverter": {
+            "inverters": {
+                "inverters": {
+                    "total": 2,
+                    "not_reporting": 1,
+                    "items": [{"name": "IQ8", "count": 2}],
+                }
+            }
+        },
+    }
+
+    type_summaries, hierarchy_summary, hierarchy_index = (
+        system_dashboard_helpers.build_system_dashboard_summaries(
+            tree_payload, details_payloads
+        )
+    )
+    assert hierarchy_summary["total_nodes"] == 3
+    assert hierarchy_index["GW-1"]["type_key"] == "envoy"
+    assert type_summaries["envoy"]["meters"] == [
+        {"name": "M1", "meter_type": "consumption"}
+    ]
+    assert type_summaries["encharge"]["batteries"][0]["app_version"] == "1.2.3"
+    assert type_summaries["microinverter"]["connectivity"] == "degraded"
+    assert (
+        system_dashboard_helpers._format_inverter_model_summary(  # noqa: SLF001
+            {"": 1, "IQ7": "bad", "IQ8": 0, "IQ8M": 2}
+        )
+        == "IQ8M x2"
+    )
+    merged_index = system_dashboard_helpers.index_dashboard_nodes(
+        [
+            {"device_uid": "GW-1", "serial_number": "GW-1", "name": "Gateway"},
+            {"serial_number": "GW-1", "name": None, "type": "envoy"},
+        ]
+    )
+    assert merged_index["GW-1"]["name"] == "Gateway"
+    with monkeypatch.context() as nested:
+        original_node_entry = system_dashboard_helpers.dashboard_node_entry
+
+        def _fake_node_entry(payload, **kwargs):
+            entry = original_node_entry(payload, **kwargs)
+            if entry is not None and payload.get("serial_number") == "GW-1-ALIAS":
+                entry["name"] = None
+            return entry
+
+        nested.setattr(
+            system_dashboard_helpers, "dashboard_node_entry", _fake_node_entry
+        )
+        merged_with_none = system_dashboard_helpers.index_dashboard_nodes(
+            [
+                {"device_uid": "GW-1", "serial_number": "GW-1", "name": "Gateway"},
+                {"serial_number": "GW-1-ALIAS", "id": "GW-1", "name": "Alias"},
+            ]
+        )
+        assert merged_with_none["GW-1"]["name"] == "Gateway"
 
 
 class _DummySummaryClient:

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -2,10 +2,12 @@ from __future__ import annotations
 
 import time
 from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.enphase_ev import inventory_runtime as inventory_runtime_mod
 from custom_components.enphase_ev.inventory_runtime import HEMS_DEVICES_STALE_AFTER_S
 
 
@@ -32,27 +34,41 @@ def test_inventory_runtime_helper_paths(coordinator_factory) -> None:
 
     grouped = {"envoy": {"count": 1}}
     ordered = ["envoy"]
-    snapshot = object()
-    coord._debug_devices_inventory_summary = MagicMock(return_value={"devices": 1})  # type: ignore[method-assign]  # noqa: SLF001
-    coord._debug_hems_inventory_summary = MagicMock(return_value={"hems": 1})  # type: ignore[method-assign]  # noqa: SLF001
-    coord._debug_system_dashboard_summary = MagicMock(return_value={"dashboard": 1})  # type: ignore[method-assign]  # noqa: SLF001
-    coord._debug_topology_summary = MagicMock(return_value={"topology": 1})  # type: ignore[method-assign]  # noqa: SLF001
-    coord._build_system_dashboard_summaries = MagicMock(  # type: ignore[method-assign]  # noqa: SLF001
-        return_value=({"envoy": {}}, {"tree": 1}, {"index": {}})
-    )
+    snapshot = runtime.topology_snapshot()
 
-    assert runtime._debug_devices_inventory_summary(grouped, ordered) == {
-        "devices": 1
-    }  # noqa: SLF001
-    assert runtime._debug_hems_inventory_summary() == {"hems": 1}  # noqa: SLF001
-    assert runtime._debug_system_dashboard_summary({}, {}, {}, {}) == {
-        "dashboard": 1
-    }  # noqa: SLF001
-    assert runtime._debug_topology_summary(snapshot) == {"topology": 1}  # noqa: SLF001
+    assert runtime._debug_devices_inventory_summary(
+        grouped, ordered
+    ) == {  # noqa: SLF001
+        "ordered_type_keys": ["envoy"],
+        "type_count": 1,
+        "types": {"envoy": {"count": 1, "field_keys": []}},
+    }
+    hems_summary = runtime._debug_hems_inventory_summary()  # noqa: SLF001
+    assert hems_summary["site_supported"] is None
+    assert hems_summary["router_count"] == 0
+    assert runtime._debug_system_dashboard_summary({}, {}, {}, {}) == {  # noqa: SLF001
+        "tree_keys": [],
+        "hierarchy_total_nodes": 0,
+        "hierarchy_counts_by_type": {},
+        "types": {},
+    }
+    assert runtime._debug_topology_summary(snapshot) == {  # noqa: SLF001
+        "inventory_ready": False,
+        "charger_count": 0,
+        "battery_count": 0,
+        "inverter_count": 0,
+        "active_type_keys": [],
+        "gateway_iq_router_count": 0,
+        "site_energy_channels": [],
+    }
     assert runtime._build_system_dashboard_summaries(None, {}) == (  # noqa: SLF001
-        {"envoy": {}},
-        {"tree": 1},
-        {"index": {}},
+        {
+            "envoy": {"hierarchy": {"count": 0, "relationships": []}},
+            "encharge": {"hierarchy": {"count": 0, "relationships": []}},
+            "microinverter": {"hierarchy": {"count": 0, "relationships": []}},
+        },
+        {"total_nodes": 0, "counts_by_type": {}, "relationships": []},
+        {},
     )
     assert runtime._coerce_optional_bool("true") is True  # noqa: SLF001
     assert (
@@ -68,6 +84,20 @@ def test_inventory_runtime_helper_paths(coordinator_factory) -> None:
         "name_router_2",
     ]
     assert runtime.system_dashboard_battery_detail("") is None  # noqa: SLF001
+
+    runtime.__dict__["_inverter_data"] = {
+        "INV-LOCAL": {"serial_number": "INV-LOCAL"}
+    }  # noqa: SLF001
+    assert runtime._coordinator_backed_attr("_inverter_data") == {  # noqa: SLF001
+        "INV-LOCAL": {"serial_number": "INV-LOCAL"}
+    }
+    runtime.__dict__.pop("_inverter_data", None)
+    coord._inverter_data = {
+        "INV-FALLBACK": {"serial_number": "INV-FALLBACK"}
+    }  # noqa: SLF001
+    assert runtime.inverter_data("INV-FALLBACK") == {  # noqa: SLF001
+        "serial_number": "INV-FALLBACK"
+    }
 
 
 def test_inventory_runtime_summary_and_inverter_helper_paths(
@@ -297,7 +327,7 @@ def test_inventory_runtime_summary_helpers_reuse_stable_cache_markers(
     heatpump_builder = MagicMock(return_value={"heatpump": 1})
     heatpump_type_builder = MagicMock(return_value={"HEAT_PUMP": {"count": 1}})
 
-    monkeypatch.setattr(runtime, "_build_gateway_inventory_summary", gateway_builder)
+    monkeypatch.setattr(coord, "_build_gateway_inventory_summary", gateway_builder)
     monkeypatch.setattr(
         runtime, "_build_microinverter_inventory_summary", micro_builder
     )
@@ -319,6 +349,169 @@ def test_inventory_runtime_summary_helpers_reuse_stable_cache_markers(
     assert micro_builder.call_count == 1
     assert heatpump_builder.call_count == 1
     assert heatpump_type_builder.call_count == 1
+
+
+def test_inventory_runtime_debug_cache_and_gateway_fallback_edges(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.inventory_runtime
+
+    class BadText:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    assert runtime._debug_sorted_keys({BadText(): 1, " ok ": 2}) == [
+        "ok"
+    ]  # noqa: SLF001
+    assert runtime._debug_field_keys([{"a": 1}, "bad"]) == ["a"]  # noqa: SLF001
+    rendered = runtime._debug_render_summary({"bad": object()})  # noqa: SLF001
+    assert isinstance(rendered, str)
+    assert "'bad':" in rendered
+
+    monkeypatch.setattr(
+        runtime,
+        "_hems_grouped_devices",
+        lambda: ["bad", {BadText(): []}, {"router": []}],
+    )
+    monkeypatch.setattr(runtime, "_hems_group_members", lambda *_args: [])
+    hems_summary = runtime._debug_hems_inventory_summary()  # noqa: SLF001
+    assert hems_summary["router_count"] == 0
+
+    coord.energy = None
+    assert runtime._live_site_energy_channels() == set()  # noqa: SLF001
+    coord.energy = SimpleNamespace(
+        site_energy={BadText(): 1, " grid_import ": 1},
+        site_energy_meta={
+            "bucket_lengths": {
+                BadText(): 2,
+                "": 1,
+                "heatpump": "2",
+                "evse": 0,
+                "ignored": [],
+                "battery_discharge": "bad",
+                "consumption": False,
+            }
+        },
+    )
+    assert runtime._live_site_energy_channels() == {  # noqa: SLF001
+        "battery_discharge",
+        "grid_import",
+        "heat_pump",
+    }
+
+    monkeypatch.setattr(runtime, "_gateway_inventory_summary_marker", lambda: "gw")
+    monkeypatch.setattr(
+        runtime, "_microinverter_inventory_summary_marker", lambda: "mi"
+    )
+    monkeypatch.setattr(runtime, "_heatpump_inventory_summary_marker", lambda: "hp")
+    monkeypatch.setattr(
+        runtime, "_gateway_iq_energy_router_records_marker", lambda: "router"
+    )
+    gateway_builder = MagicMock(return_value={"gateway": 1})
+    micro_builder = MagicMock(return_value={"micro": 1})
+    heatpump_builder = MagicMock(return_value={"heatpump": 1})
+    heatpump_type_builder = MagicMock(return_value={"HEAT_PUMP": {"count": 1}})
+    router_builder = MagicMock(return_value=[{"key": "router-1", "name": "Router"}])
+    monkeypatch.setattr(runtime, "_build_gateway_inventory_summary", gateway_builder)
+    monkeypatch.setattr(
+        runtime, "_build_microinverter_inventory_summary", micro_builder
+    )
+    monkeypatch.setattr(runtime, "_build_heatpump_inventory_summary", heatpump_builder)
+    monkeypatch.setattr(
+        runtime, "_build_heatpump_type_summaries", heatpump_type_builder
+    )
+    monkeypatch.setattr(
+        runtime, "_gateway_iq_energy_router_summary_records", router_builder
+    )
+    monkeypatch.setattr(
+        runtime,
+        "gateway_iq_energy_router_records",
+        lambda: [{"serial_number": "router-1"}],
+    )
+
+    assert runtime.gateway_inventory_summary() == {"gateway": 1}
+    assert runtime.gateway_inventory_summary() == {"gateway": 1}
+    assert runtime.microinverter_inventory_summary() == {"micro": 1}
+    assert runtime.microinverter_inventory_summary() == {"micro": 1}
+    assert runtime.heatpump_inventory_summary() == {"heatpump": 1}
+    assert runtime.heatpump_inventory_summary() == {"heatpump": 1}
+    assert runtime.heatpump_type_summary(BadText()) == {}
+    assert runtime.heatpump_type_summary("heat_pump") == {"count": 1}
+    assert runtime.gateway_iq_energy_router_summary_records() == [
+        {"key": "router-1", "name": "Router"}
+    ]
+    assert runtime.gateway_iq_energy_router_summary_records() == [
+        {"key": "router-1", "name": "Router"}
+    ]
+    assert runtime.gateway_iq_energy_router_record(" router-1 ") == {
+        "key": "router-1",
+        "name": "Router",
+    }
+    assert runtime.gateway_iq_energy_router_record(BadText()) is None
+    assert runtime.gateway_iq_energy_router_record("   ") is None
+
+    assert gateway_builder.call_count == 1
+    assert micro_builder.call_count == 1
+    assert heatpump_builder.call_count == 1
+    assert heatpump_type_builder.call_count == 1
+    assert router_builder.call_count >= 1
+
+    monkeypatch.setattr(
+        runtime,
+        "_build_gateway_inventory_summary",
+        type(runtime)._build_gateway_inventory_summary.__get__(runtime, type(runtime)),
+    )
+
+    monkeypatch.setattr(
+        runtime,
+        "type_bucket",
+        lambda _key: {"type_key": "envoy", "count": "bad", "devices": []},
+    )
+    monkeypatch.setattr(
+        runtime,
+        "system_dashboard_envoy_detail",
+        lambda: {
+            "name": "Gateway",
+            "serial_number": "GW-1",
+            "status": "normal",
+            "firmware_version": "8.2.0",
+            "last_interval_end_date": "2026-02-15T10:00:00Z",
+        },
+    )
+    gateway_summary = runtime._build_gateway_inventory_summary()  # noqa: SLF001
+    assert gateway_summary["firmware_summary"] == "8.2.0 x1"
+    assert gateway_summary["latest_reported_device"] == {
+        "name": "Gateway",
+        "serial_number": "GW-1",
+        "status": "normal",
+    }
+
+    monkeypatch.setattr(
+        runtime,
+        "type_bucket",
+        lambda _key: {
+            "type_key": "envoy",
+            "count": 1,
+            "devices": [{"name": "Online Gateway", "status": "normal"}],
+        },
+    )
+    monkeypatch.setattr(runtime, "system_dashboard_envoy_detail", lambda: None)
+    online_summary = runtime._build_gateway_inventory_summary()  # noqa: SLF001
+    assert online_summary["connected_devices"] == 1
+
+    monkeypatch.setattr(
+        runtime,
+        "type_bucket",
+        lambda _key: {
+            "type_key": "envoy",
+            "count": 1,
+            "devices": [{"name": "Offline Gateway", "status": "not_reporting"}],
+        },
+    )
+    monkeypatch.setattr(runtime, "system_dashboard_envoy_detail", lambda: None)
+    offline_summary = runtime._build_gateway_inventory_summary()  # noqa: SLF001
+    assert offline_summary["disconnected_devices"] == 1
 
 
 def test_devices_inventory_runtime_parser_shapes_and_buckets(
@@ -517,7 +710,9 @@ async def test_inventory_runtime_devices_and_hems_refresh_cache_paths(
     coord.client.devices_inventory = AsyncMock(return_value={})
     await runtime._async_refresh_devices_inventory()
 
-    monkeypatch.setattr(coord, "_redact_battery_payload", lambda payload: "raw")
+    monkeypatch.setattr(
+        inventory_runtime_mod, "redact_battery_payload", lambda payload: "raw"
+    )
     coord.client.devices_inventory = AsyncMock(
         return_value={
             "result": [{"type": "envoy", "devices": [{"name": "IQ Gateway"}]}]
@@ -526,7 +721,9 @@ async def test_inventory_runtime_devices_and_hems_refresh_cache_paths(
     await runtime._async_refresh_devices_inventory(force=True)
     assert runtime._devices_inventory_payload == {"value": "raw"}  # noqa: SLF001
 
-    monkeypatch.setattr(coord, "_redact_battery_payload", lambda payload: payload)
+    monkeypatch.setattr(
+        inventory_runtime_mod, "redact_battery_payload", lambda payload: payload
+    )
     await runtime._async_refresh_devices_inventory(force=True)
     assert coord.has_type("envoy") is True
 
@@ -577,7 +774,9 @@ async def test_inventory_runtime_devices_and_hems_refresh_cache_paths(
     await runtime._async_refresh_hems_devices()
     assert runtime._hems_devices_payload is None  # noqa: SLF001
 
-    monkeypatch.setattr(coord, "_redact_battery_payload", lambda payload: payload)
+    monkeypatch.setattr(
+        inventory_runtime_mod, "redact_battery_payload", lambda payload: payload
+    )
     runtime._hems_devices_cache_until = None  # noqa: SLF001
     coord.client.hems_devices = AsyncMock(
         return_value={"data": {"hems-devices": {"heat-pump": []}}}
@@ -829,7 +1028,7 @@ async def test_inventory_runtime_refresh_devices_inventory_without_refresh_kw(
 
 
 @pytest.mark.asyncio
-async def test_inventory_runtime_refresh_hems_devices_uses_coordinator_preflight(
+async def test_inventory_runtime_refresh_hems_devices_uses_heatpump_runtime_preflight(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -839,7 +1038,7 @@ async def test_inventory_runtime_refresh_hems_devices_uses_coordinator_preflight
         assert force is True
         coord.client._hems_site_supported = False  # noqa: SLF001
 
-    coord._async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+    coord.heatpump_runtime.async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=_mark_unsupported
     )
     coord.client.hems_devices = AsyncMock(side_effect=AssertionError("no fetch"))
@@ -848,7 +1047,7 @@ async def test_inventory_runtime_refresh_hems_devices_uses_coordinator_preflight
 
     await runtime._async_refresh_hems_devices(force=True)  # noqa: SLF001
 
-    coord._async_refresh_hems_support_preflight.assert_awaited_once_with(  # noqa: SLF001
+    coord.heatpump_runtime.async_refresh_hems_support_preflight.assert_awaited_once_with(  # noqa: SLF001
         force=True
     )
     coord.client.hems_devices.assert_not_awaited()
@@ -916,6 +1115,60 @@ async def test_coordinator_inventory_runtime_wrapper_delegation(
     runtime._extract_hems_group_members.assert_called_once_with([], {"gateway"})
     runtime._rebuild_inventory_summary_caches.assert_called_once_with()
     runtime._async_refresh_devices_inventory.assert_awaited_once_with(force=True)
+
+
+def test_inventory_runtime_rebuild_summary_caches_updates_coordinator_caches(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.inventory_runtime
+
+    coord._gateway_inventory_summary_cache = {"stale": True}  # noqa: SLF001
+    coord._microinverter_inventory_summary_cache = {"stale": True}  # noqa: SLF001
+    coord._heatpump_inventory_summary_cache = {"stale": True}  # noqa: SLF001
+    coord._heatpump_type_summaries_cache = {
+        "HEAT_PUMP": {"stale": True}
+    }  # noqa: SLF001
+    coord._gateway_iq_energy_router_records_cache = [{"key": "stale"}]  # noqa: SLF001
+
+    monkeypatch.setattr(runtime, "_gateway_inventory_summary_marker", lambda: "gw")
+    monkeypatch.setattr(
+        runtime, "_microinverter_inventory_summary_marker", lambda: "micro"
+    )
+    monkeypatch.setattr(runtime, "_heatpump_inventory_summary_marker", lambda: "heat")
+    monkeypatch.setattr(
+        runtime, "_gateway_iq_energy_router_records_marker", lambda: "router"
+    )
+    monkeypatch.setattr(
+        runtime, "_build_gateway_inventory_summary", lambda: {"gateway": 1}
+    )
+    monkeypatch.setattr(
+        runtime, "_build_microinverter_inventory_summary", lambda: {"micro": 2}
+    )
+    monkeypatch.setattr(
+        runtime, "_build_heatpump_inventory_summary", lambda: {"heatpump": 3}
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_build_heatpump_type_summaries",
+        lambda: {"HEAT_PUMP": {"count": 4}},
+    )
+    monkeypatch.setattr(
+        runtime,
+        "_gateway_iq_energy_router_summary_records",
+        lambda _records: [{"key": "router-1", "name": "Router"}],
+    )
+    monkeypatch.setattr(runtime, "gateway_iq_energy_router_records", lambda: [])
+
+    coord._rebuild_inventory_summary_caches()  # noqa: SLF001
+
+    assert coord.gateway_inventory_summary() == {"gateway": 1}
+    assert coord.microinverter_inventory_summary() == {"micro": 2}
+    assert coord.heatpump_inventory_summary() == {"heatpump": 3}
+    assert coord.heatpump_type_summary("heat_pump") == {"count": 4}
+    assert coord.gateway_iq_energy_router_summary_records() == [
+        {"key": "router-1", "name": "Router"}
+    ]
 
 
 def test_inventory_runtime_parser_and_hems_edge_cases(
@@ -1259,13 +1512,13 @@ async def test_inventory_runtime_refresh_hems_devices_unsupported_and_redaction_
     runtime._hems_devices_payload = {"existing": True}  # noqa: SLF001
     runtime._hems_devices_last_success_mono = time.monotonic()  # noqa: SLF001
     coord.client.hems_devices = AsyncMock(side_effect=RuntimeError("boom"))
-    original_preflight = coord._async_refresh_hems_support_preflight
+    original_preflight = coord.heatpump_runtime.async_refresh_hems_support_preflight
 
     async def unsupported_on_error(*, force: bool = False) -> None:
         await original_preflight(force=force)
         coord.client._hems_site_supported = True  # noqa: SLF001
 
-    coord._async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+    coord.heatpump_runtime.async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=unsupported_on_error
     )
     await runtime._async_refresh_hems_devices(force=True)  # noqa: SLF001
@@ -1275,7 +1528,7 @@ async def test_inventory_runtime_refresh_hems_devices_unsupported_and_redaction_
     async def unsupported_preflight(*, force: bool = False) -> None:
         coord.client._hems_site_supported = False  # noqa: SLF001
 
-    coord._async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+    coord.heatpump_runtime.async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=unsupported_preflight
     )
     coord.client.hems_devices = AsyncMock(side_effect=RuntimeError("unused"))
@@ -1287,7 +1540,7 @@ async def test_inventory_runtime_refresh_hems_devices_unsupported_and_redaction_
     async def supported_preflight(*, force: bool = False) -> None:
         coord.client._hems_site_supported = True  # noqa: SLF001
 
-    coord._async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+    coord.heatpump_runtime.async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=supported_preflight
     )
     runtime._hems_devices_payload = {"keep": True}  # noqa: SLF001
@@ -1303,7 +1556,7 @@ async def test_inventory_runtime_refresh_hems_devices_unsupported_and_redaction_
     async def unsupported_invalid_payload(*, force: bool = False) -> None:
         coord.client._hems_site_supported = False  # noqa: SLF001
 
-    coord._async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+    coord.heatpump_runtime.async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=unsupported_invalid_payload
     )
     runtime._hems_devices_cache_until = None  # noqa: SLF001
@@ -1312,11 +1565,15 @@ async def test_inventory_runtime_refresh_hems_devices_unsupported_and_redaction_
     assert runtime._hems_devices_payload is None  # noqa: SLF001
     assert runtime._hems_inventory_ready is True  # noqa: SLF001
 
-    coord._async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+    coord.heatpump_runtime.async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=supported_preflight
     )
     runtime._hems_devices_cache_until = None  # noqa: SLF001
-    monkeypatch.setattr(coord, "_redact_battery_payload", lambda payload: "wrapped")
+    monkeypatch.setattr(
+        inventory_runtime_mod,
+        "redact_battery_payload",
+        lambda payload: "wrapped",
+    )
     coord.client.hems_devices = AsyncMock(return_value={"result": {"devices": []}})
     await runtime._async_refresh_hems_devices(force=True)  # noqa: SLF001
     assert runtime._hems_devices_payload == {"value": "wrapped"}  # noqa: SLF001
@@ -1328,7 +1585,7 @@ async def test_inventory_runtime_refresh_hems_devices_unsupported_and_redaction_
         coord.client._hems_site_supported = False  # noqa: SLF001
         raise RuntimeError("boom")
 
-    coord._async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+    coord.heatpump_runtime.async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=unsupported_during_fetch
     )
     runtime._hems_devices_cache_until = None  # noqa: SLF001
@@ -1341,7 +1598,7 @@ async def test_inventory_runtime_refresh_hems_devices_unsupported_and_redaction_
         coord.client._hems_site_supported = False  # noqa: SLF001
         return "bad"
 
-    coord._async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+    coord.heatpump_runtime.async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=unsupported_during_fetch
     )
     runtime._hems_devices_cache_until = None  # noqa: SLF001


### PR DESCRIPTION
## Summary
- move shared runtime/coordinator helper logic into `runtime_helpers.py` and `system_dashboard_helpers.py`
- shift inventory and heat-pump runtime code off coordinator private helpers while preserving coordinator compatibility shims
- fix coordinator/runtime state mirroring regressions for summary caches, type buckets, and restored inverter discovery snapshots
- add regression coverage for the new helper modules and the coordinator compatibility paths

## Testing
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/heatpump_runtime.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/runtime_helpers.py custom_components/enphase_ev/system_dashboard_helpers.py tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_helper_modules.py tests/components/enphase_ev/test_inventory_runtime.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/runtime_helpers.py,custom_components/enphase_ev/system_dashboard_helpers.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/heatpump_runtime.py,custom_components/enphase_ev/inventory_runtime.py --fail-under=100"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
- `python3 -m pre_commit run --all-files`

Note: `pre-commit` could not run inside the Docker worktree because the container could not resolve Git metadata for this worktree checkout, so it was run successfully from the host checkout instead.
