### PR TITLE
Prepare release 2.6.7 and add security policy

### DIFF
--- a/.github/workflows/service-status.yml
+++ b/.github/workflows/service-status.yml
@@ -2,7 +2,7 @@ name: Service status
 
 on:
   schedule:
-    - cron: "0 * * * *"
+    - cron: "*/30 * * * *"
   workflow_dispatch:
 
 permissions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,45 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- Kept `Self-Consumption` available in the system profile selector even on sites where Enphase reports `showChargeFromGrid: false`, fixing automations that switch away from `Full Backup`.
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v2.6.7 - 2026-04-02
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
 - Preserved Green mode from the live EVSE schedule summary when Enphase temporarily omits the scheduler preference, keeping `preferred_mode` and the charge-mode select stable instead of dropping to `null`/`unknown`.
 - Switched heat-pump power to use the HEMS `energy-consumption` device reading as the sole source, aligned its refresh cadence to the existing 300-second HEMS daily-consumption cache, and treated missing or null `details[]` values as `0 W`.
 - Made BatteryConfig schedule XSRF preflight family-aware for create, update, and delete flows so DTG/RBD schedule writes do not validate against the CFG family first.
 - Preserved explicitly disabled DTG/RBD schedule state during ordinary time/limit edits while still avoiding unnecessary `isEnabled` writes for other schedule edit flows.
+- Safely prune stale managed button, number, select, switch, and time entities when they no longer belong to the active Enphase inventory so orphaned helpers do not linger after device changes.
+
+### 🔧 Improvements
+- Run the service-status workflow every 30 minutes instead of hourly so the published status badge and history update more quickly.
+
+### 🔄 Other changes
+- None
+
+## v2.6.6 - 2026-03-31
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Kept `Self-Consumption` available in the system profile selector even on sites where Enphase reports `showChargeFromGrid: false`, fixing automations that switch away from `Full Backup`.
 
 ### 🔧 Improvements
 - None

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,39 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are only guaranteed for the latest published release and the current `main` branch.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest release | Yes |
+| `main` | Yes |
+| Older releases | No |
+
+If you are running an older release, update to the latest published version before reporting a security issue unless the issue prevents you from upgrading safely.
+
+## Reporting a Vulnerability
+
+Do not open public GitHub issues, discussions, or pull requests for suspected security vulnerabilities.
+
+Use GitHub's private vulnerability reporting for this repository:
+
+1. Open the repository's `Security` tab.
+2. Choose `Report a vulnerability`.
+3. Include a clear description of the issue, affected versions, impact, and reproduction steps.
+4. Attach sanitized logs, diagnostics, screenshots, or sample payloads if they help explain the issue.
+
+Please include:
+
+- The integration version and Home Assistant version.
+- The affected device types or Enphase features.
+- Any required configuration or environment details.
+- Whether the issue exposes credentials, tokens, personal data, or device control.
+- Any mitigation you have already confirmed.
+
+Response targets:
+
+- Initial triage response within 7 days.
+- Status updates at least every 14 days while the report is being investigated.
+
+If the report is accepted, the maintainer will work on a fix, prepare a release, and coordinate disclosure timing when needed. If the report is declined, you will receive a short explanation so you can decide whether to provide more detail or pursue a non-security bug report instead.

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.6.6"
+  "version": "2.6.7"
 }


### PR DESCRIPTION
## Summary

Prepare the `2.6.7` release metadata and add a repository security policy.

This updates the integration manifest to `2.6.7`, reconciles the changelog entries for `v2.6.6` and `v2.6.7`, adds a root `SECURITY.md`, and increases the service-status workflow cadence from hourly to every 30 minutes.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Commands run:

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/scripts/test_service_status.py"
```

Additional validation:
- Verified the changelog contents against commits since `v2.6.6`.
- Verified the manifest version bump and workflow cron update in the git diff.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- `SECURITY.md` now documents that only the latest release and `main` are supported for security fixes.
- The service-status workflow schedule changed in `.github/workflows/service-status.yml`; no integration runtime polling interval changed.
