### PR TITLE
Harden Enlighten endpoint polling and auth handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
-## v2.7.2 - 2026-04-07
+## v2.7.3 - 2026-04-07
 
 ### 🚧 Breaking changes
 - None
@@ -29,13 +29,16 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Matched the documented Enlighten browser header profiles across implemented login, site, inverter, EV, and HEMS web endpoints so optional reads, EV controls, and initial authentication continue working when the cloud service enforces route-specific `Accept` and `Referer` handling more strictly, including a browser-form login fallback when `login.json` is rejected with `406 Not Acceptable`.
+- Switched Enlighten web and auth traffic to a browser-style `User-Agent` after Enphase started rejecting Home Assistant-branded requests with `406 Not Acceptable`, restoring the affected battery, inverter, and grid-control reads in local verification.
 
 ### 🔧 Improvements
-- Added regression coverage for the route-specific request headers used by login, site inventory/runtime, EV, battery, inverter, and HEMS web API methods.
+- Added a shared guardrail layer for read-only Enlighten endpoint families, including bounded concurrency, cooldown tracking, optional-endpoint suppression, manual-refresh bypass handling, and diagnostics-safe per-family health reporting.
+- Reduced repeat traffic to optional/detail endpoints by caching successful battery-status, inverter inventory/status, and inverter production refreshes against their endpoint-family TTLs, keeping inverter production on a once-per-day cache by default and preventing repeated failed retries from hammering Enphase.
+- Added regression coverage for the route-specific request headers, auth fallback, endpoint-family guardrails, and the new success-cache behavior used by login, site inventory/runtime, EV, battery, inverter, and HEMS web API methods.
 - Suppressed noisy warning logs when the optional HEMS lifetime endpoint returns HTML instead of JSON and is already being treated as unavailable.
 
 ### 🔄 Other changes
-- Bumped the integration manifest version to `2.7.2`.
+- Bumped the integration manifest version to `2.7.3`.
 
 ## v2.7.1 - 2026-04-06
 

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -6,6 +6,7 @@ import hashlib
 import json
 import logging
 import re
+from contextlib import asynccontextmanager
 from datetime import date, datetime, timedelta, timezone
 from urllib.parse import unquote
 import uuid
@@ -36,6 +37,12 @@ _DEBUG_KV_RE = re.compile(
     r"(?P<key>[A-Za-z][A-Za-z0-9_\-]*)(?P<sep>\s*[=:]\s*)(?P<value>[^,\s)]+)"
 )
 _XSRF_COOKIE_NAMES = ("xsrf-token", "bp-xsrf-token")
+_ENLIGHTEN_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3.1 Safari/605.1.15"
+)
+_ENLIGHTEN_READ_CONCURRENCY_LIMIT = 2
+_enlighten_read_semaphore: asyncio.Semaphore | None = None
 
 
 class Unauthorized(Exception):
@@ -690,6 +697,42 @@ def _request_failure_debug_family(method: object, path_or_url: object) -> str | 
     return None
 
 
+def _should_limit_enlighten_read_request(method: object, url: object) -> bool:
+    """Return True when the request should use the shared Enlighten read limiter."""
+
+    try:
+        method_text = str(method).strip().upper()
+    except Exception:  # noqa: BLE001 - defensive casting
+        return False
+    if method_text not in {"GET", "HEAD"}:
+        return False
+    try:
+        url_text = str(url).strip()
+    except Exception:  # noqa: BLE001 - defensive casting
+        return False
+    return url_text.startswith(f"{BASE_URL}/")
+
+
+def _get_enlighten_read_semaphore() -> asyncio.Semaphore:
+    """Return the shared semaphore used to limit concurrent Enlighten reads."""
+
+    global _enlighten_read_semaphore
+    if _enlighten_read_semaphore is None:
+        _enlighten_read_semaphore = asyncio.Semaphore(_ENLIGHTEN_READ_CONCURRENCY_LIMIT)
+    return _enlighten_read_semaphore
+
+
+@asynccontextmanager
+async def _enlighten_read_request_guard(method: object, url: object):
+    """Limit concurrent GET/HEAD requests to the Enlighten web host."""
+
+    if not _should_limit_enlighten_read_request(method, url):
+        yield
+        return
+    async with _get_enlighten_read_semaphore():
+        yield
+
+
 def _seed_cookie_jar(session: aiohttp.ClientSession, cookies: dict[str, str]) -> None:
     """Ensure the session cookie jar contains the supplied cookies."""
 
@@ -897,20 +940,23 @@ async def _request_json(
     if json_data is not None:
         req_kwargs["json"] = json_data
 
-    async with asyncio.timeout(timeout):
-        async with session.request(
-            method, url, allow_redirects=True, **req_kwargs
-        ) as resp:
-            if resp.status >= 500:
-                raise EnlightenAuthUnavailable(f"Server error {resp.status} at {url}")
-            resp.raise_for_status()
-            ctype = resp.headers.get("Content-Type", "")
-            if "json" not in ctype:
-                text = await resp.text()
-                raise EnlightenAuthUnavailable(
-                    f"Unexpected response content-type {ctype!r} at {url}: {text[:120]}"
-                )
-            return await resp.json()
+    async with _enlighten_read_request_guard(method, url):
+        async with asyncio.timeout(timeout):
+            async with session.request(
+                method, url, allow_redirects=True, **req_kwargs
+            ) as resp:
+                if resp.status >= 500:
+                    raise EnlightenAuthUnavailable(
+                        f"Server error {resp.status} at {url}"
+                    )
+                resp.raise_for_status()
+                ctype = resp.headers.get("Content-Type", "")
+                if "json" not in ctype:
+                    text = await resp.text()
+                    raise EnlightenAuthUnavailable(
+                        f"Unexpected response content-type {ctype!r} at {url}: {text[:120]}"
+                    )
+                return await resp.json()
 
 
 async def _request_mfa_json(
@@ -974,6 +1020,7 @@ def _login_headers() -> dict[str, str]:
         "Accept": "*/*",
         "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
         "Referer": f"{BASE_URL}/",
+        "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
         "X-Requested-With": "XMLHttpRequest",
     }
 
@@ -986,6 +1033,7 @@ def _login_form_headers() -> dict[str, str]:
         "Content-Type": "application/x-www-form-urlencoded",
         "Origin": BASE_URL,
         "Referer": f"{BASE_URL}/",
+        "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
     }
 
 
@@ -1205,6 +1253,7 @@ async def _build_tokens_and_sites(
         "Accept": "*/*",
         "X-Requested-With": "XMLHttpRequest",
         "Referer": f"{BASE_URL}/",
+        "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
     }
     if xsrf_token:
         site_headers["X-CSRF-Token"] = xsrf_token
@@ -1717,6 +1766,7 @@ class EnphaseEVClient:
             "Accept": "application/json, text/plain, */*",
             "X-Requested-With": "XMLHttpRequest",
             "Referer": f"{BASE_URL}/pv/systems/{site_id}/summary",
+            "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
         }
         self.update_credentials(eauth=eauth, cookie=cookie)
 
@@ -2606,155 +2656,165 @@ class EnphaseEVClient:
                     else:
                         base_headers[header_key] = header_value
 
-            async with asyncio.timeout(self._timeout):
-                async with self._s.request(
-                    method, url, headers=base_headers, **kwargs
-                ) as r:
-                    if r.status == 401:
-                        self._last_unauthorized_request = request_label
-                        if self._reauth_cb and attempt == 0:
-                            _LOGGER.debug(
-                                "Received 401 for %s; attempting stored-credential refresh",
-                                request_label,
-                            )
-                            attempt += 1
-                            reauth_ok = await self._reauth_cb()
-                            if reauth_ok:
+            async with _enlighten_read_request_guard(method, url):
+                async with asyncio.timeout(self._timeout):
+                    async with self._s.request(
+                        method, url, headers=base_headers, **kwargs
+                    ) as r:
+                        if r.status == 401:
+                            self._last_unauthorized_request = request_label
+                            if self._reauth_cb and attempt == 0:
                                 _LOGGER.debug(
-                                    "Stored-credential refresh succeeded for %s; retrying request",
+                                    "Received 401 for %s; attempting stored-credential refresh",
                                     request_label,
                                 )
