### PR TITLE
Add EVSE resume diagnostics and provenance tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 - Aligned EVSE, site energy, heat-pump, inverter, and battery power/energy entities around stable sample timestamps, stopped synthesizing EVSE measurement time from poll time when the upstream sample time is missing, and moved EVSE power derivation onto refresh-time coordinator snapshots so power and energy readings stay internally consistent.
 
 ### 🔧 Improvements
-- None
+- Added targeted EVSE diagnostics for charger connector transitions, including charge-mode source, charge-current source, and recent transition snapshots to make Green-mode resume issues easier to capture from a single diagnostics export.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -765,6 +765,101 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 return False
         return None
 
+    @staticmethod
+    def _snapshot_text(value: object) -> str | None:
+        if value is None:
+            return None
+        try:
+            text = str(value).strip()
+        except Exception:  # noqa: BLE001
+            return None
+        return text or None
+
+    def _record_evse_transition_snapshot(
+        self,
+        serial: str,
+        previous: dict[str, object] | None,
+        current: dict[str, object],
+    ) -> None:
+        prev_status = self._snapshot_text(
+            previous.get("connector_status") if isinstance(previous, dict) else None
+        )
+        cur_status = self._snapshot_text(current.get("connector_status"))
+        if prev_status is None or cur_status is None or prev_status == cur_status:
+            return
+
+        snapshot = {
+            "recorded_at_utc": dt_util.utcnow().isoformat(),
+            "from_connector_status": prev_status,
+            "to_connector_status": cur_status,
+            "charging": self._snapshot_bool(current.get("charging")),
+            "previous_charging": self._snapshot_bool(
+                previous.get("charging") if isinstance(previous, dict) else None
+            ),
+            "charge_mode": self._snapshot_text(current.get("charge_mode")),
+            "charge_mode_source": self._snapshot_text(
+                current.get("charge_mode_source")
+            ),
+            "charge_mode_pref": self._snapshot_text(current.get("charge_mode_pref")),
+            "charge_mode_pref_source": self._snapshot_text(
+                current.get("charge_mode_pref_source")
+            ),
+            "charging_level": helper_coerce_optional_int(current.get("charging_level")),
+            "charging_level_source": self._snapshot_text(
+                current.get("charging_level_source")
+            ),
+            "last_set_amps": helper_coerce_optional_int(self.last_set_amps.get(serial)),
+            "green_battery_enabled": self._snapshot_bool(
+                current.get("green_battery_enabled")
+            ),
+            "safe_limit_state": helper_coerce_optional_int(
+                current.get("safe_limit_state")
+            ),
+            "schedule_type": self._snapshot_text(current.get("schedule_type")),
+            "sampled_at_utc": self._snapshot_text(current.get("sampled_at_utc")),
+            "fetched_at_utc": self._snapshot_text(current.get("fetched_at_utc")),
+            "scheduler_available": self.scheduler_available,
+            "scheduler_backoff_active": self.scheduler_backoff_active(),
+        }
+
+        history = list(self.evse_state._evse_transition_snapshots.get(serial, []))
+        history.append(snapshot)
+        self.evse_state._evse_transition_snapshots[serial] = history[-8:]
+
+        _LOGGER.debug(
+            "EVSE connector transition for charger %s: %s -> %s "
+            "(charging=%s, charge_mode=%s[%s], preferred_mode=%s[%s], "
+            "charging_level=%s[%s], green_battery_enabled=%s, safe_limit_state=%s, "
+            "scheduler_available=%s, scheduler_backoff_active=%s)",
+            self._debug_truncate_identifier(serial) or "[unknown]",
+            prev_status,
+            cur_status,
+            snapshot["charging"],
+            snapshot["charge_mode"],
+            snapshot["charge_mode_source"],
+            snapshot["charge_mode_pref"],
+            snapshot["charge_mode_pref_source"],
+            snapshot["charging_level"],
+            snapshot["charging_level_source"],
+            snapshot["green_battery_enabled"],
+            snapshot["safe_limit_state"],
+            snapshot["scheduler_available"],
+            snapshot["scheduler_backoff_active"],
+        )
+
+    @staticmethod
+    def _charge_mode_resolution_parts(
+        value: object,
+    ) -> tuple[str | None, str | None]:
+        mode = None
+        source = None
+        if value is not None:
+            mode = getattr(value, "mode", None)
+            source = getattr(value, "source", None)
+            if mode is None and source is None:
+                mode = value
+        return mode, source
+
     def site_energy_channel_known(self, flow_key: str) -> bool:
         try:
             key = str(flow_key).strip()
