### PR TITLE
Fix unavailable heat pump daily energy totals

### DIFF
--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -531,6 +531,16 @@ class HeatpumpRuntime:
         if not isinstance(first_bucket, dict):
             return None
 
+        daily_solar_wh = coerce_optional_float(first_bucket.get("solar"))
+        daily_battery_wh = coerce_optional_float(first_bucket.get("battery"))
+        daily_grid_wh = coerce_optional_float(first_bucket.get("grid"))
+        daily_energy_wh = self._sum_optional_values(first_bucket.get("details"))
+        if daily_energy_wh is None and all(
+            value is not None
+            for value in (daily_solar_wh, daily_battery_wh, daily_grid_wh)
+        ):
+            daily_energy_wh = daily_solar_wh + daily_battery_wh + daily_grid_wh
+
         return {
             "device_uid": selected.get("device_uid"),
             "device_name": selected.get("device_name"),
@@ -548,10 +558,10 @@ class HeatpumpRuntime:
             "device_state": (
                 heatpump_device_state(member) if isinstance(member, dict) else None
             ),
-            "daily_energy_wh": self._sum_optional_values(first_bucket.get("details")),
-            "daily_solar_wh": coerce_optional_float(first_bucket.get("solar")),
-            "daily_battery_wh": coerce_optional_float(first_bucket.get("battery")),
-            "daily_grid_wh": coerce_optional_float(first_bucket.get("grid")),
+            "daily_energy_wh": daily_energy_wh,
+            "daily_solar_wh": daily_solar_wh,
+            "daily_battery_wh": daily_battery_wh,
+            "daily_grid_wh": daily_grid_wh,
             "details": (
                 list(first_bucket.get("details"))
                 if isinstance(first_bucket.get("details"), list)

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -1408,6 +1408,42 @@ def test_heatpump_daily_helper_and_property_edge_cases(
         "endpoint_type": None,
         "endpoint_timestamp": None,
     }
+    snapshot = coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
+        {
+            "data": {
+                "heat-pump": [
+                    {
+                        "device_uid": "HP-2",
+                        "device_name": "Backup",
+                        "consumption": [
+                            {
+                                "solar": 0.0,
+                                "battery": 0.0,
+                                "grid": 0.0,
+                                "details": [],
+                            },
+                        ],
+                    }
+                ]
+            }
+        }
+    )
+    assert snapshot == {
+        "device_uid": "HP-2",
+        "device_name": "Backup",
+        "member_name": None,
+        "member_device_type": "ENERGY_METER",
+        "pairing_status": None,
+        "device_state": None,
+        "daily_energy_wh": pytest.approx(0.0),
+        "daily_solar_wh": pytest.approx(0.0),
+        "daily_battery_wh": pytest.approx(0.0),
+        "daily_grid_wh": pytest.approx(0.0),
+        "details": [],
+        "source": "hems_energy_consumption:HP-2",
+        "endpoint_type": None,
+        "endpoint_timestamp": None,
+    }
     assert (
         coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
             {"data": {"heat-pump": [{"device_uid": "HP-1", "consumption": ["bad"]}]}}


### PR DESCRIPTION
## Summary

Fixes #454.

Handle HEMS heat-pump daily consumption payloads that omit `details` while still reporting explicit `solar`, `battery`, and `grid` component totals. This keeps the heat-pump daily energy entity available at `0.0 kWh` instead of `Unavailable` when Enphase returns empty detail arrays for zero-consumption days.

## Related Issues

- https://github.com/barneyonline/ha-enphase-energy/issues/454

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest -q tests/components/enphase_ev && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/heatpump_runtime.py --fail-under=100"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The failing user diagnostics showed the HEMS daily consumption endpoint returning an empty `details` array together with explicit `solar=0`, `battery=0`, and `grid=0` totals for the heat pump. The patch now treats those component totals as the fallback daily total.
