### PR TITLE
Use HEMS energy-consumption for heat pump power

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Kept `Self-Consumption` available in the system profile selector even on sites where Enphase reports `showChargeFromGrid: false`, fixing automations that switch away from `Full Backup`.
+- Preserved Green mode from the live EVSE schedule summary when Enphase temporarily omits the scheduler preference, keeping `preferred_mode` and the charge-mode select stable instead of dropping to `null`/`unknown`.
+- Switched heat-pump power to use the HEMS `energy-consumption` device reading as the sole source, aligned its refresh cadence to the existing 300-second HEMS daily-consumption cache, and treated missing or null `details[]` values as `0 W`.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -14,8 +14,6 @@ from .const import (
     HEMS_SUPPORT_PREFLIGHT_CACHE_TTL,
     HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL,
     HEATPUMP_DAILY_CONSUMPTION_FAILURE_BACKOFF_S,
-    HEATPUMP_POWER_CACHE_TTL,
-    HEATPUMP_POWER_FAILURE_BACKOFF_S,
     HEATPUMP_RUNTIME_DIAGNOSTICS_CACHE_TTL,
     HEATPUMP_RUNTIME_STATE_CACHE_TTL,
     HEATPUMP_RUNTIME_STATE_FAILURE_BACKOFF_S,
@@ -492,9 +490,25 @@ class HeatpumpRuntime:
             found = True
         return total if found else None
 
-    def _build_heatpump_daily_consumption_snapshot(
+    @staticmethod
+    def _first_optional_numeric_value(values: object) -> float | None:
+        if not isinstance(values, list):
+            return None
+        for item in values:
+            if item is None:
+                continue
+            try:
+                numeric = float(item)
+            except Exception:
+                continue
+            if numeric != numeric or numeric in (float("inf"), float("-inf")):
+                continue
+            return numeric
+        return None
+
+    def _select_heatpump_energy_consumption_entry(
         self, payload: object
-    ) -> dict[str, object] | None:
+    ) -> tuple[dict[str, object], dict[str, object] | None, dict[str, object]] | None:
         if not isinstance(payload, dict):
             return None
         families = payload.get("data")
@@ -530,6 +544,16 @@ class HeatpumpRuntime:
                     break
         if not isinstance(first_bucket, dict):
             return None
+
+        return selected, member, first_bucket
+
+    def _build_heatpump_daily_consumption_snapshot(
+        self, payload: object
+    ) -> dict[str, object] | None:
+        selection = self._select_heatpump_energy_consumption_entry(payload)
+        if selection is None:
+            return None
+        selected, member, first_bucket = selection
 
         daily_solar_wh = coerce_optional_float(first_bucket.get("solar"))
         daily_battery_wh = coerce_optional_float(first_bucket.get("battery"))
@@ -581,6 +605,50 @@ class HeatpumpRuntime:
                 payload.get("endpoint_timestamp")
                 if payload.get("endpoint_timestamp") is not None
                 else payload.get("timestamp")
+            ),
+        }
+
+    def _heatpump_power_summary_from_daily_snapshot(
+        self, snapshot: object
+    ) -> tuple[float, dict[str, object]] | None:
+        if not isinstance(snapshot, dict):
+            return None
+        details = snapshot.get("details")
+        power_w = self._first_optional_numeric_value(details)
+        if power_w is None:
+            power_w = 0.0
+        device_uid = coerce_optional_text(snapshot.get("device_uid"))
+        return power_w, {
+            "requested_device_ref": (
+                self._debug_truncate_identifier(device_uid) if device_uid else None
+            ),
+            "payload_device_ref": (
+                self._debug_truncate_identifier(device_uid) if device_uid else None
+            ),
+            "resolved_device_ref": (
+                self._debug_truncate_identifier(device_uid) if device_uid else None
+            ),
+            "member_device_type": snapshot.get("member_device_type"),
+            "pairing_status": snapshot.get("pairing_status"),
+            "device_state": snapshot.get("device_state"),
+            "status": (
+                heatpump_status_text(self._heatpump_member_for_uid(device_uid))
+                if device_uid
+                else None
+            ),
+            "recommended": self._heatpump_power_candidate_is_recommended(device_uid),
+            "detail_count": len(details) if isinstance(details, list) else 0,
+            "detail_value_w": round(power_w, 3),
+            "daily_energy_wh": snapshot.get("daily_energy_wh"),
+            "daily_solar_wh": snapshot.get("daily_solar_wh"),
+            "daily_battery_wh": snapshot.get("daily_battery_wh"),
+            "daily_grid_wh": snapshot.get("daily_grid_wh"),
+            "endpoint_timestamp": snapshot.get("endpoint_timestamp"),
+            "endpoint_type": snapshot.get("endpoint_type"),
+            "source": (
+                f"hems_energy_consumption:{self._debug_truncate_identifier(device_uid)}"
+                if device_uid
+                else "hems_energy_consumption"
             ),
         }
 
@@ -639,7 +707,14 @@ class HeatpumpRuntime:
             )
         except Exception as err:  # noqa: BLE001
             self._heatpump_daily_consumption_last_error = (
-                redact_text(err, site_ids=(self.site_id,)) or err.__class__.__name__
+                redact_text(
+                    err,
+                    site_ids=(self.site_id,),
+                    identifiers=self._heatpump_power_redaction_identifiers(
+                        self._heatpump_runtime_device_uid()
+                    ),
+                )
+                or err.__class__.__name__
             )
             self._heatpump_daily_consumption_backoff_until = (
                 now + HEATPUMP_DAILY_CONSUMPTION_FAILURE_BACKOFF_S
@@ -1112,23 +1187,17 @@ class HeatpumpRuntime:
                 "force": force,
                 "outcome": "unsupported_site",
             }
-            self._heatpump_power_cache_until = now + HEATPUMP_POWER_CACHE_TTL
+            self._heatpump_power_cache_until = (
+                now + HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL
+            )
             self._heatpump_power_backoff_until = None
             self._heatpump_power_last_error = None
             self._heatpump_power_selection_marker = None
             return
 
-        fetcher = getattr(self.client, "hems_power_timeseries", None)
-        if not callable(fetcher):
-            self._heatpump_power_snapshot = {
-                "site_date": self._site_local_current_date(),
-                "force": force,
-                "outcome": "fetcher_unavailable",
-            }
-            return
-
         site_date = self._site_local_current_date()
         candidate_uids, compare_all, marker = self._heatpump_power_fetch_plan()
