### PR TITLE
Preserve EVSE power baseline across summary gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Preserve the last known EV lifetime energy baseline when the cloud summary payload temporarily omits `lifeTimeConsumption`, preventing EV charger power attributes from collapsing to null during active sessions.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -3375,6 +3375,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 "plug_and_charge_supported": plug_and_charge_support,
                 "plug_and_charge_supported_source": plug_and_charge_support_source,
             }
+            if isinstance(previous_entry, dict):
+                previous_lifetime_kwh = _power_as_float(
+                    previous_entry.get("lifetime_kwh")
+                )
+                if previous_lifetime_kwh is not None:
+                    entry.setdefault("lifetime_kwh", previous_lifetime_kwh)
             entry.update(_build_evse_power_snapshot(sn, entry))
             if PHASE_SWITCH_CONFIG_SETTING in config_values:
                 entry["phase_switch_config"] = config_values[
@@ -3645,6 +3651,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     )
                     if filtered is not None:
                         cur["lifetime_kwh"] = filtered
+                elif isinstance(prev_sn, dict):
+                    previous_lifetime_kwh = _power_as_float(prev_sn.get("lifetime_kwh"))
+                    if previous_lifetime_kwh is not None:
+                        cur["lifetime_kwh"] = previous_lifetime_kwh
                 for key_src, key_dst in (
                     ("firmwareVersion", "firmware_version"),
                     ("systemVersion", "system_version"),

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2627,6 +2627,9 @@ def test_snapshot_helpers_and_discovery_capture_edge_paths(hass, monkeypatch) ->
     ) == {  # noqa: SLF001
         "ok": 1
     }
+    set_snapshot = coord._snapshot_compatible_value({1, "two"})  # noqa: SLF001
+    assert isinstance(set_snapshot, list)
+    assert set(set_snapshot) == {1, "two"}
     assert coord._snapshot_compatible_value(BadStr()) is None  # noqa: SLF001
 
     assert coord._snapshot_bool(None) is None  # noqa: SLF001

--- a/tests/components/enphase_ev/test_power_estimate.py
+++ b/tests/components/enphase_ev/test_power_estimate.py
@@ -158,6 +158,104 @@ async def test_missing_report_time_does_not_synthesize_sampled_at_utc(
 
 
 @pytest.mark.asyncio
+async def test_missing_lifetime_consumption_preserves_previous_evse_baseline(
+    hass, monkeypatch
+):
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    cfg = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 15,
+    }
+
+    class DummyEntry:
+        options = {}
+
+        def async_on_unload(self, cb):
+            return None
+
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    coord = EnphaseCoordinator(hass, cfg, config_entry=DummyEntry())
+
+    class StubClient:
+        def __init__(self, payloads):
+            self._payloads = list(payloads)
+
+        async def status(self):
+            return self._payloads.pop(0)
+
+    coord.client = StubClient(
+        [
+            {
+                "evChargerData": [
+                    {
+                        "sn": RANDOM_SERIAL,
+                        "name": "Garage EV",
+                        "charging": True,
+                        "pluggedIn": True,
+                        "lastReportedAt": "2024-01-01T00:05:00+00:00",
+                    }
+                ]
+            },
+            {
+                "evChargerData": [
+                    {
+                        "sn": RANDOM_SERIAL,
+                        "name": "Garage EV",
+                        "charging": True,
+                        "pluggedIn": True,
+                        "lastReportedAt": "2024-01-01T00:10:00+00:00",
+                    }
+                ]
+            },
+        ]
+    )
+    coord.summary.prepare_refresh = lambda **kwargs: False
+    coord.summary.async_fetch = AsyncMock(
+        side_effect=[
+            [
+                {
+                    "serialNumber": RANDOM_SERIAL,
+                    "lifeTimeConsumption": 2.0,
+                    "lastReportedAt": "2024-01-01T00:05:00+00:00",
+                }
+            ],
+            [
+                {
+                    "serialNumber": RANDOM_SERIAL,
+                    "lastReportedAt": "2024-01-01T00:10:00+00:00",
+                }
+            ],
+        ]
+    )
+
+    first = await coord._async_update_data()
+    coord.data = first
+    second = await coord._async_update_data()
+
+    assert first[RANDOM_SERIAL]["lifetime_kwh"] == pytest.approx(2.0)
+    assert second[RANDOM_SERIAL]["lifetime_kwh"] == pytest.approx(2.0)
+    assert second[RANDOM_SERIAL]["derived_last_lifetime_kwh"] == pytest.approx(2.0)
+    assert second[RANDOM_SERIAL]["derived_last_energy_ts"] == pytest.approx(
+        datetime(2024, 1, 1, 0, 5, tzinfo=timezone.utc).timestamp()
+    )
+
+
+@pytest.mark.asyncio
 async def test_same_sample_timestamp_still_drops_power_when_charging_stops(
     hass, monkeypatch
 ):


### PR DESCRIPTION
## Summary

Preserve the last known EVSE lifetime energy baseline when the cloud summary payload temporarily omits `lifeTimeConsumption`.

This keeps EV charger power derivation from losing its stored energy context across summary gaps, which otherwise leaves the power sensor stuck at `0 W` with null lifetime attributes during active charging.

Related issue: https://github.com/barneyonline/ha-enphase-energy/issues/424

## Related Issues

- https://github.com/barneyonline/ha-enphase-energy/issues/424

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_power_estimate.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m black custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_power_estimate.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_power_estimate.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This patch is intentionally narrow. It preserves the last known EVSE `lifetime_kwh` baseline when the summary payload omits `lifeTimeConsumption`, so downstream derived power attributes do not lose their stored energy context during transient upstream gaps.
