### PR TITLE
Extract discovery snapshot manager

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -1092,7 +1092,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
         firmware_catalog=firmware_catalog,
         evse_firmware_details=evse_firmware_details,
     )
-    restore_discovery_state = getattr(coord, "async_restore_discovery_state", None)
+    discovery_snapshot = getattr(coord, "discovery_snapshot", None)
+    restore_discovery_state = getattr(discovery_snapshot, "async_restore_state", None)
     if callable(restore_discovery_state):
         await restore_discovery_state()
     await async_prime_label_translations(hass)

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -22,7 +22,6 @@ from homeassistant.exceptions import (
 )  # noqa: F401
 from homeassistant.helpers.event import async_call_later
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
-from homeassistant.helpers.storage import Store
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 from homeassistant.util import dt as dt_util
 
@@ -73,6 +72,7 @@ from .const import (
 )
 from .battery_runtime import BatteryRuntime
 from .coordinator_diagnostics import CoordinatorDiagnostics
+from .discovery_snapshot import DiscoverySnapshotManager
 from .device_types import (
     normalize_type_key,
     parse_type_identifier,
@@ -171,8 +171,6 @@ SYSTEM_DASHBOARD_TYPE_KEY_MAP: dict[str, str] = {
     "inverters": "microinverter",
     "modems": "modem",
 }
-DISCOVERY_SNAPSHOT_STORE_VERSION = 1
-DISCOVERY_SNAPSHOT_SAVE_DELAY_S = 1.0
 BATTERY_GRID_MODE_PERMISSIONS = {
     "importexport": (True, True),
     "importonly": (True, False),
@@ -293,12 +291,6 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         from .schedule_sync import ScheduleSync
 
         self.schedule_sync = ScheduleSync(hass, self, config_entry)
-        entry_id = getattr(config_entry, "entry_id", self.site_id)
-        self._discovery_snapshot_store = Store(
-            hass,
-            DISCOVERY_SNAPSHOT_STORE_VERSION,
-            f"{DOMAIN}.discovery_snapshot.{entry_id}",
-        )
         object.__setattr__(
             self,
             "discovery_state",
@@ -402,6 +394,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self.battery_runtime = BatteryRuntime(self)
         self.heatpump_runtime = HeatpumpRuntime(self)
         self.inventory_runtime = InventoryRuntime(self)
+        self.discovery_snapshot = DiscoverySnapshotManager(self)
         self.inventory_view = InventoryView(self)
         self.diagnostics = CoordinatorDiagnostics(self)
 
@@ -635,9 +628,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         if self._warmup_task is not None:
             self._warmup_task.cancel()
             self._warmup_task = None
-        if self._discovery_snapshot_save_cancel is not None:
-            self._discovery_snapshot_save_cancel()
-            self._discovery_snapshot_save_cancel = None
+        self.discovery_snapshot.cancel_pending_save()
         session_manager = getattr(self, "session_history", None)
         if session_manager is not None and hasattr(session_manager, "clear"):
             session_manager.clear()
@@ -860,273 +851,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 mode = value
         return mode, source
 
-    def site_energy_channel_known(self, flow_key: str) -> bool:
-        try:
-            key = str(flow_key).strip()
-        except Exception:  # noqa: BLE001
-            return False
-        if not key:
-            return False
-        if key in self._live_site_energy_channels():
-            return True
-        if self._site_energy_discovery_ready:
-            return False
-        return key in self._restored_site_energy_channels
-
-    def _live_site_energy_channels(self) -> set[str]:
-        channels: set[str] = set()
-        energy = getattr(self, "energy", None)
-        if energy is None:
-            return channels
-        flows = getattr(energy, "site_energy", None)
-        if isinstance(flows, dict):
-            for key in flows:
-                try:
-                    key_text = str(key).strip()
-                except Exception:  # noqa: BLE001
-                    continue
-                if key_text:
-                    channels.add(key_text)
-        meta = getattr(energy, "site_energy_meta", None)
-        if isinstance(meta, dict):
-            bucket_lengths = meta.get("bucket_lengths")
-            if isinstance(bucket_lengths, dict):
-                for key, value in bucket_lengths.items():
-                    try:
-                        key_text = str(key).strip()
-                    except Exception:  # noqa: BLE001
-                        continue
-                    if not key_text:
-                        continue
-                    try:
-                        if int(value) <= 0:
-                            continue
-                    except Exception:
-                        if not value:
-                            continue
-                    mapped = {
-                        "heatpump": "heat_pump",
-                        "water_heater": "water_heater",
-                        "evse": "evse_charging",
-                        "solar_production": "solar_production",
-                        "consumption": "consumption",
-                        "grid_import": "grid_import",
-                        "grid_export": "grid_export",
-                        "battery_charge": "battery_charge",
-                        "battery_discharge": "battery_discharge",
-                    }.get(key_text, key_text)
-                    channels.add(mapped)
-        return channels
-
-    def _gateway_router_discovery_ready(self) -> bool:
-        return bool(getattr(self, "_hems_inventory_ready", False))
-
-    def _live_gateway_iq_energy_router_records(self) -> list[dict[str, object]]:
-        records: list[dict[str, object]] = []
-        for member in self.inventory_runtime._hems_group_members("gateway"):
-            if not isinstance(member, dict):
-                continue
-            raw_type = member.get("device-type")
-            if raw_type is None:
-                raw_type = member.get("device_type")
-            if raw_type is None:
-                continue
-            try:
-                type_text = str(raw_type).strip().upper()
-            except Exception:  # noqa: BLE001
-                continue
-            if type_text != "IQ_ENERGY_ROUTER":
-                continue
-            records.append(dict(member))
-        return records
-
-    def _capture_discovery_snapshot(self) -> dict[str, object]:
-        site_energy_channels = self._live_site_energy_channels()
-        if not site_energy_channels and not self._site_energy_discovery_ready:
-            site_energy_channels = set(self._restored_site_energy_channels)
-        router_records = self._live_gateway_iq_energy_router_records()
-        if not router_records and not self._gateway_router_discovery_ready():
-            router_records = [
-                dict(item)
-                for item in self._restored_gateway_iq_energy_router_records
-                if isinstance(item, dict)
-            ]
-        snapshot = {
-            "serial_order": self.iter_serials(),
-            "type_device_order": list(getattr(self, "_type_device_order", []) or []),
-            "type_device_buckets": self._snapshot_compatible_value(
-                dict(getattr(self, "_type_device_buckets", {}) or {})
-            ),
-            "battery_storage_order": list(
-                getattr(self, "_battery_storage_order", []) or []
-            ),
-            "battery_storage_data": self._snapshot_compatible_value(
-                dict(getattr(self, "_battery_storage_data", {}) or {})
-            ),
-            "inverter_order": list(getattr(self, "_inverter_order", []) or []),
-            "inverter_data": self._snapshot_compatible_value(
-                dict(getattr(self, "_inverter_data", {}) or {})
-            ),
-            "battery_has_encharge": getattr(self, "_battery_has_encharge", None),
-            "battery_has_enpower": getattr(self, "_battery_has_enpower", None),
-            "site_energy_channels": sorted(site_energy_channels),
-            "gateway_iq_energy_router_records": self._snapshot_compatible_value(
-                router_records
-            ),
-        }
-        return snapshot
-
-    def _apply_discovery_snapshot(self, snapshot: object) -> None:
-        if not isinstance(snapshot, dict):
-            return
-
-        serial_order = snapshot.get("serial_order")
-        if isinstance(serial_order, list):
-            for serial in serial_order:
-                if serial is None:
-                    continue
-                try:
-                    text = str(serial).strip()
-                except Exception:  # noqa: BLE001
-                    continue
-                if text:
-                    self._ensure_serial_tracked(text)
-
-        grouped = snapshot.get("type_device_buckets")
-        ordered = snapshot.get("type_device_order")
-        if isinstance(grouped, dict):
-            normalized_grouped: dict[str, dict[str, object]] = {}
-            for raw_key, raw_bucket in grouped.items():
-                type_key = normalize_type_key(raw_key)
-                if not type_key or not isinstance(raw_bucket, dict):
-                    continue
-                bucket = dict(raw_bucket)
-                members = bucket.get("devices")
-                if isinstance(members, list):
-                    bucket["devices"] = [
-                        dict(member) for member in members if isinstance(member, dict)
-                    ]
-                else:
-                    bucket["devices"] = []
-                try:
-                    count = int(bucket.get("count", len(bucket["devices"])) or 0)
-                except Exception:  # noqa: BLE001
-                    count = len(bucket["devices"])
-                bucket["count"] = max(count, len(bucket["devices"]))
-                normalized_grouped[type_key] = bucket
-            ordered_keys = (
-                [normalize_type_key(key) for key in ordered if normalize_type_key(key)]
-                if isinstance(ordered, list)
-                else list(normalized_grouped.keys())
-            )
-            if normalized_grouped:
-                self.inventory_runtime._set_type_device_buckets(
-                    normalized_grouped, ordered_keys, authoritative=False
-                )
-
-        battery_order = snapshot.get("battery_storage_order")
-        battery_data = snapshot.get("battery_storage_data")
-        if isinstance(battery_order, list) and isinstance(battery_data, dict):
-            self._battery_storage_order = [
-                str(item).strip() for item in battery_order if str(item).strip()
-            ]
-            self._battery_storage_data = {
-                str(key).strip(): dict(value)
-                for key, value in battery_data.items()
-                if str(key).strip() and isinstance(value, dict)
-            }
-
-        inverter_order = snapshot.get("inverter_order")
-        inverter_data = snapshot.get("inverter_data")
-        if isinstance(inverter_order, list) and isinstance(inverter_data, dict):
-            restored_inverter_order = [
-                str(item).strip() for item in inverter_order if str(item).strip()
-            ]
-            restored_inverter_data = {
-                str(key).strip(): dict(value)
-                for key, value in inverter_data.items()
-                if str(key).strip() and isinstance(value, dict)
-            }
-            self.inventory_runtime._update_shared_state(
-                _inverter_order=restored_inverter_order,
-                _inverter_data=restored_inverter_data,
-            )
-
-        has_encharge = self._snapshot_bool(snapshot.get("battery_has_encharge"))
-        if has_encharge is not None:
-            self._battery_has_encharge = has_encharge
-        has_enpower = self._snapshot_bool(snapshot.get("battery_has_enpower"))
-        if has_enpower is not None:
-            self._battery_has_enpower = has_enpower
-
-        restored_channels = snapshot.get("site_energy_channels")
-        if isinstance(restored_channels, list):
-            self._restored_site_energy_channels = {
-                str(item).strip() for item in restored_channels if str(item).strip()
-            }
-
-        restored_router_records = snapshot.get("gateway_iq_energy_router_records")
-        if isinstance(restored_router_records, list):
-            self._restored_gateway_iq_energy_router_records = [
-                dict(item) for item in restored_router_records if isinstance(item, dict)
-            ]
-        self._refresh_cached_topology()
-
-    async def async_restore_discovery_state(self) -> None:
-        if self._discovery_snapshot_loaded:
-            return
-        self._discovery_snapshot_loaded = True
-        self._devices_inventory_ready = False
-        self._hems_inventory_ready = False
-        self._site_energy_discovery_ready = False
-        try:
-            snapshot = await self._discovery_snapshot_store.async_load()
-        except Exception:  # noqa: BLE001
-            _LOGGER.debug(
-                "Failed to load discovery snapshot for site %s",
-                redact_site_id(self.site_id),
-                exc_info=True,
-            )
-            return
-        self._apply_discovery_snapshot(snapshot)
-
-    async def _async_save_discovery_snapshot(self) -> None:
-        self._discovery_snapshot_pending = False
-        snapshot = self._capture_discovery_snapshot()
-        try:
-            await self._discovery_snapshot_store.async_save(snapshot)
-        except Exception:  # noqa: BLE001
-            _LOGGER.debug(
-                "Failed to save discovery snapshot for site %s",
-                redact_site_id(self.site_id),
-                exc_info=True,
-            )
-
-    def _schedule_discovery_snapshot_save(self) -> None:
-        self._discovery_snapshot_pending = True
-        if self._discovery_snapshot_save_cancel is not None:
-            return
-
-        @callback
-        def _run(_now: datetime) -> None:
-            self._discovery_snapshot_save_cancel = None
-            if not self._discovery_snapshot_pending:
-                return
-            self.hass.async_create_task(self._async_save_discovery_snapshot())
-
-        self._discovery_snapshot_save_cancel = async_call_later(
-            self.hass, DISCOVERY_SNAPSHOT_SAVE_DELAY_S, _run
-        )
-
     def startup_migrations_ready(self) -> bool:
         return bool(getattr(self, "_devices_inventory_ready", False))
-
-    def _sync_site_energy_discovery_state(self) -> None:
-        energy = getattr(self, "energy", None)
-        if energy is None:
-            return
-        if getattr(energy, "_site_energy_cache_ts", None) is not None:
-            self._site_energy_discovery_ready = True
 
     def _publish_internal_state_update(self) -> None:
         current = self.data if isinstance(self.data, dict) else {}
@@ -1318,7 +1044,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         finally:
             self._warmup_in_progress = False
             self._warmup_phase_timings = warmup_timings
-            self._schedule_discovery_snapshot_save()
+            self.discovery_snapshot.schedule_save()
 
     async def async_start_startup_warmup(self) -> None:
         if self._warmup_task is not None and not self._warmup_task.done():
@@ -1335,7 +1061,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     async def _async_refresh_site_energy_for_warmup(self) -> None:
         await self.energy._async_refresh_site_energy()
-        self._sync_site_energy_discovery_state()
+        self.discovery_snapshot.sync_site_energy_discovery_state()
         self._sync_site_energy_issue()
 
     async def _async_refresh_evse_timeseries_for_warmup(
@@ -2371,7 +2097,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._has_successful_refresh = True
             site_energy_start = time.monotonic()
             await self.energy._async_refresh_site_energy()
-            self._sync_site_energy_discovery_state()
+            self.discovery_snapshot.sync_site_energy_discovery_state()
             self._sync_site_energy_issue()
             phase_timings["site_energy_s"] = round(
                 time.monotonic() - site_energy_start, 3
@@ -2390,7 +2116,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             if first_refresh:
                 self._bootstrap_phase_timings = phase_timings.copy()
             self._refresh_cached_topology()
-            self._schedule_discovery_snapshot_save()
+            self.discovery_snapshot.schedule_save()
             return {}
 
         # Helper to normalize epoch-like inputs to seconds
@@ -4023,7 +3749,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 )
             except Exception:
                 pass
-            self._sync_site_energy_discovery_state()
+            self.discovery_snapshot.sync_site_energy_discovery_state()
             self._sync_site_energy_issue()
             self._sync_battery_profile_pending_issue()
             await self._async_run_refresh_plan(
@@ -4052,7 +3778,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         if first_refresh:
             self._bootstrap_phase_timings = phase_timings.copy()
         self._refresh_cached_topology()
-        self._schedule_discovery_snapshot_save()
+        self.discovery_snapshot.schedule_save()
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
                 "Coordinator refresh timings for site %s: %s",

--- a/custom_components/enphase_ev/discovery_snapshot.py
+++ b/custom_components/enphase_ev/discovery_snapshot.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from homeassistant.core import callback
+from homeassistant.helpers.event import async_call_later
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+from .device_types import normalize_type_key
+from .log_redaction import redact_site_id
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .coordinator import EnphaseCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+DISCOVERY_SNAPSHOT_STORE_VERSION = 1
+DISCOVERY_SNAPSHOT_SAVE_DELAY_S = 1.0
+
+
+def _snapshot_compatible_value(value: object) -> object:
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, dict):
+        out: dict[str, object] = {}
+        for key, item in value.items():
+            try:
+                key_text = str(key)
+            except Exception:  # noqa: BLE001
+                continue
+            out[key_text] = _snapshot_compatible_value(item)
+        return out
+    if isinstance(value, (list, tuple, set)):
+        return [_snapshot_compatible_value(item) for item in value]
+    try:
+        return str(value)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _snapshot_bool(value: object) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in ("true", "1", "yes", "y", "enabled", "on"):
+            return True
+        if normalized in ("false", "0", "no", "n", "disabled", "off"):
+            return False
+    return None
+
+
+class DiscoverySnapshotManager:
+    """Persist and restore discovery-oriented coordinator state."""
+
+    def __init__(self, coordinator: EnphaseCoordinator) -> None:
+        self.coordinator = coordinator
+        entry_id = getattr(coordinator.config_entry, "entry_id", coordinator.site_id)
+        self._store = Store(
+            coordinator.hass,
+            DISCOVERY_SNAPSHOT_STORE_VERSION,
+            f"{DOMAIN}.discovery_snapshot.{entry_id}",
+        )
+
+    def live_site_energy_channels(self) -> set[str]:
+        channels: set[str] = set()
+        energy = getattr(self.coordinator, "energy", None)
+        if energy is None:
+            return channels
+        flows = getattr(energy, "site_energy", None)
+        if isinstance(flows, dict):
+            for key in flows:
+                try:
+                    key_text = str(key).strip()
+                except Exception:  # noqa: BLE001
+                    continue
+                if key_text:
+                    channels.add(key_text)
+        meta = getattr(energy, "site_energy_meta", None)
+        if isinstance(meta, dict):
+            bucket_lengths = meta.get("bucket_lengths")
+            if isinstance(bucket_lengths, dict):
+                for key, value in bucket_lengths.items():
+                    try:
+                        key_text = str(key).strip()
+                    except Exception:  # noqa: BLE001
+                        continue
+                    if not key_text:
+                        continue
+                    try:
+                        if int(value) <= 0:
+                            continue
+                    except Exception:  # noqa: BLE001
+                        if not value:
+                            continue
+                    mapped = {
+                        "heatpump": "heat_pump",
+                        "water_heater": "water_heater",
+                        "evse": "evse_charging",
+                        "solar_production": "solar_production",
+                        "consumption": "consumption",
+                        "grid_import": "grid_import",
+                        "grid_export": "grid_export",
+                        "battery_charge": "battery_charge",
+                        "battery_discharge": "battery_discharge",
+                    }.get(key_text, key_text)
+                    channels.add(mapped)
+        return channels
+
+    def site_energy_channel_known(self, flow_key: str) -> bool:
+        try:
+            key = str(flow_key).strip()
+        except Exception:  # noqa: BLE001
+            return False
+        if not key:
+            return False
+        if key in self.live_site_energy_channels():
+            return True
+        if self.coordinator._site_energy_discovery_ready:
+            return False
+        return key in self.coordinator._restored_site_energy_channels
+
+    def gateway_router_discovery_ready(self) -> bool:
+        return bool(getattr(self.coordinator, "_hems_inventory_ready", False))
+
+    def gateway_iq_energy_router_records(self) -> list[dict[str, object]]:
+        records: list[dict[str, object]] = []
+        for member in self.coordinator.inventory_runtime._hems_group_members("gateway"):
+            if not isinstance(member, dict):
+                continue
+            raw_type = member.get("device-type")
+            if raw_type is None:
+                raw_type = member.get("device_type")
+            if raw_type is None:
+                continue
+            try:
+                type_text = str(raw_type).strip().upper()
+            except Exception:  # noqa: BLE001
+                continue
+            if type_text != "IQ_ENERGY_ROUTER":
+                continue
+            records.append(dict(member))
+        if records:
+            return records
+        if self.gateway_router_discovery_ready():
+            return []
+        return [
+            dict(item)
+            for item in self.coordinator._restored_gateway_iq_energy_router_records
+            if isinstance(item, dict)
+        ]
+
+    def capture(self) -> dict[str, object]:
+        site_energy_channels = self.live_site_energy_channels()
+        if (
+            not site_energy_channels
+            and not self.coordinator._site_energy_discovery_ready
+        ):
+            site_energy_channels = set(self.coordinator._restored_site_energy_channels)
+        router_records = self.gateway_iq_energy_router_records()
+        snapshot = {
+            "serial_order": self.coordinator.iter_serials(),
+            "type_device_order": list(
+                getattr(self.coordinator, "_type_device_order", []) or []
+            ),
+            "type_device_buckets": _snapshot_compatible_value(
+                dict(getattr(self.coordinator, "_type_device_buckets", {}) or {})
+            ),
+            "battery_storage_order": list(
+                getattr(self.coordinator, "_battery_storage_order", []) or []
+            ),
+            "battery_storage_data": _snapshot_compatible_value(
+                dict(getattr(self.coordinator, "_battery_storage_data", {}) or {})
+            ),
+            "inverter_order": list(
+                getattr(self.coordinator, "_inverter_order", []) or []
+            ),
+            "inverter_data": _snapshot_compatible_value(
+                dict(getattr(self.coordinator, "_inverter_data", {}) or {})
+            ),
+            "battery_has_encharge": getattr(
+                self.coordinator, "_battery_has_encharge", None
+            ),
+            "battery_has_enpower": getattr(
+                self.coordinator, "_battery_has_enpower", None
+            ),
+            "site_energy_channels": sorted(site_energy_channels),
+            "gateway_iq_energy_router_records": _snapshot_compatible_value(
+                router_records
+            ),
+        }
+        return snapshot
+
+    def apply(self, snapshot: object) -> None:
+        if not isinstance(snapshot, dict):
+            return
+
+        serial_order = snapshot.get("serial_order")
+        if isinstance(serial_order, list):
+            for serial in serial_order:
+                if serial is None:
+                    continue
+                try:
+                    text = str(serial).strip()
+                except Exception:  # noqa: BLE001
+                    continue
+                if text:
+                    self.coordinator._ensure_serial_tracked(text)
+
+        grouped = snapshot.get("type_device_buckets")
+        ordered = snapshot.get("type_device_order")
+        if isinstance(grouped, dict):
+            normalized_grouped: dict[str, dict[str, object]] = {}
+            for raw_key, raw_bucket in grouped.items():
+                type_key = normalize_type_key(raw_key)
+                if not type_key or not isinstance(raw_bucket, dict):
+                    continue
+                bucket = dict(raw_bucket)
+                members = bucket.get("devices")
+                if isinstance(members, list):
+                    bucket["devices"] = [
+                        dict(member) for member in members if isinstance(member, dict)
+                    ]
+                else:
+                    bucket["devices"] = []
+                try:
+                    count = int(bucket.get("count", len(bucket["devices"])) or 0)
+                except Exception:  # noqa: BLE001
+                    count = len(bucket["devices"])
+                bucket["count"] = max(count, len(bucket["devices"]))
+                normalized_grouped[type_key] = bucket
+            ordered_keys = (
+                [normalize_type_key(key) for key in ordered if normalize_type_key(key)]
+                if isinstance(ordered, list)
+                else list(normalized_grouped.keys())
+            )
+            if normalized_grouped:
+                self.coordinator.inventory_runtime._set_type_device_buckets(
+                    normalized_grouped, ordered_keys, authoritative=False
+                )
+
+        battery_order = snapshot.get("battery_storage_order")
+        battery_data = snapshot.get("battery_storage_data")
+        if isinstance(battery_order, list) and isinstance(battery_data, dict):
+            self.coordinator._battery_storage_order = [
+                str(item).strip() for item in battery_order if str(item).strip()
+            ]
+            self.coordinator._battery_storage_data = {
+                str(key).strip(): dict(value)
+                for key, value in battery_data.items()
+                if str(key).strip() and isinstance(value, dict)
+            }
+
+        inverter_order = snapshot.get("inverter_order")
+        inverter_data = snapshot.get("inverter_data")
+        if isinstance(inverter_order, list) and isinstance(inverter_data, dict):
+            restored_inverter_order = [
+                str(item).strip() for item in inverter_order if str(item).strip()
+            ]
+            restored_inverter_data = {
+                str(key).strip(): dict(value)
+                for key, value in inverter_data.items()
+                if str(key).strip() and isinstance(value, dict)
+            }
+            self.coordinator.inventory_runtime._update_shared_state(
+                _inverter_order=restored_inverter_order,
+                _inverter_data=restored_inverter_data,
+            )
+
+        has_encharge = _snapshot_bool(snapshot.get("battery_has_encharge"))
+        if has_encharge is not None:
+            self.coordinator._battery_has_encharge = has_encharge
+        has_enpower = _snapshot_bool(snapshot.get("battery_has_enpower"))
+        if has_enpower is not None:
+            self.coordinator._battery_has_enpower = has_enpower
+
+        restored_channels = snapshot.get("site_energy_channels")
+        if isinstance(restored_channels, list):
+            self.coordinator._restored_site_energy_channels = {
+                str(item).strip() for item in restored_channels if str(item).strip()
+            }
+
+        restored_router_records = snapshot.get("gateway_iq_energy_router_records")
+        if isinstance(restored_router_records, list):
+            self.coordinator._restored_gateway_iq_energy_router_records = [
+                dict(item) for item in restored_router_records if isinstance(item, dict)
+            ]
+        self.coordinator._refresh_cached_topology()
+
+    async def async_restore_state(self) -> None:
+        if self.coordinator._discovery_snapshot_loaded:
+            return
+        self.coordinator._discovery_snapshot_loaded = True
+        self.coordinator._devices_inventory_ready = False
+        self.coordinator._hems_inventory_ready = False
+        self.coordinator._site_energy_discovery_ready = False
+        try:
+            snapshot = await self._store.async_load()
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Failed to load discovery snapshot for site %s",
+                redact_site_id(self.coordinator.site_id),
+                exc_info=True,
+            )
+            return
+        self.apply(snapshot)
+
+    async def async_save(self) -> None:
+        self.coordinator._discovery_snapshot_pending = False
+        snapshot = self.capture()
+        try:
+            await self._store.async_save(snapshot)
+        except Exception:  # noqa: BLE001
+            _LOGGER.debug(
+                "Failed to save discovery snapshot for site %s",
+                redact_site_id(self.coordinator.site_id),
+                exc_info=True,
+            )
+
+    def schedule_save(self) -> None:
+        self.coordinator._discovery_snapshot_pending = True
+        if self.coordinator._discovery_snapshot_save_cancel is not None:
+            return
+
+        @callback
+        def _run(_now: datetime) -> None:
+            self.coordinator._discovery_snapshot_save_cancel = None
+            if not self.coordinator._discovery_snapshot_pending:
+                return
+            self.coordinator.hass.async_create_task(self.async_save())
+
+        self.coordinator._discovery_snapshot_save_cancel = async_call_later(
+            self.coordinator.hass, DISCOVERY_SNAPSHOT_SAVE_DELAY_S, _run
+        )
+
+    def cancel_pending_save(self) -> None:
+        if self.coordinator._discovery_snapshot_save_cancel is not None:
+            self.coordinator._discovery_snapshot_save_cancel()
+            self.coordinator._discovery_snapshot_save_cancel = None
+
+    def sync_site_energy_discovery_state(self) -> None:
+        energy = getattr(self.coordinator, "energy", None)
+        if energy is None:
+            return
+        if getattr(energy, "_site_energy_cache_ts", None) is not None:
+            self.coordinator._site_energy_discovery_ready = True

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -330,51 +330,6 @@ class InventoryRuntime:
             "types": types,
         }
 
-    def _live_site_energy_channels(self) -> set[str]:
-        channels: set[str] = set()
-        energy = getattr(self.coordinator, "energy", None)
-        if energy is None:
-            return channels
-        flows = getattr(energy, "site_energy", None)
-        if isinstance(flows, dict):
-            for key in flows:
-                try:
-                    key_text = str(key).strip()
-                except Exception:  # noqa: BLE001
-                    continue
-                if key_text:
-                    channels.add(key_text)
-        meta = getattr(energy, "site_energy_meta", None)
-        if isinstance(meta, dict):
-            bucket_lengths = meta.get("bucket_lengths")
-            if isinstance(bucket_lengths, dict):
-                for key, value in bucket_lengths.items():
-                    try:
-                        key_text = str(key).strip()
-                    except Exception:  # noqa: BLE001
-                        continue
-                    if not key_text:
-                        continue
-                    try:
-                        if int(value) <= 0:
-                            continue
-                    except Exception:  # noqa: BLE001
-                        if not value:
-                            continue
-                    mapped = {
-                        "heatpump": "heat_pump",
-                        "water_heater": "water_heater",
-                        "evse": "evse_charging",
-                        "solar_production": "solar_production",
-                        "consumption": "consumption",
-                        "grid_import": "grid_import",
-                        "grid_export": "grid_export",
-                        "battery_charge": "battery_charge",
-                        "battery_discharge": "battery_discharge",
-                    }.get(key_text, key_text)
-                    channels.add(mapped)
-        return channels
-
     def _debug_topology_summary(
         self, snapshot: CoordinatorTopologySnapshot
     ) -> dict[str, object]:
@@ -385,7 +340,9 @@ class InventoryRuntime:
             "inverter_count": len(snapshot.inverter_serials),
             "active_type_keys": list(snapshot.active_type_keys),
             "gateway_iq_router_count": len(snapshot.gateway_iq_router_keys),
-            "site_energy_channels": sorted(self._live_site_energy_channels()),
+            "site_energy_channels": sorted(
+                self.coordinator.discovery_snapshot.live_site_energy_channels()
+            ),
         }
 
     def _build_system_dashboard_summaries(

--- a/custom_components/enphase_ev/inventory_view.py
+++ b/custom_components/enphase_ev/inventory_view.py
@@ -680,20 +680,7 @@ class InventoryView:
         return DeviceInfo(**info_kwargs)
 
     def gateway_iq_energy_router_records(self) -> list[dict[str, object]]:
-        records = self.coordinator._live_gateway_iq_energy_router_records()
-        if records:
-            return records
-        if self.coordinator._gateway_router_discovery_ready():
-            return []
-        return [
-            dict(item)
-            for item in getattr(
-                self.coordinator,
-                "_restored_gateway_iq_energy_router_records",
-                (),
-            )
-            if isinstance(item, dict)
-        ]
+        return self.coordinator.discovery_snapshot.gateway_iq_energy_router_records()
 
     def gateway_iq_energy_router_summary_records(self) -> list[dict[str, object]]:
         return self.inventory_runtime.gateway_iq_energy_router_summary_records()

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -537,7 +537,11 @@ async def async_setup_entry(
         ) -> bool:
             if flow_key in site_energy:
                 return True
-            known_channel = getattr(coord, "site_energy_channel_known", None)
+            known_channel = getattr(
+                getattr(coord, "discovery_snapshot", None),
+                "site_energy_channel_known",
+                None,
+            )
             if callable(known_channel):
                 try:
                     if known_channel(flow_key):
@@ -5626,7 +5630,11 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
         if flow_key in self._site_energy_flows():
             return True
 
-        known_channel = getattr(self._coord, "site_energy_channel_known", None)
+        known_channel = getattr(
+            getattr(self._coord, "discovery_snapshot", None),
+            "site_energy_channel_known",
+            None,
+        )
         if callable(known_channel):
             try:
                 if known_channel(flow_key):

--- a/tests/components/enphase_ev/conftest.py
+++ b/tests/components/enphase_ev/conftest.py
@@ -436,7 +436,7 @@ def setup_integration(
             )
             stack.enter_context(
                 patch(
-                    "custom_components.enphase_ev.coordinator.EnphaseCoordinator.async_restore_discovery_state",
+                    "custom_components.enphase_ev.discovery_snapshot.DiscoverySnapshotManager.async_restore_state",
                     new=AsyncMock(return_value=None),
                 )
             )

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2636,11 +2636,11 @@ def test_snapshot_helpers_and_discovery_capture_edge_paths(hass, monkeypatch) ->
     assert coord._snapshot_bool("disabled") is False  # noqa: SLF001
     assert coord._snapshot_bool("maybe") is None  # noqa: SLF001
 
-    assert coord.site_energy_channel_known(BadStr()) is False
-    assert coord.site_energy_channel_known(" ") is False
+    assert coord.discovery_snapshot.site_energy_channel_known(BadStr()) is False
+    assert coord.discovery_snapshot.site_energy_channel_known(" ") is False
 
     coord.energy = None  # type: ignore[assignment]
-    assert coord._live_site_energy_channels() == set()  # noqa: SLF001
+    assert coord.discovery_snapshot.live_site_energy_channels() == set()
 
     coord.energy = SimpleNamespace(
         site_energy={BadStr(): 1, "grid_import": 1},
@@ -2662,7 +2662,7 @@ def test_snapshot_helpers_and_discovery_capture_edge_paths(hass, monkeypatch) ->
             }
         },
     )