-                                continue
-                            _LOGGER.debug(
-                                "Stored-credential refresh failed for %s",
-                                request_label,
+                                attempt += 1
+                                reauth_ok = await self._reauth_cb()
+                                if reauth_ok:
+                                    _LOGGER.debug(
+                                        "Stored-credential refresh succeeded for %s; retrying request",
+                                        request_label,
+                                    )
+                                    continue
+                                _LOGGER.debug(
+                                    "Stored-credential refresh failed for %s",
+                                    request_label,
+                                )
+                            else:
+                                _LOGGER.debug(
+                                    "Received 401 for %s with no stored-credential refresh available",
+                                    request_label,
+                                )
+                            raise Unauthorized()
+                        if r.status in (204, 205):
+                            if mark_payload_success:
+                                self._mark_payload_healthy(endpoint or None)
+                            return {}
+                        if r.status >= 400:
+                            try:
+                                body_text = await r.text()
+                            except (
+                                Exception
+                            ):  # noqa: BLE001 - fall back to generic message
+                                body_text = ""
+                            message = (body_text or r.reason or "").strip()
+                            if len(message) > 512:
+                                message = f"{message[:512]}…"
+                            family = _request_failure_debug_family(
+                                method,
+                                endpoint or url,
                             )
-                        else:
-                            _LOGGER.debug(
-                                "Received 401 for %s with no stored-credential refresh available",
-                                request_label,
+                            if family is not None:
+                                params = kwargs.get("params")
+                                if isinstance(params, dict):
+                                    params_summary: object = _redact_debug_json_body(
+                                        params,
+                                        site_ids=(self._site,),
+                                    )
+                                elif params is None:
+                                    params_summary = None
+                                else:
+                                    params_summary = redact_text(
+                                        params,
+                                        site_ids=(self._site,),
+                                        max_length=256,
+                                    )
+                                payload_summary: object = None
+                                json_payload = kwargs.get("json")
+                                data_payload = kwargs.get("data")
+                                if isinstance(json_payload, dict):
+                                    payload_summary = {
+                                        "scheduleType": json_payload.get(
+                                            "scheduleType"
+                                        ),
+                                        "json_keys": sorted(
+                                            str(key) for key in json_payload.keys()
+                                        ),
+                                    }
+                                elif isinstance(json_payload, list):
+                                    key_union: set[str] = set()
+                                    for item in json_payload:
+                                        if isinstance(item, dict):
+                                            key_union.update(
+                                                str(key) for key in item.keys()
+                                            )
+                                    payload_summary = {
+                                        "json_item_count": len(json_payload),
+                                        "json_keys": sorted(key_union),
+                                    }
+                                elif isinstance(data_payload, dict):
+                                    payload_summary = {
+                                        "data_keys": sorted(
+                                            str(key) for key in data_payload.keys()
+                                        )
+                                    }
+                                header_flags = {
+                                    "has_authorization": "Authorization"
+                                    in base_headers,
+                                    "has_e_auth_token": "e-auth-token" in base_headers,
+                                    "has_username": "Username" in base_headers,
+                                    "has_x_xsrf_token": "X-XSRF-Token" in base_headers,
+                                }
+                                _LOGGER.debug(
+                                    "%s failed for %s: status=%s params=%s payload=%s "
+                                    "header_flags=%s cookie_names=%s headers=%s response=%s",
+                                    family,
+                                    request_label,
+                                    r.status,
+                                    params_summary,
+                                    payload_summary,
+                                    header_flags,
+                                    _cookie_names_from_header(
+                                        base_headers.get("Cookie")
+                                    ),
+                                    self._redact_headers(base_headers),
+                                    redact_text(
+                                        message,
+                                        site_ids=(self._site,),
+                                        max_length=256,
+                                    ),
+                                )
+                            raise aiohttp.ClientResponseError(
+                                r.request_info,
+                                r.history,
+                                status=r.status,
+                                message=message or r.reason,
+                                headers=r.headers,
                             )
-                        raise Unauthorized()
-                    if r.status in (204, 205):
+                        try:
+                            payload = await r.json()
+                        except (aiohttp.ContentTypeError, ValueError) as err:
+                            status = int(getattr(r, "status", 0) or 0)
+                            content_type = ""
+                            try:
+                                content_type = str(
+                                    r.headers.get("Content-Type", "")
+                                ).strip()
+                            except Exception:  # noqa: BLE001 - defensive header parsing
+                                content_type = ""
+                            try:
+                                body_text = await r.text()
+                            except Exception as text_err:  # noqa: BLE001
+                                body_text = (
+                                    f"<unavailable:{text_err.__class__.__name__}>"
+                                )
+                            failure_kind = (
+                                "content_type"
+                                if isinstance(err, aiohttp.ContentTypeError)
+                                else "json_decode"
+                            )
+                            raise self._invalid_payload_error(
+                                endpoint=endpoint or None,
+                                status=status or None,
+                                content_type=content_type or None,
+                                failure_kind=failure_kind,
+                                decode_error=err.__class__.__name__,
+                                payload=body_text,
+                                log_warning=log_invalid_payload,
+                            ) from err
                         if mark_payload_success:
                             self._mark_payload_healthy(endpoint or None)
-                        return {}
-                    if r.status >= 400:
-                        try:
-                            body_text = await r.text()
-                        except Exception:  # noqa: BLE001 - fall back to generic message
-                            body_text = ""
-                        message = (body_text or r.reason or "").strip()
-                        if len(message) > 512:
-                            message = f"{message[:512]}…"
-                        family = _request_failure_debug_family(
-                            method,
-                            endpoint or url,
-                        )
-                        if family is not None:
-                            params = kwargs.get("params")
-                            if isinstance(params, dict):
-                                params_summary: object = _redact_debug_json_body(
-                                    params,
-                                    site_ids=(self._site,),
-                                )
-                            elif params is None:
-                                params_summary = None
-                            else:
-                                params_summary = redact_text(
-                                    params,
-                                    site_ids=(self._site,),
-                                    max_length=256,
-                                )
-                            payload_summary: object = None
-                            json_payload = kwargs.get("json")
-                            data_payload = kwargs.get("data")
-                            if isinstance(json_payload, dict):
-                                payload_summary = {
-                                    "scheduleType": json_payload.get("scheduleType"),
-                                    "json_keys": sorted(
-                                        str(key) for key in json_payload.keys()
-                                    ),
-                                }
-                            elif isinstance(json_payload, list):
-                                key_union: set[str] = set()
-                                for item in json_payload:
-                                    if isinstance(item, dict):
-                                        key_union.update(
-                                            str(key) for key in item.keys()
-                                        )
-                                payload_summary = {
-                                    "json_item_count": len(json_payload),
-                                    "json_keys": sorted(key_union),
-                                }
-                            elif isinstance(data_payload, dict):
-                                payload_summary = {
-                                    "data_keys": sorted(
-                                        str(key) for key in data_payload.keys()
-                                    )
-                                }
-                            header_flags = {
-                                "has_authorization": "Authorization" in base_headers,
-                                "has_e_auth_token": "e-auth-token" in base_headers,
-                                "has_username": "Username" in base_headers,
-                                "has_x_xsrf_token": "X-XSRF-Token" in base_headers,
-                            }
-                            _LOGGER.debug(
-                                "%s failed for %s: status=%s params=%s payload=%s "
-                                "header_flags=%s cookie_names=%s headers=%s response=%s",
-                                family,
-                                request_label,
-                                r.status,
-                                params_summary,
-                                payload_summary,
-                                header_flags,
-                                _cookie_names_from_header(base_headers.get("Cookie")),
-                                self._redact_headers(base_headers),
-                                redact_text(
-                                    message,
-                                    site_ids=(self._site,),
-                                    max_length=256,
-                                ),
-                            )
-                        raise aiohttp.ClientResponseError(
-                            r.request_info,
-                            r.history,
-                            status=r.status,
-                            message=message or r.reason,
-                            headers=r.headers,
-                        )
-                    try:
-                        payload = await r.json()
-                    except (aiohttp.ContentTypeError, ValueError) as err:
-                        status = int(getattr(r, "status", 0) or 0)
-                        content_type = ""
-                        try:
-                            content_type = str(
-                                r.headers.get("Content-Type", "")
-                            ).strip()
-                        except Exception:  # noqa: BLE001 - defensive header parsing
-                            content_type = ""
-                        try:
-                            body_text = await r.text()
-                        except Exception as text_err:  # noqa: BLE001
-                            body_text = f"<unavailable:{text_err.__class__.__name__}>"
-                        failure_kind = (
-                            "content_type"
-                            if isinstance(err, aiohttp.ContentTypeError)
-                            else "json_decode"
-                        )
-                        raise self._invalid_payload_error(
-                            endpoint=endpoint or None,
-                            status=status or None,
-                            content_type=content_type or None,
-                            failure_kind=failure_kind,
-                            decode_error=err.__class__.__name__,
-                            payload=body_text,
-                            log_warning=log_invalid_payload,
-                        ) from err
-                    if mark_payload_success:
-                        self._mark_payload_healthy(endpoint or None)
-                    return payload
+                        return payload
 
     async def status(self) -> dict:
         url = f"{BASE_URL}/service/evse_controller/{self._site}/ev_chargers/status"

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -2332,17 +2332,34 @@ class BatteryRuntime:
     async def async_refresh_battery_status(self, *, force: bool = False) -> None:
         coord = self.coordinator
         state = self.battery_state
-        _ = force
+        now = time.monotonic()
+        family = "battery_status"
+        if not force and state._battery_status_cache_until:
+            if now < state._battery_status_cache_until:
+                return
+        if not coord._endpoint_family_should_run(family, force=force):
+            return
         fetcher = getattr(coord.client, "battery_status", None)
         if not callable(fetcher):
             return
-        payload = await fetcher()
+        try:
+            payload = await fetcher()
+        except Exception as err:  # noqa: BLE001
+            coord._note_endpoint_family_failure(family, err)
+            state._battery_status_cache_until = coord._endpoint_family_next_retry_mono(
+                family
+            )
+            return
         redacted_payload = coord.redact_battery_payload(payload)
         if isinstance(redacted_payload, dict):
             state._battery_status_payload = redacted_payload
         else:
             state._battery_status_payload = {"value": redacted_payload}
         self.parse_battery_status_payload(payload)
+        coord._note_endpoint_family_success(family)
+        state._battery_status_cache_until = coord._endpoint_family_next_retry_mono(
+            family
+        )
 
     async def async_refresh_battery_backup_history(
         self, *, force: bool = False
@@ -2350,29 +2367,30 @@ class BatteryRuntime:
         coord = self.coordinator
         state = self.battery_state
         now = time.monotonic()
+        family = "battery_backup_history"
         if not force and state._battery_backup_history_cache_until:
             if now < state._battery_backup_history_cache_until:
                 return
+        if not coord._endpoint_family_should_run(family, force=force):
+            return
         fetcher = getattr(coord.client, "battery_backup_history", None)
         if not callable(fetcher):
             return
         try:
             payload = await fetcher()
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug(
-                "Battery backup history fetch failed for site %s: %s",
-                redact_site_id(coord.site_id),
-                redact_text(err, site_ids=(coord.site_id,)),
-            )
+            coord._note_endpoint_family_failure(family, err)
             state._battery_backup_history_cache_until = (
                 now + BATTERY_BACKUP_HISTORY_FAILURE_CACHE_TTL
             )
             return
         parsed = self.parse_battery_backup_history_payload(payload)
         if parsed is None:
-            _LOGGER.debug(
-                "Battery backup history payload was invalid for site %s",
-                redact_site_id(coord.site_id),
+            coord._note_endpoint_family_failure(
+                family,
+                ValueError(
+                    f"Battery backup history payload was invalid for site {coord.site_id}"
+                ),
             )
             state._battery_backup_history_cache_until = (
                 now + BATTERY_BACKUP_HISTORY_FAILURE_CACHE_TTL
@@ -2387,19 +2405,30 @@ class BatteryRuntime:
         state._battery_backup_history_cache_until = (
             now + BATTERY_BACKUP_HISTORY_CACHE_TTL
         )
+        coord._note_endpoint_family_success(family)
 
     async def async_refresh_battery_settings(self, *, force: bool = False) -> None:
         coord = self.coordinator
         state = self.battery_state
         now = time.monotonic()
+        family = "battery_settings"
         pending_profile = getattr(state, "_battery_pending_profile", None)
         if not force and not pending_profile and state._battery_settings_cache_until:
             if now < state._battery_settings_cache_until:
                 return
+        if not coord._endpoint_family_should_run(
+            family,
+            force=force or bool(pending_profile),
+        ):
+            return
         fetcher = getattr(coord.client, "battery_settings_details", None)
         if not callable(fetcher):
             return
-        payload = await fetcher()
+        try:
+            payload = await fetcher()
+        except Exception as err:  # noqa: BLE001
+            coord._note_endpoint_family_failure(family, err)
+            return
         redacted_payload = coord.redact_battery_payload(payload)
         if isinstance(redacted_payload, dict):
             state._battery_settings_payload = redacted_payload
@@ -2410,22 +2439,26 @@ class BatteryRuntime:
             clear_missing_schedule_times=True,
         )
         state._battery_settings_cache_until = now + BATTERY_SETTINGS_CACHE_TTL
+        coord._note_endpoint_family_success(family)
 
     async def async_refresh_battery_schedules(self) -> None:
         coord = self.coordinator
         state = self.battery_state
+        family = "battery_schedules"
+        if not coord._endpoint_family_should_run(family):
+            return
         fetcher = getattr(coord.client, "battery_schedules", None)
         if not callable(fetcher):
             return
         try:
             payload = await fetcher()
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug(
-                "Battery schedules fetch failed: %s",
-                redact_text(err, site_ids=(coord.site_id,)),
-            )
+            coord._note_endpoint_family_failure(family, err)
             return
         if not isinstance(payload, dict):
+            coord._note_endpoint_family_failure(
+                family, ValueError("Battery schedules payload was not a dictionary")
+            )
             return
         redacted = coord.redact_battery_payload(payload)
         if isinstance(redacted, dict):
@@ -2433,18 +2466,26 @@ class BatteryRuntime:
         else:
             state._battery_schedules_payload = {"value": redacted}
         self.parse_battery_schedules_payload(payload)
+        coord._note_endpoint_family_success(family)
 
     async def async_refresh_battery_site_settings(self, *, force: bool = False) -> None:
         coord = self.coordinator
         state = self.battery_state
         now = time.monotonic()
+        family = "battery_site_settings"
         if not force and state._battery_site_settings_cache_until:
             if now < state._battery_site_settings_cache_until:
                 return
+        if not coord._endpoint_family_should_run(family, force=force):
+            return
         fetcher = getattr(coord.client, "battery_site_settings", None)
         if not callable(fetcher):
             return
-        payload = await fetcher()
+        try:
+            payload = await fetcher()
+        except Exception as err:  # noqa: BLE001
+            coord._note_endpoint_family_failure(family, err)
+            return
         redacted_payload = coord.redact_battery_payload(payload)
         if isinstance(redacted_payload, dict):
             state._battery_site_settings_payload = redacted_payload
@@ -2452,14 +2493,28 @@ class BatteryRuntime:
             state._battery_site_settings_payload = {"value": redacted_payload}
         self.parse_battery_site_settings_payload(payload)
         state._battery_site_settings_cache_until = now + BATTERY_SITE_SETTINGS_CACHE_TTL
+        coord._note_endpoint_family_success(family)
 
     async def async_refresh_grid_control_check(self, *, force: bool = False) -> None:
         coord = self.coordinator
         state = self.battery_state
         now = time.monotonic()
+        family = "grid_control_check"
         if not force and state._grid_control_check_cache_until:
             if now < state._grid_control_check_cache_until:
                 return
+        if not coord._endpoint_family_should_run(family, force=force):
+            if state._grid_control_supported is not None and (
+                coord._endpoint_family_state(family).cooldown_active
+                and not coord._endpoint_family_can_use_stale(family)
+            ):
+                state._grid_control_supported = None
+                state._grid_control_disable = None
+                state._grid_control_active_download = None
+                state._grid_control_sunlight_backup_system_check = None
+                state._grid_control_grid_outage_check = None
+                state._grid_control_user_initiated_toggle = None
+            return
         fetcher = getattr(coord.client, "grid_control_check", None)
         if not callable(fetcher):
             state._grid_control_supported = None
@@ -2472,7 +2527,11 @@ class BatteryRuntime:
         try:
             payload = await fetcher()
         except Exception as err:  # noqa: BLE001
-            state._grid_control_check_failures += 1
+            coord._note_endpoint_family_failure(family, err)
+            state._grid_control_check_failures = max(
+                state._grid_control_check_failures + 1,
+                coord._endpoint_family_state(family).consecutive_failures,
+            )
             last_success = getattr(state, "_grid_control_check_last_success_mono", None)
             if (
                 not isinstance(last_success, (int, float))
@@ -2485,11 +2544,6 @@ class BatteryRuntime:
                 state._grid_control_grid_outage_check = None
                 state._grid_control_user_initiated_toggle = None
             state._grid_control_check_cache_until = now + 15.0
-            _LOGGER.debug(
-                "Grid control check fetch failed for site %s: %s",
-                redact_site_id(coord.site_id),
-                redact_text(err, site_ids=(coord.site_id,)),
-            )
             return
         redacted_payload = coord.redact_battery_payload(payload)
         if isinstance(redacted_payload, dict):
@@ -2500,14 +2554,23 @@ class BatteryRuntime:
         state._grid_control_check_failures = 0
         state._grid_control_check_last_success_mono = now
         state._grid_control_check_cache_until = now + GRID_CONTROL_CHECK_CACHE_TTL
+        coord._note_endpoint_family_success(family)
 
     async def async_refresh_dry_contact_settings(self, *, force: bool = False) -> None:
         coord = self.coordinator
         state = self.battery_state
         now = time.monotonic()
+        family = "dry_contact_settings"
         if not force and state._dry_contact_settings_cache_until:
             if now < state._dry_contact_settings_cache_until:
                 return
+        if not coord._endpoint_family_should_run(family, force=force):
+            if state._dry_contact_settings_supported is not None and (
+                coord._endpoint_family_state(family).cooldown_active
+                and not coord._endpoint_family_can_use_stale(family)
+            ):
+                state._dry_contact_settings_supported = None
+            return
         fetcher = getattr(coord.client, "dry_contacts_settings", None)
         if not callable(fetcher):
             state._dry_contact_settings_supported = None
@@ -2515,7 +2578,11 @@ class BatteryRuntime:
         try:
             payload = await fetcher()
         except Exception as err:  # noqa: BLE001
-            state._dry_contact_settings_failures += 1
+            coord._note_endpoint_family_failure(family, err)
+            state._dry_contact_settings_failures = max(
+                state._dry_contact_settings_failures + 1,
+                coord._endpoint_family_state(family).consecutive_failures,
+            )
             last_success = getattr(
                 state, "_dry_contact_settings_last_success_mono", None
             )
@@ -2527,11 +2594,6 @@ class BatteryRuntime:
             state._dry_contact_settings_cache_until = (
                 now + DRY_CONTACT_SETTINGS_FAILURE_CACHE_TTL
             )
-            _LOGGER.debug(
-                "Dry contact settings fetch failed for site %s: %s",
-                redact_site_id(coord.site_id),
-                redact_text(err, site_ids=(coord.site_id,)),
-            )
             return
         redacted_payload = coord.redact_battery_payload(payload)
         if isinstance(redacted_payload, dict):
@@ -2542,6 +2604,7 @@ class BatteryRuntime:
         state._dry_contact_settings_failures = 0
         state._dry_contact_settings_last_success_mono = now
         state._dry_contact_settings_cache_until = now + DRY_CONTACT_SETTINGS_CACHE_TTL
+        coord._note_endpoint_family_success(family)
 
     @staticmethod
     def normalize_storm_guard_state(value: object) -> str | None:
@@ -2689,10 +2752,16 @@ class BatteryRuntime:
         coord = self.coordinator
         state = self.battery_state
         now = time.monotonic()
+        family = "storm_guard"
         pending_profile = getattr(state, "_battery_pending_profile", None)
         if not force and not pending_profile and state._storm_guard_cache_until:
             if now < state._storm_guard_cache_until:
                 return
+        if not coord._endpoint_family_should_run(
+            family,
+            force=force or bool(pending_profile),
+        ):
+            return
         try:
             locale = getattr(coord.hass.config, "language", None)
         except Exception:  # noqa: BLE001
@@ -2700,7 +2769,11 @@ class BatteryRuntime:
         fetcher = getattr(coord.client, "storm_guard_profile", None)
         if not callable(fetcher):
             return
-        payload = await fetcher(locale=locale)
+        try:
+            payload = await fetcher(locale=locale)
+        except Exception as err:  # noqa: BLE001
+            coord._note_endpoint_family_failure(family, err)
+            return
         redacted_payload = coord.redact_battery_payload(payload)
         if isinstance(redacted_payload, dict):
             state._battery_profile_payload = redacted_payload
@@ -2714,22 +2787,38 @@ class BatteryRuntime:
         if evse is not None:
             state._storm_evse_enabled = evse
         state._storm_guard_cache_until = now + STORM_GUARD_CACHE_TTL
+        coord._note_endpoint_family_success(family)
 
-    async def async_refresh_storm_alert(self, *, force: bool = False) -> None:
+    async def async_refresh_storm_alert(
+        self,
+        *,
+        force: bool = False,
+        raise_on_error: bool = False,
+    ) -> None:
         coord = self.coordinator
         state = self.battery_state
         now = time.monotonic()
+        family = "storm_alert"
         if not force and state._storm_alert_cache_until:
             if now < state._storm_alert_cache_until:
                 return
+        if not coord._endpoint_family_should_run(family, force=force):
+            return
         fetcher = getattr(coord.client, "storm_guard_alert", None)
         if not callable(fetcher):
             return
-        payload = await fetcher()
+        try:
+            payload = await fetcher()
+        except Exception as err:  # noqa: BLE001
+            coord._note_endpoint_family_failure(family, err)
+            if raise_on_error:
+                raise
+            return
         active = self.parse_storm_alert(payload)
         if active is not None:
             state._storm_alert_active = active
         state._storm_alert_cache_until = now + STORM_ALERT_CACHE_TTL
+        coord._note_endpoint_family_success(family)
 
     async def async_set_battery_reserve(self, reserve: int) -> None:
         coord = self.coordinator
@@ -3646,7 +3735,7 @@ class BatteryRuntime:
         refresh_err: Exception | None = None
         self.battery_state._storm_alert_cache_until = None
         try:
-            await coord.async_refresh_storm_alert(force=True)
+            await coord.async_refresh_storm_alert(force=True, raise_on_error=True)
             coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
             await coord.async_request_refresh()
         except Exception as err:  # noqa: BLE001

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -134,6 +134,7 @@ from .state_models import (
     BatteryControlCapability,
     BatteryState,
     DiscoveryState,
+    EndpointFamilyHealth,
     EVSEState,
     HeatpumpState,
     InventoryState,
@@ -197,6 +198,19 @@ class ChargerState:
     connector_status: str | None
     session_kwh: float | None
     session_start: int | None
+
+
+@dataclass(frozen=True, slots=True)
+class EndpointFamilyPolicy:
+    """Coordinator policy for read-only Enlighten endpoint families."""
+
+    success_ttl_s: float | None = None
+    stale_after_s: float | None = None
+    failure_backoff_schedule_s: tuple[float, ...] = ()
+    max_backoff_s: float | None = None
+    optional: bool = False
+    suppress_after_failures: int | None = None
+    support_state_on_success: bool = False
 
 
 class EnphaseCoordinator(DataUpdateCoordinator[dict]):
@@ -396,6 +410,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self.inventory_view = InventoryView(self)
         self.diagnostics = CoordinatorDiagnostics(self)
         self.refresh_runner = RefreshRunner(self)
+        self._endpoint_family_policies = self._build_endpoint_family_policies()
 
     def __setattr__(self, name, value):
         if name == "_async_fetch_sessions_today" and hasattr(self, "session_history"):
@@ -441,6 +456,335 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     async def _async_setup(self) -> None:
         """Prepare lightweight state before the first refresh."""
         self._phase_timings = {}
+
+    def _build_endpoint_family_policies(self) -> dict[str, EndpointFamilyPolicy]:
+        """Return cooldown/cache policies for read-only endpoint families."""
+
+        return {
+            "core_realtime": EndpointFamilyPolicy(
+                failure_backoff_schedule_s=(60.0, 120.0, 300.0, 600.0),
+                max_backoff_s=600.0,
+            ),
+            "battery_status": EndpointFamilyPolicy(
+                success_ttl_s=300.0,
+                stale_after_s=1800.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                support_state_on_success=True,
+            ),
+            "grid_control_check": EndpointFamilyPolicy(
+                success_ttl_s=300.0,
+                stale_after_s=180.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
+            "dry_contact_settings": EndpointFamilyPolicy(
+                success_ttl_s=300.0,
+                stale_after_s=900.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
+            "battery_backup_history": EndpointFamilyPolicy(
+                success_ttl_s=300.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                support_state_on_success=True,
+            ),
+            "battery_settings": EndpointFamilyPolicy(
+                success_ttl_s=300.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                support_state_on_success=True,
+            ),
+            "battery_site_settings": EndpointFamilyPolicy(
+                success_ttl_s=300.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                support_state_on_success=True,
+            ),
+            "battery_schedules": EndpointFamilyPolicy(
+                success_ttl_s=300.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                support_state_on_success=True,
+            ),
+            "storm_guard": EndpointFamilyPolicy(
+                success_ttl_s=300.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                support_state_on_success=True,
+            ),
+            "storm_alert": EndpointFamilyPolicy(
+                success_ttl_s=60.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                support_state_on_success=True,
+            ),
+            "inventory_topology": EndpointFamilyPolicy(
+                success_ttl_s=21600.0,
+                failure_backoff_schedule_s=(1800.0, 3600.0, 7200.0, 21600.0),
+                max_backoff_s=21600.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
+            "inverter_status": EndpointFamilyPolicy(
+                success_ttl_s=300.0,
+                stale_after_s=1800.0,
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
+            "inverter_production": EndpointFamilyPolicy(
+                failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
+                max_backoff_s=3600.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
+        }
+
+    async def async_request_refresh(self) -> None:
+        """Request a coordinator refresh and allow one cooldown-bypass cycle."""
+
+        self._endpoint_manual_bypass_requested = True
+        self._endpoint_manual_bypass_active = True
+        try:
+            await super().async_request_refresh()
+        finally:
+            self._endpoint_manual_bypass_requested = False
+            self._endpoint_manual_bypass_active = False
+
+    def _endpoint_family_policy(self, family: str) -> EndpointFamilyPolicy | None:
+        return self._endpoint_family_policies.get(family)
+
+    def _endpoint_family_state(self, family: str) -> EndpointFamilyHealth:
+        state = self._endpoint_family_health.get(family)
+        if state is None:
+            state = EndpointFamilyHealth()
+            self._endpoint_family_health[family] = state
+        return state
+
+    def _consume_endpoint_manual_bypass(self) -> bool:
+        requested = bool(self._endpoint_manual_bypass_requested)
+        self._endpoint_manual_bypass_requested = False
+        self._endpoint_manual_bypass_active = requested
+        return requested
+
+    def _clear_endpoint_manual_bypass(self) -> None:
+        self._endpoint_manual_bypass_active = False
+
+    def endpoint_manual_bypass_active(self) -> bool:
+        """Return True when the current refresh cycle is bypassing wait windows."""
+
+        return bool(self._endpoint_manual_bypass_active)
+
+    def _endpoint_family_wait_active(self, family: str) -> bool:
+        health = self._endpoint_family_state(family)
+        next_retry = health.next_retry_mono
+        if not isinstance(next_retry, (int, float)):
+            return False
+        if time.monotonic() < float(next_retry):
+            return True
+        health.next_retry_mono = None
+        health.next_retry_utc = None
+        health.cooldown_active = False
+        return False
+
+    def _endpoint_family_should_run(self, family: str, *, force: bool = False) -> bool:
+        if self._endpoint_family_policy(family) is None:
+            return True
+        if force or self.endpoint_manual_bypass_active():
+            return True
+        return not self._endpoint_family_wait_active(family)
+
+    def _endpoint_family_can_use_stale(self, family: str) -> bool:
+        policy = self._endpoint_family_policy(family)
+        if policy is None or policy.stale_after_s is None:
+            return False
+        last_success = self._endpoint_family_state(family).last_success_mono
+        if not isinstance(last_success, (int, float)):
+            return False
+        return (time.monotonic() - float(last_success)) <= float(policy.stale_after_s)
+
+    def _endpoint_family_next_retry_mono(self, family: str) -> float | None:
+        """Return the current monotonic retry/cache deadline for an endpoint family."""
+
+        next_retry = self._endpoint_family_state(family).next_retry_mono
+        if not isinstance(next_retry, (int, float)):
+            return None
+        return float(next_retry)
+
+    @staticmethod
+    def _endpoint_family_status_from_error(err: Exception) -> int | None:
+        if isinstance(err, aiohttp.ClientResponseError):
+            return int(err.status)
+        if isinstance(err, InvalidPayloadError):
+            return int(err.status) if isinstance(err.status, int) else None
+        return None
+
+    def _endpoint_family_backoff_delay(
+        self,
+        family: str,
+        consecutive_failures: int,
+    ) -> float:
+        policy = self._endpoint_family_policy(family)
+        if policy is None or not policy.failure_backoff_schedule_s:
+            return 0.0
+        index = min(
+            max(consecutive_failures - 1, 0),
+            len(policy.failure_backoff_schedule_s) - 1,
+        )
+        delay = float(policy.failure_backoff_schedule_s[index])
+        if policy.max_backoff_s is not None:
+            delay = min(delay, float(policy.max_backoff_s))
+        return delay * random.uniform(1.0, 1.1)
+
+    def _endpoint_family_failure_is_cooldown_worthy(
+        self,
+        family: str,
+        err: Exception,
+    ) -> bool:
+        status = self._endpoint_family_status_from_error(err)
+        if isinstance(err, (InvalidPayloadError, OptionalEndpointUnavailable)):
+            return True
+        if status is not None:
+            if status in (406, 429) or status >= 500:
+                return True
+            policy = self._endpoint_family_policy(family)
+            return bool(policy and policy.optional and status in (401, 403, 404))
+        if isinstance(err, (aiohttp.ClientError, asyncio.TimeoutError)):
+            return True
+        return True
+
+    def _log_endpoint_family_transition(
+        self,
+        family: str,
+        *,
+        previous_wait_active: bool,
+        previous_support_state: str,
+        health: EndpointFamilyHealth,
+        status: int | None = None,
+        delay_s: float | None = None,
+    ) -> None:
+        site = redact_site_id(self.site_id)
+        if (
+            previous_support_state != "suppressed"
+            and health.support_state == "suppressed"
+        ):
+            _LOGGER.info(
+                "Endpoint family %s suppressed for site %s after repeated failures (status=%s, retry_in_s=%s)",
+                family,
+                site,
+                status,
+                round(delay_s, 1) if isinstance(delay_s, (int, float)) else None,
+            )
+            return
+        if not previous_wait_active and health.cooldown_active:
+            _LOGGER.info(
+                "Endpoint family %s entered cooldown for site %s (status=%s, retry_in_s=%s)",
+                family,
+                site,
+                status,
+                round(delay_s, 1) if isinstance(delay_s, (int, float)) else None,
+            )
+            return
+        if (
+            (previous_wait_active or previous_support_state == "suppressed")
+            and not health.cooldown_active
+            and health.support_state in {"unknown", "supported"}
+        ):
+            _LOGGER.info(
+                "Endpoint family %s recovered for site %s",
+                family,
+                site,
+            )
+
+    def _note_endpoint_family_success(
+        self,
+        family: str,
+        *,
+        success_ttl_s: float | None = None,
+    ) -> None:
+        policy = self._endpoint_family_policy(family)
+        if policy is None:
+            return
+        health = self._endpoint_family_state(family)
+        previous_wait_active = self._endpoint_family_wait_active(family)
+        previous_support_state = health.support_state
+        now_mono = time.monotonic()
+        now_utc = dt_util.utcnow()
+        ttl = policy.success_ttl_s if success_ttl_s is None else success_ttl_s
+        health.consecutive_failures = 0
+        health.last_status = None
+        health.last_error = None
+        health.last_success_mono = now_mono
+        health.last_success_utc = now_utc
+        health.cooldown_active = False
+        if policy.support_state_on_success or previous_support_state == "suppressed":
+            health.support_state = "supported"
+        if isinstance(ttl, (int, float)) and ttl > 0:
+            health.next_retry_mono = now_mono + float(ttl)
+            try:
+                health.next_retry_utc = now_utc + timedelta(seconds=float(ttl))
+            except Exception:
+                health.next_retry_utc = None
+        else:
+            health.next_retry_mono = None
+            health.next_retry_utc = None
+        self._log_endpoint_family_transition(
+            family,
+            previous_wait_active=previous_wait_active,
+            previous_support_state=previous_support_state,
+            health=health,
+        )
+
+    def _note_endpoint_family_failure(self, family: str, err: Exception) -> bool:
+        policy = self._endpoint_family_policy(family)
+        if policy is None or not self._endpoint_family_failure_is_cooldown_worthy(
+            family, err
+        ):
+            return False
+        health = self._endpoint_family_state(family)
+        previous_wait_active = self._endpoint_family_wait_active(family)
+        previous_support_state = health.support_state
+        now_utc = dt_util.utcnow()
+        now_mono = time.monotonic()
+        status = self._endpoint_family_status_from_error(err)
+        health.consecutive_failures += 1
+        health.last_failure_utc = now_utc
+        health.last_status = status
+        health.last_error = redact_text(err, site_ids=(self.site_id,))
+        delay = self._endpoint_family_backoff_delay(family, health.consecutive_failures)
+        if policy.suppress_after_failures is not None and (
+            health.consecutive_failures >= int(policy.suppress_after_failures)
+        ):
+            health.support_state = "suppressed"
+            if policy.max_backoff_s is not None:
+                delay = max(delay, float(policy.max_backoff_s))
+        health.cooldown_active = True
+        health.next_retry_mono = now_mono + delay
+        try:
+            health.next_retry_utc = now_utc + timedelta(seconds=delay)
+        except Exception:
+            health.next_retry_utc = None
+        self._log_endpoint_family_transition(
+            family,
+            previous_wait_active=previous_wait_active,
+            previous_support_state=previous_support_state,
+            health=health,
+            status=status,
+            delay_s=delay,
+        )
+        return True
 
     @property
     def phase_timings(self) -> dict[str, float]:
@@ -5821,10 +6165,29 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     async def async_refresh_storm_guard_profile(self, *, force: bool = False) -> None:
         await self._async_refresh_storm_guard_profile(force=force)
 
-    async def _async_refresh_storm_alert(self, *, force: bool = False) -> None:
+    async def _async_refresh_storm_alert(
+        self,
+        *,
+        force: bool = False,
+        raise_on_error: bool = False,
+    ) -> None:
+        if raise_on_error:
+            await self.battery_runtime.async_refresh_storm_alert(
+                force=force,
+                raise_on_error=True,
+            )
+            return
         await self.battery_runtime.async_refresh_storm_alert(force=force)
 
-    async def async_refresh_storm_alert(self, *, force: bool = False) -> None:
+    async def async_refresh_storm_alert(
+        self,
+        *,
+        force: bool = False,
+        raise_on_error: bool = False,
+    ) -> None:
+        if raise_on_error:
+            await self._async_refresh_storm_alert(force=force, raise_on_error=True)
+            return
         await self._async_refresh_storm_alert(force=force)
 
     async def async_opt_out_all_storm_alerts(self) -> None:

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -249,6 +249,7 @@ class CoordinatorDiagnostics:
             "type_device_keys": type_keys,
             "type_device_counts": type_counts,
             "payload_health": self.payload_health_diagnostics(),
+            "endpoint_family_health": self.endpoint_family_health_diagnostics(),
             "inverters_enabled": bool(getattr(coord, "include_inverters", True)),
             "inverters_count": len(getattr(coord, "_inverter_data", {}) or {}),
             "inverters_summary_counts": dict(
@@ -930,6 +931,45 @@ class CoordinatorDiagnostics:
                 out["evse_timeseries"] = evse_timeseries.diagnostics()
             except Exception:  # noqa: BLE001
                 pass
+        return out
+
+    def endpoint_family_health_diagnostics(self) -> dict[str, object]:
+        """Return diagnostics-safe endpoint family health details."""
+
+        coord = self.coordinator
+
+        def _iso(value: datetime | None) -> str | None:
+            if not value:
+                return None
+            try:
+                return value.isoformat()
+            except Exception:
+                return str(value)
+
+        out: dict[str, object] = {}
+        health_map = getattr(coord, "_endpoint_family_health", {})
+        if not isinstance(health_map, dict):
+            return out
+        for family, state in health_map.items():
+            if not isinstance(family, str):
+                continue
+            if state is None:
+                continue
+            support_state = getattr(state, "support_state", "unknown")
+            out[family] = {
+                "family": family,
+                "consecutive_failures": int(
+                    getattr(state, "consecutive_failures", 0) or 0
+                ),
+                "last_status": getattr(state, "last_status", None),
+                "last_success_utc": _iso(getattr(state, "last_success_utc", None)),
+                "last_failure_utc": _iso(getattr(state, "last_failure_utc", None)),
+                "next_retry_utc": _iso(getattr(state, "next_retry_utc", None)),
+                "cooldown_active": bool(getattr(state, "cooldown_active", False)),
+                "support_state": support_state,
+                "suppressed": support_state == "suppressed",
+                "last_error": getattr(state, "last_error", None),
+            }
         return out
 
     def sync_session_history_issue(self) -> None:

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -6,8 +6,9 @@ import logging
 import re
 import time
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
+from zoneinfo import ZoneInfo
 
 from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
@@ -34,6 +35,7 @@ from .runtime_helpers import (
     redact_battery_payload,
     resolve_inverter_start_date,
     resolve_site_local_current_date,
+    resolve_site_timezone_name,
 )
 from .state_models import install_state_descriptors
 from .system_dashboard_helpers import (
@@ -145,6 +147,18 @@ class InventoryRuntime:
             getattr(self, "_devices_inventory_payload", None),
             getattr(self.coordinator, "_battery_timezone", None),
         )
+
+    def _seconds_until_next_site_local_day(self) -> float:
+        tz_name = resolve_site_timezone_name(
+            getattr(self.coordinator, "_battery_timezone", None)
+        )
+        now_local = datetime.now(ZoneInfo(tz_name))
+        next_midnight = datetime.combine(
+            now_local.date() + timedelta(days=1),
+            datetime.min.time(),
+            tzinfo=now_local.tzinfo,
+        )
+        return max(1.0, (next_midnight - now_local).total_seconds())
 
     def _redact_battery_payload(self, payload: object) -> object:
         return redact_battery_payload(payload)
@@ -1706,7 +1720,11 @@ class InventoryRuntime:
         )
 
     async def _async_refresh_devices_inventory(self, *, force: bool = False) -> None:
+        coord = self.coordinator
         now = time.monotonic()
+        family = "inventory_topology"
+        if not coord._endpoint_family_should_run(family, force=force):
+            return
         if not force and self._devices_inventory_cache_until:
             if now < self._devices_inventory_cache_until:
                 return
@@ -1716,10 +1734,7 @@ class InventoryRuntime:
         try:
             payload = await self._async_call_refreshable_fetcher(fetcher, force=force)
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug(
-                "Device inventory fetch failed: %s",
-                redact_text(err, site_ids=(self.site_id,)),
-            )
+            coord._note_endpoint_family_failure(family, err)
             return
         override = getattr(self.coordinator, "__dict__", {}).get(
             "_parse_devices_inventory_payload"
@@ -1729,9 +1744,8 @@ class InventoryRuntime:
         else:
             valid, grouped, ordered = self._parse_devices_inventory_payload(payload)
         if not valid:
-            _LOGGER.debug(
-                "Device inventory payload shape was invalid: %s",
-                redact_text(payload, site_ids=(self.site_id,)),
+            coord._note_endpoint_family_failure(
+                family, ValueError("Device inventory payload shape was invalid")
             )
             return
         summary = self._debug_devices_inventory_summary(grouped, ordered)
@@ -1741,6 +1755,10 @@ class InventoryRuntime:
                 "Device inventory discovery summary",
                 summary,
             )
+            self._set_shared_state_attr(
+                "_devices_inventory_cache_until", now + DEVICES_INVENTORY_CACHE_TTL
+            )
+            coord._note_endpoint_family_success(family)
             return
         has_active_members = False
         for bucket in grouped.values():
@@ -1756,6 +1774,7 @@ class InventoryRuntime:
                 redact_text(summary, site_ids=(self.site_id,)),
             )
             self._devices_inventory_cache_until = now + DEVICES_INVENTORY_CACHE_TTL
+            coord._note_endpoint_family_success(family)
             return
         self._set_type_device_buckets(grouped, ordered)
         redacted_payload = self._redact_battery_payload(payload)
@@ -1774,6 +1793,7 @@ class InventoryRuntime:
             "Device inventory discovery summary",
             summary,
         )
+        coord._note_endpoint_family_success(family)
 
     async def _async_refresh_hems_devices(self, *, force: bool = False) -> None:
         now = time.monotonic()
@@ -1935,7 +1955,11 @@ class InventoryRuntime:
         return system_dashboard_battery_detail_subset(payload)
 
     async def _async_refresh_system_dashboard(self, *, force: bool = False) -> None:
+        coord = self.coordinator
         now = time.monotonic()
+        family = "inventory_topology"
+        if not coord._endpoint_family_should_run(family, force=force):
+            return
         if not force and self._system_dashboard_cache_until:
             if now < self._system_dashboard_cache_until:
                 return
@@ -1945,14 +1969,16 @@ class InventoryRuntime:
             return
 
         tree_payload = getattr(self, "_system_dashboard_devices_tree_raw", None)
+        first_error: Exception | None = None
+        fetched_payload = False
         if callable(tree_fetcher):
             try:
                 tree_payload = await tree_fetcher()
             except Exception as err:  # noqa: BLE001
-                _LOGGER.debug(
-                    "System dashboard devices-tree fetch failed: %s",
-                    redact_text(err, site_ids=(self.site_id,)),
-                )
+                first_error = err
+            else:
+                if isinstance(tree_payload, dict):
+                    fetched_payload = True
 
         details_payloads = (
             dict(getattr(self, "_system_dashboard_devices_details_raw", {}) or {})
@@ -1966,14 +1992,12 @@ class InventoryRuntime:
                 try:
                     payload = await details_fetcher(source_type)
                 except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug(
-                        "System dashboard devices_details fetch failed for type %s: %s",
-                        source_type,
-                        redact_text(err, site_ids=(self.site_id,)),
-                    )
+                    if first_error is None:
+                        first_error = err
                     continue
                 if not isinstance(payload, dict):
                     continue
+                fetched_payload = True
                 canonical_type = self._system_dashboard_type_key(source_type)
                 if not canonical_type:
                     continue
@@ -2035,6 +2059,10 @@ class InventoryRuntime:
                 hierarchy_summary,
             ),
         )
+        if fetched_payload or tree_raw is not None or details_raw:
+            coord._note_endpoint_family_success(family)
+        elif first_error is not None:
+            coord._note_endpoint_family_failure(family, first_error)
 
     def _inverter_start_date(self) -> str | None:
         energy = getattr(self.coordinator, "energy", None)
@@ -2271,16 +2299,22 @@ class InventoryRuntime:
 
     async def _async_refresh_inverters(self) -> None:
         """Refresh inverter metadata/status/production and build serial snapshots."""
+        coord = self.coordinator
+        now = time.monotonic()
         if not self.include_inverters:
             self._update_shared_state(
+                _inverters_inventory_cache_until=None,
                 _inverters_inventory_payload=None,
+                _inverter_status_cache_until=None,
                 _inverter_status_payload=None,
+                _inverter_production_cache_until=None,
                 _inverter_production_payload=None,
                 _inverter_data={},
                 _inverter_order=[],
                 _inverter_panel_info=None,
                 _inverter_status_type_counts={},
                 _inverter_model_counts={},
+                _inverter_production_cache_key=None,
                 _inverter_summary_counts={
                     "total": 0,
                     "normal": 0,
@@ -2299,6 +2333,16 @@ class InventoryRuntime:
         if not callable(fetch_inventory) or not callable(fetch_status):
             return
 
+        inventory_family = "inventory_topology"
+        status_family = "inverter_status"
+        production_family = "inverter_production"
+        cached_inventory_payload = getattr(self, "_inverters_inventory_payload", None)
+        if not isinstance(cached_inventory_payload, dict):
+            cached_inventory_payload = None
+        inventory_cache_until = getattr(self, "_inverters_inventory_cache_until", None)
+        if not isinstance(inventory_cache_until, (int, float)):
+            inventory_cache_until = None
+
         async def _fetch_inventory_page(offset: int) -> dict[str, object] | None:
             try:
                 payload = await fetch_inventory(
@@ -2310,18 +2354,41 @@ class InventoryRuntime:
                 if offset != 0:
                     return None
                 payload = await fetch_inventory()
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug(
-                    "Inverters inventory fetch failed for site %s: %s",
-                    redact_site_id(self.site_id),
-                    redact_text(err, site_ids=(self.site_id,)),
-                )
-                return None
+            except Exception:
+                raise
             if not isinstance(payload, dict):
                 return None
             return payload
 
-        inventory_payload = await _fetch_inventory_page(0)
+        inventory_payload: dict[str, object] | None = None
+        fetch_inventory_now = True
+        if inventory_cache_until is not None and now < float(inventory_cache_until):
+            fetch_inventory_now = False
+        else:
+            fetch_inventory_now = coord._endpoint_family_should_run(inventory_family)
+        if fetch_inventory_now:
+            try:
+                inventory_payload = await _fetch_inventory_page(0)
+            except Exception as err:  # noqa: BLE001
+                coord._note_endpoint_family_failure(inventory_family, err)
+                self._set_shared_state_attr(
+                    "_inverters_inventory_cache_until",
+                    coord._endpoint_family_next_retry_mono(inventory_family),
+                )
+                inventory_payload = cached_inventory_payload
+            else:
+                if inventory_payload is None:
+                    coord._note_endpoint_family_failure(
+                        inventory_family,
+                        ValueError("Inverters inventory payload was not a dictionary"),
+                    )
+                    self._set_shared_state_attr(
+                        "_inverters_inventory_cache_until",
+                        coord._endpoint_family_next_retry_mono(inventory_family),
+                    )
+                    inventory_payload = cached_inventory_payload
+        else:
+            inventory_payload = cached_inventory_payload
         if inventory_payload is None:
             return
 
@@ -2356,41 +2423,130 @@ class InventoryRuntime:
             inventory_payload = dict(inventory_payload)
             inventory_payload["inverters"] = merged
             inverters_list = merged
-
-        try:
-            status_payload = await fetch_status()
-        except Exception as err:  # noqa: BLE001
-            _LOGGER.debug(
-                "Inverter status fetch failed for site %s: %s",
-                redact_site_id(self.site_id),
-                redact_text(err, site_ids=(self.site_id,)),
+        if fetch_inventory_now and inventory_payload is not cached_inventory_payload:
+            coord._note_endpoint_family_success(inventory_family)
+            self._set_shared_state_attr(
+                "_inverters_inventory_cache_until",
+                coord._endpoint_family_next_retry_mono(inventory_family),
             )
-            status_payload = {}
-        if not isinstance(status_payload, dict):
-            status_payload = {}
+
+        cached_status_payload = getattr(self, "_inverter_status_payload", None)
+        if not isinstance(cached_status_payload, dict):
+            cached_status_payload = {}
+        status_payload: dict[str, object] = {}
+        status_cache_until = getattr(self, "_inverter_status_cache_until", None)
+        if isinstance(status_cache_until, (int, float)) and now < float(
+            status_cache_until
+        ):
+            status_payload = dict(cached_status_payload)
+        elif coord._endpoint_family_should_run(status_family):
+            try:
+                fetched_status = await fetch_status()
+            except Exception as err:  # noqa: BLE001
+                coord._note_endpoint_family_failure(status_family, err)
+                self._set_shared_state_attr(
+                    "_inverter_status_cache_until",
+                    coord._endpoint_family_next_retry_mono(status_family),
+                )
+                if coord._endpoint_family_can_use_stale(status_family):
+                    status_payload = dict(cached_status_payload)
+            else:
+                if isinstance(fetched_status, dict):
+                    status_payload = fetched_status
+                    coord._note_endpoint_family_success(status_family)
+                    self._set_shared_state_attr(
+                        "_inverter_status_cache_until",
+                        coord._endpoint_family_next_retry_mono(status_family),
+                    )
+                else:
+                    coord._note_endpoint_family_failure(
+                        status_family,
+                        ValueError("Inverter status payload was not a dictionary"),
+                    )
+                    self._set_shared_state_attr(
+                        "_inverter_status_cache_until",
+                        coord._endpoint_family_next_retry_mono(status_family),
+                    )
+                    if coord._endpoint_family_can_use_stale(status_family):
+                        status_payload = dict(cached_status_payload)
+        elif coord._endpoint_family_can_use_stale(status_family):
+            status_payload = dict(cached_status_payload)
 
         start_date = self._inverter_start_date()
         end_date = self._site_local_current_date()
         production_payload: dict[str, object] = {}
+        cached_production_payload = getattr(self, "_inverter_production_payload", None)
+        if not isinstance(cached_production_payload, dict):
+            cached_production_payload = {}
+        current_production_cache_key = (
+            (start_date, end_date) if start_date is not None else None
+        )
+        production_cache_until = getattr(
+            self,
+            "_inverter_production_cache_until",
+            None,
+        )
+        cached_production_matches = (
+            current_production_cache_key is not None
+            and getattr(self, "_inverter_production_cache_key", None)
+            == current_production_cache_key
+            and bool(cached_production_payload)
+        )
         if callable(fetch_production) and start_date is not None:
-            try:
-                production_payload = await fetch_production(
-                    start_date=start_date, end_date=end_date
-                )
-            except Exception as err:  # noqa: BLE001
-                _LOGGER.debug(
-                    "Inverter production fetch failed for site %s: %s",
-                    redact_site_id(self.site_id),
-                    redact_text(err, site_ids=(self.site_id,)),
-                )
-                production_payload = {}
+            if (
+                cached_production_matches
+                and isinstance(production_cache_until, (int, float))
+                and now < float(production_cache_until)
+            ):
+                production_payload = dict(cached_production_payload)
+            elif coord._endpoint_family_should_run(production_family):
+                try:
+                    fetched_production = await fetch_production(
+                        start_date=start_date, end_date=end_date
+                    )
+                except Exception as err:  # noqa: BLE001
+                    coord._note_endpoint_family_failure(production_family, err)
+                    self._set_shared_state_attr(
+                        "_inverter_production_cache_until",
+                        coord._endpoint_family_next_retry_mono(production_family),
+                    )
+                    if cached_production_matches:
+                        production_payload = dict(cached_production_payload)
+                else:
+                    if isinstance(fetched_production, dict):
+                        production_payload = fetched_production
+                        coord._note_endpoint_family_success(
+                            production_family,
+                            success_ttl_s=self._seconds_until_next_site_local_day(),
+                        )
+                        self._set_shared_state_attr(
+                            "_inverter_production_cache_key",
+                            current_production_cache_key,
+                        )
+                        self._set_shared_state_attr(
+                            "_inverter_production_cache_until",
+                            coord._endpoint_family_next_retry_mono(production_family),
+                        )
+                    else:
+                        coord._note_endpoint_family_failure(
+                            production_family,
+                            ValueError(
+                                "Inverter production payload was not a dictionary"
+                            ),
+                        )
+                        self._set_shared_state_attr(
+                            "_inverter_production_cache_until",
+                            coord._endpoint_family_next_retry_mono(production_family),
+                        )
+                        if cached_production_matches:
+                            production_payload = dict(cached_production_payload)
+            elif cached_production_matches:
+                production_payload = dict(cached_production_payload)
         elif start_date is None:
             _LOGGER.debug(
                 "Skipping inverter production fetch for site %s: start date unknown",
                 redact_site_id(self.site_id),
             )
-        if not isinstance(production_payload, dict):
-            production_payload = {}
         production_raw = production_payload.get("production")
         if not isinstance(production_raw, dict):
             production_raw = {}

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.2"
+  "version": "2.7.3"
 }

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -60,6 +60,20 @@ class BatteryControlCapability:
 
 
 @dataclass(slots=True)
+class EndpointFamilyHealth:
+    consecutive_failures: int = 0
+    last_success_utc: datetime | None = None
+    last_success_mono: float | None = None
+    last_failure_utc: datetime | None = None
+    last_status: int | None = None
+    next_retry_mono: float | None = None
+    next_retry_utc: datetime | None = None
+    cooldown_active: bool = False
+    support_state: str = "unknown"
+    last_error: str | None = None
+
+
+@dataclass(slots=True)
 class RefreshHealthState:
     last_set_amps: dict[str, int] = field(default_factory=dict)
     _amp_restart_tasks: dict[str, Any] = field(default_factory=dict)
@@ -120,10 +134,16 @@ class RefreshHealthState:
     _session_history_day_retention: int = 0
     _operating_v: dict[str, int] = field(default_factory=dict)
     _fast_until: float | None = None
+    _endpoint_family_health: dict[str, EndpointFamilyHealth] = field(
+        default_factory=dict
+    )
+    _endpoint_manual_bypass_requested: bool = False
+    _endpoint_manual_bypass_active: bool = False
 
 
 @dataclass(slots=True)
 class InventoryState:
+    _inverters_inventory_cache_until: float | None = None
     _devices_inventory_cache_until: float | None = None
     _devices_inventory_payload: dict[str, object] | None = None
     _status_payload_cache: dict[str, object] | None = None
@@ -144,7 +164,9 @@ class InventoryState:
         default_factory=dict
     )
     _inverters_inventory_payload: dict[str, object] | None = None
+    _inverter_status_cache_until: float | None = None
     _inverter_status_payload: dict[str, object] | None = None
+    _inverter_production_cache_until: float | None = None
     _inverter_production_payload: dict[str, object] | None = None
     _inverter_data: dict[str, dict[str, object]] = field(default_factory=dict)
     _inverter_order: list[str] = field(default_factory=list)
@@ -162,6 +184,7 @@ class InventoryState:
     _inverter_model_counts: dict[str, int] = field(default_factory=dict)
     _type_device_buckets: dict[str, dict[str, object]] = field(default_factory=dict)
     _type_device_order: list[str] = field(default_factory=list)
+    _inverter_production_cache_key: tuple[str, str] | None = None
 
 
 @dataclass(slots=True)
@@ -371,6 +394,7 @@ class BatteryState:
     _battery_site_settings_payload: dict[str, object] | None = None
     _battery_profile_payload: dict[str, object] | None = None
     _battery_settings_payload: dict[str, object] | None = None
+    _battery_status_cache_until: float | None = None
     _battery_status_payload: dict[str, object] | None = None
     _battery_backup_history_payload: dict[str, object] | None = None
     _battery_backup_history_events: list[dict[str, object]] = field(

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -171,6 +171,7 @@ def test_root_and_today_header_helpers_use_browser_profiles() -> None:
         "Accept": "*/*",
         "X-Requested-With": "XMLHttpRequest",
         "Referer": f"{api.BASE_URL}/",
+        "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
         "Cookie": "appVersion=3.4.0; a=1",
         "e-auth-token": "EAUTH",
     }
@@ -178,6 +179,7 @@ def test_root_and_today_header_helpers_use_browser_profiles() -> None:
         "Accept": "*/*",
         "X-Requested-With": "XMLHttpRequest",
         "Referer": f"{api.BASE_URL}/web/SITE/today/graph/hours?v=3.4.0",
+        "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
         "Cookie": "appVersion=3.4.0; a=1",
         "e-auth-token": "EAUTH",
     }
@@ -185,6 +187,7 @@ def test_root_and_today_header_helpers_use_browser_profiles() -> None:
         "Accept": "application/json, text/javascript, */*; q=0.01",
         "X-Requested-With": "XMLHttpRequest",
         "Referer": f"{api.BASE_URL}/web/SITE/today/graph/hours?v=3.4.0",
+        "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
         "Cookie": "appVersion=3.4.0; a=1",
         "e-auth-token": "EAUTH",
     }
@@ -1779,6 +1782,7 @@ async def test_grid_control_check_uses_grid_control_check_endpoint() -> None:
             "Accept": "*/*",
             "X-Requested-With": "XMLHttpRequest",
             "Referer": f"{api.BASE_URL}/web/SITE/history/graph/years",
+            "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
             "Cookie": "COOKIE",
             "e-auth-token": "EAUTH",
         },
@@ -1918,6 +1922,7 @@ async def test_battery_backup_history_uses_endpoint() -> None:
             "Accept": "*/*",
             "X-Requested-With": "XMLHttpRequest",
             "Referer": f"{api.BASE_URL}/web/SITE/history/graph/years",
+            "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
             "Cookie": "COOKIE",
             "e-auth-token": "EAUTH",
         },
@@ -1959,6 +1964,7 @@ async def test_battery_status_uses_battery_status_json_endpoint() -> None:
             "Accept": "*/*",
             "X-Requested-With": "XMLHttpRequest",
             "Referer": f"{api.BASE_URL}/web/SITE/history/graph/years",
+            "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
             "Cookie": "COOKIE",
             "e-auth-token": "EAUTH",
         },
@@ -2017,6 +2023,7 @@ async def test_inverters_inventory_uses_inverters_json_endpoint() -> None:
         "Accept": "*/*",
         "X-Requested-With": "XMLHttpRequest",
         "Referer": f"{api.BASE_URL}/web/SITE/history/graph/years",
+        "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
         "Cookie": "COOKIE",
         "e-auth-token": "EAUTH",
     }
@@ -2053,6 +2060,7 @@ async def test_inverter_status_normalizes_keyed_dict() -> None:
             "Accept": "application/json, text/javascript, */*; q=0.01",
             "X-Requested-With": "XMLHttpRequest",
             "Referer": f"{api.BASE_URL}/web/SITE/layout/graph/years",
+            "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
             "Cookie": "COOKIE",
             "e-auth-token": "EAUTH",
         },
@@ -2094,6 +2102,7 @@ async def test_inverter_production_normalizes_values() -> None:
             "Accept": "application/json, text/javascript, */*; q=0.01",
             "X-Requested-With": "XMLHttpRequest",
             "Referer": f"{api.BASE_URL}/web/SITE/layout/graph/years",
+            "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
             "Cookie": "COOKIE",
             "e-auth-token": "EAUTH",
         },
@@ -3773,6 +3782,7 @@ async def test_lifetime_energy_normalization() -> None:
         "Accept": "application/json, text/javascript, */*; q=0.01",
         "X-Requested-With": "XMLHttpRequest",
         "Referer": f"{api.BASE_URL}/web/SITE/layout/graph/years",
+        "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
         "Cookie": "COOKIE",
     }
 

--- a/tests/components/enphase_ev/test_api_http_flow.py
+++ b/tests/components/enphase_ev/test_api_http_flow.py
@@ -97,6 +97,19 @@ class StubSession:
         self.cookie_jar = aiohttp.CookieJar()
 
 
+def test_should_limit_enlighten_read_request_handles_bad_string_casts() -> None:
+    class BadMethod:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    class BadUrl:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    assert api._should_limit_enlighten_read_request(BadMethod(), api.BASE_URL) is False
+    assert api._should_limit_enlighten_read_request("GET", BadUrl()) is False
+
+
 def test_cookie_header_from_map_empty() -> None:
     assert api._cookie_header_from_map(None) == ""
     assert api._cookie_header_from_map({}) == ""
@@ -262,6 +275,17 @@ def test_login_form_headers_match_browser_flow() -> None:
         "Content-Type": "application/x-www-form-urlencoded",
         "Origin": api.BASE_URL,
         "Referer": f"{api.BASE_URL}/",
+        "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
+    }
+
+
+def test_login_headers_match_xhr_flow() -> None:
+    assert api._login_headers() == {
+        "Accept": "*/*",
+        "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
+        "Referer": f"{api.BASE_URL}/",
+        "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
+        "X-Requested-With": "XMLHttpRequest",
     }
 
 
@@ -381,6 +405,7 @@ async def test_async_authenticate_success_with_jwt_fallback(monkeypatch) -> None
             "Accept": "*/*",
             "Content-Type": "application/x-www-form-urlencoded; charset=UTF-8",
             "Referer": f"{api.BASE_URL}/",
+            "User-Agent": api._ENLIGHTEN_BROWSER_USER_AGENT,
             "X-Requested-With": "XMLHttpRequest",
         }
     ]

