### PR TITLE
Treat battery status state 16 as idle

### DIFF
--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -91,6 +91,7 @@ BATTERY_LED_STATUS_STATE_MAP: dict[int, str] = {
     13: "discharging",
     14: "idle",
     15: "idle",
+    16: "idle",
     17: "idle",
 }
 

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -702,6 +702,10 @@ def test_battery_storage_detail_sensors_state_and_attributes():
     assert status.native_value == "idle"
     assert status.extra_state_attributes["state"] == 15
 
+    snapshot["led_status"] = 16
+    assert status.native_value == "idle"
+    assert status.extra_state_attributes["state"] == 16
+
     snapshot["led_status"] = 99
     assert status.native_value == "unknown"
     assert status.extra_state_attributes["state"] == 99


### PR DESCRIPTION
## Summary

Treat battery storage LED state `16` as `Idle` so Battery Status entities report the correct state instead of `unknown`.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_sensors.py -k battery_storage_detail_sensors_state_and_attributes"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Battery storage sensor coverage now includes LED state `16` mapping to `idle`.