-    channels = coord._live_site_energy_channels()  # noqa: SLF001
+    channels = coord.discovery_snapshot.live_site_energy_channels()
     assert channels >= {
         "grid_import",
         "heat_pump",
@@ -2683,7 +2683,7 @@ def test_snapshot_helpers_and_discovery_capture_edge_paths(hass, monkeypatch) ->
         {"device-type": "IQ_GATEWAY"},
         {"device_type": "IQ_ENERGY_ROUTER", "device-uid": "LIVE-1"},
     ]
-    live_records = coord._live_gateway_iq_energy_router_records()  # noqa: SLF001
+    live_records = coord.discovery_snapshot.gateway_iq_energy_router_records()
     assert live_records == [{"device_type": "IQ_ENERGY_ROUTER", "device-uid": "LIVE-1"}]
 
     coord.inventory_runtime._hems_group_members = lambda *_args: []  # type: ignore[assignment]  # noqa: SLF001
@@ -2703,7 +2703,7 @@ def test_snapshot_helpers_and_discovery_capture_edge_paths(hass, monkeypatch) ->
     coord._battery_has_encharge = True  # noqa: SLF001
     coord._battery_has_enpower = False  # noqa: SLF001
 
-    snapshot = coord._capture_discovery_snapshot()  # noqa: SLF001
+    snapshot = coord.discovery_snapshot.capture()
     assert snapshot["site_energy_channels"] == ["heat_pump"]
     assert snapshot["gateway_iq_energy_router_records"] == [
         {"device-uid": "REST-1", "device-type": "IQ_ENERGY_ROUTER"}
@@ -2718,17 +2718,37 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
     hass, monkeypatch
 ) -> None:
     coord = _make_coordinator(hass, monkeypatch)
