### PR TITLE
Restore inverter sensors after v2.7.3

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -534,6 +534,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 suppress_after_failures=3,
                 support_state_on_success=True,
             ),
+            "inverter_inventory": EndpointFamilyPolicy(
+                success_ttl_s=21600.0,
+                failure_backoff_schedule_s=(1800.0, 3600.0, 7200.0, 21600.0),
+                max_backoff_s=21600.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
             "inverter_status": EndpointFamilyPolicy(
                 success_ttl_s=300.0,
                 stale_after_s=1800.0,

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -2333,7 +2333,7 @@ class InventoryRuntime:
         if not callable(fetch_inventory) or not callable(fetch_status):
             return
 
-        inventory_family = "inventory_topology"
+        inventory_family = "inverter_inventory"
         status_family = "inverter_status"
         production_family = "inverter_production"
         cached_inventory_payload = getattr(self, "_inverters_inventory_payload", None)

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -950,7 +950,7 @@ async def test_inventory_runtime_refresh_inverters_paths(coordinator_factory) ->
     runtime = coord.inventory_runtime
 
     def _clear_family_windows() -> None:
-        for family in ("inventory_topology", "inverter_status", "inverter_production"):
+        for family in ("inverter_inventory", "inverter_status", "inverter_production"):
             health = coord._endpoint_family_state(family)  # noqa: SLF001
             health.next_retry_mono = None
             health.next_retry_utc = None
@@ -1932,7 +1932,7 @@ async def test_inventory_runtime_refresh_inverters_pagination_and_error_paths(
     runtime = coord.inventory_runtime
 
     def _clear_family_windows() -> None:
-        for family in ("inventory_topology", "inverter_status", "inverter_production"):
+        for family in ("inverter_inventory", "inverter_status", "inverter_production"):
             health = coord._endpoint_family_state(family)  # noqa: SLF001
             health.next_retry_mono = None
             health.next_retry_utc = None
@@ -2197,7 +2197,7 @@ async def test_inventory_runtime_refresh_inverters_uses_cached_payloads_during_c
         "2022-08-10",
         "2026-02-09",
     )
-    for family in ("inventory_topology", "inverter_status", "inverter_production"):
+    for family in ("inverter_inventory", "inverter_status", "inverter_production"):
         health = coord._endpoint_family_state(family)  # noqa: SLF001
         health.next_retry_mono = now + 600
         health.cooldown_active = True
@@ -2269,6 +2269,52 @@ async def test_inventory_runtime_refresh_inverters_uses_success_cache_ttls(
 
 
 @pytest.mark.asyncio
+async def test_inventory_runtime_refresh_inverters_not_blocked_by_topology_family_ttl(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    now = time.monotonic()
+
+    coord._devices_inventory_payload = {"curr_date_site": "2026-02-09"}  # noqa: SLF001
+    coord.energy._site_energy_meta = {"start_date": "2022-08-10"}  # noqa: SLF001
+    topology_health = coord._endpoint_family_state("inventory_topology")  # noqa: SLF001
+    topology_health.next_retry_mono = now + 21_600
+    topology_health.cooldown_active = True
+    topology_health.last_success_mono = now
+    coord.client.inverters_inventory = AsyncMock(
+        return_value={
+            "total": 1,
+            "inverters": [
+                {"serial_number": "INV-A", "name": "IQ7", "status": "normal"}
+            ],
+        }
+    )
+    coord.client.inverter_status = AsyncMock(
+        return_value={
+            "1001": {
+                "serialNum": "INV-A",
+                "deviceId": 11,
+                "statusCode": "normal",
+                "type": "IQ7",
+            }
+        }
+    )
+    coord.client.inverter_production = AsyncMock(
+        return_value={
+            "production": {"1001": 456.0},
+            "start_date": "2022-08-10",
+            "end_date": "2026-02-09",
+        }
+    )
+
+    await runtime._async_refresh_inverters()  # noqa: SLF001
+
+    coord.client.inverters_inventory.assert_awaited_once()
+    assert coord.iter_inverter_serials() == ["INV-A"]
+
+
+@pytest.mark.asyncio
 async def test_inventory_runtime_refresh_inverters_manual_bypass_refetches_same_day_production(
     coordinator_factory,
 ) -> None:
@@ -2279,7 +2325,7 @@ async def test_inventory_runtime_refresh_inverters_manual_bypass_refetches_same_
     coord._devices_inventory_payload = {"curr_date_site": "2026-02-09"}  # noqa: SLF001
     coord.energy._site_energy_meta = {"start_date": "2022-08-10"}  # noqa: SLF001
     coord._endpoint_manual_bypass_active = True  # noqa: SLF001
-    for family in ("inventory_topology", "inverter_status", "inverter_production"):
+    for family in ("inverter_inventory", "inverter_status", "inverter_production"):
         health = coord._endpoint_family_state(family)  # noqa: SLF001
         health.next_retry_mono = now + 600
         health.cooldown_active = True


### PR DESCRIPTION
## Summary

Fix a `v2.7.3` regression where microinverter sensors could remain unavailable after upgrade even though Enlighten requests were succeeding.

The new endpoint-family traffic guardrails accidentally grouped inverter inventory under the broader topology family. A successful earlier topology refresh could therefore satisfy the shared TTL and suppress the later inverter fetch, leaving microinverter entities empty with `inverters_s: 0.0` on every poll. This change moves inverter inventory onto its own endpoint family and adds regression coverage so topology TTLs cannot block inverter refreshes again.

## Related Issues

- Follow-up to the `v2.7.3` Enlighten compatibility work.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/inventory_runtime.py tests/components/enphase_ev/test_inventory_runtime.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/inventory_runtime.py tests/components/enphase_ev/test_inventory_runtime.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_inventory_runtime.py tests/components/enphase_ev/test_coordinator_remaining_coverage.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
```

Manual validation:
- Reviewed a production diagnostics export showing `count: 0`, empty microinverter devices, and `inverters_s: 0.0` on every coordinator cycle.
- Confirmed the regression was caused by topology-family TTL reuse suppressing the later inverter fetch.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The symptom in the field was microinverter entities becoming unavailable after `v2.7.3` with no 406 errors in the log.
- The fix keeps the traffic guardrails but separates inverter inventory from the general topology TTL bucket.