--- a/tests/components/enphase_ev/test_auth_site_discovery.py
+++ b/tests/components/enphase_ev/test_auth_site_discovery.py
@@ -55,6 +55,7 @@ async def test_async_authenticate_populates_site_headers(monkeypatch):
     assert captured["X-CSRF-Token"] == "xsrf123"
     assert captured["X-Requested-With"] == "XMLHttpRequest"
     assert captured["Referer"] == f"{api.BASE_URL}/"
+    assert captured["User-Agent"] == api._ENLIGHTEN_BROWSER_USER_AGENT
     assert captured["Authorization"] == "Bearer token123"
     assert captured["e-auth-token"] == "token123"
     # Ensure the caller explicitly sets Cookie so the request works without relying on session defaults

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import time
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
@@ -1140,6 +1141,92 @@ async def test_battery_runtime_refresh_status_wraps_non_dict_redacted_payload(
     await coord.battery_runtime.async_refresh_battery_status()
 
     assert coord.battery_status_payload == {"value": ["unexpected"]}
+
+
+@pytest.mark.asyncio
+async def test_battery_runtime_refresh_status_uses_success_cache_ttl(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.battery_status = AsyncMock(
+        return_value={"storages": [{"serial_number": "BAT-1", "current_charge": 48}]}
+    )
+
+    await coord.battery_runtime.async_refresh_battery_status()
+
+    assert coord.client.battery_status.await_count == 1
+    assert coord._battery_status_cache_until is not None  # noqa: SLF001
+
+    await coord.battery_runtime.async_refresh_battery_status()
+
+    assert coord.client.battery_status.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_battery_runtime_refresh_status_skips_during_endpoint_cooldown(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    health = coord._endpoint_family_state("battery_status")  # noqa: SLF001
+    health.next_retry_mono = time.monotonic() + 300
+    health.cooldown_active = True
+    coord.client.battery_status = AsyncMock(side_effect=AssertionError("no fetch"))
+
+    await coord.battery_runtime.async_refresh_battery_status()
+
+    coord.client.battery_status.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_battery_runtime_optional_refreshes_respect_cooldown_and_clear_stale_state(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    backup_health = coord._endpoint_family_state(
+        "battery_backup_history"
+    )  # noqa: SLF001
+    backup_health.next_retry_mono = time.monotonic() + 300
+    backup_health.cooldown_active = True
+    coord._battery_backup_history_cache_until = None  # noqa: SLF001
+    coord.client.battery_backup_history = AsyncMock(
+        side_effect=AssertionError("unused")
+    )
+    await coord.battery_runtime.async_refresh_battery_backup_history()
+    coord.client.battery_backup_history.assert_not_awaited()
+
+    site_health = coord._endpoint_family_state("battery_site_settings")  # noqa: SLF001
+    site_health.next_retry_mono = time.monotonic() + 300
+    site_health.cooldown_active = True
+    coord._battery_site_settings_cache_until = None  # noqa: SLF001
+    coord.client.battery_site_settings = AsyncMock(side_effect=AssertionError("unused"))
+    await coord.battery_runtime.async_refresh_battery_site_settings()
+    coord.client.battery_site_settings.assert_not_awaited()
+
+    grid_health = coord._endpoint_family_state("grid_control_check")  # noqa: SLF001
+    grid_health.next_retry_mono = time.monotonic() + 300
+    grid_health.cooldown_active = True
+    grid_health.last_success_mono = time.monotonic() - 500
+    coord._grid_control_check_cache_until = None  # noqa: SLF001
+    coord._grid_control_supported = True  # noqa: SLF001
+    coord._grid_control_disable = False  # noqa: SLF001
+    coord._grid_control_active_download = True  # noqa: SLF001
+    coord._grid_control_sunlight_backup_system_check = True  # noqa: SLF001
+    coord._grid_control_grid_outage_check = True  # noqa: SLF001
+    coord._grid_control_user_initiated_toggle = True  # noqa: SLF001
+    await coord.battery_runtime.async_refresh_grid_control_check()
+    assert coord._grid_control_supported is None  # noqa: SLF001
+    assert coord._grid_control_disable is None  # noqa: SLF001
+    assert coord._grid_control_active_download is None  # noqa: SLF001
+
+    dry_health = coord._endpoint_family_state("dry_contact_settings")  # noqa: SLF001
+    dry_health.next_retry_mono = time.monotonic() + 300
+    dry_health.cooldown_active = True
+    dry_health.last_success_mono = time.monotonic() - 2_000
+    coord._dry_contact_settings_cache_until = None  # noqa: SLF001
+    coord._dry_contact_settings_supported = True  # noqa: SLF001
+    await coord.battery_runtime.async_refresh_dry_contact_settings()
+    assert coord._dry_contact_settings_supported is None  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -52,6 +52,220 @@ def _request_info() -> RequestInfo:
 
 
 @pytest.mark.asyncio
+async def test_async_request_refresh_marks_manual_bypass_for_single_cycle(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+
+    async def _fake_super_refresh(self):
+        assert self.endpoint_manual_bypass_active() is True
+
+    monkeypatch.setattr(
+        coord_mod.DataUpdateCoordinator,
+        "async_request_refresh",
+        _fake_super_refresh,
+    )
+
+    assert coord.endpoint_manual_bypass_active() is False
+    await coord.async_request_refresh()
+    assert coord.endpoint_manual_bypass_active() is False
+
+
+def test_endpoint_family_failure_classification_and_core_backoff(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    monkeypatch.setattr(coord_mod.random, "uniform", lambda _a, _b: 1.0)
+
+    err_404 = aiohttp.ClientResponseError(
+        _request_info(),
+        (),
+        status=404,
+        message="missing",
+    )
+    err_invalid = InvalidPayloadError(
+        "Invalid payload",
+        status=429,
+        endpoint="/systems/1/inverter_status_x.json",
+        failure_kind="content_type",
+    )
+
+    assert coord._endpoint_family_status_from_error(err_404) == 404  # noqa: SLF001
+    assert coord._endpoint_family_status_from_error(err_invalid) == 429  # noqa: SLF001
+    assert (
+        coord._endpoint_family_failure_is_cooldown_worthy(  # noqa: SLF001
+            "core_realtime", err_404
+        )
+        is False
+    )
+    assert (
+        coord._endpoint_family_failure_is_cooldown_worthy(  # noqa: SLF001
+            "grid_control_check", err_404
+        )
+        is True
+    )
+    assert (
+        coord._endpoint_family_failure_is_cooldown_worthy(  # noqa: SLF001
+            "core_realtime", ValueError("bad")
+        )
+        is True
+    )
+    assert (
+        coord._note_endpoint_family_failure("missing", ValueError("bad")) is False
+    )  # noqa: SLF001
+
+    err_406 = aiohttp.ClientResponseError(
+        _request_info(),
+        (),
+        status=406,
+        message="Not Acceptable",
+    )
+    assert (
+        coord._note_endpoint_family_failure("core_realtime", err_406) is True
+    )  # noqa: SLF001
+    health = coord._endpoint_family_state("core_realtime")  # noqa: SLF001
+    assert health.consecutive_failures == 1
+    assert health.support_state == "unknown"
+    assert health.cooldown_active is True
+    assert health.next_retry_utc is not None
+    assert coord._endpoint_family_should_run("core_realtime") is False  # noqa: SLF001
+
+
+def test_endpoint_family_suppression_recovery_and_metrics(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    monkeypatch.setattr(coord_mod.random, "uniform", lambda _a, _b: 1.0)
+
+    err = aiohttp.ClientResponseError(
+        _request_info(),
+        (),
+        status=406,
+        message="Not Acceptable",
+    )
+    for _ in range(3):
+        assert (
+            coord._note_endpoint_family_failure("grid_control_check", err) is True
+        )  # noqa: SLF001
+
+    health = coord._endpoint_family_state("grid_control_check")  # noqa: SLF001
+    assert health.consecutive_failures == 3
+    assert health.support_state == "suppressed"
+    assert health.cooldown_active is True
+    assert (
+        coord._endpoint_family_can_use_stale("grid_control_check") is False
+    )  # noqa: SLF001
+
+    metrics = coord.collect_site_metrics()
+    family = metrics["endpoint_family_health"]["grid_control_check"]
+    assert family["family"] == "grid_control_check"
+    assert family["consecutive_failures"] == 3
+    assert family["last_status"] == 406
+    assert family["suppressed"] is True
+    assert family["next_retry_utc"] is not None
+    assert family["last_failure_utc"] is not None
+
+    coord._note_endpoint_family_success("grid_control_check")  # noqa: SLF001
+    recovered = coord._endpoint_family_state("grid_control_check")  # noqa: SLF001
+    assert recovered.consecutive_failures == 0
+    assert recovered.support_state == "supported"
+    assert recovered.last_success_utc is not None
+    assert recovered.cooldown_active is False
+
+    recovered.next_retry_mono = coord_mod.time.monotonic() - 1
+    recovered.next_retry_utc = datetime.now(timezone.utc) - timedelta(seconds=1)
+    recovered.cooldown_active = True
+    assert (
+        coord._endpoint_family_wait_active("grid_control_check") is False
+    )  # noqa: SLF001
+    assert recovered.next_retry_utc is None
+
+
+def test_endpoint_family_misc_branches_and_diagnostics(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    monkeypatch.setattr(coord_mod.random, "uniform", lambda _a, _b: 1.0)
+
+    coord._endpoint_manual_bypass_requested = True  # noqa: SLF001
+    assert coord._consume_endpoint_manual_bypass() is True  # noqa: SLF001
+    assert coord.endpoint_manual_bypass_active() is True
+    coord._clear_endpoint_manual_bypass()  # noqa: SLF001
+    assert coord.endpoint_manual_bypass_active() is False
+
+    assert coord._endpoint_family_should_run("unknown-family") is True  # noqa: SLF001
+    assert (
+        coord._endpoint_family_next_retry_mono("battery_status") is None
+    )  # noqa: SLF001
+    assert (
+        coord._endpoint_family_can_use_stale("core_realtime") is False
+    )  # noqa: SLF001
+    assert (
+        coord._endpoint_family_backoff_delay("unknown-family", 3) == 0.0
+    )  # noqa: SLF001
+    assert (
+        coord._endpoint_family_failure_is_cooldown_worthy(  # noqa: SLF001
+            "core_realtime",
+            aiohttp.ClientConnectionError("boom"),
+        )
+        is True
+    )
+    assert (
+        coord._endpoint_family_failure_is_cooldown_worthy(  # noqa: SLF001
+            "grid_control_check",
+            InvalidPayloadError("bad payload"),
+        )
+        is True
+    )
+    assert coord._note_endpoint_family_success("unknown-family") is None  # noqa: SLF001
+
+    monkeypatch.setattr(
+        coord_mod,
+        "timedelta",
+        lambda *args, **kwargs: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    coord._note_endpoint_family_success("battery_status")  # noqa: SLF001
+    battery_health = coord._endpoint_family_state("battery_status")  # noqa: SLF001
+    assert battery_health.next_retry_utc is None
+    coord._note_endpoint_family_success(
+        "inverter_production", success_ttl_s=0.0
+    )  # noqa: SLF001
+    production_health = coord._endpoint_family_state(
+        "inverter_production"
+    )  # noqa: SLF001
+    assert production_health.next_retry_mono is None
+    assert production_health.next_retry_utc is None
+
+    err = aiohttp.ClientResponseError(
+        _request_info(),
+        (),
+        status=406,
+        message="Not Acceptable",
+    )
+    coord._note_endpoint_family_failure("grid_control_check", err)  # noqa: SLF001
+    grid_health = coord._endpoint_family_state("grid_control_check")  # noqa: SLF001
+    assert grid_health.next_retry_utc is None
+
+    class BadDate:
+        def isoformat(self) -> str:
+            raise RuntimeError("boom")
+
+        def __str__(self) -> str:
+            return "bad-date"
+
+    battery_health.last_success_utc = BadDate()  # type: ignore[assignment]
+    coord._endpoint_family_health[123] = grid_health  # type: ignore[index]  # noqa: SLF001
+    coord._endpoint_family_health["none"] = None  # type: ignore[index]  # noqa: SLF001
+    diagnostics = coord.diagnostics.endpoint_family_health_diagnostics()
+    assert diagnostics["battery_status"]["last_success_utc"] == "bad-date"
+    assert "none" not in diagnostics
+    assert 123 not in diagnostics
+
+    coord._endpoint_family_health = []  # type: ignore[assignment]  # noqa: SLF001
+    assert coord.diagnostics.endpoint_family_health_diagnostics() == {}
+
+
+@pytest.mark.asyncio
 async def test_coordinator_runtime_delegate_helpers_cover_direct_runtime_calls(
     coordinator_factory,
 ):

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -948,6 +948,17 @@ def test_inventory_runtime_inverter_helper_paths(coordinator_factory) -> None:
 async def test_inventory_runtime_refresh_inverters_paths(coordinator_factory) -> None:
     coord = coordinator_factory()
     runtime = coord.inventory_runtime
+
+    def _clear_family_windows() -> None:
+        for family in ("inventory_topology", "inverter_status", "inverter_production"):
+            health = coord._endpoint_family_state(family)  # noqa: SLF001
+            health.next_retry_mono = None
+            health.next_retry_utc = None
+            health.cooldown_active = False
+        coord._inverters_inventory_cache_until = None  # noqa: SLF001
+        coord._inverter_status_cache_until = None  # noqa: SLF001
+        coord._inverter_production_cache_until = None  # noqa: SLF001
+
     coord.energy._site_energy_meta = {"start_date": "2022-08-10"}  # noqa: SLF001
     coord.client.inverters_inventory = AsyncMock(
         return_value={
@@ -1023,6 +1034,7 @@ async def test_inventory_runtime_refresh_inverters_paths(coordinator_factory) ->
     coord.client.inverters_inventory = AsyncMock(return_value={"inverters": {"bad": 1}})
     coord.client.inverter_status = AsyncMock(side_effect=RuntimeError("boom"))
     coord.client.inverter_production = AsyncMock(side_effect=RuntimeError("boom"))
+    _clear_family_windows()
     await runtime._async_refresh_inverters()  # noqa: SLF001
     assert coord.iter_inverter_serials() == []
 
@@ -1044,6 +1056,7 @@ async def test_inventory_runtime_refresh_inverters_paths(coordinator_factory) ->
     coord.client.inverter_production = AsyncMock(
         return_value={"production": {"1001": 1}}
     )
+    _clear_family_windows()
     await runtime._async_refresh_inverters()  # noqa: SLF001
     coord.client.inverter_production.assert_not_awaited()
 
@@ -1917,6 +1930,17 @@ async def test_inventory_runtime_refresh_inverters_pagination_and_error_paths(
 ) -> None:
     coord = coordinator_factory()
     runtime = coord.inventory_runtime
+
+    def _clear_family_windows() -> None:
+        for family in ("inventory_topology", "inverter_status", "inverter_production"):
+            health = coord._endpoint_family_state(family)  # noqa: SLF001
+            health.next_retry_mono = None
+            health.next_retry_utc = None
+            health.cooldown_active = False
+        coord._inverters_inventory_cache_until = None  # noqa: SLF001
+        coord._inverter_status_cache_until = None  # noqa: SLF001
+        coord._inverter_production_cache_until = None  # noqa: SLF001
+
     coord.energy._site_energy_meta = {"start_date": "2022-08-10"}  # noqa: SLF001
     runtime._merge_microinverter_type_bucket = MagicMock()  # type: ignore[method-assign]  # noqa: SLF001
     runtime._merge_heatpump_type_bucket = MagicMock()  # type: ignore[method-assign]  # noqa: SLF001
@@ -2027,6 +2051,7 @@ async def test_inventory_runtime_refresh_inverters_pagination_and_error_paths(
     assert runtime._inverter_panel_info is None  # noqa: SLF001
 
     coord.client.inverters_inventory = AsyncMock(return_value="bad")
+    _clear_family_windows()
     await runtime._async_refresh_inverters()  # noqa: SLF001
     assert coord.iter_inverter_serials() == ["INV-A", "INV-B", "INV-C"]
 
@@ -2046,6 +2071,7 @@ async def test_inventory_runtime_refresh_inverters_pagination_and_error_paths(
     coord.client.inverter_status = AsyncMock(return_value={})
     coord.client.inverter_production = AsyncMock(return_value={})
     coord._inverter_data = {}  # noqa: SLF001
+    _clear_family_windows()
     await runtime._async_refresh_inverters()  # noqa: SLF001
     assert runtime._inverter_summary_counts == {  # noqa: SLF001
         "total": 2,
@@ -2064,6 +2090,7 @@ async def test_inventory_runtime_refresh_inverters_pagination_and_error_paths(
     coord.client.inverters_inventory = AsyncMock(side_effect=legacy_inventory_fetcher)
     coord.client.inverter_status = AsyncMock(return_value=[])
     coord.client.inverter_production = AsyncMock(return_value="bad")
+    _clear_family_windows()
     await runtime._async_refresh_inverters()  # noqa: SLF001
     coord.client.inverter_production.assert_awaited_once()
 
@@ -2085,6 +2112,7 @@ async def test_inventory_runtime_refresh_inverters_pagination_and_error_paths(
     coord._inverter_data = {
         "INV-1": {"serial_number": "INV-1", "inverter_id": "1001"}
     }  # noqa: SLF001
+    _clear_family_windows()
     await runtime._async_refresh_inverters()  # noqa: SLF001
     assert coord.iter_inverter_serials() == ["INV-1"]
     assert coord.inverter_data("INV-1")["lifetime_production_wh"] is None
@@ -2100,6 +2128,7 @@ async def test_inventory_runtime_refresh_inverters_pagination_and_error_paths(
     coord.client.inverters_inventory = AsyncMock(
         side_effect=pagination_non_list_fetcher
     )
+    _clear_family_windows()
     await runtime._async_refresh_inverters()  # noqa: SLF001
     assert coord.iter_inverter_serials() == ["INV-2"]
 
@@ -2114,6 +2143,7 @@ async def test_inventory_runtime_refresh_inverters_pagination_and_error_paths(
     coord.client.inverters_inventory = AsyncMock(
         side_effect=pagination_empty_page_fetcher
     )
+    _clear_family_windows()
     await runtime._async_refresh_inverters()  # noqa: SLF001
     assert coord.iter_inverter_serials() == ["INV-3"]
 
@@ -2131,8 +2161,263 @@ async def test_inventory_runtime_refresh_inverters_pagination_and_error_paths(
     coord.client.inverters_inventory = AsyncMock(
         side_effect=pagination_total_growth_fetcher
     )
+    _clear_family_windows()
     await runtime._async_refresh_inverters()  # noqa: SLF001
     assert coord.iter_inverter_serials() == ["INV-4", "INV-5"]
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_refresh_inverters_uses_cached_payloads_during_cooldown(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    now = time.monotonic()
+
+    coord._devices_inventory_payload = {"curr_date_site": "2026-02-09"}  # noqa: SLF001
+    coord.energy._site_energy_meta = {"start_date": "2022-08-10"}  # noqa: SLF001
+    coord._inverters_inventory_payload = {  # noqa: SLF001
+        "total": 1,
+        "inverters": [{"serial_number": "INV-A", "name": "IQ7", "status": "normal"}],
+    }
+    coord._inverter_status_payload = {  # noqa: SLF001
+        "1001": {
+            "serialNum": "INV-A",
+            "deviceId": 11,
+            "statusCode": "normal",
+            "type": "IQ7",
+        }
+    }
+    coord._inverter_production_payload = {  # noqa: SLF001
+        "production": {"1001": 321.0},
+        "start_date": "2022-08-10",
+        "end_date": "2026-02-09",
+    }
+    coord._inverter_production_cache_key = (  # noqa: SLF001
+        "2022-08-10",
+        "2026-02-09",
+    )
+    for family in ("inventory_topology", "inverter_status", "inverter_production"):
+        health = coord._endpoint_family_state(family)  # noqa: SLF001
+        health.next_retry_mono = now + 600
+        health.cooldown_active = True
+        health.last_success_mono = now
+
+    coord.client.inverters_inventory = AsyncMock(side_effect=AssertionError("unused"))
+    coord.client.inverter_status = AsyncMock(side_effect=AssertionError("unused"))
+    coord.client.inverter_production = AsyncMock(side_effect=AssertionError("unused"))
+
+    await runtime._async_refresh_inverters()  # noqa: SLF001
+
+    coord.client.inverters_inventory.assert_not_awaited()
+    coord.client.inverter_status.assert_not_awaited()
+    coord.client.inverter_production.assert_not_awaited()
+    assert coord.iter_inverter_serials() == ["INV-A"]
+    assert coord.inverter_data("INV-A")["lifetime_production_wh"] == 321.0
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_refresh_inverters_uses_success_cache_ttls(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+
+    coord._devices_inventory_payload = {"curr_date_site": "2026-02-09"}  # noqa: SLF001
+    coord.energy._site_energy_meta = {"start_date": "2022-08-10"}  # noqa: SLF001
+    coord.client.inverters_inventory = AsyncMock(
+        return_value={
+            "total": 1,
+            "inverters": [
+                {"serial_number": "INV-A", "name": "IQ7", "status": "normal"}
+            ],
+        }
+    )
+    coord.client.inverter_status = AsyncMock(
+        return_value={
+            "1001": {
+                "serialNum": "INV-A",
+                "deviceId": 11,
+                "statusCode": "normal",
+                "type": "IQ7",
+            }
+        }
+    )
+    coord.client.inverter_production = AsyncMock(
+        return_value={
+            "production": {"1001": 456.0},
+            "start_date": "2022-08-10",
+            "end_date": "2026-02-09",
+        }
+    )
+
+    await runtime._async_refresh_inverters()  # noqa: SLF001
+
+    assert coord.client.inverters_inventory.await_count == 1
+    assert coord.client.inverter_status.await_count == 1
+    assert coord.client.inverter_production.await_count == 1
+    assert coord._inverters_inventory_cache_until is not None  # noqa: SLF001
+    assert coord._inverter_status_cache_until is not None  # noqa: SLF001
+    assert coord._inverter_production_cache_until is not None  # noqa: SLF001
+
+    await runtime._async_refresh_inverters()  # noqa: SLF001
+
+    assert coord.client.inverters_inventory.await_count == 1
+    assert coord.client.inverter_status.await_count == 1
+    assert coord.client.inverter_production.await_count == 1
+    assert coord.inverter_data("INV-A")["lifetime_production_wh"] == 456.0
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_refresh_inverters_manual_bypass_refetches_same_day_production(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    now = time.monotonic()
+
+    coord._devices_inventory_payload = {"curr_date_site": "2026-02-09"}  # noqa: SLF001
+    coord.energy._site_energy_meta = {"start_date": "2022-08-10"}  # noqa: SLF001
+    coord._endpoint_manual_bypass_active = True  # noqa: SLF001
+    for family in ("inventory_topology", "inverter_status", "inverter_production"):
+        health = coord._endpoint_family_state(family)  # noqa: SLF001
+        health.next_retry_mono = now + 600
+        health.cooldown_active = True
+        health.last_success_mono = now
+    coord._inverter_production_payload = {  # noqa: SLF001
+        "production": {"1001": 123.0},
+        "start_date": "2022-08-10",
+        "end_date": "2026-02-09",
+    }
+    coord._inverter_production_cache_key = (  # noqa: SLF001
+        "2022-08-10",
+        "2026-02-09",
+    )
+    coord.client.inverters_inventory = AsyncMock(
+        return_value={
+            "total": 1,
+            "inverters": [
+                {"serial_number": "INV-A", "name": "IQ7", "status": "normal"}
+            ],
+        }
+    )
+    coord.client.inverter_status = AsyncMock(
+        return_value={
+            "1001": {
+                "serialNum": "INV-A",
+                "deviceId": 11,
+                "statusCode": "normal",
+                "type": "IQ7",
+            }
+        }
+    )
+    coord.client.inverter_production = AsyncMock(
+        return_value={
+            "production": {"1001": 456.0},
+            "start_date": "2022-08-10",
+            "end_date": "2026-02-09",
+        }
+    )
+
+    await runtime._async_refresh_inverters()  # noqa: SLF001
+
+    coord.client.inverter_production.assert_awaited_once()
+    assert coord.inverter_data("INV-A")["lifetime_production_wh"] == 456.0
+    assert (
+        coord._endpoint_family_state("inverter_production").next_retry_utc is not None
+    )  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_refresh_system_dashboard_records_endpoint_failure(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    coord.client.devices_tree = AsyncMock(side_effect=RuntimeError("tree"))
+    coord.client.devices_details = AsyncMock(side_effect=RuntimeError("detail"))
+
+    await runtime._async_refresh_system_dashboard(force=True)  # noqa: SLF001
+
+    health = coord._endpoint_family_state("inventory_topology")  # noqa: SLF001
+    assert health.consecutive_failures == 1
+    assert health.cooldown_active is True
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_refresh_system_dashboard_respects_cache_and_details_error_branch(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    runtime._system_dashboard_cache_until = time.monotonic() + 300  # noqa: SLF001
+    coord.client.devices_tree = AsyncMock(side_effect=AssertionError("unused"))
+    coord.client.devices_details = AsyncMock(side_effect=AssertionError("unused"))
+
+    await runtime._async_refresh_system_dashboard()  # noqa: SLF001
+
+    coord.client.devices_tree.assert_not_awaited()
+    coord.client.devices_details.assert_not_awaited()
+
+    runtime._system_dashboard_cache_until = None  # noqa: SLF001
+    coord.client.devices_tree = None
+    coord.client.devices_details = AsyncMock(side_effect=RuntimeError("detail"))
+
+    await runtime._async_refresh_system_dashboard(force=True)  # noqa: SLF001
+
+    health = coord._endpoint_family_state("inventory_topology")  # noqa: SLF001
+    assert health.consecutive_failures >= 1
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_refresh_inverters_handles_inventory_exception_and_cached_bad_production(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    now = time.monotonic()
+
+    coord._devices_inventory_payload = {"curr_date_site": "2026-02-09"}  # noqa: SLF001
+    coord.energy._site_energy_meta = {"start_date": "2022-08-10"}  # noqa: SLF001
+    coord._inverters_inventory_payload = {  # noqa: SLF001
+        "total": 1,
+        "inverters": [{"serial_number": "INV-A", "name": "IQ7", "status": "normal"}],
+    }
+    coord._inverter_status_payload = {  # noqa: SLF001
+        "1001": {
+            "serialNum": "INV-A",
+            "deviceId": 11,
+            "statusCode": "normal",
+            "type": "IQ7",
+        }
+    }
+    coord._inverter_production_payload = {  # noqa: SLF001
+        "production": {"1001": 222.0},
+        "start_date": "2022-08-10",
+        "end_date": "2026-02-09",
+    }
+    coord._inverter_data = {  # noqa: SLF001
+        "INV-A": {"serial_number": "INV-A", "inverter_id": "1001"}
+    }
+    coord._inverter_production_cache_key = (  # noqa: SLF001
+        "2022-08-10",
+        "2026-02-09",
+    )
+    status_health = coord._endpoint_family_state("inverter_status")  # noqa: SLF001
+    status_health.last_success_mono = now
+    production_health = coord._endpoint_family_state(
+        "inverter_production"
+    )  # noqa: SLF001
+    production_health.last_success_mono = now
+
+    coord.client.inverters_inventory = AsyncMock(side_effect=RuntimeError("boom"))
+    coord.client.inverter_status = AsyncMock(return_value={})
+    coord.client.inverter_production = AsyncMock(return_value="bad")
+
+    await runtime._async_refresh_inverters()  # noqa: SLF001
+
+    assert coord.iter_inverter_serials() == ["INV-A"]
+    assert coord.inverter_data("INV-A")["lifetime_production_wh"] == 222.0
 
 
 def test_inventory_runtime_misc_helper_edges(coordinator_factory) -> None:


### PR DESCRIPTION
## Summary

Harden the Enlighten web client so browser-gated endpoints keep working and the integration sends less unnecessary traffic.

This updates the Enphase client to use browser-style request headers and `User-Agent`, adds a form-login fallback when `login.json` is rejected, introduces endpoint-family cooldown and success-cache guardrails for optional/detail reads, and bumps the release metadata to `2.7.3`.

## Related Issues

- Addresses https://github.com/barneyonline/ha-enphase-energy/issues/492

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/coordinator_diagnostics.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_api_http_flow.py tests/components/enphase_ev/test_auth_site_discovery.py tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_coordinator_remaining_coverage.py tests/components/enphase_ev/test_inventory_runtime.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker-compose -f devtools/docker/docker-compose.yml run -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/inventory_runtime.py,custom_components/enphase_ev/state_models.py --fail-under=100"
```

Manual validation:
- Recreated a local Home Assistant runtime container that mounted this branch directly and enabled `custom_components.enphase_ev` debug logging.
- Verified the previous Enlighten `406 Not Acceptable` failures did not recur.
- Verified scheduled refreshes stopped refetching `battery_status` and inverter detail endpoints on every poll once the new success-cache windows were active.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- `manifest.json` is bumped to `2.7.3`.
- Endpoint-family diagnostics now expose cooldown/suppression state for support investigations.
- The pre-commit command mounts the parent repo `.git` directory because this branch was developed in a Git worktree and pre-commit needs that metadata path available inside Docker.