@@ -1324,8 +1419,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             payload = merged.get(sn)
             if payload is None:
                 continue
-            if charge_modes.get(sn):
-                payload["charge_mode_pref"] = charge_modes[sn]
+            charge_mode_resolution = charge_modes.get(sn)
+            charge_mode_value, charge_mode_source = self._charge_mode_resolution_parts(
+                charge_mode_resolution
+            )
+            if charge_mode_value:
+                payload["charge_mode_pref"] = charge_mode_value
+                if charge_mode_source is not None:
+                    payload["charge_mode_pref_source"] = charge_mode_source
             if green_settings.get(sn) is not None:
                 enabled, supported = green_settings[sn]
                 payload["green_battery_supported"] = supported
@@ -2117,6 +2218,35 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             if not sources:
                 continue
             charger_support_sources.append({"serial": serial, "sources": sources})
+        charger_runtime_sources = []
+        for serial, snapshot in sorted((self.data or {}).items()):
+            if not isinstance(snapshot, dict):
+                continue
+            runtime_sources = {
+                key: snapshot.get(key)
+                for key in (
+                    "charge_mode_source",
+                    "charge_mode_pref_source",
+                    "charging_level_source",
+                )
+                if snapshot.get(key) is not None
+            }
+            if snapshot.get("charging_level") is not None:
+                runtime_sources["charging_level"] = snapshot.get("charging_level")
+            last_set_amps = self.last_set_amps.get(serial)
+            if last_set_amps is not None:
+                runtime_sources["last_set_amps"] = last_set_amps
+            if runtime_sources:
+                charger_runtime_sources.append(
+                    {"serial": serial, "sources": runtime_sources}
+                )
+        charger_transition_history = [
+            {"serial": serial, "transitions": copy_diagnostics_value(transitions)}
+            for serial, transitions in sorted(
+                getattr(self, "_evse_transition_snapshots", {}).items()
+            )
+            if transitions
+        ]
         payload = getattr(self, "_evse_feature_flags_payload", None)
         payload_meta = payload.get("meta") if isinstance(payload, dict) else None
         payload_error = payload.get("error") if isinstance(payload, dict) else None
@@ -2132,6 +2262,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             ),
             "charger_feature_flags": charger_feature_flags,
             "charger_support_sources": charger_support_sources,
+            "charger_runtime_sources": charger_runtime_sources,
+            "charger_transition_history": charger_transition_history,
             "timeseries": self.evse_timeseries_diagnostics(),
         }
 
@@ -3094,6 +3226,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
         for sn, obj in records:
             conn0 = (obj.get("connectors") or [{}])[0]
+            previous_entry = None
+            if isinstance(self.data, dict):
+                previous_entry = self.data.get(sn)
             has_embedded_charge_mode = self._has_embedded_charge_mode(obj)
             raw_safe_limit = conn0.get("safeLimitState")
             if raw_safe_limit is None:
@@ -3105,12 +3240,19 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             else:
                 safe_limit_state = _as_int(raw_safe_limit)
             charging_level = None
+            charging_level_source = None
             for key in ("chargingLevel", "charging_level", "charginglevel"):
                 if key in obj and obj.get(key) is not None:
-                    charging_level = obj.get(key)
+                    coerced_level = _as_int(obj.get(key))
+                    if coerced_level is None:
+                        continue
+                    charging_level = coerced_level
+                    charging_level_source = "status_payload"
                     break
             if charging_level is None:
-                charging_level = self.last_set_amps.get(sn)
+                charging_level = _as_int(self.last_set_amps.get(sn))
+                if charging_level is not None:
+                    charging_level_source = "last_set_amps"
             # On initial load or after restart, seed the local last_set_amps
             # so UI controls (number entity) reflect the current setpoint
             # instead of defaulting to 0/min.