+        previous_device_uid = self._heatpump_power_device_uid
         candidate_summaries = [
             self._heatpump_power_debug_candidate_summary(candidate_uid)
             for candidate_uid in candidate_uids
@@ -1137,9 +1206,7 @@ class HeatpumpRuntime:
             "site_date": site_date,
             "force": force,
             "compare_all": compare_all,
-            "previous_device_ref": self._debug_truncate_identifier(
-                self._heatpump_power_device_uid
-            ),
+            "previous_device_ref": self._debug_truncate_identifier(previous_device_uid),
             "candidates": candidate_summaries,
             "attempts": [],
             "selected_payload": None,
@@ -1149,6 +1216,11 @@ class HeatpumpRuntime:
             "outcome": "pending",
         }
         self._heatpump_power_snapshot = power_snapshot
+        self._heatpump_power_w = None
+        self._heatpump_power_sample_utc = None
+        self._heatpump_power_start_utc = None
+        self._heatpump_power_device_uid = None
+        self._heatpump_power_source = None
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
                 "Heat pump power fetch plan for site %s: site_date=%s force=%s compare_all=%s previous_device_uid=%s candidates=%s",
@@ -1156,203 +1228,127 @@ class HeatpumpRuntime:
                 site_date,
                 force,
                 compare_all,
-                self._debug_truncate_identifier(self._heatpump_power_device_uid)
-                or "[redacted]",
+                self._debug_truncate_identifier(previous_device_uid) or "[redacted]",
                 candidate_summaries,
             )
