### PR TITLE
Keep self-consumption selectable when grid charging is hidden

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Kept `Self-Consumption` available in the system profile selector even on sites where Enphase reports `showChargeFromGrid: false`, fixing automations that switch away from `Full Backup`.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -5074,9 +5074,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @property
     def battery_profile_option_keys(self) -> list[str]:
-        options: list[str] = []
-        if getattr(self, "_battery_show_charge_from_grid", None):
-            options.append("self-consumption")
+        options: list[str] = ["self-consumption"]
         if getattr(self, "_battery_show_savings_mode", None):
             options.append("cost_savings")
         if getattr(self, "_battery_show_ai_optimisation_mode", None):

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.6.5"
+  "version": "2.6.6"
 }

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -621,6 +621,29 @@ def test_system_profile_select_options_include_ai_optimization(coordinator_facto
     assert sel.options == ["Self-Consumption", "AI Optimisation", "Full Backup"]
 
 
+def test_system_profile_select_includes_self_consumption_when_grid_charge_hidden(
+    coordinator_factory,
+):
+    from custom_components.enphase_ev.select import SystemProfileSelect
+
+    coord = coordinator_factory()
+    coord._battery_show_charge_from_grid = False  # noqa: SLF001
+    coord._battery_show_savings_mode = True  # noqa: SLF001
+    coord._battery_show_ai_optimisation_mode = True  # noqa: SLF001
+    coord._battery_show_full_backup = True  # noqa: SLF001
+    coord._battery_profile = "backup_only"  # noqa: SLF001
+
+    sel = SystemProfileSelect(coord)
+
+    assert sel.options == [
+        "Self-Consumption",
+        "Savings",
+        "AI Optimisation",
+        "Full Backup",
+    ]
+    assert sel.current_option == "Full Backup"
+
+
 @pytest.mark.asyncio
 async def test_system_profile_select_sets_ai_optimization_profile(
     coordinator_factory,


### PR DESCRIPTION
## Summary

Keep `Self-Consumption` available in the Home Assistant system profile selector even when Enphase reports `showChargeFromGrid: false`. This fixes automations that need to switch away from `Full Backup` on sites where grid charging is hidden but `Self-Consumption` is still a valid profile in Enlighten.

References: https://github.com/barneyonline/ha-enphase-energy/issues/425

## Related Issues

- https://github.com/barneyonline/ha-enphase-energy/issues/425

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_select_charge_mode.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_select_charge_mode.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev/test_select_charge_mode.py -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage json -o /tmp/enphase_ev_coverage.json"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
```

Additional validation:
- Confirmed the changed source line in `custom_components/enphase_ev/coordinator.py` is exercised by the new regression test using Coverage JSON output.
- Attempted the repository's full-file `--fail-under=100` coverage gate for `custom_components/enphase_ev/coordinator.py`, but that existing file is not 100% covered overall. The change itself is covered.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Root cause: the integration treated `showChargeFromGrid` as if it controlled whether `Self-Consumption` was a valid system profile. On affected sites that flag stays false even though Enlighten still allows `Self-Consumption`, so the option disappeared whenever another profile such as `Full Backup` was active.
