### PR TITLE
Fix BatteryConfig schedule family writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to this project will be documented in this file.
 - Kept `Self-Consumption` available in the system profile selector even on sites where Enphase reports `showChargeFromGrid: false`, fixing automations that switch away from `Full Backup`.
 - Preserved Green mode from the live EVSE schedule summary when Enphase temporarily omits the scheduler preference, keeping `preferred_mode` and the charge-mode select stable instead of dropping to `null`/`unknown`.
 - Switched heat-pump power to use the HEMS `energy-consumption` device reading as the sole source, aligned its refresh cadence to the existing 300-second HEMS daily-consumption cache, and treated missing or null `details[]` values as `0 W`.
+- Made BatteryConfig schedule XSRF preflight family-aware for create, update, and delete flows so DTG/RBD schedule writes do not validate against the CFG family first.
+- Preserved explicitly disabled DTG/RBD schedule state during ordinary time/limit edits while still avoiding unnecessary `isEnabled` writes for other schedule edit flows.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2034,7 +2034,7 @@ class EnphaseEVClient:
                 return token
         return None
 
-    async def _acquire_xsrf_token(self) -> str | None:
+    async def _acquire_xsrf_token(self, schedule_type: str = "cfg") -> str | None:
         """Acquire a BP-XSRF-Token by POSTing to the schedules isValid endpoint.
 
         The Enphase BatteryConfig API requires an XSRF token for write operations.
@@ -2063,7 +2063,7 @@ class EnphaseEVClient:
         if cookie:
             headers["Cookie"] = cookie
         payload = {
-            "scheduleType": "cfg",
+            "scheduleType": str(schedule_type).lower(),
             "forceScheduleOpted": True,
         }
 
@@ -2507,9 +2507,10 @@ class EnphaseEVClient:
                             data_payload = kwargs.get("data")
                             if isinstance(json_payload, dict):
                                 payload_summary = {
+                                    "scheduleType": json_payload.get("scheduleType"),
                                     "json_keys": sorted(
                                         str(key) for key in json_payload.keys()
-                                    )
+                                    ),
                                 }
                             elif isinstance(json_payload, list):
                                 key_union: set[str] = set()
@@ -3347,7 +3348,7 @@ class EnphaseEVClient:
             timezone: IANA timezone string.
         """
 