@@ -3205,30 +3347,51 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     charging_now_flag = target_state
 
             # Keep preference state stable when scheduler lookups temporarily omit it.
-            charge_mode_pref = self._normalize_charge_mode_preference(
-                charge_modes.get(sn)
+            charge_mode_pref_source = None
+            charge_mode_resolution = charge_modes.get(sn)
+            charge_mode_pref = None
+            charge_mode_value, charge_mode_source = self._charge_mode_resolution_parts(
+                charge_mode_resolution
             )
+            if charge_mode_value is not None:
+                charge_mode_pref = self._normalize_charge_mode_preference(
+                    charge_mode_value
+                )
+                if charge_mode_pref is not None:
+                    charge_mode_pref_source = charge_mode_source
             if charge_mode_pref is None:
                 charge_mode_pref = self._schedule_type_charge_mode_preference(
                     sch_info0.get("type")
                 )
+                if charge_mode_pref is not None:
+                    charge_mode_pref_source = "schedule_type_fallback"
             if charge_mode_pref is None:
                 charge_mode_pref = self._cached_charge_mode_preference(sn)
+                if charge_mode_pref is not None:
+                    charge_mode_pref_source = "cache"
             if charge_mode_pref is None:
                 charge_mode_pref = self._battery_profile_charge_mode_preference(sn)
+                if charge_mode_pref is not None:
+                    charge_mode_pref_source = "battery_profile_fallback"
 
+            charge_mode_source = None
             charge_mode = self._normalize_effective_charge_mode(
                 obj.get("chargeMode")
                 or obj.get("chargingMode")
                 or (obj.get("sch_d") or {}).get("mode")
             )
+            if charge_mode is not None:
+                charge_mode_source = "explicit_status"
             if charge_mode is None:
                 if charge_mode_pref:
                     charge_mode = charge_mode_pref
+                    charge_mode_source = charge_mode_pref_source
                 elif charging_now_flag:
                     charge_mode = "IMMEDIATE"
+                    charge_mode_source = "charging_inference"
                 else:
                     charge_mode = "IDLE"
+                    charge_mode_source = "idle_inference"
 
             green_setting = green_settings.get(sn)
             green_enabled: bool | None = None
@@ -3456,9 +3619,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 "schedule_reminder_enabled": schedule_remind,
                 "schedule_reminder_min": _as_int(sch_info0.get("remindTime")),
                 "charge_mode": charge_mode,
+                "charge_mode_source": charge_mode_source,
                 # Expose scheduler preference explicitly for entities that care
                 "charge_mode_pref": charge_mode_pref,
+                "charge_mode_pref_source": charge_mode_pref_source,
                 "charging_level": charging_level,
+                "charging_level_source": charging_level_source,
                 "storm_guard_state": self._storm_guard_state,
                 "storm_evse_enabled": self._storm_evse_enabled,
                 "session_charge_level": session_charge_level,
@@ -3502,6 +3668,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 entry["app_auth_enabled"] = app_auth_enabled
                 entry["rfid_auth_enabled"] = rfid_auth_enabled
                 entry["auth_required"] = auth_required
+            self._record_evse_transition_snapshot(sn, previous_entry, entry)
 
             out[sn] = entry
 

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -69,6 +69,12 @@ class ChargeModeStartPreferences:
     enforce_mode: str | None = None
 
 
+@dataclass(slots=True)
+class ChargeModeResolution:
+    mode: str | None = None
+    source: str | None = None
+
+
 class EvseRuntime:
     def __init__(self, coordinator: EnphaseCoordinator) -> None:
         self.coordinator = coordinator
@@ -282,6 +288,7 @@ class EvseRuntime:
             "_auto_resume_attempts",
             "_session_end_fix",
             "_streaming_targets",
+            "_evse_transition_snapshots",
         ):
             cache = getattr(coord, attr_name, None)
             if not isinstance(cache, dict):
