### PR TITLE
Extract coordinator refresh runner

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -1151,7 +1151,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
             f"{DOMAIN}_schedule_sync_start",
         )
 
-    startup_warmup = getattr(coord, "async_start_startup_warmup", None)
+    refresh_runner = getattr(coord, "refresh_runner", None)
+    startup_warmup = getattr(refresh_runner, "async_start_startup_warmup", None)
     if callable(startup_warmup):
         _schedule_background_task(
             startup_warmup(),

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -125,12 +125,10 @@ from . import system_dashboard_helpers as sd_helpers
 from .refresh_plan import (
     FOLLOWUP_PLAN,
     HEATPUMP_FOLLOWUP_PLAN,
-    RefreshPlan,
     SITE_ONLY_FOLLOWUP_PLAN,
-    bind_refresh_plan,
     post_session_followup_plan,
-    warmup_plan,
 )
+from .refresh_runner import CoordinatorRefreshRunner
 from .service_validation import raise_translated_service_validation
 from .state_models import (
     BatteryControlCapability,
@@ -394,6 +392,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self.battery_runtime = BatteryRuntime(self)
         self.heatpump_runtime = HeatpumpRuntime(self)
         self.inventory_runtime = InventoryRuntime(self)
+        self.refresh_runner = CoordinatorRefreshRunner(self)
         self.discovery_snapshot = DiscoverySnapshotManager(self)
         self.inventory_view = InventoryView(self)
         self.diagnostics = CoordinatorDiagnostics(self)
@@ -858,139 +857,6 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         current = self.data if isinstance(self.data, dict) else {}
         self.async_set_updated_data(dict(current))
 
-    async def _async_run_refresh_call(
-        self,
-        timing_key: str,
-        log_label: str,
-        callback_factory: Callable[[], object],
-    ) -> tuple[str, float | None]:
-        started = time.monotonic()
-        try:
-            result = callback_factory()
-            if inspect.isawaitable(result):
-                await result
-        except asyncio.CancelledError:
-            raise
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.debug(
-                "Skipping %s refresh for site %s: %s",
-                log_label,
-                redact_site_id(self.site_id),
-                redact_text(err, site_ids=(self.site_id,)),
-            )
-        return timing_key, round(time.monotonic() - started, 3)
-
-    async def _async_run_refresh_calls(
-        self,
-        phase_timings: dict[str, float],
-        *,
-        calls: tuple[tuple[str, str, Callable[[], object]], ...],
-        stage_key: str | None = None,
-        defer_topology: bool = False,
-    ) -> None:
-        if defer_topology:
-            self._begin_topology_refresh_batch()
-
-        group_started = time.monotonic()
-        try:
-            results = await asyncio.gather(
-                *(
-                    self._async_run_refresh_call(
-                        timing_key, log_label, callback_factory
-                    )
-                    for timing_key, log_label, callback_factory in calls
-                )
-            )
-        finally:
-            if defer_topology:
-                self._end_topology_refresh_batch()
-
-        for timing_key, duration in results:
-            if duration is not None:
-                phase_timings[timing_key] = duration
-        if stage_key is not None:
-            phase_timings[f"{stage_key}_s"] = round(time.monotonic() - group_started, 3)
-
-    async def _async_run_ordered_refresh_calls(
-        self,
-        phase_timings: dict[str, float],
-        *,
-        calls: tuple[tuple[str, str, Callable[[], object]], ...],
-        stage_key: str | None = None,
-        defer_topology: bool = False,
-    ) -> None:
-        if defer_topology:
-            self._begin_topology_refresh_batch()
-
-        group_started = time.monotonic()
-        try:
-            for timing_key, log_label, callback_factory in calls:
-                key, duration = await self._async_run_refresh_call(
-                    timing_key,
-                    log_label,
-                    callback_factory,
-                )
-                if duration is not None:
-                    phase_timings[key] = duration
-        finally:
-            if defer_topology:
-                self._end_topology_refresh_batch()
-
-        if stage_key is not None:
-            phase_timings[f"{stage_key}_s"] = round(time.monotonic() - group_started, 3)
-
-    async def _async_run_staged_refresh_calls(
-        self,
-        phase_timings: dict[str, float],
-        *,
-        parallel_calls: tuple[tuple[str, str, Callable[[], object]], ...] = (),
-        ordered_calls: tuple[tuple[str, str, Callable[[], object]], ...] = (),
-        stage_key: str | None = None,
-        defer_topology: bool = False,
-    ) -> None:
-        if not parallel_calls and not ordered_calls:
-            if stage_key is not None:
-                phase_timings[f"{stage_key}_s"] = 0.0
-            return
-
-        if defer_topology:
-            self._begin_topology_refresh_batch()
-
-        group_started = time.monotonic()
-        try:
-            if parallel_calls:
-                await self._async_run_refresh_calls(
-                    phase_timings,
-                    calls=parallel_calls,
-                )
-            if ordered_calls:
-                await self._async_run_ordered_refresh_calls(
-                    phase_timings,
-                    calls=ordered_calls,
-                )
-        finally:
-            if defer_topology:
-                self._end_topology_refresh_batch()
-
-        if stage_key is not None:
-            phase_timings[f"{stage_key}_s"] = round(time.monotonic() - group_started, 3)
-
-    async def _async_run_refresh_plan(
-        self,
-        phase_timings: dict[str, float],
-        *,
-        plan: RefreshPlan,
-    ) -> None:
-        bound_plan = bind_refresh_plan(self, plan)
-        for stage in bound_plan.stages:
-            await self._async_run_staged_refresh_calls(
-                phase_timings,
-                stage_key=stage.stage_key,
-                defer_topology=stage.defer_topology,
-                parallel_calls=stage.parallel_calls,
-                ordered_calls=stage.ordered_calls,
-            )
-
     async def async_ensure_system_dashboard_diagnostics(self) -> None:
         await self.inventory_runtime.async_ensure_system_dashboard_diagnostics()
 
@@ -1012,182 +878,6 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         await self.heatpump_runtime.async_ensure_heatpump_runtime_diagnostics(
             force=force
         )
-
-    async def _async_startup_warmup_runner(self) -> None:
-        warmup_timings: dict[str, float] = {}
-        self._warmup_in_progress = True
-        self._warmup_last_error = None
-        warmup_data = (
-            {sn: dict(payload) for sn, payload in self.data.items()}
-            if isinstance(self.data, dict)
-            else {}
-        )
-        try:
-            await self._async_run_refresh_plan(
-                warmup_timings,
-                plan=warmup_plan(warmup_data),
-            )
-            if warmup_data:
-                self.async_set_updated_data(warmup_data)
-        except asyncio.CancelledError:
-            raise
-        except Exception as err:  # noqa: BLE001
-            self._warmup_last_error = (
-                redact_text(err, site_ids=(self.site_id,)) or err.__class__.__name__
-            )
-            _LOGGER.debug(
-                "Startup warmup failed for site %s: %s",
-                redact_site_id(self.site_id),
-                redact_text(err, site_ids=(self.site_id,)),
-                exc_info=True,
-            )
-        finally:
-            self._warmup_in_progress = False
-            self._warmup_phase_timings = warmup_timings
-            self.discovery_snapshot.schedule_save()
-
-    async def async_start_startup_warmup(self) -> None:
-        if self._warmup_task is not None and not self._warmup_task.done():
-            return
-        try:
-            self._warmup_task = self.hass.async_create_task(
-                self._async_startup_warmup_runner(),
-                name=f"{DOMAIN}_warmup_{self.site_id}",
-            )
-        except TypeError:
-            self._warmup_task = self.hass.async_create_task(
-                self._async_startup_warmup_runner()
-            )
-
-    async def _async_refresh_site_energy_for_warmup(self) -> None:
-        await self.energy._async_refresh_site_energy()
-        self.discovery_snapshot.sync_site_energy_discovery_state()
-        self._sync_site_energy_issue()
-
-    async def _async_refresh_evse_timeseries_for_warmup(
-        self,
-        *,
-        working_data: dict[str, dict[str, object]] | None = None,
-    ) -> None:
-        try:
-            day_local = dt_util.as_local(dt_util.now())
-        except Exception:
-            day_local = datetime.now(tz=_tz.utc)
-        await self.evse_timeseries.async_refresh(day_local=day_local)
-        target = working_data
-        if target is None and isinstance(self.data, dict) and self.data:
-            target = {sn: dict(payload) for sn, payload in self.data.items()}
-        if target:
-            self.evse_timeseries.merge_charger_payloads(target, day_local=day_local)
-            if working_data is None:
-                self.async_set_updated_data(target)
-
-    async def _async_refresh_session_state_for_warmup(
-        self,
-        *,
-        working_data: dict[str, dict[str, object]] | None = None,
-    ) -> None:
-        target = working_data if working_data is not None else self.data
-        if not isinstance(target, dict) or not target:
-            return
-        try:
-            day_ref = dt_util.as_local(dt_util.now())
-        except Exception:
-            day_ref = datetime.now(tz=_tz.utc)
-        updates = await self._async_enrich_sessions(
-            target.keys(),
-            day_ref,
-            in_background=False,
-        )
-        if not updates:
-            return
-        merged = (
-            target
-            if working_data is not None
-            else {sn: dict(payload) for sn, payload in target.items()}
-        )
-        for sn, sessions in updates.items():
-            payload = merged.get(sn)
-            if payload is None:
-                continue
-            payload["energy_today_sessions"] = sessions
-            payload["energy_today_sessions_kwh"] = self._sum_session_energy(sessions)
-        if working_data is None:
-            self.async_set_updated_data(merged)
-        self._sync_session_history_issue()
-
-    async def _async_refresh_secondary_evse_state_for_warmup(
-        self,
-        *,
-        working_data: dict[str, dict[str, object]] | None = None,
-    ) -> None:
-        target = working_data if working_data is not None else self.data
-        if not isinstance(target, dict) or not target:
-            return
-        serials = [sn for sn in self.iter_serials() if sn]
-        if not serials:
-            return
-        charge_modes = await self.evse_runtime.async_resolve_charge_modes(serials)
-        green_settings = await self.evse_runtime.async_resolve_green_battery_settings(
-            serials
-        )
-        auth_settings = await self.evse_runtime.async_resolve_auth_settings(serials)
-        charger_config = await self.evse_runtime.async_resolve_charger_config(
-            serials,
-            keys=(DEFAULT_CHARGE_LEVEL_SETTING, PHASE_SWITCH_CONFIG_SETTING),
-        )
-        merged = (
-            target
-            if working_data is not None
-            else {sn: dict(payload) for sn, payload in target.items()}
-        )
-        for sn in serials:
-            payload = merged.get(sn)
-            if payload is None:
-                continue
-            charge_mode_resolution = charge_modes.get(sn)
-            charge_mode_value, charge_mode_source = self._charge_mode_resolution_parts(
-                charge_mode_resolution
-            )
-            if charge_mode_value:
-                payload["charge_mode_pref"] = charge_mode_value
-                if charge_mode_source is not None:
-                    payload["charge_mode_pref_source"] = charge_mode_source
-            if green_settings.get(sn) is not None:
-                enabled, supported = green_settings[sn]
-                payload["green_battery_supported"] = supported
-                if supported:
-                    payload["green_battery_enabled"] = enabled
-            if auth_settings.get(sn) is not None:
-                (
-                    app_enabled,
-                    rfid_enabled,
-                    app_supported,
-                    rfid_supported,
-                ) = auth_settings[sn]
-                payload["app_auth_supported"] = app_supported
-                payload["rfid_auth_supported"] = rfid_supported
-                payload["app_auth_enabled"] = app_enabled
-                payload["rfid_auth_enabled"] = rfid_enabled
-                if app_supported or rfid_supported:
-                    values = [
-                        value
-                        for value in (app_enabled, rfid_enabled)
-                        if value is not None
-                    ]
-                    payload["auth_required"] = any(values) if values else None
-            config_values = charger_config.get(sn)
-            if isinstance(config_values, dict):
-                if PHASE_SWITCH_CONFIG_SETTING in config_values:
-                    payload["phase_switch_config"] = config_values[
-                        PHASE_SWITCH_CONFIG_SETTING
-                    ]
-                if DEFAULT_CHARGE_LEVEL_SETTING in config_values:
-                    payload["default_charge_level"] = config_values[
-                        DEFAULT_CHARGE_LEVEL_SETTING
-                    ]
-        if working_data is None:
-            self.async_set_updated_data(merged)
 
     @staticmethod
     def _copy_diagnostics_value(value: object) -> object:  # pragma: no cover
@@ -2103,7 +1793,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 time.monotonic() - site_energy_start, 3
             )
             if not first_refresh:
-                await self._async_run_refresh_plan(
+                await self.refresh_runner._async_run_refresh_plan(
                     phase_timings,
                     plan=SITE_ONLY_FOLLOWUP_PLAN,
                 )
@@ -2483,7 +2173,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._last_error = self.last_failure_description
 
         if not first_refresh:
-            await self._async_run_refresh_plan(
+            await self.refresh_runner._async_run_refresh_plan(
                 phase_timings,
                 plan=FOLLOWUP_PLAN,
             )
@@ -3749,7 +3439,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._sync_session_history_issue()
 
         if not first_refresh:
-            await self._async_run_refresh_plan(
+            await self.refresh_runner._async_run_refresh_plan(
                 phase_timings,
                 plan=post_session_followup_plan(day_local_default),
             )
@@ -3762,7 +3452,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self.discovery_snapshot.sync_site_energy_discovery_state()
             self._sync_site_energy_issue()
             self._sync_battery_profile_pending_issue()
-            await self._async_run_refresh_plan(
+            await self.refresh_runner._async_run_refresh_plan(
                 phase_timings,
                 plan=HEATPUMP_FOLLOWUP_PLAN,
             )

--- a/custom_components/enphase_ev/refresh_plan.py
+++ b/custom_components/enphase_ev/refresh_plan.py
@@ -316,29 +316,32 @@ def warmup_energy_stage(working_data: dict[str, dict]) -> RefreshStage:
     return RefreshStage(
         stage_key="energy",
         parallel_tasks=(
-            method_task(
-                "site_energy_s", "site energy", "_async_refresh_site_energy_for_warmup"
+            object_method_task(
+                "site_energy_s",
+                "site energy",
+                "refresh_runner",
+                "_async_refresh_site_energy_for_warmup",
             ),
-            callback_task(
+            object_method_task(
                 "evse_timeseries_s",
                 "EVSE timeseries",
-                lambda owner: owner._async_refresh_evse_timeseries_for_warmup(
-                    working_data=working_data
-                ),
+                "refresh_runner",
+                "_async_refresh_evse_timeseries_for_warmup",
+                working_data=working_data,
             ),
-            callback_task(
+            object_method_task(
                 "sessions_s",
                 "session state",
-                lambda owner: owner._async_refresh_session_state_for_warmup(
-                    working_data=working_data
-                ),
+                "refresh_runner",
+                "_async_refresh_session_state_for_warmup",
+                working_data=working_data,
             ),
-            callback_task(
+            object_method_task(
                 "secondary_evse_state_s",
                 "secondary EVSE state",
-                lambda owner: owner._async_refresh_secondary_evse_state_for_warmup(
-                    working_data=working_data
-                ),
+                "refresh_runner",
+                "_async_refresh_secondary_evse_state_for_warmup",
+                working_data=working_data,
             ),
         ),
     )

--- a/custom_components/enphase_ev/refresh_runner.py
+++ b/custom_components/enphase_ev/refresh_runner.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+import time
+from collections.abc import Callable
+from datetime import datetime
+from datetime import timezone as _tz
+from typing import TYPE_CHECKING
+
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    DEFAULT_CHARGE_LEVEL_SETTING,
+    DOMAIN,
+    PHASE_SWITCH_CONFIG_SETTING,
+)
+from .log_redaction import redact_site_id, redact_text
+from .refresh_plan import RefreshPlan, bind_refresh_plan, warmup_plan
+
+if TYPE_CHECKING:
+    from .coordinator import EnphaseCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CoordinatorRefreshRunner:
+    def __init__(self, coordinator: EnphaseCoordinator) -> None:
+        self.coordinator = coordinator
+
+    async def _async_run_refresh_call(
+        self,
+        timing_key: str,
+        log_label: str,
+        callback_factory: Callable[[], object],
+    ) -> tuple[str, float | None]:
+        started = time.monotonic()
+        try:
+            result = callback_factory()
+            if inspect.isawaitable(result):
+                await result
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Skipping %s refresh for site %s: %s",
+                log_label,
+                redact_site_id(self.coordinator.site_id),
+                redact_text(err, site_ids=(self.coordinator.site_id,)),
+            )
+        return timing_key, round(time.monotonic() - started, 3)
+
+    async def _async_run_refresh_calls(
+        self,
+        phase_timings: dict[str, float],
+        *,
+        calls: tuple[tuple[str, str, Callable[[], object]], ...],
+        stage_key: str | None = None,
+        defer_topology: bool = False,
+    ) -> None:
+        if defer_topology:
+            self.coordinator._begin_topology_refresh_batch()
+
+        group_started = time.monotonic()
+        try:
+            results = await asyncio.gather(
+                *(
+                    self._async_run_refresh_call(
+                        timing_key, log_label, callback_factory
+                    )
+                    for timing_key, log_label, callback_factory in calls
+                )
+            )
+        finally:
+            if defer_topology:
+                self.coordinator._end_topology_refresh_batch()
+
+        for timing_key, duration in results:
+            if duration is not None:
+                phase_timings[timing_key] = duration
+        if stage_key is not None:
+            phase_timings[f"{stage_key}_s"] = round(time.monotonic() - group_started, 3)
+
+    async def _async_run_ordered_refresh_calls(
+        self,
+        phase_timings: dict[str, float],
+        *,
+        calls: tuple[tuple[str, str, Callable[[], object]], ...],
+        stage_key: str | None = None,
+        defer_topology: bool = False,
+    ) -> None:
+        if defer_topology:
+            self.coordinator._begin_topology_refresh_batch()
+
+        group_started = time.monotonic()
+        try:
+            for timing_key, log_label, callback_factory in calls:
+                key, duration = await self._async_run_refresh_call(
+                    timing_key,
+                    log_label,
+                    callback_factory,
+                )
+                if duration is not None:
+                    phase_timings[key] = duration
+        finally:
+            if defer_topology:
+                self.coordinator._end_topology_refresh_batch()
+
+        if stage_key is not None:
+            phase_timings[f"{stage_key}_s"] = round(time.monotonic() - group_started, 3)
+
+    async def _async_run_staged_refresh_calls(
+        self,
+        phase_timings: dict[str, float],
+        *,
+        parallel_calls: tuple[tuple[str, str, Callable[[], object]], ...] = (),
+        ordered_calls: tuple[tuple[str, str, Callable[[], object]], ...] = (),
+        stage_key: str | None = None,
+        defer_topology: bool = False,
+    ) -> None:
+        if not parallel_calls and not ordered_calls:
+            if stage_key is not None:
+                phase_timings[f"{stage_key}_s"] = 0.0
+            return
+
+        if defer_topology:
+            self.coordinator._begin_topology_refresh_batch()
+
+        group_started = time.monotonic()
+        try:
+            if parallel_calls:
+                await self._async_run_refresh_calls(
+                    phase_timings,
+                    calls=parallel_calls,
+                )
+            if ordered_calls:
+                await self._async_run_ordered_refresh_calls(
+                    phase_timings,
+                    calls=ordered_calls,
+                )
+        finally:
+            if defer_topology:
+                self.coordinator._end_topology_refresh_batch()
+
+        if stage_key is not None:
+            phase_timings[f"{stage_key}_s"] = round(time.monotonic() - group_started, 3)
+
+    async def _async_run_refresh_plan(
+        self,
+        phase_timings: dict[str, float],
+        *,
+        plan: RefreshPlan,
+    ) -> None:
+        bound_plan = bind_refresh_plan(self.coordinator, plan)
+        for stage in bound_plan.stages:
+            await self._async_run_staged_refresh_calls(
+                phase_timings,
+                stage_key=stage.stage_key,
+                defer_topology=stage.defer_topology,
+                parallel_calls=stage.parallel_calls,
+                ordered_calls=stage.ordered_calls,
+            )
+
+    async def _async_startup_warmup_runner(self) -> None:
+        coord = self.coordinator
+        warmup_timings: dict[str, float] = {}
+        coord._warmup_in_progress = True
+        coord._warmup_last_error = None
+        warmup_data = (
+            {sn: dict(payload) for sn, payload in coord.data.items()}
+            if isinstance(coord.data, dict)
+            else {}
+        )
+        try:
+            await self._async_run_refresh_plan(
+                warmup_timings,
+                plan=warmup_plan(warmup_data),
+            )
+            if warmup_data:
+                coord.async_set_updated_data(warmup_data)
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001
+            coord._warmup_last_error = (
+                redact_text(err, site_ids=(coord.site_id,)) or err.__class__.__name__
+            )
+            _LOGGER.debug(
+                "Startup warmup failed for site %s: %s",
+                redact_site_id(coord.site_id),
+                redact_text(err, site_ids=(coord.site_id,)),
+                exc_info=True,
+            )
+        finally:
+            coord._warmup_in_progress = False
+            coord._warmup_phase_timings = warmup_timings
+            coord.discovery_snapshot.schedule_save()
+
+    async def async_start_startup_warmup(self) -> None:
+        coord = self.coordinator
+        if coord._warmup_task is not None and not coord._warmup_task.done():
+            return
+        try:
+            coord._warmup_task = coord.hass.async_create_task(
+                self._async_startup_warmup_runner(),
+                name=f"{DOMAIN}_warmup_{coord.site_id}",
+            )
+        except TypeError:
+            coord._warmup_task = coord.hass.async_create_task(
+                self._async_startup_warmup_runner()
+            )
+
+    async def _async_refresh_site_energy_for_warmup(self) -> None:
+        coord = self.coordinator
+        await coord.energy._async_refresh_site_energy()
+        coord.discovery_snapshot.sync_site_energy_discovery_state()
+        coord._sync_site_energy_issue()
+
+    async def _async_refresh_evse_timeseries_for_warmup(
+        self,
+        *,
+        working_data: dict[str, dict[str, object]] | None = None,
+    ) -> None:
+        coord = self.coordinator
+        try:
+            day_local = dt_util.as_local(dt_util.now())
+        except Exception:
+            day_local = datetime.now(tz=_tz.utc)
+        await coord.evse_timeseries.async_refresh(day_local=day_local)
+        target = working_data
+        if target is None and isinstance(coord.data, dict) and coord.data:
+            target = {sn: dict(payload) for sn, payload in coord.data.items()}
+        if target:
+            coord.evse_timeseries.merge_charger_payloads(target, day_local=day_local)
+            if working_data is None:
+                coord.async_set_updated_data(target)
+
+    async def _async_refresh_session_state_for_warmup(
+        self,
+        *,
+        working_data: dict[str, dict[str, object]] | None = None,
+    ) -> None:
+        coord = self.coordinator
+        target = working_data if working_data is not None else coord.data
+        if not isinstance(target, dict) or not target:
+            return
+        try:
+            day_ref = dt_util.as_local(dt_util.now())
+        except Exception:
+            day_ref = datetime.now(tz=_tz.utc)
+        updates = await coord._async_enrich_sessions(
+            target.keys(),
+            day_ref,
+            in_background=False,
+        )
+        if not updates:
+            return
+        merged = (
+            target
+            if working_data is not None
+            else {sn: dict(payload) for sn, payload in target.items()}
+        )
+        for sn, sessions in updates.items():
+            payload = merged.get(sn)
+            if payload is None:
+                continue
+            payload["energy_today_sessions"] = sessions
+            payload["energy_today_sessions_kwh"] = coord._sum_session_energy(sessions)
+        if working_data is None:
+            coord.async_set_updated_data(merged)
+        coord._sync_session_history_issue()
+
+    async def _async_refresh_secondary_evse_state_for_warmup(
+        self,
+        *,
+        working_data: dict[str, dict[str, object]] | None = None,
+    ) -> None:
+        coord = self.coordinator
+        target = working_data if working_data is not None else coord.data
+        if not isinstance(target, dict) or not target:
+            return
+        serials = [sn for sn in coord.iter_serials() if sn]
+        if not serials:
+            return
+        charge_modes = await coord.evse_runtime.async_resolve_charge_modes(serials)
+        green_settings = await coord.evse_runtime.async_resolve_green_battery_settings(
+            serials
+        )
+        auth_settings = await coord.evse_runtime.async_resolve_auth_settings(serials)
+        charger_config = await coord.evse_runtime.async_resolve_charger_config(
+            serials,
+            keys=(DEFAULT_CHARGE_LEVEL_SETTING, PHASE_SWITCH_CONFIG_SETTING),
+        )
+        merged = (
+            target
+            if working_data is not None
+            else {sn: dict(payload) for sn, payload in target.items()}
+        )
+        for sn in serials:
+            payload = merged.get(sn)
+            if payload is None:
+                continue
+            charge_mode_resolution = charge_modes.get(sn)
+            charge_mode_value, charge_mode_source = coord._charge_mode_resolution_parts(
+                charge_mode_resolution
+            )
+            if charge_mode_value:
+                payload["charge_mode_pref"] = charge_mode_value
+                if charge_mode_source is not None:
+                    payload["charge_mode_pref_source"] = charge_mode_source
+            if green_settings.get(sn) is not None:
+                enabled, supported = green_settings[sn]
+                payload["green_battery_supported"] = supported
+                if supported:
+                    payload["green_battery_enabled"] = enabled
+            if auth_settings.get(sn) is not None:
+                (
+                    app_enabled,
+                    rfid_enabled,
+                    app_supported,
+                    rfid_supported,
+                ) = auth_settings[sn]
+                payload["app_auth_supported"] = app_supported
+                payload["rfid_auth_supported"] = rfid_supported
+                payload["app_auth_enabled"] = app_enabled
+                payload["rfid_auth_enabled"] = rfid_enabled
+                if app_supported or rfid_supported:
+                    values = [
+                        value
+                        for value in (app_enabled, rfid_enabled)
+                        if value is not None
+                    ]
+                    payload["auth_required"] = any(values) if values else None
+            config_values = charger_config.get(sn)
+            if isinstance(config_values, dict):
+                if PHASE_SWITCH_CONFIG_SETTING in config_values:
+                    payload["phase_switch_config"] = config_values[
+                        PHASE_SWITCH_CONFIG_SETTING
+                    ]
+                if DEFAULT_CHARGE_LEVEL_SETTING in config_values:
+                    payload["default_charge_level"] = config_values[
+                        DEFAULT_CHARGE_LEVEL_SETTING
+                    ]
+        if working_data is None:
+            coord.async_set_updated_data(merged)

--- a/tests/components/enphase_ev/conftest.py
+++ b/tests/components/enphase_ev/conftest.py
@@ -442,7 +442,7 @@ def setup_integration(
             )
             stack.enter_context(
                 patch(
-                    "custom_components.enphase_ev.coordinator.EnphaseCoordinator.async_start_startup_warmup",
+                    "custom_components.enphase_ev.refresh_runner.CoordinatorRefreshRunner.async_start_startup_warmup",
                     new=AsyncMock(return_value=None),
                 )
             )

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1024,7 +1024,7 @@ async def test_refresh_helper_wrappers_cover_stage_and_topology_paths(
     coord._begin_topology_refresh_batch = begin  # type: ignore[assignment]  # noqa: SLF001
     coord._end_topology_refresh_batch = end  # type: ignore[assignment]  # noqa: SLF001
 
-    await coord._async_run_ordered_refresh_calls(  # noqa: SLF001
+    await coord.refresh_runner._async_run_ordered_refresh_calls(  # noqa: SLF001
         phase_timings,
         stage_key="ordered",
         defer_topology=True,
@@ -1040,7 +1040,7 @@ async def test_refresh_helper_wrappers_cover_stage_and_topology_paths(
     begin.reset_mock()
     end.reset_mock()
 
-    await coord._async_run_staged_refresh_calls(  # noqa: SLF001
+    await coord.refresh_runner._async_run_staged_refresh_calls(  # noqa: SLF001
         phase_timings,
         stage_key="empty",
     )
@@ -2894,7 +2894,7 @@ async def test_startup_warmup_runner_and_task_edge_paths(
     coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]
     coord._async_refresh_battery_site_settings = None  # type: ignore[assignment]  # noqa: SLF001
 
-    await coord._async_startup_warmup_runner()  # noqa: SLF001
+    await coord.refresh_runner._async_startup_warmup_runner()  # noqa: SLF001
 
     assert coord._warmup_last_error == "publish"  # noqa: SLF001
     assert coord._warmup_in_progress is False  # noqa: SLF001
@@ -2907,7 +2907,7 @@ async def test_startup_warmup_runner_and_task_edge_paths(
         side_effect=asyncio.CancelledError()
     )
     with pytest.raises(asyncio.CancelledError):
-        await coord._async_startup_warmup_runner()  # noqa: SLF001
+        await coord.refresh_runner._async_startup_warmup_runner()  # noqa: SLF001
     assert coord._warmup_in_progress is False  # noqa: SLF001
     coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
 
@@ -2916,7 +2916,7 @@ async def test_startup_warmup_runner_and_task_edge_paths(
     coord._async_refresh_heatpump_power = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=RuntimeError("heatpump")
     )
-    await coord._async_startup_warmup_runner()  # noqa: SLF001
+    await coord.refresh_runner._async_startup_warmup_runner()  # noqa: SLF001
     assert "heatpump_power_s" in coord._warmup_phase_timings  # noqa: SLF001
     coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
 
@@ -2928,7 +2928,7 @@ async def test_startup_warmup_runner_and_task_edge_paths(
     coord._async_refresh_heatpump_daily_consumption = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
         side_effect=RuntimeError("daily")
     )
-    await coord._async_startup_warmup_runner()  # noqa: SLF001
+    await coord.refresh_runner._async_startup_warmup_runner()  # noqa: SLF001
     assert "heatpump_runtime_s" in coord._warmup_phase_timings  # noqa: SLF001
     assert "heatpump_daily_s" in coord._warmup_phase_timings  # noqa: SLF001
     coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
@@ -2939,7 +2939,7 @@ async def test_startup_warmup_runner_and_task_edge_paths(
         side_effect=asyncio.CancelledError()
     )
     with pytest.raises(asyncio.CancelledError):
-        await coord._async_startup_warmup_runner()  # noqa: SLF001
+        await coord.refresh_runner._async_startup_warmup_runner()  # noqa: SLF001
     assert coord._warmup_in_progress is False  # noqa: SLF001
     coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
 
@@ -2949,7 +2949,7 @@ async def test_startup_warmup_runner_and_task_edge_paths(
         side_effect=asyncio.CancelledError()
     )
     with pytest.raises(asyncio.CancelledError):
-        await coord._async_startup_warmup_runner()  # noqa: SLF001
+        await coord.refresh_runner._async_startup_warmup_runner()  # noqa: SLF001
     assert coord._warmup_in_progress is False  # noqa: SLF001
     coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
 
@@ -2959,7 +2959,7 @@ async def test_startup_warmup_runner_and_task_edge_paths(
         side_effect=asyncio.CancelledError()
     )
     with pytest.raises(asyncio.CancelledError):
-        await coord._async_startup_warmup_runner()  # noqa: SLF001
+        await coord.refresh_runner._async_startup_warmup_runner()  # noqa: SLF001
     assert coord._warmup_in_progress is False  # noqa: SLF001
     coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
 
@@ -2970,7 +2970,7 @@ async def test_startup_warmup_runner_and_task_edge_paths(
     async def _runner() -> None:
         return None
 
-    coord._async_startup_warmup_runner = _runner  # type: ignore[assignment]  # noqa: SLF001
+    coord.refresh_runner._async_startup_warmup_runner = _runner  # type: ignore[assignment]  # noqa: SLF001
 
     def _create_task(coro, name=None):
         create_calls.append(name)
@@ -2980,11 +2980,11 @@ async def test_startup_warmup_runner_and_task_edge_paths(
         return "task"
 
     object.__setattr__(coord.hass, "async_create_task", _create_task)
-    await coord.async_start_startup_warmup()
+    await coord.refresh_runner.async_start_startup_warmup()
     assert create_calls == []
 
     coord._warmup_task = None  # noqa: SLF001
-    await coord.async_start_startup_warmup()
+    await coord.refresh_runner.async_start_startup_warmup()
     assert create_calls == [f"{DOMAIN}_warmup_{coord.site_id}", None]
     assert coord._warmup_task == "task"  # noqa: SLF001
 
@@ -2998,15 +2998,15 @@ async def test_startup_warmup_helper_refreshes_cover_fallback_and_merge_paths(
     set_updated = Mock()
     coord.async_set_updated_data = set_updated  # type: ignore[assignment]
 
-    from custom_components.enphase_ev import coordinator as coord_mod
+    from custom_components.enphase_ev import refresh_runner as runner_mod
 
     monkeypatch.setattr(
-        coord_mod.dt_util, "as_local", Mock(side_effect=RuntimeError("boom"))
+        runner_mod.dt_util, "as_local", Mock(side_effect=RuntimeError("boom"))
     )
 
     coord.energy._async_refresh_site_energy = AsyncMock()  # noqa: SLF001
     coord._sync_site_energy_issue = Mock()  # type: ignore[assignment]  # noqa: SLF001
-    await coord._async_refresh_site_energy_for_warmup()  # noqa: SLF001
+    await coord.refresh_runner._async_refresh_site_energy_for_warmup()  # noqa: SLF001
     coord.energy._async_refresh_site_energy.assert_awaited_once()
 
     coord.evse_timeseries.async_refresh = AsyncMock()
@@ -3015,7 +3015,7 @@ async def test_startup_warmup_helper_refreshes_cover_fallback_and_merge_paths(
             {"timeseries": True}
         )
     )
-    await coord._async_refresh_evse_timeseries_for_warmup()  # noqa: SLF001
+    await coord.refresh_runner._async_refresh_evse_timeseries_for_warmup()  # noqa: SLF001
     merged_timeseries = set_updated.call_args_list[-1].args[0]
     assert merged_timeseries[RANDOM_SERIAL]["timeseries"] is True
 
@@ -3027,7 +3027,7 @@ async def test_startup_warmup_helper_refreshes_cover_fallback_and_merge_paths(
     )
     coord._sum_session_energy = Mock(return_value=1.5)  # type: ignore[assignment]  # noqa: SLF001
     coord._sync_session_history_issue = Mock()  # type: ignore[assignment]  # noqa: SLF001
-    await coord._async_refresh_session_state_for_warmup()  # noqa: SLF001
+    await coord.refresh_runner._async_refresh_session_state_for_warmup()  # noqa: SLF001
     merged_sessions = set_updated.call_args_list[-1].args[0]
     assert merged_sessions[RANDOM_SERIAL]["energy_today_sessions"] == [
         {"energy_kwh": 1.5}
@@ -3036,7 +3036,7 @@ async def test_startup_warmup_helper_refreshes_cover_fallback_and_merge_paths(
     coord._sync_session_history_issue.assert_called_once()
 
     coord._async_enrich_sessions = AsyncMock(return_value={})  # type: ignore[assignment]  # noqa: SLF001
-    await coord._async_refresh_session_state_for_warmup()  # noqa: SLF001
+    await coord.refresh_runner._async_refresh_session_state_for_warmup()  # noqa: SLF001
 
     coord.iter_serials = lambda: [RANDOM_SERIAL, "SECONDARY"]  # type: ignore[assignment]
     coord.evse_runtime.async_resolve_charge_modes = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
@@ -3056,7 +3056,7 @@ async def test_startup_warmup_helper_refreshes_cover_fallback_and_merge_paths(
             }
         }
     )
-    await coord._async_refresh_secondary_evse_state_for_warmup()  # noqa: SLF001
+    await coord.refresh_runner._async_refresh_secondary_evse_state_for_warmup()  # noqa: SLF001
     merged_secondary = set_updated.call_args_list[-1].args[0]
     assert merged_secondary[RANDOM_SERIAL]["charge_mode_pref"] == "SCHEDULED"
     assert merged_secondary[RANDOM_SERIAL]["charge_mode_pref_source"] == "cache_backoff"
@@ -3069,7 +3069,7 @@ async def test_startup_warmup_helper_refreshes_cover_fallback_and_merge_paths(
     assert merged_secondary[RANDOM_SERIAL]["default_charge_level"] is None
 
     coord.iter_serials = lambda: [""]  # type: ignore[assignment]
-    await coord._async_refresh_secondary_evse_state_for_warmup()  # noqa: SLF001
+    await coord.refresh_runner._async_refresh_secondary_evse_state_for_warmup()  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -282,6 +282,12 @@ class _RefreshOwner:
             _async_refresh_devices_inventory=self._async_refresh_devices_inventory,
             _async_refresh_hems_devices=self._async_refresh_hems_devices,
         )
+        self.refresh_runner = SimpleNamespace(
+            _async_refresh_site_energy_for_warmup=self._async_refresh_site_energy_for_warmup,
+            _async_refresh_evse_timeseries_for_warmup=self._async_refresh_evse_timeseries_for_warmup,
+            _async_refresh_session_state_for_warmup=self._async_refresh_session_state_for_warmup,
+            _async_refresh_secondary_evse_state_for_warmup=self._async_refresh_secondary_evse_state_for_warmup,
+        )
 
     def _record(self, value: str) -> str:
         self.calls.append(value)
@@ -458,9 +464,11 @@ async def test_coordinator_refresh_plan_runner_executes_each_stage(
             )
         )
 
-    coord._async_run_staged_refresh_calls = _run_stage  # type: ignore[method-assign]  # noqa: SLF001
+    coord.refresh_runner._async_run_staged_refresh_calls = _run_stage  # type: ignore[method-assign]  # noqa: SLF001
 
-    await coord._async_run_refresh_plan({}, plan=FOLLOWUP_PLAN)  # noqa: SLF001
+    await coord.refresh_runner._async_run_refresh_plan(  # noqa: SLF001
+        {}, plan=FOLLOWUP_PLAN
+    )
 
     assert seen == [
         (None, True, 9, 3),
@@ -474,12 +482,12 @@ async def test_coordinator_run_refresh_calls_tracks_stage_and_topology_batch(
     coord = coordinator_factory()
     coord._begin_topology_refresh_batch = MagicMock()  # type: ignore[method-assign]  # noqa: SLF001
     coord._end_topology_refresh_batch = MagicMock()  # type: ignore[method-assign]  # noqa: SLF001
-    coord._async_run_refresh_call = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
+    coord.refresh_runner._async_run_refresh_call = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
         side_effect=(("first_s", 0.1), ("second_s", 0.2))
     )
     phase_timings: dict[str, float] = {}
 
-    await coord._async_run_refresh_calls(  # noqa: SLF001
+    await coord.refresh_runner._async_run_refresh_calls(  # noqa: SLF001
         phase_timings,
         calls=(
             ("first_s", "first", lambda: None),

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -386,7 +386,9 @@ async def test_async_setup_entry_uses_background_task_for_startup_warmup(
     class DummyCoordinator:
         def __init__(self) -> None:
             self.site_id = site_id
-            self.async_start_startup_warmup = AsyncMock()
+            self.refresh_runner = SimpleNamespace(
+                async_start_startup_warmup=AsyncMock()
+            )
 
         async def async_config_entry_first_refresh(self) -> None:
             return None
@@ -420,7 +422,7 @@ async def test_async_setup_entry_uses_background_task_for_startup_warmup(
     assert await async_setup_entry(hass, config_entry)
 
     assert background_calls == [(hass, "enphase_ev_startup_warmup", True)]
-    dummy_coord.async_start_startup_warmup.assert_not_awaited()
+    dummy_coord.refresh_runner.async_start_startup_warmup.assert_not_awaited()
     forward.assert_awaited_once()
 
 


### PR DESCRIPTION
## Summary

Extract refresh-plan execution and startup warmup orchestration from the coordinator into a dedicated `refresh_runner.py` helper, and update internal callers and tests to use the new boundary directly.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/.codex/worktrees/262f/ha-enphase-ev-charger:/Users/james/.codex/worktrees/262f/ha-enphase-ev-charger -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git -w /Users/james/.codex/worktrees/262f/ha-enphase-ev-charger ha-dev bash -lc "python3 -m pre_commit run --all-files"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/refresh_plan.py,custom_components/enphase_ev/refresh_runner.py --fail-under=100"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- No user-facing behavior change intended.
- Startup warmup and refresh-plan execution now live in `custom_components/enphase_ev/refresh_runner.py`.