-        payload: dict[str, object] | None = None
-        sample: tuple[int, float] | None = None
-        requested_uid: str | None = None
-        selected_key: tuple[int, int, int, int, float, int, int] | None = None
-        last_error: Exception | None = None
-        for candidate_uid in candidate_uids:
-            try:
-                current_payload = await fetcher(
-                    device_uid=candidate_uid,
-                    site_date=site_date,
+
+        try:
+            await self._async_refresh_heatpump_daily_consumption(force=force)
+        except Exception as err:  # noqa: BLE001
+            last_error_text = (
+                redact_text(
+                    err,
+                    site_ids=(self.site_id,),
+                    identifiers=self._heatpump_power_redaction_identifiers(),
                 )
-            except Exception as err:  # noqa: BLE001
-                last_error = err
-                redacted_error = (
-                    redact_text(
-                        err,
-                        site_ids=(self.site_id,),
-                        identifiers=self._heatpump_power_redaction_identifiers(
-                            candidate_uid
-                        ),
-                    )
-                    or err.__class__.__name__
-                )
-                attempts = power_snapshot.setdefault("attempts", [])
-                if isinstance(attempts, list):
-                    attempts.append(
-                        {
-                            "requested_device_ref": self._debug_truncate_identifier(
-                                candidate_uid
-                            ),
-                            "error": redacted_error,
-                        }
-                    )
-                _LOGGER.debug(
-                    "Heat pump power fetch failed (requested_device_uid=%s): %s",
-                    self._debug_truncate_identifier(candidate_uid) or "[redacted]",
-                    redacted_error,
-                )
-                continue
-            if not isinstance(current_payload, dict):
-                attempts = power_snapshot.setdefault("attempts", [])
-                if isinstance(attempts, list):
-                    attempts.append(
-                        {
-                            "requested_device_ref": self._debug_truncate_identifier(
-                                candidate_uid
-                            ),
-                            "payload_type": type(current_payload).__name__,
-                            "usable_payload": False,
-                        }
-                    )
-                if _LOGGER.isEnabledFor(logging.DEBUG):
-                    _LOGGER.debug(
-                        "Heat pump power fetch returned unusable payload for site %s: requested_device_uid=%s payload_type=%s",
-                        redact_site_id(self.site_id),
-                        self._debug_truncate_identifier(candidate_uid) or "[redacted]",
-                        type(current_payload).__name__,
-                    )
-                continue
-            current_sample = self._heatpump_latest_power_sample(current_payload)
-            current_key = self._heatpump_power_selection_key(
-                current_payload,
-                requested_uid=candidate_uid,
-                sample=current_sample,
-            )
-            current_summary = self._heatpump_power_debug_payload_summary(
-                current_payload,
-                requested_uid=candidate_uid,
-                sample=current_sample,
-                selection_key=current_key,
+                or err.__class__.__name__
             )
             attempts = power_snapshot.setdefault("attempts", [])
             if isinstance(attempts, list):
-                attempts.append(current_summary)
-            if _LOGGER.isEnabledFor(logging.DEBUG):
-                _LOGGER.debug(
-                    "Heat pump power candidate payload for site %s: %s",
-                    redact_site_id(self.site_id),
-                    current_summary,
+                attempts.append(
+                    {
+                        "source": "hems_energy_consumption",
+                        "error": last_error_text,
+                    }
                 )
-            if selected_key is None or current_key > selected_key:
-                payload = current_payload
-                requested_uid = candidate_uid
-                sample = current_sample
-                selected_key = current_key
-
-        if payload is None and last_error is not None:
-            last_error_text = (
-                redact_text(
-                    last_error,
-                    site_ids=(self.site_id,),
-                    identifiers=self._heatpump_power_redaction_identifiers(
-                        requested_uid
-                    ),
-                )
-                or last_error.__class__.__name__
-            )
-            self._heatpump_power_last_error = last_error_text
             power_snapshot["last_error"] = last_error_text
             power_snapshot["outcome"] = "fetch_error"
-            self._heatpump_power_backoff_until = now + HEATPUMP_POWER_FAILURE_BACKOFF_S
+            self._heatpump_power_last_error = last_error_text
+            self._heatpump_power_backoff_until = (
+                now + HEATPUMP_DAILY_CONSUMPTION_FAILURE_BACKOFF_S
+            )
             self._heatpump_power_cache_until = None
-            return
-
-        self._heatpump_power_cache_until = now + HEATPUMP_POWER_CACHE_TTL
-        self._heatpump_power_backoff_until = None
-        self._heatpump_power_last_error = None
-        if payload is not None:
-            self._heatpump_power_selection_marker = marker
-        self._heatpump_power_w = None
-        self._heatpump_power_sample_utc = None
-        self._heatpump_power_start_utc = None
-        self._heatpump_power_device_uid = requested_uid
-        self._heatpump_power_source = "hems_power_timeseries"
-
-        if not isinstance(payload, dict):
-            power_snapshot["outcome"] = "no_usable_payload"
-            if _LOGGER.isEnabledFor(logging.DEBUG):
-                _LOGGER.debug(
-                    "Heat pump power refresh found no usable payload for site %s: site_date=%s candidates=%s",
-                    redact_site_id(self.site_id),
-                    site_date,
-                    candidate_summaries,
-                )
-            return
-
-        payload_uid = type_member_text(payload, "device_uid", "uid")
-        if payload_uid:
-            self._heatpump_power_device_uid = payload_uid
-        if self._heatpump_power_device_uid:
-            self._heatpump_power_source = (
-                f"hems_power_timeseries:{self._heatpump_power_device_uid}"
-            )
-        selected_summary = self._heatpump_power_debug_payload_summary(
-            payload,
-            requested_uid=requested_uid,
-            sample=sample,
-            selection_key=selected_key,
-        )
-        power_snapshot["selected_payload"] = selected_summary
-        if self._heatpump_power_device_uid:
-            power_snapshot["selected_source"] = (
-                "hems_power_timeseries:"
-                f"{self._debug_truncate_identifier(self._heatpump_power_device_uid)}"
-            )
-        else:
-            power_snapshot["selected_source"] = self._heatpump_power_source
-        if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
-                "Heat pump power selected payload for site %s: %s",
+                "Heat pump power daily-consumption refresh failed for site %s: %s",
                 redact_site_id(self.site_id),
-                selected_summary,
+                last_error_text,
             )
-        if sample is None:
-            power_snapshot["outcome"] = "no_usable_sample"
             return
-        sample_index, sample_value = sample
-        self._heatpump_power_w = sample_value
-        power_snapshot["outcome"] = "selected_sample"
 
-        start_utc = parse_inverter_last_report(payload.get("start_date"))
-        self._heatpump_power_start_utc = start_utc
-        interval_minutes = coerce_optional_float(payload.get("interval_minutes"))
-        if interval_minutes is None:
-            values = payload.get("heat_pump_consumption")
-            if isinstance(values, list):
-                now_utc = dt_util.utcnow()
-                if now_utc.tzinfo is None:
-                    now_utc = now_utc.replace(tzinfo=_tz.utc)
-                interval_minutes = self._infer_heatpump_interval_minutes(
-                    start_utc,
-                    len(values),
-                    now_utc,
+        last_error_text = coerce_optional_text(
+            getattr(self, "_heatpump_daily_consumption_last_error", None)
+        )
+        if last_error_text:
+            attempts = power_snapshot.setdefault("attempts", [])
+            if isinstance(attempts, list):
+                attempts.append(
+                    {
+                        "source": "hems_energy_consumption",
+                        "error": last_error_text,
+                    }
                 )
-        if (
-            start_utc is not None
-            and interval_minutes is not None
-            and interval_minutes > 0
-            and sample_index is not None
-        ):
-            try:
-                self._heatpump_power_sample_utc = start_utc + timedelta(
-                    minutes=interval_minutes * sample_index
-                )
-            except Exception:
-                self._heatpump_power_sample_utc = None
-        elif sample_index is not None:
-            self._heatpump_power_sample_utc = dt_util.utcnow()
-        power_snapshot["selected_sample_at_utc"] = (
-            self._heatpump_power_sample_utc.isoformat()
-            if self._heatpump_power_sample_utc is not None
+            power_snapshot["last_error"] = last_error_text
+            power_snapshot["outcome"] = "fetch_error"
+            self._heatpump_power_last_error = last_error_text
+            self._heatpump_power_backoff_until = getattr(
+                self, "_heatpump_daily_consumption_backoff_until", None
+            )
+            self._heatpump_power_cache_until = None
+            _LOGGER.debug(
+                "Heat pump power daily-consumption path unavailable for site %s: %s",
+                redact_site_id(self.site_id),
+                last_error_text,
+            )
+            return
+
+        primary_power = self._heatpump_power_summary_from_daily_snapshot(
+            getattr(self, "_heatpump_daily_consumption", None)
+        )
+        if primary_power is None:
+            power_snapshot["outcome"] = "no_usable_payload"
+            self._heatpump_power_last_error = None
+            self._heatpump_power_backoff_until = None
+            self._heatpump_power_cache_until = getattr(
+                self, "_heatpump_daily_consumption_cache_until", None
+            ) or (now + HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL)
+            return
+
+        power_value, daily_summary = primary_power
+        attempts = power_snapshot.setdefault("attempts", [])
+        if isinstance(attempts, list):
+            attempts.append(dict(daily_summary))
+        self._heatpump_power_w = power_value
+        self._heatpump_power_device_uid = coerce_optional_text(
+            getattr(self, "_heatpump_daily_consumption", {}).get("device_uid")
+            if isinstance(getattr(self, "_heatpump_daily_consumption", None), dict)
             else None
         )
+        self._heatpump_power_source = (
+            str(getattr(self, "_heatpump_daily_consumption", {}).get("source")).strip()
+            if isinstance(getattr(self, "_heatpump_daily_consumption", None), dict)
+            and getattr(self, "_heatpump_daily_consumption", {}).get("source")
+            is not None
+            else "hems_energy_consumption"
+        )
+        endpoint_timestamp = parse_inverter_last_report(
+            daily_summary.get("endpoint_timestamp")
+        )
+        self._heatpump_power_sample_utc = endpoint_timestamp
+        self._heatpump_power_start_utc = None
+        if self._heatpump_power_device_uid:
+            self._heatpump_power_selection_marker = marker
+        power_snapshot["selected_payload"] = dict(daily_summary)
+        power_snapshot["selected_source"] = (
+            f"hems_energy_consumption:{self._debug_truncate_identifier(self._heatpump_power_device_uid)}"
+            if self._heatpump_power_device_uid
+            else "hems_energy_consumption"
+        )
+        power_snapshot["selected_sample_at_utc"] = (
+            endpoint_timestamp.isoformat() if endpoint_timestamp is not None else None
+        )
+        power_snapshot["outcome"] = "selected_sample"
+        self._heatpump_power_cache_until = getattr(
+            self, "_heatpump_daily_consumption_cache_until", None
+        ) or (now + HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL)
+        self._heatpump_power_backoff_until = None
+        self._heatpump_power_last_error = None
+        if _LOGGER.isEnabledFor(logging.DEBUG):
+            _LOGGER.debug(
+                "Heat pump power selected daily-consumption payload for site %s: %s",
+                redact_site_id(self.site_id),
+                daily_summary,
+            )
+        return
 
     async def async_refresh_heatpump_power(self, *, force: bool = False) -> None:
         await self._async_refresh_heatpump_power(force=force)

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -3101,9 +3101,9 @@ Inference:
 ```
 GET https://hems-integration.enphaseenergy.com/api/v1/hems/<site_id>/energy-consumption?from=<iso8601>&to=<iso8601>&timezone=<iana_tz>&step=P1D
 Headers:
-  Accept: application/json
+  Accept: application/json or */*
   Authorization: Bearer <jwt>
-  Cookie: ...; XSRF-TOKEN=<token>; ...
+  Cookie: ...; XSRF-TOKEN=<token>; BP-XSRF-Token=<token>; ...
   Origin: https://enlighten.enphaseenergy.com
   username: <user_id>
   requestId: <uuid>
@@ -3140,12 +3140,15 @@ Observed structure:
 - `type` was `hems-device-details` in the captured responses.
 - Results are grouped by HEMS family (`heat-pump`, `evse`, `water-heater`).
 - The `consumption[]` item exposes source-split totals (`solar`, `battery`, `grid`) plus a `details[]` numeric array.
-- The supplied March 28 capture returned `solar=0`, `battery=0`, `grid=0`, and `details=[987]`; earlier captures used decimal-looking values (`47.0`, `201.0`, `211.0`, `220.0`, `230.0`), so clients should treat these as generic numbers rather than fixed-format floats.
+- The supplied March 28 capture returned `solar=0`, `battery=0`, `grid=0`, and `details=[987]`; earlier captures used decimal-looking values (`47.0`, `201.0`, `211.0`, `220.0`, `230.0`), and a later idle browser capture returned `details=[3]`, so clients should treat these as generic numeric values rather than fixed-format floats.
 - In active-heating captures the `details[]` value increased across polls (`201.0`, `211.0`, `220.0`, `230.0`) while `/heatpump/<device_uid>/state` reported `heatpump-status: RUNNING`.
-- Mobile captures also included `username` and `requestId` headers; `step` was observed as `P1D`.
+- Browser captures also used `Authorization: Bearer <jwt>` together with Enlighten cookies, `username`, and `requestId`; one Safari capture additionally included `BP-XSRF-Token` and `Accept: */*`.
+- Captured browser requests used local-day bounds encoded as UTC strings, for example `from=2026-04-02T00:00:00.000Z`, `to=2026-04-02T23:59:59.999Z`, `timezone=Europe/Berlin`, `step=P1D`.
 
 Inference:
-- In the "not running" capture, `details: [47.0]` was still present even though the runtime endpoint reported `heatpump-status: IDLE`, so this endpoint should be treated as daily aggregate consumption, not instantaneous on/off state.
+- In the "not running" capture, `details: [47.0]` was still present even though the runtime endpoint reported `heatpump-status: IDLE`, so clients should not treat this endpoint as a strict on/off signal.
+- A later idle browser capture returned `details: [3]` while runtime-state still reported `IDLE`, which suggests this payload may carry a small instantaneous or near-live device reading rather than a strict zeroed idle state.
+- Running-state browser captures are still inconsistent: some observations align with current watts-style values, while others resemble larger day-accumulating totals. Consumers should therefore treat the semantics of `details[]` as observed-but-not-fully-stable and verify behavior against runtime-state and UI captures when changing parsing logic.
 
 ### 2.17.3 HEMS Supported Models Catalog
 ```

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -466,16 +466,15 @@ class DummyCoordinator(SimpleNamespace):
                 {
                     "requested_device_ref": "H...1",
                     "resolved_device_ref": "H...1",
-                    "bucket_count": 3,
-                    "non_null_bucket_count": 1,
-                    "latest_sample_w": 550.0,
+                    "detail_count": 1,
+                    "detail_value_w": 550.0,
                 }
             ],
             "selected_payload": {
                 "resolved_device_ref": "H...1",
-                "latest_sample_w": 550.0,
+                "detail_value_w": 550.0,
             },
-            "selected_source": "hems_power_timeseries:H...1",
+            "selected_source": "hems_energy_consumption:H...1",
             "selected_sample_at_utc": "2026-03-01T00:05:00+00:00",
             "last_error": None,
             "outcome": "selected_sample",
@@ -747,13 +746,13 @@ async def test_config_entry_diagnostics_includes_coordinator(
     )
     assert (
         diag["coordinator"]["heatpump_runtime"]["power_snapshot"]["selected_payload"][
-            "latest_sample_w"
+            "detail_value_w"
         ]
         == 550.0
     )
     assert (
         diag["coordinator"]["heatpump_runtime"]["power_snapshot"]["selected_source"]
-        == "hems_power_timeseries:H...1"
+        == "hems_energy_consumption:H...1"
     )
     assert diag["coordinator"]["battery_config"]["devices_inventory_payload"] == {
         "result": [{"type": "encharge"}]
@@ -1281,7 +1280,7 @@ async def test_device_diagnostics_heatpump_includes_runtime_payloads(
     )
     assert (
         result["heatpump_runtime"]["power_snapshot"]["selected_source"]
-        == "hems_power_timeseries:H...1"
+        == "hems_energy_consumption:H...1"
     )
 
 

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import time
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -151,15 +151,7 @@ async def test_heatpump_runtime_diagnostics_logs_power_refresh_failures(
 async def test_heatpump_runtime_power_failure_logs_truncated_device_uid(
     coordinator_factory, caplog
 ) -> None:
-    client = type(
-        "Client",
-        (),
-        {
-            "hems_site_supported": True,
-            "hems_power_timeseries": AsyncMock(side_effect=RuntimeError("boom")),
-        },
-    )()
-    coord = coordinator_factory(client=client, serials=[])
+    coord = coordinator_factory(serials=[])
     coord._set_type_device_buckets(  # noqa: SLF001
         {
             "heatpump": {
@@ -171,17 +163,19 @@ async def test_heatpump_runtime_power_failure_logs_truncated_device_uid(
         ["heatpump"],
     )
     coord.heatpump_runtime._async_refresh_hems_support_preflight = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
-    coord.heatpump_runtime._heatpump_power_fetch_plan = lambda: (["DEVICE-UID-123456789"], False, ())  # type: ignore[assignment]  # noqa: SLF001
     coord._devices_inventory_payload = {"curr_date_site": "2026-03-13"}  # noqa: SLF001
+    coord.client.hems_energy_consumption = AsyncMock(
+        side_effect=RuntimeError("fetch failed for HP-1")
+    )
 
     with caplog.at_level(logging.DEBUG):
         await coord.heatpump_runtime._async_refresh_heatpump_power(
             force=True
         )  # noqa: SLF001
 
-    assert "Heat pump power fetch failed" in caplog.text
-    assert "DEVICE-UID-123456789" not in caplog.text
-    assert "DEVI...6789" in caplog.text
+    assert "Heat pump power daily-consumption path unavailable for site" in caplog.text
+    assert "HP-1" not in caplog.text
+    assert "H...1" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -213,22 +207,25 @@ async def test_heatpump_runtime_power_logs_fetch_plan_and_selection_summary(
         },
         ["heatpump"],
     )
-    coord.client.hems_power_timeseries = AsyncMock(
-        side_effect=[
-            {
-                "device_uid": primary_uid,
-                "heat_pump_consumption": [None, 25.0],
-                "start_date": "2026-03-13T00:00:00Z",
-                "interval_minutes": 5,
+    coord.client.hems_energy_consumption = AsyncMock(
+        return_value={
+            "type": "hems-device-details",
+            "timestamp": "2026-03-13T00:05:00Z",
+            "data": {
+                "heat-pump": [
+                    {
+                        "device_uid": primary_uid,
+                        "device_name": "Primary",
+                        "consumption": [{"details": [550.0]}],
+                    },
+                    {
+                        "device_uid": meter_uid,
+                        "device_name": "Meter",
+                        "consumption": [{"details": [25.0]}],
+                    },
+                ]
             },
-            {
-                "device_uid": meter_uid,
-                "heat_pump_consumption": [None, 550.0],
-                "start_date": "2026-03-13T00:00:00Z",
-                "interval_minutes": 5,
-            },
-            "bad",
-        ]
+        }
     )
 
     with caplog.at_level(logging.DEBUG):
@@ -237,26 +234,23 @@ async def test_heatpump_runtime_power_logs_fetch_plan_and_selection_summary(
         )
 
     assert "Heat pump power fetch plan for site" in caplog.text
-    assert "Heat pump power candidate payload for site" in caplog.text
-    assert "Heat pump power selected payload for site" in caplog.text
-    assert "Heat pump power fetch returned unusable payload for site" in caplog.text
+    assert "Heat pump power selected daily-consumption payload for site" in caplog.text
     assert primary_uid not in caplog.text
     assert meter_uid not in caplog.text
     assert "DEVI...6789" in caplog.text
-    assert "METE...4321" in caplog.text
-    assert "'latest_sample_w': 550.0" in caplog.text
-    assert coord.heatpump_power_device_uid == meter_uid
+    assert "'detail_value_w': 550.0" in caplog.text
+    assert coord.heatpump_power_device_uid == primary_uid
     power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
         "power_snapshot"
     ]
     assert power_snapshot["compare_all"] is True
     assert power_snapshot["previous_device_ref"] is None
     assert power_snapshot["outcome"] == "selected_sample"
-    assert power_snapshot["selected_source"] == "hems_power_timeseries:METE...4321"
-    assert power_snapshot["selected_payload"]["resolved_device_ref"] == "METE...4321"
-    assert power_snapshot["selected_payload"]["latest_sample_w"] == pytest.approx(550.0)
+    assert power_snapshot["selected_source"] == "hems_energy_consumption:DEVI...6789"
+    assert power_snapshot["selected_payload"]["resolved_device_ref"] == "DEVI...6789"
+    assert power_snapshot["selected_payload"]["detail_value_w"] == pytest.approx(550.0)
     assert power_snapshot["selected_sample_at_utc"] is not None
-    assert len(power_snapshot["attempts"]) == 3
+    assert len(power_snapshot["attempts"]) == 1
 
 
 @pytest.mark.asyncio
@@ -275,31 +269,19 @@ async def test_heatpump_runtime_power_logs_when_no_candidate_payload_is_usable(
         },
         ["heatpump"],
     )
-    coord.client.hems_power_timeseries = AsyncMock(return_value="bad")
+    coord.client.hems_energy_consumption = AsyncMock(return_value=None)
 
     with caplog.at_level(logging.DEBUG):
         await coord.heatpump_runtime._async_refresh_heatpump_power(  # noqa: SLF001
             force=True
         )
 
-    assert "Heat pump power refresh found no usable payload for site" in caplog.text
     assert coord.heatpump_power_w is None
     power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
         "power_snapshot"
     ]
     assert power_snapshot["outcome"] == "no_usable_payload"
-    assert power_snapshot["attempts"] == [
-        {
-            "requested_device_ref": "H...1",
-            "payload_type": "str",
-            "usable_payload": False,
-        },
-        {
-            "requested_device_ref": None,
-            "payload_type": "str",
-            "usable_payload": False,
-        },
-    ]
+    assert power_snapshot["attempts"] == []
 
 
 @pytest.mark.asyncio
@@ -318,11 +300,11 @@ async def test_heatpump_runtime_power_snapshot_handles_selected_payload_without_
         },
         ["heatpump"],
     )
-    coord.client.hems_power_timeseries = AsyncMock(
+    coord.client.hems_energy_consumption = AsyncMock(
         return_value={
-            "heat_pump_consumption": [125.0],
-            "start_date": "2026-03-13T00:00:00Z",
-            "interval_minutes": 5,
+            "type": "hems-device-details",
+            "timestamp": "2026-03-13T00:05:00Z",
+            "data": {"heat-pump": [{"consumption": [{"details": [125.0]}]}]},
         }
     )
 
@@ -332,11 +314,11 @@ async def test_heatpump_runtime_power_snapshot_handles_selected_payload_without_
 
     assert coord.heatpump_power_w == pytest.approx(125.0)
     assert coord.heatpump_power_device_uid is None
-    assert coord.heatpump_power_source == "hems_power_timeseries"
+    assert coord.heatpump_power_source == "hems_energy_consumption"
     power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
         "power_snapshot"
     ]
-    assert power_snapshot["selected_source"] == "hems_power_timeseries"
+    assert power_snapshot["selected_source"] == "hems_energy_consumption"
 
 
 @pytest.mark.asyncio
@@ -363,10 +345,12 @@ async def test_heatpump_runtime_power_snapshot_redacts_identifier_bearing_errors
         ["heatpump"],
     )
 
-    async def _raise_fetch_error(*, device_uid=None, site_date=None):
+    async def _raise_fetch_error(
+        *, start_at=None, end_at=None, timezone=None, step=None
+    ):
         raise RuntimeError(f"fetch failed for {raw_uid} serial SERIAL-123456")
 
-    coord.client.hems_power_timeseries = _raise_fetch_error  # type: ignore[method-assign]
+    coord.client.hems_energy_consumption = _raise_fetch_error  # type: ignore[method-assign]
     coord.heatpump_runtime._async_refresh_hems_support_preflight = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
 
     await coord.heatpump_runtime._async_refresh_heatpump_power(
@@ -432,7 +416,7 @@ async def test_coordinator_heatpump_runtime_wrapper_delegation(
     runtime.heatpump_power_sample_utc = datetime(2026, 3, 27, tzinfo=timezone.utc)
     runtime.heatpump_power_start_utc = datetime(2026, 3, 27, tzinfo=timezone.utc)
     runtime.heatpump_power_device_uid = "HP-1"
-    runtime.heatpump_power_source = "hems_power_timeseries:HP-1"
+    runtime.heatpump_power_source = "hems_energy_consumption:HP-1"
     runtime.heatpump_power_last_error = "power boom"
     coord.heatpump_runtime = runtime
 
@@ -503,7 +487,7 @@ async def test_coordinator_heatpump_runtime_wrapper_delegation(
     assert coord.heatpump_power_sample_utc == datetime(2026, 3, 27, tzinfo=timezone.utc)
     assert coord.heatpump_power_start_utc == datetime(2026, 3, 27, tzinfo=timezone.utc)
     assert coord.heatpump_power_device_uid == "HP-1"
-    assert coord.heatpump_power_source == "hems_power_timeseries:HP-1"
+    assert coord.heatpump_power_source == "hems_energy_consumption:HP-1"
     assert coord.heatpump_power_last_error == "power boom"
 
     runtime._heatpump_primary_member.assert_called_once_with()
@@ -753,6 +737,132 @@ def test_heatpump_runtime_power_helper_edge_branches(monkeypatch) -> None:
     )
 
 
+def test_heatpump_runtime_power_helper_additional_coverage(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.heatpump_runtime
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 4,
+                "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-1",
+                        "pairing-status": "PAIRED",
+                        "device-state": "ACTIVE",
+                        "statusText": "Normal",
+                    },
+                    {"device_type": "ENERGY_METER", "device_uid": "MTR-1"},
+                    {"device_type": "SG_READY_GATEWAY", "device_uid": "SG-1"},
+                    {"device_type": "OTHER", "device_uid": "OT-1"},
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+
+    monkeypatch.setattr(
+        heatpump_runtime_mod.dt_util,
+        "utcnow",
+        lambda: datetime(2026, 3, 27, 2, 5, tzinfo=timezone.utc),
+    )
+    assert HeatpumpRuntime._heatpump_latest_power_sample(
+        {
+            "start_date": "2026-03-27T00:00:00Z",
+            "heat_pump_consumption": [1.0, 2.0],
+        }
+    ) == (1, 2.0)
+
+    assert (
+        coord._heatpump_power_candidate_type_rank(  # noqa: SLF001
+            {},
+            "MTR-1",
+            is_recommended=False,
+        )
+        == 0
+    )
+    assert (
+        coord._heatpump_power_candidate_type_rank(  # noqa: SLF001
+            {},
+            "MTR-1",
+            is_recommended=True,
+        )
+        == 3
+    )
+    assert (
+        coord._heatpump_power_candidate_type_rank(  # noqa: SLF001
+            {},
+            "HP-1",
+            is_recommended=True,
+        )
+        == 2
+    )
+    assert (
+        coord._heatpump_power_candidate_type_rank(  # noqa: SLF001
+            {},
+            "SG-1",
+            is_recommended=True,
+        )
+        == 1
+    )
+    assert (
+        coord._heatpump_power_candidate_type_rank(  # noqa: SLF001
+            {},
+            "OT-1",
+            is_recommended=True,
+        )
+        == 0
+    )
+
+    assert coord._heatpump_power_selection_key(  # noqa: SLF001
+        {"device_uid": "HP-1"},
+        requested_uid="REQ-1",
+        sample=None,
+    ) == (0, 0, 0, 0, float("-inf"), 1, -1)
+    assert coord._heatpump_power_selection_key(  # noqa: SLF001
+        {"uid": "MTR-1"},
+        requested_uid=None,
+        sample=(2, 0.0),
+    ) == (1, 0, 0, 0, 0.0, 1, 2)
+
+    summary = runtime._heatpump_power_debug_payload_summary(  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "heat_pump_consumption": [None, "bad", 1.0, 2.0, float("inf")],
+            "start_date": "2026-03-27T00:00:00Z",
+            "interval_minutes": "15",
+        },
+        requested_uid="REQ-1",
+        sample=(3, 2.0),
+        selection_key=(1, 1, 1, 2, 2.0, 1, 3),
+    )
+    assert summary == {
+        "requested_device_ref": "R...1",
+        "payload_device_ref": "H...1",
+        "resolved_device_ref": "H...1",
+        "member_device_type": "HEAT_PUMP",
+        "pairing_status": "PAIRED",
+        "device_state": "ACTIVE",
+        "status": "Normal",
+        "recommended": False,
+        "bucket_count": 5,
+        "non_null_bucket_count": 3,
+        "sample_tail": [
+            {"index": 4, "value_w": float("inf")},
+            {"index": 3, "value_w": 2.0},
+            {"index": 2, "value_w": 1.0},
+        ],
+        "latest_sample_index": 3,
+        "latest_sample_w": 2.0,
+        "start_date": "2026-03-27T00:00:00Z",
+        "interval_minutes": 15.0,
+        "selection_key": [1, 1, 1, 2, 2.0, 1, 3],
+    }
+
+
 @pytest.mark.asyncio
 async def test_heatpump_runtime_diagnostics_and_refresh_edge_branches(
     coordinator_factory, monkeypatch
@@ -815,17 +925,21 @@ async def test_heatpump_runtime_diagnostics_and_refresh_edge_branches(
     assert coord.heatpump_runtime_diagnostics()["show_livestream_payload"] is None
     assert coord.heatpump_runtime_diagnostics()["last_error"] == "live boom"
 
+    runtime._async_refresh_heatpump_daily_consumption = HeatpumpRuntime._async_refresh_heatpump_daily_consumption.__get__(  # type: ignore[method-assign]  # noqa: SLF001
+        runtime, HeatpumpRuntime
+    )
+
     runtime._heatpump_power_cache_until = time.monotonic() + 60  # noqa: SLF001
-    coord.client.hems_power_timeseries = AsyncMock(
+    coord.client.hems_energy_consumption = AsyncMock(
         side_effect=AssertionError("no fetch")
     )
     await runtime.async_refresh_heatpump_power()
-    coord.client.hems_power_timeseries.assert_not_awaited()
+    coord.client.hems_energy_consumption.assert_not_awaited()
 
     runtime._heatpump_power_cache_until = None  # noqa: SLF001
     runtime._heatpump_power_backoff_until = time.monotonic() + 60  # noqa: SLF001
     await runtime.async_refresh_heatpump_power()
-    coord.client.hems_power_timeseries.assert_not_awaited()
+    coord.client.hems_energy_consumption.assert_not_awaited()
 
     runtime._heatpump_power_backoff_until = None  # noqa: SLF001
     coord.client._hems_site_supported = False  # noqa: SLF001
@@ -833,51 +947,31 @@ async def test_heatpump_runtime_diagnostics_and_refresh_edge_branches(
     assert coord.heatpump_power_source is None
 
     coord.client._hems_site_supported = True  # noqa: SLF001
-    coord.client.hems_power_timeseries = None
-    await runtime.async_refresh_heatpump_power(force=True)
-
-    coord.client.hems_power_timeseries = AsyncMock(return_value="bad")
+    coord.client.hems_energy_consumption = None
     await runtime.async_refresh_heatpump_power(force=True)
     assert coord.heatpump_power_w is None
 
-    coord.client.hems_power_timeseries = AsyncMock(
-        return_value={"device_uid": "HP-1", "heat_pump_consumption": [None]}
-    )
+    coord.client.hems_energy_consumption = AsyncMock(return_value=None)
     await runtime.async_refresh_heatpump_power(force=True)
     assert coord.heatpump_power_w is None
 
-    monkeypatch.setattr(
-        heatpump_runtime_mod.dt_util, "utcnow", lambda: datetime(2026, 3, 27, 12, 0)
-    )
-    monkeypatch.setattr(
-        heatpump_runtime_mod,
-        "timedelta",
-        lambda **kwargs: (_ for _ in ()).throw(OverflowError("boom")),
-    )
-    coord.client.hems_power_timeseries = AsyncMock(
+    coord.client.hems_energy_consumption = AsyncMock(
         return_value={
-            "device_uid": "HP-1",
-            "start_date": "2026-03-27T00:00:00Z",
-            "interval_minutes": 60,
-            "heat_pump_consumption": [1.0],
+            "type": "hems-device-details",
+            "timestamp": "bad",
+            "data": {
+                "heat-pump": [
+                    {
+                        "device_uid": "HP-1",
+                        "consumption": [{"details": [None]}],
+                    }
+                ]
+            },
         }
     )
     await runtime.async_refresh_heatpump_power(force=True)
+    assert coord.heatpump_power_w == pytest.approx(0.0)
     assert coord.heatpump_power_sample_utc is None
-
-    monkeypatch.setattr(
-        heatpump_runtime_mod.dt_util, "utcnow", lambda: datetime(2026, 3, 27, 12, 0)
-    )
-    monkeypatch.setattr(heatpump_runtime_mod, "timedelta", timedelta)
-    coord.client.hems_power_timeseries = AsyncMock(
-        return_value={
-            "device_uid": "HP-1",
-            "start_date": "2026-03-27T00:00:00Z",
-            "heat_pump_consumption": [1.0],
-        }
-    )
-    await runtime.async_refresh_heatpump_power(force=True)
-    assert coord.heatpump_power_sample_utc is not None
 
     class BadFloat:
         def __float__(self) -> float:
@@ -897,6 +991,16 @@ async def test_heatpump_runtime_diagnostics_and_refresh_edge_branches(
     assert coerce_optional_bool("disabled") is False
     assert coerce_optional_bool(None) is None
     assert type_member_text(None, "name") is None
+    assert HeatpumpRuntime._first_optional_numeric_value("bad") is None
+    assert (
+        HeatpumpRuntime._first_optional_numeric_value(
+            [None, "bad", float("inf"), float("nan")]
+        )
+        is None
+    )
+    assert HeatpumpRuntime._first_optional_numeric_value(
+        [None, "2.5"]
+    ) == pytest.approx(2.5)
 
 
 def test_heatpump_runtime_recommended_parent_matching(coordinator_factory) -> None:
@@ -1008,6 +1112,7 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
 ) -> None:
     coord = coordinator_factory(serials=[])
     coord._devices_inventory_payload = {"curr_date_site": "2026-03-13"}  # noqa: SLF001
+    coord._battery_timezone = "UTC"  # noqa: SLF001
     coord._set_type_device_buckets(  # noqa: SLF001
         {
             "heatpump": {
@@ -1024,11 +1129,19 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
         },
         ["heatpump"],
     )
-    coord.client.hems_power_timeseries = AsyncMock(
+    coord.client.hems_energy_consumption = AsyncMock(
         return_value={
-            "heat_pump_consumption": [None, 400.0, "500.5", None],
-            "start_date": "2026-02-27T00:00:00Z",
-            "interval_minutes": 5,
+            "type": "hems-device-details",
+            "timestamp": "2026-02-27T00:10:00Z",
+            "data": {
+                "heat-pump": [
+                    {
+                        "device_uid": "HP-1",
+                        "device_name": "Waermepumpe",
+                        "consumption": [{"details": [500.5, None]}],
+                    }
+                ]
+            },
         }
     )
 
@@ -1038,17 +1151,21 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
 
     assert coord.heatpump_power_w == pytest.approx(500.5)
     assert coord.heatpump_power_device_uid == "HP-1"
-    assert coord.heatpump_power_source == "hems_power_timeseries:HP-1"
-    assert coord.heatpump_power_start_utc is not None
+    assert coord.heatpump_power_source == "hems_energy_consumption:HP-1"
+    assert coord.heatpump_power_start_utc is None
     assert coord.heatpump_power_sample_utc is not None
     assert coord.heatpump_power_last_error is None
     assert coord._heatpump_power_cache_until is not None  # noqa: SLF001
-    first_call = coord.client.hems_power_timeseries.await_args_list[0]
-    assert first_call.kwargs["device_uid"] == "HP-1"
-    assert first_call.kwargs["site_date"] == "2026-03-13"
+    assert (
+        coord._heatpump_power_cache_until
+        == coord._heatpump_daily_consumption_cache_until
+    )  # noqa: SLF001
+    first_call = coord.client.hems_energy_consumption.await_args_list[0]
+    assert first_call.kwargs["timezone"] == "UTC"
+    assert first_call.kwargs["step"] == "P1D"
 
     coord._heatpump_power_cache_until = None  # noqa: SLF001
-    coord.client.hems_power_timeseries = AsyncMock(side_effect=RuntimeError("boom"))
+    coord.client.hems_energy_consumption = AsyncMock(side_effect=RuntimeError("boom"))
     await coord.heatpump_runtime._async_refresh_heatpump_power(
         force=True
     )  # noqa: SLF001
@@ -1061,6 +1178,83 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
     )  # noqa: SLF001
     assert coord.heatpump_power_w is None
     assert coord.heatpump_power_source is None
+
+
+@pytest.mark.asyncio
+async def test_refresh_heatpump_power_prefers_energy_consumption_details(
+    coordinator_factory, caplog
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._devices_inventory_payload = {"curr_date_site": "2026-04-02"}  # noqa: SLF001
+    coord._battery_timezone = "Europe/Berlin"  # noqa: SLF001
+    coord._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-1",
+                        "statusText": "Normal",
+                    }
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    coord.client.hems_energy_consumption = AsyncMock(
+        return_value={
+            "type": "hems-device-details",
+            "timestamp": "2026-04-01T22:31:12.407610009Z",
+            "data": {
+                "heat-pump": [
+                    {
+                        "device_uid": "HP-1",
+                        "device_name": "Waermepumpe",
+                        "consumption": [
+                            {
+                                "solar": 0,
+                                "battery": 0,
+                                "grid": 0,
+                                "details": [3],
+                            }
+                        ],
+                    }
+                ]
+            },
+        }
+    )
+    coord.client.hems_power_timeseries = AsyncMock(
+        side_effect=AssertionError("timeseries should not be used")
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        await coord.heatpump_runtime._async_refresh_heatpump_power(
+            force=True
+        )  # noqa: SLF001
+
+    assert coord.heatpump_power_w == pytest.approx(3.0)
+    assert coord.heatpump_power_device_uid == "HP-1"
+    assert coord.heatpump_power_source == "hems_energy_consumption:HP-1"
+    assert coord.heatpump_power_sample_utc == datetime(
+        2026, 4, 1, 22, 31, 12, 407610, tzinfo=timezone.utc
+    )
+    coord.client.hems_power_timeseries.assert_not_awaited()
+    power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
+        "power_snapshot"
+    ]
+    assert power_snapshot["outcome"] == "selected_sample"
+    assert power_snapshot["selected_source"] == "hems_energy_consumption:H...1"
+    assert power_snapshot["selected_payload"]["detail_value_w"] == pytest.approx(3.0)
+    assert "Heat pump power selected daily-consumption payload for site" in caplog.text
+
+    coord._heatpump_daily_consumption = {"details": ["bad", None]}  # noqa: SLF001
+    summary = coord.heatpump_runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        coord._heatpump_daily_consumption  # noqa: SLF001
+    )
+    assert summary is not None
+    assert summary[0] == pytest.approx(0.0)
 
 
 @pytest.mark.asyncio
@@ -1770,34 +1964,48 @@ async def test_heatpump_runtime_power_and_diagnostics_paths(
         },
         ["heatpump"],
     )
-
-    coord.client.hems_power_timeseries = AsyncMock(
-        side_effect=[
-            {"device_uid": "HP-CTRL", "heat_pump_consumption": [610.0]},
-            {"device_uid": "HP-METER", "heat_pump_consumption": [550.0]},
-            {"device_uid": "HP-SG", "heat_pump_consumption": [None]},
-            {"heat_pump_consumption": [725.0]},
-        ]
+    coord.client.hems_energy_consumption = AsyncMock(
+        return_value={
+            "type": "hems-device-details",
+            "timestamp": "2026-03-13T00:05:00Z",
+            "data": {
+                "heat-pump": [
+                    {
+                        "device_uid": "HP-CTRL",
+                        "device_name": "Primary",
+                        "consumption": [{"details": [610.0]}],
+                    }
+                ]
+            },
+        }
     )
     await runtime._async_refresh_heatpump_power(force=True)  # noqa: SLF001
-    assert coord.heatpump_power_w == pytest.approx(550.0)
-    assert coord.heatpump_power_device_uid == "HP-METER"
+    assert coord.heatpump_power_w == pytest.approx(610.0)
+    assert coord.heatpump_power_device_uid == "HP-CTRL"
 
     runtime._heatpump_power_cache_until = None  # noqa: SLF001
     runtime._heatpump_power_selection_marker = (
         runtime._heatpump_power_inventory_marker()
     )  # noqa: SLF001
     runtime._heatpump_power_device_uid = "HP-CTRL"  # noqa: SLF001
-    coord.client.hems_power_timeseries = AsyncMock(
-        side_effect=[
-            {"device_uid": "HP-CTRL", "heat_pump_consumption": [0.0]},
-            {"device_uid": "HP-METER", "heat_pump_consumption": [140.0]},
-            {"heat_pump_consumption": [360.0]},
-        ]
+    coord.client.hems_energy_consumption = AsyncMock(
+        return_value={
+            "type": "hems-device-details",
+            "timestamp": "2026-03-13T00:10:00Z",
+            "data": {
+                "heat-pump": [
+                    {
+                        "device_uid": "HP-CTRL",
+                        "device_name": "Primary",
+                        "consumption": [{"details": [0.0]}],
+                    }
+                ]
+            },
+        }
     )
     await runtime._async_refresh_heatpump_power(force=True)  # noqa: SLF001
-    assert coord.heatpump_power_w == pytest.approx(140.0)
-    assert coord.heatpump_power_device_uid == "HP-METER"
+    assert coord.heatpump_power_w == pytest.approx(0.0)
+    assert coord.heatpump_power_device_uid == "HP-CTRL"
 
     runtime._heatpump_runtime_diagnostics_cache_until = (
         time.monotonic() + 60

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -1876,7 +1876,7 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
         2026, 2, 27, 0, 0, tzinfo=timezone.utc
     )  # noqa: SLF001
     coord._heatpump_power_device_uid = "HP-1"  # noqa: SLF001
-    coord._heatpump_power_source = "hems_power_timeseries:HP-1"  # noqa: SLF001
+    coord._heatpump_power_source = "hems_energy_consumption:HP-1"  # noqa: SLF001
     coord._heatpump_power_last_error = None  # noqa: SLF001
     coord._heatpump_runtime_state = {  # noqa: SLF001
         "device_uid": "HP-1",
@@ -1951,7 +1951,7 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
     assert power_sensor.native_value == pytest.approx(863.2)
     power_attrs = power_sensor.extra_state_attributes
     assert power_attrs["device_uid"] == "HP-1"
-    assert power_attrs["source"] == "hems_power_timeseries:HP-1"
+    assert power_attrs["source"] == "hems_energy_consumption:HP-1"
 
 
 def test_heatpump_power_sensor_unavailable_without_sample(coordinator_factory) -> None:


### PR DESCRIPTION
## Summary

Use the HEMS `energy-consumption` payload as the sole heat-pump power source, align the power refresh cadence to the existing 300-second HEMS cache, and treat missing `details[]` values as `0 W`.

Related to #443.

## Related Issues

- #443

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_diagnostics.py tests/components/enphase_ev/test_sensor_additional_coverage.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q -k 'not test_async_update_data_success_enriches_payload' && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/heatpump_runtime.py --fail-under=100"
git diff --check
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Updates the HEMS API notes with the newer browser-observed `energy-consumption` request/response details and the mixed observed `details[]` semantics.
- Keeps diagnostics sources redacted while preserving the raw internal source identifier used by entities.