+    from custom_components.enphase_ev.discovery_snapshot import (
+        _snapshot_bool,
+        _snapshot_compatible_value,
+    )
 
     class BadStr:
         def __str__(self) -> str:
             raise ValueError("boom")
+
+    class BadKey:
+        def __str__(self) -> str:
+            raise RuntimeError("key")
+
+    assert _snapshot_compatible_value(datetime(2024, 1, 1, tzinfo=timezone.utc)) == (
+        "2024-01-01T00:00:00+00:00"
+    )
+    assert _snapshot_compatible_value({BadKey(): "drop", "ok": BadStr()}) == {
+        "ok": None
+    }
+    assert _snapshot_compatible_value({BadStr()}) == [None]
+    assert _snapshot_bool(None) is None
+    assert _snapshot_bool(0) is False
+    assert _snapshot_bool("maybe") is None
 
     ensure_serial = Mock()
     set_buckets = Mock()
     coord._ensure_serial_tracked = ensure_serial  # type: ignore[assignment]  # noqa: SLF001
     coord.inventory_runtime._set_type_device_buckets = set_buckets  # type: ignore[assignment]  # noqa: SLF001
 
-    coord._apply_discovery_snapshot(  # noqa: SLF001
+    coord.discovery_snapshot.apply(None)
+    coord.discovery_snapshot.apply(
         {
             "serial_order": [None, BadStr(), "REST-1"],
             "type_device_buckets": {
@@ -2778,25 +2798,25 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
     assert coord._devices_inventory_ready is True  # noqa: SLF001
 
     coord._discovery_snapshot_loaded = True  # noqa: SLF001
-    coord._discovery_snapshot_store = SimpleNamespace(  # noqa: SLF001
+    coord.discovery_snapshot._store = SimpleNamespace(  # type: ignore[assignment]  # noqa: SLF001
         async_load=AsyncMock(side_effect=AssertionError("no load"))
     )
-    await coord.async_restore_discovery_state()
+    await coord.discovery_snapshot.async_restore_state()
 
     coord._discovery_snapshot_loaded = False  # noqa: SLF001
-    coord._discovery_snapshot_store = SimpleNamespace(  # noqa: SLF001
+    coord.discovery_snapshot._store = SimpleNamespace(  # type: ignore[assignment]  # noqa: SLF001
         async_load=AsyncMock(side_effect=RuntimeError("boom"))
     )
-    await coord.async_restore_discovery_state()
+    await coord.discovery_snapshot.async_restore_state()
     assert coord._devices_inventory_ready is False  # noqa: SLF001
     assert coord._hems_inventory_ready is False  # noqa: SLF001
     assert coord._site_energy_discovery_ready is False  # noqa: SLF001
 
-    coord._capture_discovery_snapshot = Mock(return_value={"serial_order": []})  # type: ignore[assignment]  # noqa: SLF001
-    coord._discovery_snapshot_store = SimpleNamespace(  # noqa: SLF001
+    coord.discovery_snapshot.capture = Mock(return_value={"serial_order": []})  # type: ignore[assignment]
+    coord.discovery_snapshot._store = SimpleNamespace(  # type: ignore[assignment]  # noqa: SLF001
         async_save=AsyncMock(side_effect=RuntimeError("boom"))
     )
-    await coord._async_save_discovery_snapshot()  # noqa: SLF001
+    await coord.discovery_snapshot.async_save()
 
     create_calls: list[object] = []
 
@@ -2812,15 +2832,15 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
         scheduled.append(callback)
         return lambda: None
 
-    from custom_components.enphase_ev import coordinator as coord_mod
+    from custom_components.enphase_ev import discovery_snapshot as snapshot_mod
 
-    monkeypatch.setattr(coord_mod, "async_call_later", _capture_call_later)
+    monkeypatch.setattr(snapshot_mod, "async_call_later", _capture_call_later)
     coord._discovery_snapshot_save_cancel = lambda: None  # type: ignore[assignment]  # noqa: SLF001
-    coord._schedule_discovery_snapshot_save()  # noqa: SLF001
+    coord.discovery_snapshot.schedule_save()
     assert scheduled == []
 
     coord._discovery_snapshot_save_cancel = None  # noqa: SLF001
-    coord._schedule_discovery_snapshot_save()  # noqa: SLF001
+    coord.discovery_snapshot.schedule_save()
     assert len(scheduled) == 1
     coord._discovery_snapshot_pending = False  # noqa: SLF001
     scheduled[0](datetime.now(tz=timezone.utc))
@@ -2829,11 +2849,16 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
     coord._discovery_snapshot_pending = True  # noqa: SLF001
     scheduled[0](datetime.now(tz=timezone.utc))
     assert len(create_calls) == 1
+    cancelled: list[bool] = []
+    coord._discovery_snapshot_save_cancel = lambda: cancelled.append(True)  # type: ignore[assignment]  # noqa: SLF001
+    coord.discovery_snapshot.cancel_pending_save()
+    assert cancelled == [True]
+    assert coord._discovery_snapshot_save_cancel is None  # noqa: SLF001
 
     coord.energy = None  # type: ignore[assignment]
-    coord._sync_site_energy_discovery_state()  # noqa: SLF001
+    coord.discovery_snapshot.sync_site_energy_discovery_state()
     coord.energy = SimpleNamespace(_site_energy_cache_ts=1)
-    coord._sync_site_energy_discovery_state()  # noqa: SLF001
+    coord.discovery_snapshot.sync_site_energy_discovery_state()
     assert coord._site_energy_discovery_ready is True  # noqa: SLF001
 
     coord._system_dashboard_type_summaries = {"envoy": {}}  # noqa: SLF001
@@ -2863,7 +2888,7 @@ async def test_startup_warmup_runner_and_task_edge_paths(
 ) -> None:
     coord = coordinator_factory()
     coord.async_set_updated_data = Mock(side_effect=RuntimeError("publish"))  # type: ignore[assignment]
-    coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]
     coord._async_refresh_battery_site_settings = None  # type: ignore[assignment]  # noqa: SLF001
 
     await coord._async_startup_warmup_runner()  # noqa: SLF001
@@ -2871,29 +2896,29 @@ async def test_startup_warmup_runner_and_task_edge_paths(
     assert coord._warmup_last_error == "publish"  # noqa: SLF001
     assert coord._warmup_in_progress is False  # noqa: SLF001
     assert "discovery_s" in coord._warmup_phase_timings  # noqa: SLF001
-    coord._schedule_discovery_snapshot_save.assert_called_once()  # type: ignore[attr-defined]
+    coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
 
     coord = coordinator_factory()
-    coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]
     coord._async_refresh_battery_site_settings = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=asyncio.CancelledError()
     )
     with pytest.raises(asyncio.CancelledError):
         await coord._async_startup_warmup_runner()  # noqa: SLF001
     assert coord._warmup_in_progress is False  # noqa: SLF001
-    coord._schedule_discovery_snapshot_save.assert_called_once()  # type: ignore[attr-defined]
+    coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
 
     coord = coordinator_factory()
-    coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]
     coord._async_refresh_heatpump_power = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=RuntimeError("heatpump")
     )
     await coord._async_startup_warmup_runner()  # noqa: SLF001
     assert "heatpump_power_s" in coord._warmup_phase_timings  # noqa: SLF001
-    coord._schedule_discovery_snapshot_save.assert_called_once()  # type: ignore[attr-defined]
+    coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
 
     coord = coordinator_factory()
-    coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]
     coord._async_refresh_heatpump_runtime_state = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=RuntimeError("runtime")
     )
@@ -2903,37 +2928,37 @@ async def test_startup_warmup_runner_and_task_edge_paths(
     await coord._async_startup_warmup_runner()  # noqa: SLF001
     assert "heatpump_runtime_s" in coord._warmup_phase_timings  # noqa: SLF001
     assert "heatpump_daily_s" in coord._warmup_phase_timings  # noqa: SLF001
-    coord._schedule_discovery_snapshot_save.assert_called_once()  # type: ignore[attr-defined]
+    coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
 
     coord = coordinator_factory()
-    coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]
     coord._async_refresh_heatpump_runtime_state = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=asyncio.CancelledError()
     )
     with pytest.raises(asyncio.CancelledError):
         await coord._async_startup_warmup_runner()  # noqa: SLF001
     assert coord._warmup_in_progress is False  # noqa: SLF001
