### PR TITLE
Prepare release 2.6.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,33 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- Aligned EVSE, site energy, heat-pump, inverter, and battery power/energy entities around stable sample timestamps, stopped synthesizing EVSE measurement time from poll time when the upstream sample time is missing, and moved EVSE power derivation onto refresh-time coordinator snapshots so power and energy readings stay internally consistent.
+- None
 
 ### 🔧 Improvements
-- Added targeted EVSE diagnostics for charger connector transitions, including charge-mode source, charge-current source, and recent transition snapshots to make Green-mode resume issues easier to capture from a single diagnostics export.
+- None
 
 ### 🔄 Other changes
 - None
+
+## v2.6.8 - 2026-04-03
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Aligned EVSE, site energy, heat-pump, inverter, and battery power/energy entities around stable sample timestamps, stopped synthesizing EVSE measurement time from poll time when the upstream sample time is missing, and moved EVSE power derivation onto refresh-time coordinator snapshots so power and energy readings stay internally consistent.
+- Added targeted EVSE diagnostics for charger connector transitions, including charge-mode source, charge-current source, and recent transition snapshots to make Green-mode resume issues easier to capture from a single diagnostics export.
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- Removed coordinator facade shims and introduced the new inventory view plumbing to simplify internal entity wiring and coordinator state handling without changing supported functionality.
+- Added GitHub issue triage workflows for automatic labeling, missing-diagnostics follow-up comments, and stale blocked issue handling.
+- Updated `docs/api/api_spec.md` so the documented authentication requirements match the current implementation.
 
 ## v2.6.7 - 2026-04-02
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -15,5 +15,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.6.7"
+  "version": "2.6.8"
 }


### PR DESCRIPTION
## Summary

Prepare the `2.6.8` release metadata by bumping the integration manifest version and promoting the accumulated unreleased notes into a dated changelog entry.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release metadata update.

## Testing

List the exact commands you ran. Prefer the pinned Docker environment from `devtools/docker/`.

```bash
git status --short --branch
git fetch origin --tags
git merge --ff-only origin/main
```

No linting or test suite was run for this metadata-only change.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This PR only updates `custom_components/enphase_ev/manifest.json` and `CHANGELOG.md` after reviewing commits since `v2.6.7`.