### PR TITLE
Fix BatteryConfig XSRF refresh handling

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -34,6 +34,7 @@ _EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b")
 _DEBUG_KV_RE = re.compile(
     r"(?P<key>[A-Za-z][A-Za-z0-9_\-]*)(?P<sep>\s*[=:]\s*)(?P<value>[^,\s)]+)"
 )
+_XSRF_COOKIE_NAMES = ("xsrf-token", "bp-xsrf-token")
 
 
 class Unauthorized(Exception):
@@ -580,7 +581,7 @@ def _extract_xsrf_token(cookies: dict[str, str] | None) -> str | None:
 
     if not cookies:
         return None
-    for preferred in ("xsrf-token", "bp-xsrf-token"):
+    for preferred in _XSRF_COOKIE_NAMES:
         for name, value in cookies.items():
             if name and name.lower() == preferred:
                 try:
@@ -596,6 +597,58 @@ def _extract_xsrf_token(cookies: dict[str, str] | None) -> str | None:
                 except Exception:  # noqa: BLE001 - defensive decoding
                     return token
     return None
+
+
+def _coerce_cookie_map(cookies: object) -> dict[str, str]:
+    """Normalize cookie containers to a simple string mapping."""
+
+    items = getattr(cookies, "items", None)
+    if not callable(items):
+        return {}
+
+    normalized: dict[str, str] = {}
+    try:
+        cookie_items = list(items())
+    except Exception:  # noqa: BLE001 - defensive cookie parsing
+        return normalized
+
+    for name, morsel in cookie_items:
+        try:
+            cookie_name = str(name).strip()
+        except Exception:  # noqa: BLE001 - defensive parsing
+            continue
+        if not cookie_name:
+            continue
+        raw_value = getattr(morsel, "value", morsel)
+        try:
+            normalized[cookie_name] = str(raw_value).strip()
+        except Exception:  # noqa: BLE001 - defensive parsing
+            continue
+    return normalized
+
+
+def _cookie_map_from_header(cookie_header: object) -> dict[str, str]:
+    """Parse a Cookie header string into a simple mapping."""
+
+    try:
+        text = str(cookie_header or "")
+    except Exception:  # noqa: BLE001 - defensive cookie parsing
+        return {}
+
+    if not text:
+        return {}
+
+    cookies: dict[str, str] = {}
+    for part in text.split(";"):
+        item = part.strip()
+        if not item:
+            continue
+        name, sep, value = item.partition("=")
+        name = name.strip()
+        if not sep or not name:
+            continue
+        cookies[name] = value.strip()
+    return cookies
 
 
 def _seed_cookie_jar(session: aiohttp.ClientSession, cookies: dict[str, str]) -> None:
@@ -1855,7 +1908,8 @@ class EnphaseEVClient:
         parts = [
             part.strip()
             for part in cookie_str.split(";")
-            if part.strip() and not part.strip().startswith("BP-XSRF-Token=")
+            if part.strip()
+            and part.strip().partition("=")[0].strip().lower() not in _XSRF_COOKIE_NAMES
         ]
         if include_xsrf:
             xsrf = self._xsrf_token()
@@ -1923,22 +1977,19 @@ class EnphaseEVClient:
             parts = [p.strip() for p in (self._cookie or "").split(";")]
         except Exception:  # noqa: BLE001 - defensive parsing
             return None
-        for key in ("XSRF-TOKEN", "BP-XSRF-Token"):
-            for part in parts:
-                if part.startswith(f"{key}="):
-                    token = part.split("=", 1)[1].strip()
-                    if (
-                        token.startswith('"')
-                        and token.endswith('"')
-                        and len(token) >= 2
-                    ):
-                        token = token[1:-1]
-                    if not token:
-                        continue
-                    try:
-                        return unquote(token)
-                    except Exception:  # noqa: BLE001 - defensive decoding
-                        return token
+        for part in parts:
+            key, sep, value = part.partition("=")
+            if not sep or key.strip().lower() not in _XSRF_COOKIE_NAMES:
+                continue
+            token = value.strip()
+            if token.startswith('"') and token.endswith('"') and len(token) >= 2:
+                token = token[1:-1]
+            if not token:
+                continue
+            try:
+                return unquote(token)
+            except Exception:  # noqa: BLE001 - defensive decoding
+                return token
         return None
 
     async def _acquire_xsrf_token(self) -> str | None:
@@ -1975,27 +2026,42 @@ class EnphaseEVClient:
         }
 
         try:
+            _seed_cookie_jar(self._s, _cookie_map_from_header(self._cookie))
+
+            def _remember_xsrf(token: str | None, source: str) -> str | None:
+                if not token:
+                    return None
+                self._bp_xsrf_token = token
+                _LOGGER.debug("Acquired BP-XSRF-Token from %s", source)
+                return token
+
             async with asyncio.timeout(self._timeout):
                 async with self._s.request(
                     "POST", url, json=payload, headers=headers
                 ) as r:
-                    # Extract BP-XSRF-Token from Set-Cookie header
-                    set_cookie = r.headers.get("Set-Cookie", "")
-                    match = re.search(r"BP-XSRF-Token=([^;]+)", set_cookie)
-                    if match:
-                        self._bp_xsrf_token = match.group(1)
-                        _LOGGER.debug("Acquired BP-XSRF-Token from isValid endpoint")
-                        return self._bp_xsrf_token
-
-                    # Fallback: check all Set-Cookie headers
                     for value in r.headers.getall("Set-Cookie", []):
-                        match = re.search(r"BP-XSRF-Token=([^;]+)", value)
+                        match = re.search(
+                            r"(?i)(?:^|;\s*)(?:bp-)?xsrf-token=([^;]+)", value
+                        )
                         if match:
-                            self._bp_xsrf_token = match.group(1)
-                            _LOGGER.debug(
-                                "Acquired BP-XSRF-Token from Set-Cookie header"
+                            return _remember_xsrf(
+                                unquote(match.group(1)), "Set-Cookie header"
                             )
-                            return self._bp_xsrf_token
+
+                    response_cookie_token = _extract_xsrf_token(
+                        _coerce_cookie_map(getattr(r, "cookies", None))
+                    )
+                    if response_cookie_token:
+                        return _remember_xsrf(response_cookie_token, "response cookies")
+
+                    cookie_header, cookie_map = _serialize_cookie_jar(
+                        self._s.cookie_jar, (url, BASE_URL, ENTREZ_URL)
+                    )
+                    session_cookie_token = _extract_xsrf_token(cookie_map)
+                    if session_cookie_token:
+                        return _remember_xsrf(
+                            session_cookie_token, "session cookie jar"
+                        )
 
                     _LOGGER.warning(
                         "isValid endpoint did not return BP-XSRF-Token cookie"

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock
 import aiohttp
 import pytest
 from multidict import CIMultiDict
+from yarl import URL
 
 from custom_components.enphase_ev import api
 from custom_components.enphase_ev.const import (
@@ -42,6 +43,7 @@ class _FakeResponse:
         self.history: tuple = ()
         self.reason = "reason"
         self.headers: dict[str, str] = {}
+        self.cookies: dict[str, object] = {}
 
     async def __aenter__(self) -> "_FakeResponse":
         return self
@@ -167,6 +169,56 @@ def test_extract_xsrf_token_branches(monkeypatch) -> None:
     assert api._extract_xsrf_token({"XSRF-TOKEN": "raw-token"}) == "raw-token"
 
 
+def test_extract_xsrf_token_handles_bad_and_empty_cookie_values() -> None:
+    class BadTokenValue:
+        def __str__(self) -> str:
+            raise ValueError("bad")
+
+    assert api._extract_xsrf_token({"XSRF-TOKEN": BadTokenValue()}) is None
+    assert api._extract_xsrf_token({"XSRF-TOKEN": '""'}) is None
+
+
+def test_coerce_cookie_map_handles_defensive_branches() -> None:
+    class _ItemsFail:
+        def items(self):
+            raise RuntimeError("boom")
+
+    class _BadName:
+        def __str__(self) -> str:
+            raise ValueError("bad-name")
+
+    class _BadValue:
+        def __str__(self) -> str:
+            raise ValueError("bad-value")
+
+    class _CookieMap:
+        def items(self):
+            return [
+                (_BadName(), "skip"),
+                ("", "skip"),
+                ("bad", _BadValue()),
+                ("good", SimpleNamespace(value="value")),
+            ]
+
+    assert api._coerce_cookie_map(SimpleNamespace(items="not-callable")) == {}
+    assert api._coerce_cookie_map(_ItemsFail()) == {}
+    assert api._coerce_cookie_map(_CookieMap()) == {"good": "value"}
+
+
+def test_cookie_map_from_header_handles_defensive_branches() -> None:
+    class _BadCookieHeader:
+        def __str__(self) -> str:
+            raise ValueError("bad-cookie-header")
+
+    assert api._cookie_map_from_header(_BadCookieHeader()) == {}
+    assert api._cookie_map_from_header("") == {}
+    assert api._cookie_map_from_header("session=1; ; invalid; other=2; blank=") == {
+        "session": "1",
+        "other": "2",
+        "blank": "",
+    }
+
+
 def test_xsrf_token_handles_empty_and_decode_fallback(monkeypatch) -> None:
     client = _make_client()
     client.update_credentials(cookie='XSRF-TOKEN=""; BP-XSRF-Token=bp%3Dtoken')
@@ -179,6 +231,16 @@ def test_xsrf_token_handles_empty_and_decode_fallback(monkeypatch) -> None:
     )
     client.update_credentials(cookie="XSRF-TOKEN=raw-token")
     assert client._xsrf_token() == "raw-token"
+
+
+def test_xsrf_helpers_accept_lower_case_cookie_names() -> None:
+    client = _make_client()
+    client.update_credentials(cookie="bp-xsrf-token=bp%3Dtoken; other=1")
+
+    assert client._xsrf_token() == "bp=token"
+    assert client._battery_config_cookie(include_xsrf=True) == (
+        "other=1; BP-XSRF-Token=bp=token"
+    )
 
 
 def test_system_dashboard_should_fallback_rejects_unexpected_errors() -> None:
@@ -2699,6 +2761,59 @@ async def test_acquire_xsrf_token_returns_none_when_cookie_missing() -> None:
     client = _make_client(session)
 
     assert await client._acquire_xsrf_token() is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_acquire_xsrf_token_returns_none_for_empty_decoded_cookie() -> None:
+    response = _FakeResponse(status=200, json_body={"isValid": True})
+    response.headers = CIMultiDict(
+        [("Set-Cookie", "BP-XSRF-Token=fresh-token; Path=/; Secure")]
+    )
+    session = _FakeSession([response])
+    client = _make_client(session)
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setattr(api, "unquote", lambda _value: "")
+        assert await client._acquire_xsrf_token() is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_acquire_xsrf_token_uses_response_cookies_when_header_missing() -> None:
+    response = _FakeResponse(status=200, json_body={"isValid": True})
+    response.headers = CIMultiDict()
+    response.cookies = {"bp-xsrf-token": SimpleNamespace(value="fresh-token")}
+    session = _FakeSession([response])
+    client = _make_client(session)
+
+    assert await client._acquire_xsrf_token() == "fresh-token"  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_acquire_xsrf_token_falls_back_to_session_cookie_jar() -> None:
+    response = _FakeResponse(status=200, json_body={"isValid": True})
+    response.headers = CIMultiDict()
+    session = _FakeSession([response])
+    request_url = URL(
+        f"{api.BASE_URL}/service/batteryConfig/api/v1/battery/sites/SITE/schedules/isValid"
+    )
+    session.cookie_jar.update_cookies(
+        {"bp-xsrf-token": "jar-token"},
+        response_url=request_url,
+    )
+    client = _make_client(session)
+    client.update_credentials(
+        cookie="session=1; other=1; enlighten_manager_token_production=bearer"
+    )
+
+    assert await client._acquire_xsrf_token() == "jar-token"  # noqa: SLF001
+    assert (
+        client._cookie
+        == "session=1; other=1; enlighten_manager_token_production=bearer"
+    )  # noqa: SLF001
+    assert client._battery_config_headers(include_xsrf=True)["Cookie"] == (
+        "session=1; other=1; enlighten_manager_token_production=bearer; "
+        "BP-XSRF-Token=jar-token"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix BatteryConfig XSRF refresh handling so battery writes still succeed when Enphase returns the token via lowercase cookie names, response cookies, or the session cookie jar.

The fix preserves the existing auth cookie state while seeding the jar for token discovery, which avoids dropping session/bearer cookies after the `isValid` preflight. This addresses issue #460: https://github.com/barneyonline/ha-enphase-energy/issues/460

## Related Issues

- https://github.com/barneyonline/ha-enphase-energy/issues/460

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py tests/components/enphase_ev/test_api_client_methods.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/api.py tests/components/enphase_ev/test_api_client_methods.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_api_client_methods.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py --fail-under=100"
```

Also ran locally because the worktree-mounted Docker container cannot resolve this checkout as a Git repository for pre-commit:

```bash
pre-commit run --all-files
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Root cause: the BatteryConfig write preflight only trusted a narrow `BP-XSRF-Token` delivery path and could also replace the client cookie state with a partial cookie-jar snapshot.
- The regression tests cover lowercase cookie names, response-cookie/jar fallback, and preservation of the original auth cookies during XSRF refresh.