-    coord._schedule_discovery_snapshot_save.assert_called_once()  # type: ignore[attr-defined]
+    coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
 
     coord = coordinator_factory()
-    coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]
     coord._async_refresh_heatpump_daily_consumption = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=asyncio.CancelledError()
     )
     with pytest.raises(asyncio.CancelledError):
         await coord._async_startup_warmup_runner()  # noqa: SLF001
     assert coord._warmup_in_progress is False  # noqa: SLF001
-    coord._schedule_discovery_snapshot_save.assert_called_once()  # type: ignore[attr-defined]
+    coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
 
     coord = coordinator_factory()
-    coord._schedule_discovery_snapshot_save = Mock()  # type: ignore[assignment]  # noqa: SLF001
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]
     coord._async_refresh_heatpump_power = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=asyncio.CancelledError()
     )
     with pytest.raises(asyncio.CancelledError):
         await coord._async_startup_warmup_runner()  # noqa: SLF001
     assert coord._warmup_in_progress is False  # noqa: SLF001
-    coord._schedule_discovery_snapshot_save.assert_called_once()  # type: ignore[attr-defined]
+    coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
 
     coord = coordinator_factory()
     coord._warmup_task = SimpleNamespace(done=lambda: False)  # type: ignore[assignment]  # noqa: SLF001
