### PR TITLE
Improve issue labeling automation

### DIFF
--- a/.github/workflows/auto_label_issues.yml
+++ b/.github/workflows/auto_label_issues.yml
@@ -6,6 +6,12 @@ on:
       - opened
       - reopened
       - edited
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: Optional issue number to reconcile. Leave blank to process all open form issues.
+        required: false
+        type: string
 
 permissions:
   issues: write
@@ -13,12 +19,17 @@ permissions:
 jobs:
   label_issue:
     if: >
+      github.event_name == 'workflow_dispatch' ||
       startsWith(github.event.issue.title, '[Bug]:') ||
       startsWith(github.event.issue.title, '[Feature]:') ||
       startsWith(github.event.issue.title, '[Device support]:')
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Determine issue form
+        if: github.event_name == 'issues'
         id: form
         uses: actions/github-script@v8
         with:
@@ -50,228 +61,28 @@ jobs:
             core.setFailed(`Unsupported issue form title: ${title}`);
 
       - name: Parse issue form
+        if: github.event_name == 'issues'
         id: issue_parser
         uses: stefanbuck/github-issue-parser@10dcc54158ba4c137713d9d69d70a2da63b6bda3
         with:
           template-path: ${{ steps.form.outputs.template_path }}
 
-      - name: Reconcile automation labels
-        uses: actions/github-script@v8
+      - name: Set up Python
+        uses: actions/setup-python@v5
         env:
-          ISSUE_KIND: ${{ steps.form.outputs.kind }}
           PRIMARY_AREA: ${{ steps.issue_parser.outputs.issueparser_primary_area }}
           FEATURE_AREA: ${{ steps.issue_parser.outputs.issueparser_area }}
           DEVICE_FAMILY: ${{ steps.issue_parser.outputs.issueparser_device_family }}
-          BUG_DIAGNOSTICS: ${{ steps.issue_parser.outputs.issueparser_diagnostics_status }}
-          DEVICE_DIAGNOSTICS: ${{ steps.issue_parser.outputs.issueparser_diagnostics_status }}
-          ISSUE_ACTION: ${{ github.event.action }}
         with:
-          script: |
-            const { owner, repo } = context.repo;
-            const issue = context.payload.issue;
-            const action = process.env.ISSUE_ACTION;
-            const kind = process.env.ISSUE_KIND;
+          python-version: '3.x'
 
-            const managedPrefixes = ["area/"];
-            const managedLabels = new Set([
-              "type/device-support",
-              "status/needs-diagnostics",
-            ]);
-
-            const labelDefinitions = {
-              "type/device-support": {
-                color: "0E8A16",
-                description: "Requests support for a missing device, model, or capability",
-              },
-              "status/needs-triage": {
-                color: "FBCA04",
-                description: "New or reopened issue awaiting maintainer triage",
-              },
-              "status/needs-diagnostics": {
-                color: "D93F0B",
-                description: "More diagnostics or evidence are needed before triage can finish",
-              },
-              "area/setup-auth": {
-                color: "1D76DB",
-                description: "Setup, sign-in, MFA, or reauthentication",
-              },
-              "area/gateway": {
-                color: "1D76DB",
-                description: "IQ Gateway or System Controller behavior",
-              },
-              "area/battery": {
-                color: "1D76DB",
-                description: "IQ Battery, Encharge, or BatteryConfig behavior",
-              },
-              "area/ev-charger": {
-                color: "1D76DB",
-                description: "IQ EV Charger or IQ EVSE behavior",
-              },
-              "area/microinverters": {
-                color: "1D76DB",
-                description: "IQ Microinverter behavior",
-              },
-              "area/hems": {
-                color: "1D76DB",
-                description: "Heat pump or HEMS device data",
-              },
-              "area/water-heater": {
-                color: "1D76DB",
-                description: "Water heater or site-energy channel behavior",
-              },
-              "area/site-energy": {
-                color: "1D76DB",
-                description: "Site or cloud energy telemetry and presentation",
-              },
-              "area/diagnostics": {
-                color: "1D76DB",
-                description: "Diagnostics, repairs, or service-availability reporting",
-              },
-              "area/docs": {
-                color: "1D76DB",
-                description: "Documentation and setup guidance",
-              },
-              "area/tooling": {
-                color: "1D76DB",
-                description: "Developer workflow or repository tooling",
-              },
-            };
-
-            for (const labelName of Object.keys(labelDefinitions)) {
-              managedLabels.add(labelName);
-            }
-
-            const ensureLabel = async (name, config) => {
-              try {
-                await github.rest.issues.getLabel({ owner, repo, name });
-              } catch (error) {
-                if (error.status !== 404) {
-                  throw error;
-                }
-                await github.rest.issues.createLabel({
-                  owner,
-                  repo,
-                  name,
-                  color: config.color,
-                  description: config.description,
-                });
-              }
-            };
-
-            const normalize = (value) => (value ?? "").trim();
-
-            const mapAreaLabel = (value) => {
-              const normalized = normalize(value);
-              const mapping = {
-                "Setup, sign-in, MFA, or reauthentication": "area/setup-auth",
-                "IQ Gateway / System Controller": "area/gateway",
-                "IQ Battery / Encharge / BatteryConfig": "area/battery",
-                "IQ EV Charger / IQ EVSE": "area/ev-charger",
-                "IQ Microinverters": "area/microinverters",
-                "Heat Pump / HEMS device data": "area/hems",
-                "Heat Pump / HEMS device": "area/hems",
-                "Water Heater / site-energy channel": "area/water-heater",
-                "Site or cloud energy telemetry": "area/site-energy",
-                "Site / cloud telemetry capability": "area/site-energy",
-                "Diagnostics, repairs, or service-availability reporting": "area/diagnostics",
-                Documentation: "area/docs",
-                "Developer workflow / repository tooling": "area/tooling",
-              };
-              return mapping[normalized] ?? null;
-            };
-
-            const wantsDiagnosticsLabel = () => {
-              if (kind === "bug") {
-                const diagnostics = normalize(process.env.BUG_DIAGNOSTICS);
-                return (
-                  diagnostics === "Not yet, but I can upload them" ||
-                  diagnostics === "I cannot capture diagnostics"
-                );
-              }
-
-              if (kind === "device_support") {
-                const diagnostics = normalize(process.env.DEVICE_DIAGNOSTICS);
-                return (
-                  diagnostics === "Screenshots only" ||
-                  diagnostics === "Nothing attached yet"
-                );
-              }
-
-              return false;
-            };
-
-            const currentLabels = issue.labels.map((label) =>
-              typeof label === "string" ? label : label.name,
-            );
-            const desiredLabels = new Set();
-
-            if (kind === "device_support") {
-              desiredLabels.add("type/device-support");
-            }
-
-            if (
-              action === "opened" ||
-              action === "reopened" ||
-              currentLabels.includes("status/needs-triage")
-            ) {
-              desiredLabels.add("status/needs-triage");
-            }
-
-            if (wantsDiagnosticsLabel()) {
-              desiredLabels.add("status/needs-diagnostics");
-            }
-
-            const areaSource =
-              kind === "bug"
-                ? process.env.PRIMARY_AREA
-                : kind === "feature"
-                  ? process.env.FEATURE_AREA
-                  : process.env.DEVICE_FAMILY;
-            const areaLabel = mapAreaLabel(areaSource);
-            if (areaLabel) {
-              desiredLabels.add(areaLabel);
-            }
-
-            const managedCurrent = currentLabels.filter((label) =>
-              managedLabels.has(label) ||
-              managedPrefixes.some((prefix) => label.startsWith(prefix)),
-            );
-
-            const toAdd = [...desiredLabels].filter(
-              (label) => !currentLabels.includes(label),
-            );
-            const toRemove = managedCurrent.filter(
-              (label) => !desiredLabels.has(label),
-            );
-
-            const labelsToEnsure = new Set([...toAdd, ...toRemove]);
-            for (const labelName of labelsToEnsure) {
-              const definition = labelDefinitions[labelName];
-              if (definition) {
-                await ensureLabel(labelName, definition);
-              }
-            }
-
-            if (toAdd.length > 0) {
-              await github.rest.issues.addLabels({
-                owner,
-                repo,
-                issue_number: issue.number,
-                labels: toAdd,
-              });
-            }
-
-            for (const labelName of toRemove) {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner,
-                  repo,
-                  issue_number: issue.number,
-                  name: labelName,
-                });
-              } catch (error) {
-                if (error.status !== 404) {
-                  throw error;
-                }
-              }
-            }
+      - name: Reconcile automation labels
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PRIMARY_AREA: ${{ steps.issue_parser.outputs.issueparser_primary_area }}
+          FEATURE_AREA: ${{ steps.issue_parser.outputs.issueparser_area }}
+          DEVICE_FAMILY: ${{ steps.issue_parser.outputs.issueparser_device_family }}
+          INSTALL_METHOD: ${{ steps.issue_parser.outputs.issueparser_install_method }}
+          DIAGNOSTICS_STATUS: ${{ steps.issue_parser.outputs.issueparser_diagnostics_status }}
+          WORKFLOW_DISPATCH_ISSUE_NUMBER: ${{ inputs.issue_number }}
+        run: python scripts/issue_labeling.py