-        await self._acquire_xsrf_token()
+        await self._acquire_xsrf_token(schedule_type)
 
         try:
             url = (
@@ -3399,7 +3400,7 @@ class EnphaseEVClient:
             timezone: IANA timezone string.
         """
 
-        await self._acquire_xsrf_token()
+        await self._acquire_xsrf_token(schedule_type)
 
         try:
             url = (
@@ -3425,13 +3426,18 @@ class EnphaseEVClient:
         finally:
             self._bp_xsrf_token = None
 
-    async def delete_battery_schedule(self, schedule_id: str | int) -> dict:
+    async def delete_battery_schedule(
+        self,
+        schedule_id: str | int,
+        *,
+        schedule_type: str = "cfg",
+    ) -> dict:
         """Delete a battery schedule by ID.
 
         POST /service/batteryConfig/api/v1/battery/sites/{site_id}/schedules/{id}/delete
         """
 
-        await self._acquire_xsrf_token()
+        await self._acquire_xsrf_token(schedule_type)
 
         try:
             url = (

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -3197,7 +3197,7 @@ class BatteryRuntime:
                 start_minutes=next_start,
                 end_minutes=next_end,
                 limit=next_limit,
-                is_enabled=current_enabled,
+                is_enabled=False if current_enabled is False else None,
             )
         setattr(state, self._battery_schedule_start_attr(schedule_type), next_start)
         setattr(state, self._battery_schedule_end_attr(schedule_type), next_end)
@@ -3247,7 +3247,7 @@ class BatteryRuntime:
                 start_minutes=current_start,
                 end_minutes=current_end,
                 limit=int(limit),
-                is_enabled=current_enabled,
+                is_enabled=False if current_enabled is False else None,
             )
         setattr(state, self._battery_schedule_limit_attr(schedule_type), int(limit))
         setattr(state, self._battery_schedule_start_attr(schedule_type), current_start)

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -1160,7 +1160,7 @@ async def test_json_logs_batteryconfig_write_failure_details(caplog) -> None:
         "BatteryConfig write failed for PUT "
         "/service/batteryConfig/api/v1/batterySettings/SITE: status=403" in caplog.text
     )
-    assert "payload={'json_keys': ['veryLowSoc']}" in caplog.text
+    assert "payload={'scheduleType': None, 'json_keys': ['veryLowSoc']}" in caplog.text
     assert "cookie_names=['bp-xsrf-token', 'other', 'session']" in caplog.text
     assert "'has_authorization': True" in caplog.text
     assert "'has_e_auth_token': True" in caplog.text
@@ -1195,6 +1195,34 @@ async def test_json_logs_batteryconfig_write_failure_without_params(caplog) -> N
 
     assert "BatteryConfig write failed for POST" in caplog.text
     assert "params=None" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_json_logs_battery_schedule_write_failure_includes_schedule_type(
+    caplog,
+) -> None:
+    session = _FakeSession([_FakeResponse(status=403, json_body={}, text_body="deny")])
+    client = _make_client(session)
+
+    with caplog.at_level(logging.DEBUG):
+        with pytest.raises(aiohttp.ClientResponseError):
+            await client._json(
+                "PUT",
+                "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/"
+                "battery/sites/SITE/schedules/sched-1",
+                json={
+                    "scheduleType": "DTG",
+                    "startTime": "07:15",
+                    "endTime": "09:45",
+                    "days": [2, 6],
+                },
+            )
+
+    assert "BatteryConfig write failed for PUT" in caplog.text
+    assert (
+        "payload={'scheduleType': 'DTG', 'json_keys': ['days', 'endTime', 'scheduleType', 'startTime']}"
+        in caplog.text
+    )
 
 
 @pytest.mark.asyncio
@@ -2930,7 +2958,7 @@ async def test_set_battery_settings_payload_and_xsrf() -> None:
 
 
 @pytest.mark.asyncio
-async def test_acquire_xsrf_token_uses_cfg_validation_payload() -> None:
+async def test_acquire_xsrf_token_uses_requested_validation_payload() -> None:
     token = _make_token({"user_id": "88"})
     response = _FakeResponse(status=200, json_body={"isValid": True})
     response.headers = CIMultiDict(
@@ -2943,7 +2971,7 @@ async def test_acquire_xsrf_token_uses_cfg_validation_payload() -> None:
         cookie="session=1; BP-XSRF-Token=stale-token; other=1",
     )
 
-    out = await client._acquire_xsrf_token()  # noqa: SLF001
+    out = await client._acquire_xsrf_token("dtg")  # noqa: SLF001
 
     assert out == "fresh-token"
     method, url, kwargs = session.calls[0]
@@ -2952,7 +2980,7 @@ async def test_acquire_xsrf_token_uses_cfg_validation_payload() -> None:
         "/service/batteryConfig/api/v1/battery/sites/SITE/schedules/isValid"
     )
     assert kwargs["json"] == {
-        "scheduleType": "cfg",
+        "scheduleType": "dtg",
         "forceScheduleOpted": True,
     }
     assert kwargs["headers"]["Cookie"] == "session=1; other=1"
@@ -3076,7 +3104,7 @@ async def test_battery_schedule_crud_methods_build_requests() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"message": "success"})
 
-    async def _acquire() -> str:
+    async def _acquire(*_args: object) -> str:
         client._bp_xsrf_token = "fresh-token"  # noqa: SLF001
         return "fresh-token"
 
@@ -3091,7 +3119,7 @@ async def test_battery_schedule_crud_methods_build_requests() -> None:
         timezone="Europe/Lisbon",
     )
     client._bp_xsrf_token = None  # noqa: SLF001
-    await client.delete_battery_schedule("sched-1")
+    await client.delete_battery_schedule("sched-1", schedule_type="rbd")
     await client.validate_battery_schedule("dtg")
 
     create_call, delete_call, validate_call = client._json.await_args_list
@@ -3107,11 +3135,13 @@ async def test_battery_schedule_crud_methods_build_requests() -> None:
         "scheduleType": "CFG",
         "days": [1, 7],
     }
+    assert client._acquire_xsrf_token.await_args_list[0].args == ("cfg",)
     assert delete_call.args == (
         "POST",
         "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/battery/sites/SITE/schedules/sched-1/delete",
     )
     assert delete_call.kwargs["json"] == {}
+    assert client._acquire_xsrf_token.await_args_list[1].args == ("rbd",)
     assert validate_call.args == (
         "POST",
         "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/battery/sites/SITE/schedules/isValid",
@@ -3130,7 +3160,7 @@ async def test_create_battery_schedule_omits_optional_limit_and_sets_is_enabled(
     client = _make_client()
     client._json = AsyncMock(return_value={"message": "success"})
 
-    async def _acquire() -> str:
+    async def _acquire(*_args: object) -> str:
         client._bp_xsrf_token = "fresh-token"  # noqa: SLF001
         return "fresh-token"
 
@@ -3147,6 +3177,7 @@ async def test_create_battery_schedule_omits_optional_limit_and_sets_is_enabled(
     )
 
     call = client._json.await_args
+    client._acquire_xsrf_token.assert_awaited_once_with("rbd")
     assert call.kwargs["json"] == {
         "timezone": "Europe/London",
         "startTime": "01:00",
@@ -3164,7 +3195,7 @@ async def test_update_battery_schedule_sets_optional_is_enabled_and_is_deleted()
     client = _make_client()
     client._json = AsyncMock(return_value={"message": "success"})
 
-    async def _acquire() -> str:
+    async def _acquire(*_args: object) -> str:
         client._bp_xsrf_token = "fresh-token"  # noqa: SLF001
         return "fresh-token"
 
@@ -3183,6 +3214,7 @@ async def test_update_battery_schedule_sets_optional_is_enabled_and_is_deleted()
     )
 
     call = client._json.await_args
+    client._acquire_xsrf_token.assert_awaited_once_with("rbd")
     assert call.kwargs["json"] == {
         "timezone": "Europe/London",
         "startTime": "01:00",
@@ -3199,7 +3231,7 @@ async def test_update_battery_schedule_builds_request_and_clears_xsrf() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"message": "success"})
 
-    async def _acquire() -> str:
+    async def _acquire(*_args: object) -> str:
         client._bp_xsrf_token = "fresh-token"  # noqa: SLF001
         return "fresh-token"
 
@@ -3216,7 +3248,7 @@ async def test_update_battery_schedule_builds_request_and_clears_xsrf() -> None:
     )
 
     assert out == {"message": "success"}
-    client._acquire_xsrf_token.assert_awaited_once_with()
+    client._acquire_xsrf_token.assert_awaited_once_with("dtg")
     args, kwargs = client._json.await_args
     assert args == (
         "PUT",

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -2170,7 +2170,7 @@ async def test_dtg_schedule_enabled_uses_in_place_put(
 
 
 @pytest.mark.asyncio
-async def test_dtg_schedule_time_update_uses_existing_enabled_state(
+async def test_dtg_schedule_time_update_omits_enabled_flag(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -2183,8 +2183,22 @@ async def test_dtg_schedule_time_update_uses_existing_enabled_state(
     assert call.kwargs["schedule_type"] == "DTG"
     assert call.kwargs["start_time"] == "17:30"
     assert call.kwargs["end_time"] == "23:00"
-    assert call.kwargs["is_enabled"] is True
+    assert call.kwargs["is_enabled"] is None
     assert coord._battery_dtg_begin_time == 1050  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_dtg_schedule_time_update_preserves_disabled_state(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_schedule_family(coord, "dtg")
+    coord._battery_dtg_schedule_enabled = False  # noqa: SLF001
+
+    await coord.async_set_discharge_to_grid_schedule_time(start=dt_time(17, 30))
+
+    call = coord.client.update_battery_schedule.await_args
+    assert call.kwargs["is_enabled"] is False
 
 
 @pytest.mark.asyncio
@@ -2203,8 +2217,22 @@ async def test_rbd_schedule_limit_update_uses_in_place_put(
     assert call.kwargs["end_time"] == "16:00"
     assert call.kwargs["limit"] == 80
     assert call.kwargs["timezone"] == "Europe/London"
-    assert call.kwargs["is_enabled"] is True
+    assert call.kwargs["is_enabled"] is None
     assert coord._battery_rbd_schedule_limit == 80  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_rbd_schedule_limit_update_preserves_disabled_state(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_schedule_family(coord, "rbd")
+    coord._battery_rbd_schedule_enabled = False  # noqa: SLF001
+
+    await coord.async_set_restrict_battery_discharge_schedule_limit(80)
+
+    call = coord.client.update_battery_schedule.await_args
+    assert call.kwargs["is_enabled"] is False
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Tighten BatteryConfig schedule write handling for issue #460 by validating XSRF tokens against the actual schedule family for create, update, and delete flows, and by preserving a known disabled DTG/RBD schedule state during ordinary time and limit edits.

## Related Issues

- https://github.com/barneyonline/ha-enphase-energy/issues/460

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_battery_runtime_settings.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_battery_runtime_settings.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_battery_runtime_settings.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/battery_runtime.py --fail-under=100"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The remaining `403 Forbidden` reports on issue #460 showed fully populated auth/XSRF headers but still failed on schedule-family `PUT` requests.
- This change keeps the XSRF preflight aligned with the actual schedule family and avoids dropping a known disabled schedule state during ordinary DTG/RBD edits.