@@ -466,9 +473,9 @@ class EvseRuntime:
 
     async def async_resolve_charge_modes(
         self, serials: Iterable[str]
-    ) -> dict[str, str | None]:
+    ) -> dict[str, ChargeModeResolution]:
         coord = self.coordinator
-        results: dict[str, str | None] = {}
+        results: dict[str, ChargeModeResolution] = {}
         pending: dict[str, asyncio.Task[str | None]] = {}
         if coord._scheduler_backoff_active():
             for sn in dict.fromkeys(serials):
@@ -476,14 +483,14 @@ class EvseRuntime:
                     continue
                 cached = self.cached_charge_mode_preference(sn)
                 if cached is not None:
-                    results[sn] = cached
+                    results[sn] = ChargeModeResolution(cached, "cache_backoff")
             return results
         for sn in dict.fromkeys(serials):
             if not sn:
                 continue
             cached = self.cached_charge_mode_preference(sn)
             if cached is not None:
-                results[sn] = cached
+                results[sn] = ChargeModeResolution(cached, "cache")
                 continue
             pending[sn] = asyncio.create_task(self.async_get_charge_mode(sn))
         if pending:
@@ -499,9 +506,10 @@ class EvseRuntime:
                             identifiers=(sn,),
                         ),
                     )
+                    results[sn] = ChargeModeResolution(source="lookup_failed")
                     continue
                 if response:
-                    results[sn] = response
+                    results[sn] = ChargeModeResolution(response, "scheduler_endpoint")
         return results
 
     async def async_start_charging(

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -229,6 +229,9 @@ class EVSEState:
     _auto_resume_attempts: dict[str, float] = field(default_factory=dict)
     _session_end_fix: dict[str, int] = field(default_factory=dict)
     _evse_power_snapshots: dict[str, dict[str, object]] = field(default_factory=dict)
+    _evse_transition_snapshots: dict[str, list[dict[str, object]]] = field(
+        default_factory=dict
+    )
 
 
 @dataclass(slots=True)

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import time
 from collections import deque
 from datetime import datetime, timedelta, timezone
@@ -53,6 +54,7 @@ from custom_components.enphase_ev.evse_runtime import (
     AUTH_SETTINGS_CACHE_TTL,
     CHARGER_CONFIG_CACHE_TTL,
     CHARGE_MODE_CACHE_TTL,
+    ChargeModeResolution,
     FAST_TOGGLE_POLL_HOLD_S,
     GREEN_BATTERY_CACHE_TTL,
     STREAMING_DEFAULT_DURATION_S,
@@ -565,7 +567,9 @@ async def test_async_resolve_charge_modes_backoff_uses_cache(
 
     result = await coord.evse_runtime.async_resolve_charge_modes(["", SERIAL_ONE])
 
-    assert result == {SERIAL_ONE: "MANUAL_CHARGING"}
+    assert result == {
+        SERIAL_ONE: ChargeModeResolution("MANUAL_CHARGING", "cache_backoff")
+    }
 
 
 def test_scheduler_note_default_reason_and_backoff_error(
@@ -949,6 +953,10 @@ def test_prune_runtime_caches_removes_stale_serial_state(coordinator_factory):
         "EV1": (True, False, True, True, 1.0),
         "EV3": (False, False, True, True, 1.0),
     }
+    coord._evse_transition_snapshots = {  # noqa: SLF001
+        "EV1": [{"to_connector_status": "CHARGING"}],
+        "EV2": [{"to_connector_status": "SUSPENDED_EVSE"}],
+    }
     coord._desired_charging = {"EV1": True, "EV2": False}  # noqa: SLF001
     coord._session_history_cache_shim = {  # noqa: SLF001
         ("EV1", "2020-01-02"): (1.0, [{"session_id": "keep"}]),
@@ -968,6 +976,9 @@ def test_prune_runtime_caches_removes_stale_serial_state(coordinator_factory):
     assert "EV2" not in coord._charge_mode_cache  # noqa: SLF001
     assert "EV2" not in coord._green_battery_cache  # noqa: SLF001
     assert "EV3" not in coord._auth_settings_cache  # noqa: SLF001
+    assert coord._evse_transition_snapshots == {  # noqa: SLF001
+        "EV1": [{"to_connector_status": "CHARGING"}]
+    }
     assert coord._desired_charging == {"EV1": True}  # noqa: SLF001
     assert coord._session_history_cache_shim == {  # noqa: SLF001
         ("EV1", "2020-01-02"): (1.0, [{"session_id": "keep"}])
@@ -1029,12 +1040,197 @@ def test_prune_helpers_cover_edge_branches(monkeypatch):
     coord._desired_charging = {}  # noqa: SLF001
     coord._auto_resume_attempts = {}  # noqa: SLF001
     coord._session_end_fix = {}  # noqa: SLF001
+    coord._evse_transition_snapshots = {}  # noqa: SLF001
     coord._streaming_targets = {}  # noqa: SLF001
 
     keep = coord._prune_serial_runtime_state(["EV1"])  # noqa: SLF001
     assert keep == {"EV1"}
     assert coord.serials == {"EV1"}
     assert coord._serial_order == ["EV1"]  # noqa: SLF001
+
+
+def test_evse_diagnostics_payloads_include_runtime_sources_and_history(
+    coordinator_factory,
+):
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.data = {
+        SERIAL_ONE: {
+            "charge_mode_supported_source": "feature_flag",
+            "charge_mode_source": "cache_backoff",
+            "charge_mode_pref_source": "cache_backoff",
+            "charging_level_source": "last_set_amps",
+            "charging_level": 32,
+        }
+    }
+    coord.last_set_amps = {SERIAL_ONE: 16}
+    coord._evse_transition_snapshots = {  # noqa: SLF001
+        SERIAL_ONE: [
+            {
+                "from_connector_status": "SUSPENDED_EVSE",
+                "to_connector_status": "CHARGING",
+                "charge_mode_source": "schedule_type_fallback",
+            }
+        ]
+    }
+
+    diagnostics = coord.evse_diagnostics_payloads()
+
+    assert diagnostics["charger_runtime_sources"] == [
+        {
+            "serial": SERIAL_ONE,
+            "sources": {
+                "charge_mode_source": "cache_backoff",
+                "charge_mode_pref_source": "cache_backoff",
+                "charging_level_source": "last_set_amps",
+                "charging_level": 32,
+                "last_set_amps": 16,
+            },
+        }
+    ]
+    assert diagnostics["charger_transition_history"] == [
+        {
+            "serial": SERIAL_ONE,
+            "transitions": [
+                {
+                    "from_connector_status": "SUSPENDED_EVSE",
+                    "to_connector_status": "CHARGING",
+                    "charge_mode_source": "schedule_type_fallback",
+                }
+            ],
+        }
+    ]
+
+
+def test_record_evse_transition_snapshot_ignores_missing_or_unchanged_status(
+    coordinator_factory,
+):
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+
+    coord._record_evse_transition_snapshot(  # noqa: SLF001
+        SERIAL_ONE,
+        None,
+        {"connector_status": "CHARGING"},
+    )
+    coord._record_evse_transition_snapshot(  # noqa: SLF001
+        SERIAL_ONE,
+        {"connector_status": "CHARGING"},
+        {"connector_status": "CHARGING"},
+    )
+
+    assert coord._evse_transition_snapshots == {}  # noqa: SLF001
+
+
+def test_snapshot_text_handles_bad_str(coordinator_factory):
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+
+    class BadStr:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    assert coord._snapshot_text(BadStr()) is None  # noqa: SLF001
+
+
+def test_charge_mode_resolution_parts_supports_legacy_string(coordinator_factory):
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+
+    assert coord._charge_mode_resolution_parts("SCHEDULED") == (  # noqa: SLF001
+        "SCHEDULED",
+        None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_records_evse_transition_snapshot(
+    coordinator_factory, monkeypatch, caplog
+):
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.data = {
+        SERIAL_ONE: {
+            "sn": SERIAL_ONE,
+            "name": "Charger",
+            "connector_status": "SUSPENDED_EVSE",
+            "charging": False,
+        }
+    }
+    coord.last_set_amps = {SERIAL_ONE: 16}
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": SERIAL_ONE,
+                    "name": "Garage EV",
+                    "pluggedIn": True,
+                    "charging": False,
+                    "chargingLevel": 32,
+                    "connectors": [{"connectorStatusType": "CHARGING"}],
+                    "sch_d": {"info": [{"type": "greencharging"}]},
+                }
+            ]
+        }
+    )
+    timestamp = datetime(2026, 4, 3, 1, 2, 3, tzinfo=timezone.utc)
+    monkeypatch.setattr(coord_mod.dt_util, "utcnow", lambda: timestamp)
+
+    with caplog.at_level(logging.DEBUG):
+        result = await coord._async_update_data()
+
+    assert result[SERIAL_ONE]["charge_mode"] == "GREEN_CHARGING"
+    assert result[SERIAL_ONE]["charge_mode_source"] == "schedule_type_fallback"
+    assert result[SERIAL_ONE]["charge_mode_pref_source"] == "schedule_type_fallback"
+    assert result[SERIAL_ONE]["charging_level"] == 32
+    assert result[SERIAL_ONE]["charging_level_source"] == "status_payload"
+
+    assert coord._evse_transition_snapshots[SERIAL_ONE] == [  # noqa: SLF001
+        {
+            "recorded_at_utc": timestamp.isoformat(),
+            "from_connector_status": "SUSPENDED_EVSE",
+            "to_connector_status": "CHARGING",
+            "charging": True,
+            "previous_charging": False,
+            "charge_mode": "GREEN_CHARGING",
+            "charge_mode_source": "schedule_type_fallback",
+            "charge_mode_pref": "GREEN_CHARGING",
+            "charge_mode_pref_source": "schedule_type_fallback",
+            "charging_level": 32,
+            "charging_level_source": "status_payload",
+            "last_set_amps": 16,
+            "green_battery_enabled": None,
+            "safe_limit_state": None,
+            "schedule_type": "greencharging",
+            "sampled_at_utc": None,
+            "fetched_at_utc": result[SERIAL_ONE]["fetched_at_utc"],
+            "scheduler_available": True,
+            "scheduler_backoff_active": False,
+        }
+    ]
+    assert "EVSE connector transition for charger" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_invalid_charging_level_uses_last_set_amps(
+    coordinator_factory,
+):
+    coord = coordinator_factory(serials=[SERIAL_ONE])
+    coord.last_set_amps = {SERIAL_ONE: 16}
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": SERIAL_ONE,
+                    "name": "Garage EV",
+                    "pluggedIn": True,
+                    "charging": False,
+                    "chargingLevel": [],
+                    "connectors": [{"connectorStatusType": "SUSPENDED_EVSE"}],
+                }
+            ]
+        }
+    )
+
+    result = await coord._async_update_data()
+
+    assert result[SERIAL_ONE]["charging_level"] == 16
+    assert result[SERIAL_ONE]["charging_level_source"] == "last_set_amps"
 
 
 def _make_minimal_history() -> SimpleNamespace:
@@ -2049,9 +2245,9 @@ async def test_async_resolve_charge_modes_uses_cache_and_handles_errors(
         side_effect=fake_get
     )
     result = await coord.evse_runtime.async_resolve_charge_modes(["EV1", "EV2", "EV3"])
-    assert result["EV1"] == "SCHEDULED_CHARGING"
-    assert result["EV2"] == "GREEN_CHARGING"
-    assert "EV3" not in result
+    assert result["EV1"] == ChargeModeResolution("SCHEDULED_CHARGING", "cache")
+    assert result["EV2"] == ChargeModeResolution("GREEN_CHARGING", "scheduler_endpoint")
+    assert result["EV3"] == ChargeModeResolution(None, "lookup_failed")
 
 
 def test_amp_helpers_and_expectation_management(coordinator_factory, monkeypatch):

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -31,7 +31,10 @@ from custom_components.enphase_ev.const import (
     OPT_NOMINAL_VOLTAGE,
     OPT_SESSION_HISTORY_INTERVAL,
 )
-from custom_components.enphase_ev.evse_runtime import FAST_TOGGLE_POLL_HOLD_S
+from custom_components.enphase_ev.evse_runtime import (
+    FAST_TOGGLE_POLL_HOLD_S,
+    ChargeModeResolution,
+)
 from custom_components.enphase_ev.voltage import resolve_nominal_voltage_for_hass
 
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL, RANDOM_SITE_ID
@@ -3009,7 +3012,7 @@ async def test_startup_warmup_helper_refreshes_cover_fallback_and_merge_paths(
 
     coord.iter_serials = lambda: [RANDOM_SERIAL, "SECONDARY"]  # type: ignore[assignment]
     coord.evse_runtime.async_resolve_charge_modes = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
-        return_value={RANDOM_SERIAL: "SCHEDULED"}
+        return_value={RANDOM_SERIAL: ChargeModeResolution("SCHEDULED", "cache_backoff")}
     )
     coord.evse_runtime.async_resolve_green_battery_settings = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
         return_value={RANDOM_SERIAL: (True, True)}