@@ -3124,7 +3149,7 @@ async def test_restore_discovery_state_applies_snapshot_topology(
 ) -> None:
     coord = coordinator_factory(serials=[])
     coord._hems_inventory_ready = False  # noqa: SLF001
-    coord._discovery_snapshot_store = SimpleNamespace(  # noqa: SLF001
+    coord.discovery_snapshot._store = SimpleNamespace(  # type: ignore[assignment]  # noqa: SLF001
         async_load=AsyncMock(
             return_value={
                 "serial_order": [RANDOM_SERIAL, "RESTORED123"],
@@ -3168,15 +3193,15 @@ async def test_restore_discovery_state_applies_snapshot_topology(
         )
     )
 
-    await coord.async_restore_discovery_state()
+    await coord.discovery_snapshot.async_restore_state()
 
     assert coord.iter_serials() == [RANDOM_SERIAL, "RESTORED123"]
     assert coord.inventory_view.type_bucket("heatpump")["count"] == 1
     assert coord._battery_storage_order == ["BAT-1"]  # noqa: SLF001
     assert coord._inverter_order == ["INV-1"]  # noqa: SLF001
     assert coord._devices_inventory_ready is False  # noqa: SLF001
-    assert coord.site_energy_channel_known("heat_pump") is True
-    assert coord.site_energy_channel_known("water_heater") is True
+    assert coord.discovery_snapshot.site_energy_channel_known("heat_pump") is True
+    assert coord.discovery_snapshot.site_energy_channel_known("water_heater") is True
     router_records = coord.inventory_view.gateway_iq_energy_router_records()
     assert router_records[0]["device-uid"] == "ROUTER-1"
 
@@ -3197,7 +3222,7 @@ def test_restored_site_energy_and_router_hints_expire_after_authoritative_refres
         }
     ]
 
-    assert coord.site_energy_channel_known("heat_pump") is True
+    assert coord.discovery_snapshot.site_energy_channel_known("heat_pump") is True
     assert (
         coord.inventory_view.gateway_iq_energy_router_records()[0]["device-uid"]
         == "ROUTER-1"
@@ -3206,8 +3231,8 @@ def test_restored_site_energy_and_router_hints_expire_after_authoritative_refres
     coord._site_energy_discovery_ready = True  # noqa: SLF001
     coord._hems_inventory_ready = True  # noqa: SLF001
 
-    assert coord.site_energy_channel_known("heat_pump") is False
-    assert coord.site_energy_channel_known("water_heater") is False
+    assert coord.discovery_snapshot.site_energy_channel_known("heat_pump") is False
+    assert coord.discovery_snapshot.site_energy_channel_known("water_heater") is False
     assert coord.inventory_view.gateway_iq_energy_router_records() == []
 
 

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -302,8 +302,11 @@ async def test_async_setup_entry_restores_discovery_before_first_refresh(
     class DummyCoordinator:
         def __init__(self) -> None:
             self.site_id = site_id
+            self.discovery_snapshot = SimpleNamespace(
+                async_restore_state=self._async_restore_state
+            )
 
-        async def async_restore_discovery_state(self) -> None:
+        async def _async_restore_state(self) -> None:
             calls.append("restore")
 
         async def async_config_entry_first_refresh(self) -> None:

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -384,7 +384,7 @@ def test_inventory_runtime_debug_cache_and_gateway_fallback_edges(
     assert hems_summary["router_count"] == 0
 
     coord.energy = None
-    assert runtime._live_site_energy_channels() == set()  # noqa: SLF001
+    assert coord.discovery_snapshot.live_site_energy_channels() == set()
     coord.energy = SimpleNamespace(
         site_energy={BadText(): 1, " grid_import ": 1},
         site_energy_meta={
@@ -399,7 +399,7 @@ def test_inventory_runtime_debug_cache_and_gateway_fallback_edges(
             }
         },
     )
-    assert runtime._live_site_energy_channels() == {  # noqa: SLF001
+    assert coord.discovery_snapshot.live_site_energy_channels() == {
         "battery_discharge",
         "grid_import",
         "heat_pump",

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -226,7 +226,7 @@ async def test_async_setup_entry_site_energy_known_error_falls_back_to_bucket_le
     def _raise_known(_flow_key: str) -> bool:
         raise RuntimeError("boom")
 
-    coord.site_energy_channel_known = _raise_known  # type: ignore[assignment]
+    coord.discovery_snapshot.site_energy_channel_known = _raise_known  # type: ignore[assignment]
     callbacks: list = []
 
     def fake_add_listener(cb):

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -2494,7 +2494,9 @@ def test_site_lifetime_power_sensor_helper_edge_cases(
     assert ts == 1_700_000_200
 
     coord.energy = None  # type: ignore[assignment]
-    coord.site_energy_channel_known = lambda flow_key: flow_key == "grid_export"  # type: ignore[assignment]
+    coord.discovery_snapshot.site_energy_channel_known = (  # type: ignore[assignment]
+        lambda flow_key: flow_key == "grid_export"
+    )
     export_sensor = EnphaseGridPowerSensor(coord)
     assert export_sensor._flow_supported("grid_export") is True
     assert export_sensor._current_flow_values() == (
@@ -2509,7 +2511,7 @@ def test_site_lifetime_power_sensor_helper_edge_cases(
     def _raise_known(_flow_key: str) -> bool:
         raise RuntimeError("boom")
 
-    coord.site_energy_channel_known = _raise_known  # type: ignore[assignment]
+    coord.discovery_snapshot.site_energy_channel_known = _raise_known  # type: ignore[assignment]
     coord.site_energy_meta = {"bucket_lengths": {"solar_grid": "yes"}}  # type: ignore[assignment]
     assert export_sensor._flow_supported("grid_export") is True
     coord.site_energy_meta = {"bucket_lengths": {"solar_grid": 0}}  # type: ignore[assignment]


### PR DESCRIPTION
## Summary

Extract the discovery snapshot persistence logic out of the coordinator into a dedicated manager.

This keeps snapshot capture, apply, restore, save scheduling, and restored discovery hint lookups in one place while preserving the existing storage format and behavior.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/discovery_snapshot.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/__init__.py custom_components/enphase_ev/inventory_view.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/conftest.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_site_energy.py tests/components/enphase_ev/test_sensor_additional_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_inventory_runtime.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/discovery_snapshot.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/__init__.py custom_components/enphase_ev/inventory_view.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/conftest.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_site_energy.py tests/components/enphase_ev/test_sensor_additional_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_inventory_runtime.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_inventory_runtime.py tests/components/enphase_ev/test_site_energy.py tests/components/enphase_ev/test_sensor_additional_coverage.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_inventory_runtime.py tests/components/enphase_ev/test_site_energy.py tests/components/enphase_ev/test_sensor_additional_coverage.py -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/discovery_snapshot.py --fail-under=100"
```

Add any extra commands, targeted tests, or manual validation below.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This is an internal refactor only. The persisted discovery snapshot schema, store version, and save delay remain unchanged.
