### PR TITLE
Fix grid control status cooldown regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Prevented `Grid Control Status` from flapping between `Ready` and `Unknown` after transient `grid_control_check` failures by keeping the last confirmed state valid for the full endpoint cooldown window before the next retry.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/const.py
+++ b/custom_components/enphase_ev/const.py
@@ -85,7 +85,10 @@ STORM_GUARD_CACHE_TTL = 300.0
 STORM_ALERT_CACHE_TTL = 60.0
 STORM_GUARD_PENDING_HOLD_S = 90.0
 GRID_CONTROL_CHECK_CACHE_TTL = 60.0
-GRID_CONTROL_CHECK_STALE_AFTER_S = 180.0
+# Keep the last confirmed grid-control state valid across the initial
+# endpoint-family cooldown window after a transient failure. This avoids
+# spurious ready/unknown flapping while the retry is intentionally deferred.
+GRID_CONTROL_CHECK_STALE_AFTER_S = 360.0
 DRY_CONTACT_SETTINGS_CACHE_TTL = 300.0
 DRY_CONTACT_SETTINGS_FAILURE_CACHE_TTL = 15.0
 DRY_CONTACT_SETTINGS_STALE_AFTER_S = 900.0

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -474,7 +474,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             ),
             "grid_control_check": EndpointFamilyPolicy(
                 success_ttl_s=300.0,
-                stale_after_s=180.0,
+                stale_after_s=GRID_CONTROL_CHECK_STALE_AFTER_S,
                 failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
                 max_backoff_s=3600.0,
                 optional=True,

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -1230,6 +1230,33 @@ async def test_battery_runtime_optional_refreshes_respect_cooldown_and_clear_sta
 
 
 @pytest.mark.asyncio
+async def test_battery_runtime_grid_control_refresh_keeps_recent_state_during_cooldown(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    grid_health = coord._endpoint_family_state("grid_control_check")  # noqa: SLF001
+    grid_health.next_retry_mono = time.monotonic() + 300
+    grid_health.cooldown_active = True
+    grid_health.last_success_mono = time.monotonic() - 240
+    coord._grid_control_check_last_success_mono = (
+        grid_health.last_success_mono
+    )  # noqa: SLF001
+    coord._grid_control_check_cache_until = None  # noqa: SLF001
+    coord._grid_control_supported = True  # noqa: SLF001
+    coord._grid_control_disable = False  # noqa: SLF001
+    coord._grid_control_active_download = False  # noqa: SLF001
+    coord._grid_control_sunlight_backup_system_check = False  # noqa: SLF001
+    coord._grid_control_grid_outage_check = False  # noqa: SLF001
+    coord._grid_control_user_initiated_toggle = False  # noqa: SLF001
+
+    await coord.battery_runtime.async_refresh_grid_control_check()
+
+    assert coord._grid_control_supported is True  # noqa: SLF001
+    assert coord._grid_control_disable is False  # noqa: SLF001
+    assert coord._grid_control_active_download is False  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_battery_runtime_async_set_grid_connection_uses_runtime_grid_mode() -> (
     None
 ):


### PR DESCRIPTION
## Summary

Fix a regression from v2.7.3 where the `Grid Control Status` sensor could flap between `ready` and `unknown` after a transient `grid_control_check` failure.

The root cause was a mismatch between the endpoint-family cooldown window and the grid-control stale window. After a transient failure, retries were intentionally deferred for 5 minutes, but the previously confirmed grid-control state expired after 3 minutes, which caused Home Assistant to record temporary `unknown` states before the next successful retry.

This change keeps the last confirmed grid-control state valid for the full cooldown window and adds a regression test covering the cooldown path. It also adds an `Unreleased` changelog entry because this is a user-facing bugfix.

## Related Issues

- Latest release regression from `v2.7.3`

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Ran in the pinned Docker environment available on this machine via `docker-compose`.

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_battery_runtime_grid_control.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/const.py custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_battery_runtime.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/const.py custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_battery_runtime.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_battery_runtime_grid_control.py -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/const.py,custom_components/enphase_ev/battery_runtime.py --fail-under=100"
```

Notes:
- The focused pytest suite passed (`68 passed`).
- `ruff check` passed.
- `black` reformatted `tests/components/enphase_ev/test_battery_runtime.py`.
- The targeted coverage command failed because the touched runtime logic lives in very large modules (`coordinator.py` and `battery_runtime.py`) and the focused regression suite only exercises a narrow slice of those files.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This regression was visible in Home Assistant history/activity as repeated `Ready -> Unknown -> Ready` transitions for `Grid Control Status` even though the underlying issue was only a transient upstream failure during the endpoint-family cooldown period.