--- a/scripts/issue_labeling.py
+++ b/scripts/issue_labeling.py
@@ -1,0 +1,604 @@
+"""Issue labeling helpers and GitHub workflow entrypoint."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import re
+import sys
+from typing import Any
+from urllib import error, parse, request
+
+TITLE_PREFIX_TO_KIND = {
+    "[Bug]:": "bug",
+    "[Feature]:": "feature",
+    "[Device support]:": "device_support",
+}
+
+NO_AREA_SELECTIONS = {
+    "Other",
+    "Other / unsure",
+    "Other Enphase device or capability",
+}
+
+AREA_LABEL_MAP = {
+    "Setup, sign-in, MFA, or reauthentication": "area/setup-auth",
+    "IQ Gateway / System Controller": "area/gateway",
+    "IQ Battery / Encharge / BatteryConfig": "area/battery",
+    "IQ EV Charger / IQ EVSE": "area/ev-charger",
+    "IQ Microinverters": "area/microinverters",
+    "Heat Pump / HEMS device data": "area/hems",
+    "Heat Pump / HEMS device": "area/hems",
+    "Water Heater / site-energy channel": "area/water-heater",
+    "Site or cloud energy telemetry": "area/site-energy",
+    "Site / cloud telemetry capability": "area/site-energy",
+    "Diagnostics, repairs, or service-availability reporting": "area/diagnostics",
+    "Documentation": "area/docs",
+    "Developer workflow / repository tooling": "area/tooling",
+}
+
+NO_SOURCE_SELECTIONS = {"Other"}
+
+SOURCE_LABEL_MAP = {
+    "HACS": "source/hacs",
+    "Manual install in custom_components": "source/manual-install",
+    "Development checkout": "source/dev-checkout",
+}
+
+BUG_DIAGNOSTICS_NEEDS_LABEL = {
+    "Not yet, but I can upload them",
+    "I cannot capture diagnostics",
+}
+
+DEVICE_DIAGNOSTICS_NEEDS_LABEL = {
+    "Screenshots only",
+    "Nothing attached yet",
+}
+
+LABEL_DEFINITIONS = {
+    "type/device-support": {
+        "color": "0E8A16",
+        "description": "Requests support for a missing device, model, or capability",
+    },
+    "status/needs-triage": {
+        "color": "FBCA04",
+        "description": "New or reopened issue awaiting maintainer triage",
+    },
+    "status/needs-diagnostics": {
+        "color": "D93F0B",
+        "description": "More diagnostics or evidence are needed before triage can finish",
+    },
+    "area/setup-auth": {
+        "color": "1D76DB",
+        "description": "Setup, sign-in, MFA, or reauthentication",
+    },
+    "area/gateway": {
+        "color": "1D76DB",
+        "description": "IQ Gateway or System Controller behavior",
+    },
+    "area/battery": {
+        "color": "1D76DB",
+        "description": "IQ Battery, Encharge, or BatteryConfig behavior",
+    },
+    "area/ev-charger": {
+        "color": "1D76DB",
+        "description": "IQ EV Charger or IQ EVSE behavior",
+    },
+    "area/microinverters": {
+        "color": "1D76DB",
+        "description": "IQ Microinverter behavior",
+    },
+    "area/hems": {
+        "color": "1D76DB",
+        "description": "Heat pump or HEMS device data",
+    },
+    "area/water-heater": {
+        "color": "1D76DB",
+        "description": "Water heater or site-energy channel behavior",
+    },
+    "area/site-energy": {
+        "color": "1D76DB",
+        "description": "Site or cloud energy telemetry and presentation",
+    },
+    "area/diagnostics": {
+        "color": "1D76DB",
+        "description": "Diagnostics, repairs, or service-availability reporting",
+    },
+    "area/docs": {
+        "color": "1D76DB",
+        "description": "Documentation and setup guidance",
+    },
+    "area/tooling": {
+        "color": "1D76DB",
+        "description": "Developer workflow or repository tooling",
+    },
+    "source/hacs": {
+        "color": "5319E7",
+        "description": "Installed via HACS",
+    },
+    "source/manual-install": {
+        "color": "5319E7",
+        "description": "Installed manually in custom_components",
+    },
+    "source/dev-checkout": {
+        "color": "5319E7",
+        "description": "Running from a development checkout",
+    },
+}
+
+MANAGED_PREFIXES = ("area/", "source/")
+MANAGED_LABELS = set(LABEL_DEFINITIONS)
+MANAGED_LABELS.update(
+    {
+        "type/device-support",
+        "status/needs-diagnostics",
+        "status/needs-triage",
+    }
+)
+
+BODY_FIELD_LABELS = {
+    "bug": {
+        "area": "Primary affected area",
+        "install_method": "Installation method",
+        "diagnostics_status": "Diagnostics attached?",
+    },
+    "feature": {
+        "area": "Area",
+    },
+    "device_support": {
+        "area": "Device family",
+        "diagnostics_status": "Evidence attached?",
+    },
+}
+
+
+@dataclass(frozen=True)
+class LabelDecision:
+    """Desired label state for one issue."""
+
+    desired_labels: set[str]
+    managed_labels: set[str]
+    to_add: list[str]
+    to_remove: list[str]
+
+
+def normalize(value: object) -> str:
+    """Return a clean single-line string."""
+    if value is None:
+        return ""
+    return re.sub(r"\s+", " ", str(value)).strip()
+
+
+def issue_kind_from_title(title: str) -> str | None:
+    """Infer issue kind from the title prefix."""
+    for prefix, kind in TITLE_PREFIX_TO_KIND.items():
+        if title.startswith(prefix):
+            return kind
+    return None
+
+
+def parse_issue_form_section(body: str | None, heading: str) -> str:
+    """Extract the first logical line below a rendered issue form heading."""
+    if not body:
+        return ""
+
+    pattern = rf"(?ms)^### {re.escape(heading)}\s*\n(.*?)(?=^### |\Z)"
+    match = re.search(pattern, body)
+    if not match:
+        return ""
+
+    block = match.group(1)
+    for raw_line in block.splitlines():
+        line = raw_line.strip()
+        if not line or line == "_No response_":
+            continue
+        if line.startswith("<!--"):
+            continue
+        return normalize(line.lstrip("- ").strip())
+    return ""
+
+
+def _mapped_area_label(value: str) -> str | None:
+    normalized = normalize(value)
+    if not normalized or normalized in NO_AREA_SELECTIONS:
+        return None
+    return AREA_LABEL_MAP.get(normalized)
+
+
+def _mapped_source_label(value: str) -> str | None:
+    normalized = normalize(value)
+    if not normalized or normalized in NO_SOURCE_SELECTIONS:
+        return None
+    return SOURCE_LABEL_MAP.get(normalized)
+
+
+def _resolved_field(
+    parser_value: str,
+    body_value: str,
+    resolver: Any,
+) -> str:
+    """Prefer parser output if it is recognized, otherwise fall back to body text."""
+    parser_text = normalize(parser_value)
+    if parser_text and (
+        resolver(parser_text) is not None or parser_text in NO_AREA_SELECTIONS
+    ):
+        return parser_text
+
+    body_text = normalize(body_value)
+    if body_text:
+        return body_text
+
+    return parser_text
+
+
+def _current_label_names(issue: dict[str, Any]) -> list[str]:
+    labels = issue.get("labels") or []
+    names: list[str] = []
+    for label in labels:
+        if isinstance(label, str):
+            names.append(label)
+            continue
+        name = label.get("name")
+        if isinstance(name, str):
+            names.append(name)
+    return names
+
+
+def desired_labels_for_issue(
+    issue: dict[str, Any],
+    *,
+    action: str,
+    parser_outputs: dict[str, str] | None = None,
+) -> LabelDecision:
+    """Compute desired managed labels for an issue."""
+    parser_outputs = parser_outputs or {}
+    kind = issue_kind_from_title(normalize(issue.get("title")))
+    if kind is None:
+        return LabelDecision(set(), set(), [], [])
+
+    current_labels = _current_label_names(issue)
+    desired_labels: set[str] = set()
+
+    if kind == "device_support":
+        desired_labels.add("type/device-support")
+
+    if action in {"opened", "reopened"} or "status/needs-triage" in current_labels:
+        desired_labels.add("status/needs-triage")
+
+    body = issue.get("body") or ""
+    body_fields = BODY_FIELD_LABELS[kind]
+
+    area_value = _resolved_field(
+        parser_outputs.get(
+            (
+                "primary_area"
+                if kind == "bug"
+                else "area" if kind == "feature" else "device_family"
+            ),
+            "",
+        ),
+        parse_issue_form_section(body, body_fields["area"]),
+        _mapped_area_label,
+    )
+    area_label = _mapped_area_label(area_value)
+    if area_label:
+        desired_labels.add(area_label)
+
+    if kind == "bug":
+        install_method = _resolved_field(
+            parser_outputs.get("install_method", ""),
+            parse_issue_form_section(body, body_fields["install_method"]),
+            _mapped_source_label,
+        )
+        source_label = _mapped_source_label(install_method)
+        if source_label:
+            desired_labels.add(source_label)
+
+    diagnostics_heading = body_fields.get("diagnostics_status")
+    diagnostics_value = _resolved_field(
+        parser_outputs.get("diagnostics_status", ""),
+        (
+            parse_issue_form_section(body, diagnostics_heading)
+            if diagnostics_heading
+            else ""
+        ),
+        lambda value: value,
+    )
+    if kind == "bug" and diagnostics_value in BUG_DIAGNOSTICS_NEEDS_LABEL:
+        desired_labels.add("status/needs-diagnostics")
+    if kind == "device_support" and diagnostics_value in DEVICE_DIAGNOSTICS_NEEDS_LABEL:
+        desired_labels.add("status/needs-diagnostics")
+
+    managed_current = [
+        label
+        for label in current_labels
+        if label in MANAGED_LABELS
+        or any(label.startswith(prefix) for prefix in MANAGED_PREFIXES)
+    ]
+    to_add = sorted(label for label in desired_labels if label not in current_labels)
+    to_remove = sorted(
+        label for label in managed_current if label not in desired_labels
+    )
+    return LabelDecision(desired_labels, set(managed_current), to_add, to_remove)
+
+
+def extract_dropdown_metadata(template_path: Path) -> dict[str, dict[str, Any]]:
+    """Extract dropdown labels and options without third-party YAML parsers."""
+    dropdowns: dict[str, dict[str, Any]] = {}
+    lines = template_path.read_text(encoding="utf-8").splitlines()
+    index = 0
+
+    while index < len(lines):
+        line = lines[index]
+        if line.strip() != "- type: dropdown":
+            index += 1
+            continue
+
+        dropdown_indent = len(line) - len(line.lstrip(" "))
+        index += 1
+        field_id = ""
+        field_label = ""
+
+        while index < len(lines):
+            line = lines[index]
+            stripped = line.strip()
+            indent = len(line) - len(line.lstrip(" "))
+
+            if stripped.startswith("- type:") and indent == dropdown_indent:
+                break
+
+            if stripped.startswith("id:"):
+                field_id = stripped.split(":", 1)[1].strip()
+
+            if stripped.startswith("label:") and field_id:
+                field_label = stripped.split(":", 1)[1].strip()
+
+            if stripped == "options:" and field_id:
+                option_indent = indent
+                index += 1
+                options: list[str] = []
+                while index < len(lines):
+                    option_line = lines[index]
+                    option_stripped = option_line.strip()
+                    option_line_indent = len(option_line) - len(option_line.lstrip(" "))
+
+                    if option_line_indent <= option_indent:
+                        break
+
+                    if option_stripped.startswith("- "):
+                        options.append(option_stripped[2:].strip())
+
+                    index += 1
+                dropdowns[field_id] = {
+                    "label": field_label,
+                    "options": options,
+                }
+                continue
+
+            index += 1
+
+    return dropdowns
+
+
+def validate_template_mappings(repo_root: Path) -> list[str]:
+    """Return validation errors for issue template dropdown mappings."""
+    template_dir = repo_root / ".github" / "ISSUE_TEMPLATE"
+    expected = {
+        template_dir
+        / "bug_report.yml": {
+            "labels": {
+                "primary_area": BODY_FIELD_LABELS["bug"]["area"],
+                "install_method": BODY_FIELD_LABELS["bug"]["install_method"],
+            },
+            "primary_area": set(AREA_LABEL_MAP) | NO_AREA_SELECTIONS,
+            "install_method": set(SOURCE_LABEL_MAP) | NO_SOURCE_SELECTIONS,
+        },
+        template_dir
+        / "feature_request.yml": {
+            "labels": {
+                "area": BODY_FIELD_LABELS["feature"]["area"],
+            },
+            "area": set(AREA_LABEL_MAP) | NO_AREA_SELECTIONS,
+        },
+        template_dir
+        / "device_support_request.yml": {
+            "labels": {
+                "device_family": BODY_FIELD_LABELS["device_support"]["area"],
+            },
+            "device_family": set(AREA_LABEL_MAP) | NO_AREA_SELECTIONS,
+        },
+    }
+
+    errors: list[str] = []
+    for template_path, required_fields in expected.items():
+        dropdowns = extract_dropdown_metadata(template_path)
+        expected_labels = required_fields.get("labels", {})
+        for field_id, expected_label in expected_labels.items():
+            metadata = dropdowns.get(field_id)
+            actual_label = normalize(metadata.get("label") if metadata else "")
+            if actual_label != expected_label:
+                errors.append(
+                    f"{template_path.name}:{field_id} label mismatch: expected '{expected_label}', got '{actual_label or '<missing>'}'"
+                )
+
+        for field_id, allowed_options in required_fields.items():
+            if field_id == "labels":
+                continue
+            metadata = dropdowns.get(field_id)
+            actual = set(metadata.get("options", []) if metadata else [])
+            if not actual:
+                errors.append(f"{template_path.name}:{field_id} dropdown not found")
+                continue
+            missing = sorted(actual - allowed_options)
+            if missing:
+                errors.append(
+                    f"{template_path.name}:{field_id} has unmapped options: {', '.join(missing)}"
+                )
+    return errors
+
+
+def _github_api_request(
+    token: str,
+    method: str,
+    url: str,
+    data: dict[str, Any] | None = None,
+) -> Any:
+    payload = None if data is None else json.dumps(data).encode("utf-8")
+    req = request.Request(
+        url,
+        data=payload,
+        method=method,
+        headers={
+            "Accept": "application/vnd.github+json",
+            "Authorization": f"Bearer {token}",
+            "User-Agent": "ha-enphase-ev-issue-labeling",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+    )
+    with request.urlopen(req) as response:
+        if response.status == 204:
+            return None
+        charset = response.headers.get_content_charset() or "utf-8"
+        raw = response.read().decode(charset)
+        return json.loads(raw) if raw else None
+
+
+def _list_target_issues(
+    token: str, repo: str, issue_number: str | None
+) -> list[dict[str, Any]]:
+    base_url = f"https://api.github.com/repos/{repo}"
+    if issue_number:
+        issue = _github_api_request(token, "GET", f"{base_url}/issues/{issue_number}")
+        return [issue] if issue_kind_from_title(normalize(issue.get("title"))) else []
+
+    issues: list[dict[str, Any]] = []
+    page = 1
+    while True:
+        page_issues = _github_api_request(
+            token,
+            "GET",
+            f"{base_url}/issues?state=open&per_page=100&page={page}",
+        )
+        if not page_issues:
+            return issues
+        for issue in page_issues:
+            if "pull_request" in issue:
+                continue
+            if issue_kind_from_title(normalize(issue.get("title"))):
+                issues.append(issue)
+        page += 1
+
+
+def _ensure_labels(token: str, repo: str, label_names: set[str]) -> None:
+    base_url = f"https://api.github.com/repos/{repo}"
+    for label_name in sorted(label_names):
+        definition = LABEL_DEFINITIONS.get(label_name)
+        if definition is None:
+            continue
+        encoded = parse.quote(label_name, safe="")
+        try:
+            _github_api_request(token, "GET", f"{base_url}/labels/{encoded}")
+        except error.HTTPError as exc:
+            if exc.code != 404:
+                raise
+            _github_api_request(
+                token,
+                "POST",
+                f"{base_url}/labels",
+                {"name": label_name, **definition},
+            )
+
+
+def _reconcile_issue(
+    token: str,
+    repo: str,
+    issue: dict[str, Any],
+    *,
+    action: str,
+    parser_outputs: dict[str, str] | None = None,
+) -> LabelDecision:
+    decision = desired_labels_for_issue(
+        issue, action=action, parser_outputs=parser_outputs
+    )
+    if not decision.to_add and not decision.to_remove:
+        return decision
+
+    base_url = f"https://api.github.com/repos/{repo}"
+    _ensure_labels(token, repo, set(decision.to_add))
+
+    if decision.to_add:
+        _github_api_request(
+            token,
+            "POST",
+            f"{base_url}/issues/{issue['number']}/labels",
+            {"labels": decision.to_add},
+        )
+
+    for label_name in decision.to_remove:
+        encoded = parse.quote(label_name, safe="")
+        try:
+            _github_api_request(
+                token,
+                "DELETE",
+                f"{base_url}/issues/{issue['number']}/labels/{encoded}",
+            )
+        except error.HTTPError as exc:
+            if exc.code != 404:
+                raise
+
+    return decision
+
+
+def _parser_outputs_from_env() -> dict[str, str]:
+    return {
+        "primary_area": os.getenv("PRIMARY_AREA", ""),
+        "area": os.getenv("FEATURE_AREA", ""),
+        "device_family": os.getenv("DEVICE_FAMILY", ""),
+        "install_method": os.getenv("INSTALL_METHOD", ""),
+        "diagnostics_status": os.getenv("DIAGNOSTICS_STATUS", ""),
+    }
+
+
+def main() -> int:
+    """Reconcile labels for issue events or workflow_dispatch backfills."""
+    token = os.getenv("GITHUB_TOKEN")
+    repo = os.getenv("GITHUB_REPOSITORY")
+    event_name = os.getenv("GITHUB_EVENT_NAME", "")
+    event_path = os.getenv("GITHUB_EVENT_PATH", "")
+
+    if not token or not repo:
+        print("GITHUB_TOKEN and GITHUB_REPOSITORY are required", file=sys.stderr)
+        return 1
+
+    if event_name == "issues":
+        if not event_path:
+            print("GITHUB_EVENT_PATH is required for issue events", file=sys.stderr)
+            return 1
+        payload = json.loads(Path(event_path).read_text(encoding="utf-8"))
+        issue = payload.get("issue") or {}
+        action = normalize(payload.get("action"))
+        if issue_kind_from_title(normalize(issue.get("title"))) is None:
+            return 0
+        _reconcile_issue(
+            token,
+            repo,
+            issue,
+            action=action,
+            parser_outputs=_parser_outputs_from_env(),
+        )
+        return 0
+
+    if event_name == "workflow_dispatch":
+        issue_number = normalize(os.getenv("WORKFLOW_DISPATCH_ISSUE_NUMBER"))
+        for issue in _list_target_issues(token, repo, issue_number or None):
+            _reconcile_issue(token, repo, issue, action="workflow_dispatch")
+        return 0
+
+    print(f"Unsupported event: {event_name}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/scripts/test_issue_labeling.py
+++ b/tests/scripts/test_issue_labeling.py
@@ -1,0 +1,663 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+import sys
+from urllib import error
+
+import pytest
+
+
+def _load_module():
+    root = Path(__file__).resolve().parents[2]
+    module_path = root / "scripts" / "issue_labeling.py"
+    spec = importlib.util.spec_from_file_location("issue_labeling", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+issue_labeling = _load_module()
+
+
+def _issue(title: str, body: str, labels: list[str] | None = None) -> dict[str, object]:
+    return {
+        "number": 42,
+        "title": title,
+        "body": body,
+        "labels": [{"name": label} for label in (labels or [])],
+    }
+
+
+def test_bug_issue_uses_parser_area_install_method_and_diagnostics() -> None:
+    decision = issue_labeling.desired_labels_for_issue(
+        _issue(
+            "[Bug]: Charger controls fail",
+            "### Primary affected area\n\nOther / unsure\n",
+            labels=["bug", "status/needs-triage"],
+        ),
+        action="opened",
+        parser_outputs={
+            "primary_area": "IQ EV Charger / IQ EVSE",
+            "install_method": "HACS",
+            "diagnostics_status": "Not yet, but I can upload them",
+        },
+    )
+
+    assert decision.desired_labels == {
+        "area/ev-charger",
+        "source/hacs",
+        "status/needs-diagnostics",
+        "status/needs-triage",
+    }
+    assert decision.to_add == [
+        "area/ev-charger",
+        "source/hacs",
+        "status/needs-diagnostics",
+    ]
+    assert decision.to_remove == []
+
+
+def test_feature_issue_falls_back_to_raw_body_when_parser_area_missing() -> None:
+    body = """
+### Area
+
+Documentation
+
+### Problem statement
+
+Current docs are incomplete.
+""".strip()
+
+    decision = issue_labeling.desired_labels_for_issue(
+        _issue(
+            "[Feature]: Improve docs",
+            body,
+            labels=["enhancement", "status/needs-triage"],
+        ),
+        action="edited",
+        parser_outputs={"area": ""},
+    )
+
+    assert decision.desired_labels == {"area/docs", "status/needs-triage"}
+    assert decision.to_add == ["area/docs"]
+    assert decision.to_remove == []
+
+
+def test_device_support_issue_falls_back_when_parser_value_is_unmapped() -> None:
+    body = """
+### Device family
+
+Heat Pump / HEMS device
+
+### Evidence attached?
+
+Nothing attached yet
+""".strip()
+
+    decision = issue_labeling.desired_labels_for_issue(
+        _issue("[Device support]: Add heat pump", body, labels=["enhancement"]),
+        action="reopened",
+        parser_outputs={
+            "device_family": "Unexpected parser output",
+            "diagnostics_status": "",
+        },
+    )
+
+    assert decision.desired_labels == {
+        "area/hems",
+        "status/needs-diagnostics",
+        "status/needs-triage",
+        "type/device-support",
+    }
+
+
+def test_bug_issue_other_selections_do_not_add_area_or_source_labels() -> None:
+    body = """
+### Installation method
+
+Other
+
+### Primary affected area
+
+Other / unsure
+
+### Diagnostics attached?
+
+Yes, both config-entry and device diagnostics attached
+""".strip()
+
+    decision = issue_labeling.desired_labels_for_issue(
+        _issue("[Bug]: Intermittent error", body, labels=["status/needs-triage"]),
+        action="edited",
+        parser_outputs={},
+    )
+
+    assert decision.desired_labels == {"status/needs-triage"}
+    assert decision.to_add == []
+    assert decision.to_remove == []
+
+
+def test_bug_diagnostics_states_are_mapped_correctly() -> None:
+    body = """
+### Diagnostics attached?
+
+I cannot capture diagnostics
+""".strip()
+    with_label = issue_labeling.desired_labels_for_issue(
+        _issue("[Bug]: Auth loop", body),
+        action="opened",
+        parser_outputs={},
+    )
+    assert "status/needs-diagnostics" in with_label.desired_labels
+
+    without_label = issue_labeling.desired_labels_for_issue(
+        _issue(
+            "[Bug]: Auth loop",
+            "### Diagnostics attached?\n\nYes, config-entry diagnostics attached",
+        ),
+        action="opened",
+        parser_outputs={},
+    )
+    assert "status/needs-diagnostics" not in without_label.desired_labels
+
+
+def test_bug_install_method_source_labels_are_mapped_correctly() -> None:
+    expectations = {
+        "HACS": "source/hacs",
+        "Manual install in custom_components": "source/manual-install",
+        "Development checkout": "source/dev-checkout",
+    }
+
+    for install_method, expected_label in expectations.items():
+        decision = issue_labeling.desired_labels_for_issue(
+            _issue(
+                "[Bug]: Setup fails",
+                "### Diagnostics attached?\n\nYes, config-entry diagnostics attached",
+            ),
+            action="opened",
+            parser_outputs={"install_method": install_method},
+        )
+        assert expected_label in decision.desired_labels
+
+
+def test_template_dropdown_options_are_fully_mapped() -> None:
+    repo_root = Path(__file__).resolve().parents[2]
+    errors = issue_labeling.validate_template_mappings(repo_root)
+    assert errors == []
+
+
+def test_parse_helpers_cover_empty_and_comment_only_sections() -> None:
+    assert issue_labeling.normalize(None) == ""
+    assert issue_labeling.issue_kind_from_title("[Question]: Help") is None
+    assert issue_labeling.parse_issue_form_section(None, "Area") == ""
+    assert (
+        issue_labeling.parse_issue_form_section("### Area\n\n_No response_", "Area")
+        == ""
+    )
+    assert (
+        issue_labeling.parse_issue_form_section(
+            "### Area\n\n<!-- comment -->\n- Documentation",
+            "Area",
+        )
+        == "Documentation"
+    )
+
+
+def test_unknown_issue_kind_returns_empty_decision() -> None:
+    decision = issue_labeling.desired_labels_for_issue(
+        _issue("[Question]: Help", "### Area\n\nDocumentation"),
+        action="opened",
+        parser_outputs={},
+    )
+    assert decision.desired_labels == set()
+    assert decision.to_add == []
+    assert decision.to_remove == []
+
+
+def test_managed_labels_are_removed_when_no_longer_desired() -> None:
+    decision = issue_labeling.desired_labels_for_issue(
+        {
+            "number": 42,
+            "title": "[Feature]: Improve docs",
+            "body": "### Area\n\nDocumentation",
+            "labels": [
+                "status/needs-triage",
+                "area/gateway",
+                "source/hacs",
+                {"name": "enhancement"},
+            ],
+        },
+        action="edited",
+        parser_outputs={},
+    )
+    assert decision.to_add == ["area/docs"]
+    assert decision.to_remove == ["area/gateway", "source/hacs"]
+    assert decision.managed_labels == {
+        "area/gateway",
+        "source/hacs",
+        "status/needs-triage",
+    }
+
+
+def test_validate_template_mappings_reports_missing_dropdowns(tmp_path: Path) -> None:
+    template_dir = tmp_path / ".github" / "ISSUE_TEMPLATE"
+    template_dir.mkdir(parents=True)
+    (template_dir / "bug_report.yml").write_text(
+        "body:\n  - type: dropdown\n    id: install_method\n    attributes:\n      label: Installation method\n      options:\n        - HACS\n",
+        encoding="utf-8",
+    )
+    (template_dir / "feature_request.yml").write_text("body: []\n", encoding="utf-8")
+    (template_dir / "device_support_request.yml").write_text(
+        "body:\n  - type: dropdown\n    id: device_family\n    attributes:\n      label: Device family\n      options:\n        - Unknown capability\n",
+        encoding="utf-8",
+    )
+
+    errors = issue_labeling.validate_template_mappings(tmp_path)
+
+    assert "bug_report.yml:primary_area dropdown not found" in errors
+    assert "feature_request.yml:area dropdown not found" in errors
+    assert any(
+        "device_support_request.yml:device_family has unmapped options" in item
+        for item in errors
+    )
+
+
+def test_validate_template_mappings_reports_label_mismatches(tmp_path: Path) -> None:
+    template_dir = tmp_path / ".github" / "ISSUE_TEMPLATE"
+    template_dir.mkdir(parents=True)
+    (template_dir / "bug_report.yml").write_text(
+        "body:\n  - type: dropdown\n    id: primary_area\n    attributes:\n      label: Affected area\n      options:\n        - IQ EV Charger / IQ EVSE\n  - type: dropdown\n    id: install_method\n    attributes:\n      label: Installation method\n      options:\n        - HACS\n",
+        encoding="utf-8",
+    )
+    (template_dir / "feature_request.yml").write_text(
+        "body:\n  - type: dropdown\n    id: area\n    attributes:\n      label: Area\n      options:\n        - Documentation\n",
+        encoding="utf-8",
+    )
+    (template_dir / "device_support_request.yml").write_text(
+        "body:\n  - type: dropdown\n    id: device_family\n    attributes:\n      label: Device family\n      options:\n        - IQ EV Charger / IQ EVSE\n",
+        encoding="utf-8",
+    )
+
+    errors = issue_labeling.validate_template_mappings(tmp_path)
+
+    assert (
+        "bug_report.yml:primary_area label mismatch: expected 'Primary affected area', got 'Affected area'"
+        in errors
+    )
+
+
+def test_list_target_issues_filters_pull_requests_and_non_form_titles(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    responses = [
+        [
+            {"number": 1, "title": "[Bug]: One"},
+            {"number": 2, "title": "[Question]: Two"},
+            {"number": 3, "title": "[Feature]: Three", "pull_request": {"url": "x"}},
+        ],
+        [],
+    ]
+
+    def fake_request(token: str, method: str, url: str, data=None):
+        assert token == "token"
+        assert method == "GET"
+        assert data is None
+        return responses.pop(0)
+
+    monkeypatch.setattr(issue_labeling, "_github_api_request", fake_request)
+
+    issues = issue_labeling._list_target_issues("token", "owner/repo", None)
+
+    assert issues == [{"number": 1, "title": "[Bug]: One"}]
+
+
+def test_list_target_issues_returns_requested_issue_when_supported(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        issue_labeling,
+        "_github_api_request",
+        lambda token, method, url, data=None: {
+            "number": 99,
+            "title": "[Feature]: Docs",
+        },
+    )
+
+    issues = issue_labeling._list_target_issues("token", "owner/repo", "99")
+
+    assert issues == [{"number": 99, "title": "[Feature]: Docs"}]
+
+
+def test_ensure_labels_creates_missing_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[str, str, str, object]] = []
+
+    def fake_request(token: str, method: str, url: str, data=None):
+        calls.append((token, method, url, data))
+        if method == "GET" and url.endswith("/labels/source%2Fhacs"):
+            raise error.HTTPError(url, 404, "missing", None, None)
+        return None
+
+    monkeypatch.setattr(issue_labeling, "_github_api_request", fake_request)
+
+    issue_labeling._ensure_labels("token", "owner/repo", {"source/hacs", "unknown"})
+
+    assert calls[0][1] == "GET"
+    assert calls[1][1] == "POST"
+    assert calls[1][3]["name"] == "source/hacs"
+
+
+def test_ensure_labels_reraises_non_404_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    def fake_request(token: str, method: str, url: str, data=None):
+        raise error.HTTPError(url, 500, "boom", None, None)
+
+    monkeypatch.setattr(issue_labeling, "_github_api_request", fake_request)
+
+    with pytest.raises(error.HTTPError):
+        issue_labeling._ensure_labels("token", "owner/repo", {"source/hacs"})
+
+
+def test_reconcile_issue_adds_and_removes_labels(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ensured: list[set[str]] = []
+    calls: list[tuple[str, str, str, object]] = []
+
+    monkeypatch.setattr(
+        issue_labeling,
+        "_ensure_labels",
+        lambda token, repo, names: ensured.append(names),
+    )
+
+    def fake_request(token: str, method: str, url: str, data=None):
+        calls.append((token, method, url, data))
+        if method == "DELETE" and url.endswith("/labels/source%2Fhacs"):
+            raise error.HTTPError(url, 404, "missing", None, None)
+        return None
+
+    monkeypatch.setattr(issue_labeling, "_github_api_request", fake_request)
+
+    issue = {
+        "number": 42,
+        "title": "[Feature]: Improve docs",
+        "body": "### Area\n\nDocumentation",
+        "labels": ["status/needs-triage", "source/hacs"],
+    }
+
+    decision = issue_labeling._reconcile_issue(
+        "token", "owner/repo", issue, action="edited"
+    )
+
+    assert ensured == [{"area/docs"}]
+    assert decision.to_add == ["area/docs"]
+    assert decision.to_remove == ["source/hacs"]
+    assert calls[0][1] == "POST"
+    assert calls[1][1] == "DELETE"
+
+
+def test_reconcile_issue_returns_early_when_no_changes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ensured: list[set[str]] = []
+    monkeypatch.setattr(
+        issue_labeling,
+        "_ensure_labels",
+        lambda token, repo, names: ensured.append(names),
+    )
+    monkeypatch.setattr(
+        issue_labeling,
+        "_github_api_request",
+        lambda token, method, url, data=None: pytest.fail("unexpected API call"),
+    )
+
+    issue = {
+        "number": 42,
+        "title": "[Feature]: Improve docs",
+        "body": "### Area\n\nDocumentation",
+        "labels": ["status/needs-triage", "area/docs"],
+    }
+
+    decision = issue_labeling._reconcile_issue(
+        "token", "owner/repo", issue, action="edited"
+    )
+
+    assert decision.to_add == []
+    assert decision.to_remove == []
+    assert ensured == []
+
+
+def test_reconcile_issue_reraises_delete_errors_other_than_404(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        issue_labeling, "_ensure_labels", lambda token, repo, names: None
+    )
+
+    def fake_request(token: str, method: str, url: str, data=None):
+        if method == "DELETE":
+            raise error.HTTPError(url, 500, "boom", None, None)
+        return None
+
+    monkeypatch.setattr(issue_labeling, "_github_api_request", fake_request)
+
+    issue = {
+        "number": 42,
+        "title": "[Feature]: Improve docs",
+        "body": "### Area\n\nDocumentation",
+        "labels": ["status/needs-triage", "source/hacs"],
+    }
+
+    with pytest.raises(error.HTTPError):
+        issue_labeling._reconcile_issue("token", "owner/repo", issue, action="edited")
+
+
+def test_parser_outputs_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIMARY_AREA", "IQ Gateway / System Controller")
+    monkeypatch.setenv("FEATURE_AREA", "Documentation")
+    monkeypatch.setenv("DEVICE_FAMILY", "IQ EV Charger / IQ EVSE")
+    monkeypatch.setenv("INSTALL_METHOD", "HACS")
+    monkeypatch.setenv("DIAGNOSTICS_STATUS", "Nothing attached yet")
+
+    assert issue_labeling._parser_outputs_from_env() == {
+        "primary_area": "IQ Gateway / System Controller",
+        "area": "Documentation",
+        "device_family": "IQ EV Charger / IQ EVSE",
+        "install_method": "HACS",
+        "diagnostics_status": "Nothing attached yet",
+    }
+
+
+def test_main_handles_missing_required_environment(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_REPOSITORY", raising=False)
+
+    assert issue_labeling.main() == 1
+    assert "GITHUB_TOKEN and GITHUB_REPOSITORY are required" in capsys.readouterr().err
+
+
+def test_main_handles_issue_events(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        '{"action":"opened","issue":{"number":7,"title":"[Bug]: Demo","body":"### Diagnostics attached?\\n\\nYes, config-entry diagnostics attached","labels":[]}}',
+        encoding="utf-8",
+    )
+
+    recorded: list[tuple[str, str, dict[str, object], str, dict[str, str]]] = []
+
+    def fake_reconcile(
+        token: str,
+        repo: str,
+        issue: dict[str, object],
+        *,
+        action: str,
+        parser_outputs=None,
+    ):
+        recorded.append((token, repo, issue, action, parser_outputs or {}))
+        return None
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "issues")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setenv("PRIMARY_AREA", "IQ Gateway / System Controller")
+    monkeypatch.setattr(issue_labeling, "_reconcile_issue", fake_reconcile)
+
+    assert issue_labeling.main() == 0
+    assert recorded[0][3] == "opened"
+    assert recorded[0][4]["primary_area"] == "IQ Gateway / System Controller"
+
+
+def test_main_handles_issue_events_without_event_path(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "issues")
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+
+    assert issue_labeling.main() == 1
+    assert "GITHUB_EVENT_PATH is required for issue events" in capsys.readouterr().err
+
+
+def test_main_skips_non_form_issue_titles(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        '{"action":"opened","issue":{"number":7,"title":"[Question]: Demo","body":"","labels":[]}}',
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "issues")
+    monkeypatch.setenv("GITHUB_EVENT_PATH", str(event_path))
+    monkeypatch.setattr(
+        issue_labeling,
+        "_reconcile_issue",
+        lambda *args, **kwargs: pytest.fail("unexpected reconcile"),
+    )
+
+    assert issue_labeling.main() == 0
+
+
+def test_main_handles_workflow_dispatch(monkeypatch: pytest.MonkeyPatch) -> None:
+    dispatched = [{"number": 1, "title": "[Feature]: Docs"}]
+    reconciled: list[tuple[dict[str, object], str]] = []
+
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "workflow_dispatch")
+    monkeypatch.setenv("WORKFLOW_DISPATCH_ISSUE_NUMBER", "15")
+    monkeypatch.setattr(
+        issue_labeling,
+        "_list_target_issues",
+        lambda token, repo, issue_number: dispatched,
+    )
+    monkeypatch.setattr(
+        issue_labeling,
+        "_reconcile_issue",
+        lambda token, repo, issue, *, action, parser_outputs=None: reconciled.append(
+            (issue, action)
+        ),
+    )
+
+    assert issue_labeling.main() == 0
+    assert reconciled == [(dispatched[0], "workflow_dispatch")]
+
+
+def test_main_rejects_unsupported_events(
+    monkeypatch: pytest.MonkeyPatch, capsys
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "token")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "owner/repo")
+    monkeypatch.setenv("GITHUB_EVENT_NAME", "push")
+
+    assert issue_labeling.main() == 1
+    assert "Unsupported event: push" in capsys.readouterr().err
+
+
+def test_github_api_request_serializes_and_decodes_json(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    class FakeHeaders:
+        @staticmethod
+        def get_content_charset():
+            return "utf-8"
+
+    class FakeResponse:
+        status = 200
+        headers = FakeHeaders()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        @staticmethod
+        def read():
+            return b'{"ok": true}'
+
+    def fake_urlopen(req):
+        captured["full_url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["data"] = req.data
+        return FakeResponse()
+
+    monkeypatch.setattr(issue_labeling.request, "urlopen", fake_urlopen)
+
+    response = issue_labeling._github_api_request(
+        "token",
+        "POST",
+        "https://api.github.com/example",
+        {"name": "value"},
+    )
+
+    assert response == {"ok": True}
+    assert captured["full_url"] == "https://api.github.com/example"
+    assert captured["method"] == "POST"
+    assert captured["data"] == b'{"name": "value"}'
+
+
+def test_github_api_request_handles_empty_204_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeHeaders:
+        @staticmethod
+        def get_content_charset():
+            return "utf-8"
+
+    class FakeResponse:
+        status = 204
+        headers = FakeHeaders()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        @staticmethod
+        def read():
+            return b""
+
+    monkeypatch.setattr(issue_labeling.request, "urlopen", lambda req: FakeResponse())
+
+    assert (
+        issue_labeling._github_api_request(
+            "token",
+            "DELETE",
+            "https://api.github.com/example",
+        )
+        is None
+    )


### PR DESCRIPTION
## Summary

Improve automatic issue labeling by moving reconciliation into a tested Python helper, adding reliable fallback parsing for issue-form bodies, and supporting manual backfills via `workflow_dispatch`.

This fixes the current gap where selected issue-form areas can fail to become `area/*` labels, adds deterministic `source/*` labels for bug install methods, and hardens the workflow against parser-output failures and form drift.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/scripts/test_issue_labeling.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check scripts/issue_labeling.py tests/scripts/test_issue_labeling.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check scripts/issue_labeling.py tests/scripts/test_issue_labeling.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/issue_labeling.coverage python -m coverage erase && COVERAGE_FILE=/tmp/issue_labeling.coverage python -m coverage run -m pytest tests/scripts/test_issue_labeling.py -q && COVERAGE_FILE=/tmp/issue_labeling.coverage python -m coverage report -m --include=scripts/issue_labeling.py --fail-under=100"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python - <<'PY'
import yaml
from pathlib import Path
yaml.safe_load(Path('.github/workflows/auto_label_issues.yml').read_text())
print('validated .github/workflows/auto_label_issues.yml')
PY"
```

Additional targeted validation:

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/scripts/test_issue_labeling.py && ruff check scripts/issue_labeling.py tests/scripts/test_issue_labeling.py"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The workflow now checks out the repository before invoking the Python helper on GitHub-hosted runners.
- Template validation now checks both dropdown options and the field labels used by fallback issue-body parsing so heading-text drift fails tests.
- Manual GitHub-side validation of live issue open/edit flows has not been performed yet.
