### PR TITLE
Add X-CSRF-Token to BatteryConfig writes

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2250,6 +2250,7 @@ class EnphaseEVClient:
         if include_xsrf:
             xsrf = self._xsrf_token()
             if xsrf:
+                headers["X-CSRF-Token"] = xsrf
                 headers["X-XSRF-Token"] = xsrf
         return headers
 
@@ -2805,6 +2806,7 @@ class EnphaseEVClient:
                                     in base_headers,
                                     "has_e_auth_token": "e-auth-token" in base_headers,
                                     "has_username": "Username" in base_headers,
+                                    "has_x_csrf_token": "X-CSRF-Token" in base_headers,
                                     "has_x_xsrf_token": "X-XSRF-Token" in base_headers,
                                 }
                                 _LOGGER.debug(

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -4382,13 +4382,15 @@ Example response (anonymized):
 
 ```
 PUT /service/batteryConfig/api/v1/batterySettings/<site_id>?userId=<user_id>
-Headers: X-XSRF-Token: <token>
+Headers:
+  X-CSRF-Token: <token>
+  X-XSRF-Token: <token>
 ```
 Updates battery settings. Captured requests used partial payloads to change individual controls.
 
 Implementation auth notes:
 - The current client first acquires a fresh `BP-XSRF-Token` via `/battery/sites/<site_id>/schedules/isValid`.
-- It then sends bearer-preferred BatteryConfig headers, normalized cookies, and `X-XSRF-Token`.
+- It then sends bearer-preferred BatteryConfig headers, normalized cookies, `X-CSRF-Token`, and `X-XSRF-Token`.
 
 Example payloads observed:
 ```json
@@ -4720,6 +4722,7 @@ the Enlighten battery profile UI when the user modifies a CFG schedule.
 - `e-auth-token`: stored access token when present, otherwise bearer token
 - `Username`: Enphase user ID when decodable from JWT
 - normalized BatteryConfig `Cookie` header, optionally including `BP-XSRF-Token`
+- `X-CSRF-Token`: freshly acquired XSRF token echoed in request header
 - `X-XSRF-Token`: freshly acquired XSRF token echoed in request header
 
 Implementation auth notes:
@@ -4971,7 +4974,7 @@ There is no single universal header set; the implementation varies headers by en
 | System dashboard reads | authenticated cookies; may also include bearer auth opportunistically |
 | HEMS | bearer-preferred auth plus cookies/base headers; `username` and `requestId` when available |
 | BatteryConfig reads | bearer-preferred auth, `e-auth-token`, normalized cookies, `Username` when decodable, battery-profile `Origin`/`Referer` |
-| BatteryConfig writes | acquire fresh XSRF via `/battery/sites/<site_id>/schedules/isValid`, then send bearer-preferred BatteryConfig headers plus `X-XSRF-Token` |
+| BatteryConfig writes | acquire fresh XSRF via `/battery/sites/<site_id>/schedules/isValid`, then send bearer-preferred BatteryConfig headers plus `X-CSRF-Token` and `X-XSRF-Token` |
 
 - Base Enlighten reads:
   - `Cookie: <serialized cookie jar>`

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -500,6 +500,8 @@ def test_battery_config_auth_helpers_cover_token_and_cookie_fallback() -> None:
     assert client._battery_config_auth_token() == token  # noqa: SLF001
     assert client._xsrf_token() == "dynamic-token"  # noqa: SLF001
     assert headers["e-auth-token"] == token
+    assert headers["X-CSRF-Token"] == "dynamic-token"
+    assert headers["X-XSRF-Token"] == "dynamic-token"
     assert headers["Cookie"] == "BP-XSRF-Token=dynamic-token"
 
 
@@ -521,6 +523,8 @@ def test_battery_config_headers_preserve_original_eauth_and_replace_stale_xsrf()
 
     assert headers["Authorization"] == f"Bearer {bearer}"
     assert headers["e-auth-token"] == "session-token"
+    assert headers["X-CSRF-Token"] == "fresh-token"
+    assert headers["X-XSRF-Token"] == "fresh-token"
     assert headers["Cookie"] == (
         "session=1; other=1; "
         f"enlighten_manager_token_production={bearer}; BP-XSRF-Token=fresh-token"
@@ -1344,6 +1348,7 @@ async def test_json_logs_batteryconfig_write_failure_details(caplog) -> None:
                     "Authorization": "Bearer secret-auth",
                     "e-auth-token": "secret-eauth",
                     "Username": "123456",
+                    "X-CSRF-Token": "secret-xsrf",
                     "X-XSRF-Token": "secret-xsrf",
                     "Cookie": ("session=1; bp-xsrf-token=secret-xsrf; other=1"),
                 },
@@ -1360,6 +1365,7 @@ async def test_json_logs_batteryconfig_write_failure_details(caplog) -> None:
     assert "'has_authorization': True" in caplog.text
     assert "'has_e_auth_token': True" in caplog.text
     assert "'has_username': True" in caplog.text
+    assert "'has_x_csrf_token': True" in caplog.text
     assert "'has_x_xsrf_token': True" in caplog.text
     assert "'source': 'enho'" in caplog.text
     assert "'userId': '[redacted]'" in caplog.text
@@ -3207,6 +3213,7 @@ async def test_set_battery_settings_payload_and_xsrf() -> None:
     assert args[0] == "PUT"
     assert "batterySettings" in args[1]
     assert kwargs["params"]["userId"] == "88"
+    assert kwargs["headers"]["X-CSRF-Token"] == "xsrf=token"
     assert kwargs["headers"]["X-XSRF-Token"] == "xsrf=token"
     assert kwargs["json"] == {"veryLowSoc": 15}
 
@@ -3228,6 +3235,7 @@ async def test_set_battery_settings_uses_requested_schedule_type_for_xsrf() -> N
     )
 
     client._acquire_xsrf_token.assert_awaited_once_with("dtg")
+    assert client._json.await_args.kwargs["headers"]["X-CSRF-Token"] == "dtg-token"
     assert client._json.await_args.kwargs["headers"]["X-XSRF-Token"] == "dtg-token"
 
 
@@ -3537,6 +3545,7 @@ async def test_update_battery_schedule_builds_request_and_clears_xsrf() -> None:
         "days": [2, 6],
     }
     assert kwargs["headers"]["Authorization"] == "Bearer EAUTH"
+    assert kwargs["headers"]["X-CSRF-Token"] == "fresh-token"
     assert kwargs["headers"]["X-XSRF-Token"] == "fresh-token"
     assert kwargs["headers"]["Content-Type"] == "application/json"
     assert kwargs["headers"]["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
@@ -3608,6 +3617,7 @@ async def test_set_battery_profile_payload_variants_and_xsrf() -> None:
     assert args[0] == "PUT"
     assert "api/v1/profile" in args[1]
     assert kwargs["params"]["userId"] == "100"
+    assert kwargs["headers"]["X-CSRF-Token"] == "xsrf-token"
     assert kwargs["headers"]["X-XSRF-Token"] == "xsrf-token"
     assert kwargs["json"] == {
         "profile": "cost_savings",
@@ -3632,6 +3642,7 @@ async def test_cancel_battery_profile_update_uses_empty_body() -> None:
     assert "cancel/profile" in args[1]
     assert kwargs["json"] == {}
     assert kwargs["params"]["userId"] == "44"
+    assert kwargs["headers"]["X-CSRF-Token"] == "t"
     assert kwargs["headers"]["X-XSRF-Token"] == "t"
 
 
@@ -3654,6 +3665,7 @@ async def test_set_storm_guard_passes_payload_and_xsrf() -> None:
         "evseStormEnabled": False,
     }
     assert kwargs["params"]["userId"] == "99"
+    assert kwargs["headers"]["X-CSRF-Token"] == "xsrf-token"
     assert kwargs["headers"]["X-XSRF-Token"] == "xsrf-token"
 
 


### PR DESCRIPTION
## Summary

Add `X-CSRF-Token` alongside `X-XSRF-Token` on BatteryConfig writes, extend the BatteryConfig failure debug logging to report whether `X-CSRF-Token` was present, and update the API spec to document the dual-header write flow. Related issue: #460.

## Related Issues

- #460

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py tests/components/enphase_ev/test_api_client_methods.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/api.py tests/components/enphase_ev/test_api_client_methods.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_api_client_methods.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py --fail-under=100"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The change applies only to BatteryConfig writes that already use `include_xsrf=True`; it does not alter unrelated endpoint families.
- Failure logging now records both `has_x_csrf_token` and `has_x_xsrf_token` so future 403 traces can distinguish a missing shared header from payload/auth issues.