@@ -3028,6 +3031,7 @@ async def test_startup_warmup_helper_refreshes_cover_fallback_and_merge_paths(
     await coord._async_refresh_secondary_evse_state_for_warmup()  # noqa: SLF001
     merged_secondary = set_updated.call_args_list[-1].args[0]
     assert merged_secondary[RANDOM_SERIAL]["charge_mode_pref"] == "SCHEDULED"
+    assert merged_secondary[RANDOM_SERIAL]["charge_mode_pref_source"] == "cache_backoff"
     assert merged_secondary[RANDOM_SERIAL]["green_battery_enabled"] is True
     assert merged_secondary[RANDOM_SERIAL]["app_auth_supported"] is True
     assert merged_secondary[RANDOM_SERIAL]["rfid_auth_supported"] is True

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -1041,7 +1041,8 @@ async def test_async_resolve_charge_modes_skips_empty_serials(coordinator_factor
         return_value="IDLE"
     )
     result = await coord.evse_runtime.async_resolve_charge_modes(["", RANDOM_SERIAL])
-    assert result.get(RANDOM_SERIAL) == "IDLE"
+    assert result.get(RANDOM_SERIAL).mode == "IDLE"
+    assert result.get(RANDOM_SERIAL).source == "scheduler_endpoint"
 
 
 def test_has_embedded_charge_mode_for_non_dict(coordinator_factory):

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -12,6 +12,7 @@ from homeassistant.util import dt as dt_util
 
 from custom_components.enphase_ev.evse_runtime import (
     FAST_TOGGLE_POLL_HOLD_S,
+    ChargeModeResolution,
     ChargeModeStartPreferences,
     EvseRuntime,
 )
@@ -176,7 +177,7 @@ async def test_evse_runtime_resolvers_use_runtime_methods(
     )
 
     assert await runtime.async_resolve_charge_modes(["EV1"]) == {
-        "EV1": "GREEN_CHARGING"
+        "EV1": ChargeModeResolution("GREEN_CHARGING", "scheduler_endpoint")
     }
     assert await runtime.async_resolve_green_battery_settings(["EV1"]) == {
         "EV1": (True, True)


### PR DESCRIPTION
## Summary

Add targeted EVSE resume diagnostics and provenance tracking to help diagnose Green-mode resume mismatches after suspended charging transitions. Related issue: https://github.com/barneyonline/ha-enphase-energy/issues/424

## Related Issues

- https://github.com/barneyonline/ha-enphase-energy/issues/424

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [x] Other (diagnostics / observability improvements for EVSE resume investigations)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/evse_runtime.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_remaining_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/evse_runtime.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_remaining_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_remaining_coverage.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/evse_runtime.py,custom_components/enphase_ev/state_models.py --fail-under=100"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This change is intentionally observability-only. It adds:
- EVSE connector transition snapshots for recent charger state changes
- `charge_mode_source`, `charge_mode_pref_source`, and `charging_level_source` provenance fields
- compatibility handling for legacy string-style charge-mode resolution in warmup/mocked paths
- diagnostics output that lets a user provide one integration diagnostics export plus HA logs after the next incident instead of manual data capture