### PR TITLE
Fix heat-pump daily energy semantics

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -4965,6 +4965,30 @@ class EnphaseEVClient:
             families[family_key] = entries
         return normalized
 
+    @classmethod
+    def _normalize_pv_system_today_payload(cls, payload: object) -> dict | None:
+        """Normalize site-today payloads used by heat-pump daily totals."""
+
+        if not isinstance(payload, dict):
+            return None
+        stats = payload.get("stats")
+        normalized_stats: list[dict[str, object]] = []
+        if isinstance(stats, list):
+            for item in stats:
+                if not isinstance(item, dict):
+                    continue
+                normalized_stat = dict(item)
+                for key in ("heatpump", "heat_pump", "heat-pump"):
+                    value = item.get(key)
+                    if value is None:
+                        continue
+                    normalized_stat["heatpump"] = value
+                    break
+                normalized_stats.append(normalized_stat)
+        normalized = dict(payload)
+        normalized["stats"] = normalized_stats
+        return normalized
+
     async def hems_heatpump_state(
         self, device_uid: str, *, timezone: str | None = None
     ) -> dict | None:
@@ -5061,6 +5085,38 @@ class EnphaseEVClient:
                 return None
             raise
         return self._normalize_hems_energy_consumption_payload(data)
+
+    async def pv_system_today(self) -> dict | None:
+        """Return the site today payload when available."""
+
+        url = f"{BASE_URL}/pv/systems/{self._site}/today"
+        try:
+            data = await self._json("GET", url, headers=self._today_json_headers)
+        except Unauthorized:
+            _LOGGER.debug(
+                "PV site today endpoint unavailable for site %s (unauthorized)",
+                redact_site_id(self._site),
+            )
+            return None
+        except InvalidPayloadError as err:
+            if _is_optional_non_json_payload(err):
+                _LOGGER.debug(
+                    "PV site today endpoint unavailable for site %s (%s)",
+                    redact_site_id(self._site),
+                    redact_text(err.summary, site_ids=(self._site,)),
+                )
+                return None
+            raise
+        except aiohttp.ClientResponseError as err:
+            if err.status in (401, 403, 404):
+                _LOGGER.debug(
+                    "PV site today endpoint unavailable for site %s (status=%s)",
+                    redact_site_id(self._site),
+                    err.status,
+                )
+                return None
+            raise
+        return self._normalize_pv_system_today_payload(data)
 
     @classmethod
     def _normalize_hems_power_timeseries_payload(cls, payload: object) -> dict | None:

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1684,8 +1684,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return total if found else None
 
     def _build_heatpump_daily_consumption_snapshot(
-        self, split_payload: object, site_today_payload: object
+        self, split_payload: object, site_today_payload: object | None = None
     ) -> dict[str, object] | None:
+        if site_today_payload is None:
+            return self.heatpump_runtime._build_heatpump_daily_consumption_snapshot(
+                split_payload
+            )
         return self.heatpump_runtime._build_heatpump_daily_consumption_snapshot(
             split_payload,
             site_today_payload,

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1684,9 +1684,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return total if found else None
 
     def _build_heatpump_daily_consumption_snapshot(
-        self, payload: object
+        self, split_payload: object, site_today_payload: object
     ) -> dict[str, object] | None:
-        return self.heatpump_runtime._build_heatpump_daily_consumption_snapshot(payload)
+        return self.heatpump_runtime._build_heatpump_daily_consumption_snapshot(
+            split_payload,
+            site_today_payload,
+        )
 
     def _heatpump_power_candidate_device_uids(self) -> list[str | None]:
         return self.heatpump_runtime._heatpump_power_candidate_device_uids()
@@ -5289,6 +5292,18 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     @property
     def heatpump_daily_consumption_last_success_utc(self) -> datetime | None:
         return self.heatpump_runtime.heatpump_daily_consumption_last_success_utc
+
+    @property
+    def heatpump_daily_split_last_error(self) -> str | None:
+        return self.heatpump_runtime.heatpump_daily_split_last_error
+
+    @property
+    def heatpump_daily_split_using_stale(self) -> bool:
+        return self.heatpump_runtime.heatpump_daily_split_using_stale
+
+    @property
+    def heatpump_daily_split_last_success_utc(self) -> datetime | None:
+        return self.heatpump_runtime.heatpump_daily_split_last_success_utc
 
     @property
     def heatpump_power_w(self) -> float | None:

--- a/custom_components/enphase_ev/discovery_snapshot.py
+++ b/custom_components/enphase_ev/discovery_snapshot.py
@@ -193,6 +193,16 @@ class DiscoverySnapshotManager:
             "battery_has_enpower": getattr(
                 self.coordinator, "_battery_has_enpower", None
             ),
+            "heatpump_known_present": bool(
+                getattr(self.coordinator, "_heatpump_known_present", False)
+                or (
+                    isinstance(
+                        getattr(self.coordinator, "_type_device_buckets", None), dict
+                    )
+                    and "heatpump"
+                    in getattr(self.coordinator, "_type_device_buckets", {})
+                )
+            ),
             "site_energy_channels": sorted(site_energy_channels),
             "gateway_iq_energy_router_records": _snapshot_compatible_value(
                 router_records
@@ -282,6 +292,9 @@ class DiscoverySnapshotManager:
         has_enpower = _snapshot_bool(snapshot.get("battery_has_enpower"))
         if has_enpower is not None:
             self.coordinator._battery_has_enpower = has_enpower
+        heatpump_known_present = _snapshot_bool(snapshot.get("heatpump_known_present"))
+        if heatpump_known_present is not None:
+            self.coordinator._heatpump_known_present = heatpump_known_present
 
         restored_channels = snapshot.get("site_energy_channels")
         if isinstance(restored_channels, list):

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -78,6 +78,20 @@ class HeatpumpRuntime:
         except Exception:
             return False
 
+    def _heatpump_mark_known_present(self) -> None:
+        self._heatpump_known_present = True
+
+    def heatpump_entities_established(self) -> bool:
+        if self.has_type("heatpump"):
+            return True
+        if bool(getattr(self, "_heatpump_known_present", False)):
+            return True
+        if isinstance(getattr(self, "_heatpump_runtime_state", None), dict):
+            return True
+        if isinstance(getattr(self, "_heatpump_daily_consumption", None), dict):
+            return True
+        return self._heatpump_power_w is not None
+
     def _type_bucket_members(self, type_key: object) -> list[dict[str, object]]:
         normalized = normalize_type_key(type_key)
         if not normalized:
@@ -171,6 +185,21 @@ class HeatpumpRuntime:
         self._heatpump_daily_consumption = None
         self._heatpump_daily_consumption_using_stale = False
         self._heatpump_daily_consumption_last_error = error
+        return False
+
+    def _heatpump_mark_daily_split_stale(self, *, now: float, error: str) -> bool:
+        if self._heatpump_daily_split_available(
+            getattr(self, "_heatpump_daily_consumption", None)
+        ) and self._heatpump_snapshot_is_fresh(
+            self._heatpump_daily_split_last_success_mono,
+            HEATPUMP_DAILY_CONSUMPTION_STALE_AFTER_S,
+            now,
+        ):
+            self._heatpump_daily_split_using_stale = True
+            self._heatpump_daily_split_last_error = error
+            return True
+        self._heatpump_daily_split_using_stale = False
+        self._heatpump_daily_split_last_error = error
         return False
 
     def _heatpump_mark_power_stale(
@@ -287,6 +316,10 @@ class HeatpumpRuntime:
             self._heatpump_daily_consumption_backoff_until = None
             self._heatpump_daily_consumption_last_error = None
             self._heatpump_daily_consumption_cache_key = None
+            self._heatpump_daily_split_last_error = None
+            self._heatpump_daily_split_last_success_mono = None
+            self._heatpump_daily_split_last_success_utc = None
+            self._heatpump_daily_split_using_stale = False
             self._heatpump_power_snapshot = None
             return
 
@@ -425,7 +458,11 @@ class HeatpumpRuntime:
                 continue
             uid = type_member_text(member, "device_uid")
             if uid:
+                self._heatpump_mark_known_present()
                 return uid
+        snapshot = getattr(self, "_heatpump_runtime_state", None)
+        if isinstance(snapshot, dict):
+            return coerce_optional_text(snapshot.get("device_uid"))
         return None
 
     def _heatpump_runtime_member(self) -> dict[str, object] | None:
@@ -444,6 +481,16 @@ class HeatpumpRuntime:
     ) -> None:
         now = time.monotonic()
         if not self.has_type("heatpump"):
+            if self.heatpump_entities_established():
+                self._heatpump_mark_runtime_state_stale(
+                    now=now,
+                    error="Heat pump type temporarily missing from inventory",
+                )
+                self._heatpump_runtime_state_cache_until = (
+                    now + HEATPUMP_RUNTIME_STATE_CACHE_TTL
+                )
+                self._heatpump_runtime_state_backoff_until = None
+                return
             self._heatpump_runtime_state = None
             self._heatpump_runtime_state_cache_until = None
             self._heatpump_runtime_state_backoff_until = None
@@ -467,24 +514,26 @@ class HeatpumpRuntime:
 
         await self._async_refresh_hems_support_preflight(force=force)
         if getattr(self.client, "hems_site_supported", None) is False:
-            self._heatpump_runtime_state = None
+            self._heatpump_mark_runtime_state_stale(
+                now=now,
+                error="HEMS runtime endpoint unavailable for this site",
+            )
             self._heatpump_runtime_state_cache_until = (
                 now + HEATPUMP_RUNTIME_STATE_CACHE_TTL
             )
             self._heatpump_runtime_state_backoff_until = None
-            self._heatpump_runtime_state_last_error = None
-            self._heatpump_runtime_state_using_stale = False
             return
 
         device_uid = self._heatpump_runtime_device_uid()
         if not device_uid:
-            self._heatpump_runtime_state = None
+            self._heatpump_mark_runtime_state_stale(
+                now=now,
+                error="Heat pump runtime device UID temporarily unavailable",
+            )
             self._heatpump_runtime_state_cache_until = (
                 now + HEATPUMP_RUNTIME_STATE_CACHE_TTL
             )
             self._heatpump_runtime_state_backoff_until = None
-            self._heatpump_runtime_state_last_error = None
-            self._heatpump_runtime_state_using_stale = False
             return
 
         fetcher = getattr(self.client, "hems_heatpump_state", None)
@@ -525,6 +574,7 @@ class HeatpumpRuntime:
             snapshot.setdefault("device_state", heatpump_device_state(member))
         snapshot["source"] = f"hems_heatpump_state:{device_uid}"
         self._heatpump_runtime_state = snapshot
+        self._heatpump_mark_known_present()
         self._heatpump_runtime_state_last_error = None
         self._heatpump_runtime_state_using_stale = False
         self._heatpump_runtime_state_last_success_mono = now
@@ -635,78 +685,234 @@ class HeatpumpRuntime:
 
         return selected, member, first_bucket
 
-    def _build_heatpump_daily_consumption_snapshot(
-        self, payload: object
-    ) -> dict[str, object] | None:
-        selection = self._select_heatpump_energy_consumption_entry(payload)
-        if selection is None:
-            return None
-        selected, member, first_bucket = selection
-
-        daily_solar_wh = coerce_optional_float(first_bucket.get("solar"))
-        daily_battery_wh = coerce_optional_float(first_bucket.get("battery"))
-        daily_grid_wh = coerce_optional_float(first_bucket.get("grid"))
-        daily_energy_wh = self._sum_optional_values(first_bucket.get("details"))
-        if daily_energy_wh is None and all(
-            value is not None
-            for value in (daily_solar_wh, daily_battery_wh, daily_grid_wh)
+    @staticmethod
+    def _heatpump_daily_split_available(snapshot: object) -> bool:
+        if not isinstance(snapshot, dict):
+            return False
+        if snapshot.get("split_source") is not None:
+            return True
+        for key in (
+            "split_device_uid",
+            "split_device_name",
+            "split_daily_energy_wh",
+            "daily_solar_wh",
+            "daily_battery_wh",
+            "daily_grid_wh",
+            "split_endpoint_type",
+            "split_endpoint_timestamp",
         ):
-            daily_energy_wh = daily_solar_wh + daily_battery_wh + daily_grid_wh
+            if snapshot.get(key) is not None:
+                return True
+        details = snapshot.get("details")
+        return isinstance(details, list) and bool(details)
 
-        return {
-            "device_uid": selected.get("device_uid"),
-            "device_name": selected.get("device_name"),
-            "member_name": (
-                type_member_text(member, "name") if isinstance(member, dict) else None
-            ),
-            "member_device_type": (
-                heatpump_member_device_type(member)
-                if isinstance(member, dict)
+    @classmethod
+    def _heatpump_clear_daily_split_fields(cls, snapshot: dict[str, object]) -> None:
+        snapshot["split_device_uid"] = None
+        snapshot["split_device_name"] = None
+        snapshot["split_daily_energy_wh"] = None
+        snapshot["daily_solar_wh"] = None
+        snapshot["daily_battery_wh"] = None
+        snapshot["daily_grid_wh"] = None
+        snapshot["details"] = []
+        snapshot["split_source"] = None
+        snapshot["split_endpoint_type"] = None
+        snapshot["split_endpoint_timestamp"] = None
+
+    @classmethod
+    def _heatpump_copy_daily_split_fields(
+        cls, target: dict[str, object], source: object
+    ) -> bool:
+        if not cls._heatpump_daily_split_available(source):
+            cls._heatpump_clear_daily_split_fields(target)
+            return False
+        assert isinstance(source, dict)
+        for key in (
+            "split_device_uid",
+            "split_device_name",
+            "split_daily_energy_wh",
+            "daily_solar_wh",
+            "daily_battery_wh",
+            "daily_grid_wh",
+            "split_source",
+            "split_endpoint_type",
+            "split_endpoint_timestamp",
+        ):
+            target[key] = source.get(key)
+        target["details"] = (
+            list(source.get("details"))
+            if isinstance(source.get("details"), list)
+            else []
+        )
+        return True
+
+    def _build_heatpump_daily_consumption_snapshot(
+        self,
+        split_payload: object,
+        site_today_payload: object,
+    ) -> dict[str, object] | None:
+        site_today_total_wh = self._site_today_heatpump_total_wh(site_today_payload)
+        if site_today_total_wh is None:
+            return None
+        site_today_timestamp = (
+            site_today_payload.get("timestamp")
+            if isinstance(site_today_payload, dict)
+            else None
+        )
+        snapshot: dict[str, object] = {
+            "device_uid": None,
+            "device_name": None,
+            "split_device_uid": None,
+            "split_device_name": None,
+            "member_name": None,
+            "member_device_type": None,
+            "pairing_status": None,
+            "device_state": None,
+            "daily_energy_wh": site_today_total_wh,
+            "split_daily_energy_wh": None,
+            "daily_solar_wh": None,
+            "daily_battery_wh": None,
+            "daily_grid_wh": None,
+            "details": [],
+            "source": "site_today_heatpump",
+            "split_source": None,
+            "endpoint_type": (
+                site_today_payload.get("type")
+                if isinstance(site_today_payload, dict)
                 else None
             ),
-            "pairing_status": (
-                heatpump_pairing_status(member) if isinstance(member, dict) else None
-            ),
-            "device_state": (
-                heatpump_device_state(member) if isinstance(member, dict) else None
-            ),
-            "daily_energy_wh": daily_energy_wh,
-            "daily_solar_wh": daily_solar_wh,
-            "daily_battery_wh": daily_battery_wh,
-            "daily_grid_wh": daily_grid_wh,
-            "details": (
-                list(first_bucket.get("details"))
-                if isinstance(first_bucket.get("details"), list)
-                else []
-            ),
-            "source": (
-                f"hems_energy_consumption:{selected.get('device_uid')}"
-                if selected.get("device_uid")
-                else "hems_energy_consumption"
-            ),
-            "endpoint_type": (
-                payload.get("endpoint_type")
-                if payload.get("endpoint_type") is not None
-                else payload.get("type")
-            ),
-            "endpoint_timestamp": (
-                payload.get("endpoint_timestamp")
-                if payload.get("endpoint_timestamp") is not None
-                else payload.get("timestamp")
-            ),
+            "endpoint_timestamp": site_today_timestamp,
+            "split_endpoint_type": None,
+            "split_endpoint_timestamp": None,
             "sampled_at_utc": (
                 parsed.isoformat()
-                if (
-                    parsed := parse_inverter_last_report(
-                        payload.get("endpoint_timestamp")
-                        if payload.get("endpoint_timestamp") is not None
-                        else payload.get("timestamp")
-                    )
-                )
+                if (parsed := parse_inverter_last_report(site_today_timestamp))
                 is not None
                 else None
             ),
         }
+        selection = self._select_heatpump_energy_consumption_entry(split_payload)
+        if selection is None:
+            return snapshot
+
+        selected, member, first_bucket = selection
+        daily_solar_wh = coerce_optional_float(first_bucket.get("solar"))
+        daily_battery_wh = coerce_optional_float(first_bucket.get("battery"))
+        daily_grid_wh = coerce_optional_float(first_bucket.get("grid"))
+        split_daily_energy_wh = self._sum_optional_values(first_bucket.get("details"))
+        if split_daily_energy_wh is None and all(
+            value is not None
+            for value in (daily_solar_wh, daily_battery_wh, daily_grid_wh)
+        ):
+            split_daily_energy_wh = daily_solar_wh + daily_battery_wh + daily_grid_wh
+
+        snapshot.update(
+            {
+                "split_device_uid": selected.get("device_uid"),
+                "split_device_name": selected.get("device_name"),
+                "member_name": (
+                    type_member_text(member, "name")
+                    if isinstance(member, dict)
+                    else None
+                ),
+                "member_device_type": (
+                    heatpump_member_device_type(member)
+                    if isinstance(member, dict)
+                    else None
+                ),
+                "pairing_status": (
+                    heatpump_pairing_status(member)
+                    if isinstance(member, dict)
+                    else None
+                ),
+                "device_state": (
+                    heatpump_device_state(member) if isinstance(member, dict) else None
+                ),
+                "split_daily_energy_wh": split_daily_energy_wh,
+                "daily_solar_wh": daily_solar_wh,
+                "daily_battery_wh": daily_battery_wh,
+                "daily_grid_wh": daily_grid_wh,
+                "details": (
+                    list(first_bucket.get("details"))
+                    if isinstance(first_bucket.get("details"), list)
+                    else []
+                ),
+                "split_source": (
+                    f"hems_energy_consumption:{selected.get('device_uid')}"
+                    if selected.get("device_uid")
+                    else "hems_energy_consumption"
+                ),
+                "split_endpoint_type": (
+                    split_payload.get("endpoint_type")
+                    if isinstance(split_payload, dict)
+                    and split_payload.get("endpoint_type") is not None
+                    else (
+                        split_payload.get("type")
+                        if isinstance(split_payload, dict)
+                        else None
+                    )
+                ),
+                "split_endpoint_timestamp": (
+                    split_payload.get("endpoint_timestamp")
+                    if isinstance(split_payload, dict)
+                    and split_payload.get("endpoint_timestamp") is not None
+                    else (
+                        split_payload.get("timestamp")
+                        if isinstance(split_payload, dict)
+                        else None
+                    )
+                ),
+            }
+        )
+        return snapshot
+
+    @classmethod
+    def _site_today_heatpump_numeric_total(cls, value: object) -> float | None:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            total = 0.0
+            found = False
+            for nested in value.values():
+                nested_total = cls._site_today_heatpump_numeric_total(nested)
+                if nested_total is None:
+                    continue
+                total += nested_total
+                found = True
+            return total if found else None
+        if isinstance(value, list):
+            total = 0.0
+            found = False
+            for nested in value:
+                nested_total = cls._site_today_heatpump_numeric_total(nested)
+                if nested_total is None:
+                    continue
+                total += nested_total
+                found = True
+            return total if found else None
+        try:
+            numeric = float(value)
+        except Exception:
+            return None
+        if numeric != numeric or numeric in (float("inf"), float("-inf")):
+            return None
+        return numeric
+
+    @classmethod
+    def _site_today_heatpump_total_wh(cls, payload: object) -> float | None:
+        if not isinstance(payload, dict):
+            return None
+        stats = payload.get("stats")
+        if not isinstance(stats, list) or not stats:
+            return None
+        first_stat = next((item for item in stats if isinstance(item, dict)), None)
+        if not isinstance(first_stat, dict):
+            return None
+        for key in ("heatpump", "heat_pump", "heat-pump"):
+            total = cls._site_today_heatpump_numeric_total(first_stat.get(key))
+            if total is not None:
+                return total
+        return None
 
     @staticmethod
     def _heatpump_runtime_mode(snapshot: object) -> str | None:
@@ -725,9 +931,11 @@ class HeatpumpRuntime:
     ) -> dict[str, object] | None:
         if not isinstance(snapshot, dict):
             return None
+        if not self._heatpump_daily_split_available(snapshot):
+            return None
         details = snapshot.get("details")
         detail_value = self._first_optional_numeric_value(details)
-        device_uid = coerce_optional_text(snapshot.get("device_uid"))
+        device_uid = coerce_optional_text(snapshot.get("split_device_uid"))
         runtime_mode = self._heatpump_runtime_mode(runtime_snapshot)
         is_running = runtime_mode == "RUNNING"
         is_idle = runtime_mode in {"IDLE", "OFF", "STOPPED", "STANDBY"}
@@ -773,14 +981,15 @@ class HeatpumpRuntime:
                 round(accepted_value, 3) if accepted_value is not None else None
             ),
             "daily_energy_wh": snapshot.get("daily_energy_wh"),
+            "split_daily_energy_wh": snapshot.get("split_daily_energy_wh"),
             "daily_solar_wh": snapshot.get("daily_solar_wh"),
             "daily_battery_wh": snapshot.get("daily_battery_wh"),
             "daily_grid_wh": snapshot.get("daily_grid_wh"),
             "runtime_mode": runtime_mode,
             "validation": validation,
             "rejected": rejected,
-            "endpoint_timestamp": snapshot.get("endpoint_timestamp"),
-            "endpoint_type": snapshot.get("endpoint_type"),
+            "endpoint_timestamp": snapshot.get("split_endpoint_timestamp"),
+            "endpoint_type": snapshot.get("split_endpoint_type"),
             "source": (
                 f"hems_energy_consumption:{self._debug_truncate_identifier(device_uid)}"
                 if device_uid
@@ -794,6 +1003,20 @@ class HeatpumpRuntime:
     ) -> None:
         now = time.monotonic()
         if not self.has_type("heatpump"):
+            if self.heatpump_entities_established():
+                self._heatpump_mark_daily_consumption_stale(
+                    now=now,
+                    error="Heat pump type temporarily missing from inventory",
+                )
+                self._heatpump_mark_daily_split_stale(
+                    now=now,
+                    error="Heat pump type temporarily missing from inventory",
+                )
+                self._heatpump_daily_consumption_cache_until = (
+                    now + HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL
+                )
+                self._heatpump_daily_consumption_backoff_until = None
+                return
             self._heatpump_daily_consumption = None
             self._heatpump_daily_consumption_cache_until = None
             self._heatpump_daily_consumption_backoff_until = None
@@ -802,6 +1025,10 @@ class HeatpumpRuntime:
             self._heatpump_daily_consumption_last_success_mono = None
             self._heatpump_daily_consumption_last_success_utc = None
             self._heatpump_daily_consumption_using_stale = False
+            self._heatpump_daily_split_last_error = None
+            self._heatpump_daily_split_last_success_mono = None
+            self._heatpump_daily_split_last_success_utc = None
+            self._heatpump_daily_split_using_stale = False
             return
 
         window = self._heatpump_daily_window()
@@ -823,29 +1050,15 @@ class HeatpumpRuntime:
         ):
             return
 
-        await self._async_refresh_hems_support_preflight(force=force)
-        if getattr(self.client, "hems_site_supported", None) is False:
-            self._heatpump_daily_consumption = None
-            self._heatpump_daily_consumption_cache_until = (
-                now + HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL
-            )
-            self._heatpump_daily_consumption_backoff_until = None
-            self._heatpump_daily_consumption_last_error = None
-            self._heatpump_daily_consumption_cache_key = marker
-            self._heatpump_daily_consumption_using_stale = False
+        split_fetcher = getattr(self.client, "hems_energy_consumption", None)
+        site_today_fetcher = getattr(self.client, "pv_system_today", None)
+        if not callable(site_today_fetcher):
             return
 
-        fetcher = getattr(self.client, "hems_energy_consumption", None)
-        if not callable(fetcher):
-            return
-
+        split_payload: object = None
+        split_error: str | None = None
         try:
-            payload = await fetcher(
-                start_at=start_at,
-                end_at=end_at,
-                timezone=tz_name,
-                step="P1D",
-            )
+            site_today_payload = await site_today_fetcher()
         except Exception as err:  # noqa: BLE001
             error = (
                 redact_text(
@@ -865,28 +1078,79 @@ class HeatpumpRuntime:
             self._heatpump_daily_consumption_cache_key = marker
             return
 
+        if callable(split_fetcher):
+            try:
+                split_payload = await split_fetcher(
+                    start_at=start_at,
+                    end_at=end_at,
+                    timezone=tz_name,
+                    step="P1D",
+                )
+            except Exception as err:  # noqa: BLE001
+                split_error = (
+                    redact_text(
+                        err,
+                        site_ids=(self.site_id,),
+                        identifiers=self._heatpump_power_redaction_identifiers(
+                            self._heatpump_runtime_device_uid()
+                        ),
+                    )
+                    or err.__class__.__name__
+                )
+        else:
+            split_error = "HEMS daily split endpoint unavailable"
+
         self._heatpump_daily_consumption_cache_until = (
             now + HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL
         )
         self._heatpump_daily_consumption_backoff_until = None
         self._heatpump_daily_consumption_cache_key = marker
-        if not isinstance(payload, dict):
+        if not isinstance(site_today_payload, dict):
             self._heatpump_mark_daily_consumption_stale(
                 now=now,
-                error="No usable HEMS daily-consumption payload",
+                error="No usable site today heat-pump payload",
             )
             return
 
-        snapshot = self._build_heatpump_daily_consumption_snapshot(payload)
+        snapshot = self._build_heatpump_daily_consumption_snapshot(
+            split_payload,
+            site_today_payload,
+        )
         if snapshot is None:
             self._heatpump_mark_daily_consumption_stale(
                 now=now,
-                error="No usable HEMS daily-consumption payload",
+                error="No usable site today heat-pump payload",
             )
             return
+        if split_error is None and not self._heatpump_daily_split_available(snapshot):
+            split_error = "No usable HEMS daily split payload"
+        if split_error is None:
+            self._heatpump_daily_split_last_error = None
+            self._heatpump_daily_split_using_stale = False
+            self._heatpump_daily_split_last_success_mono = now
+            self._heatpump_daily_split_last_success_utc = dt_util.utcnow()
+        else:
+            previous_snapshot = getattr(self, "_heatpump_daily_consumption", None)
+            same_day = bool(
+                isinstance(previous_snapshot, dict)
+                and previous_snapshot.get("day_key") == marker[0]
+                and previous_snapshot.get("timezone") == marker[1]
+            )
+            used_stale_split = same_day and self._heatpump_mark_daily_split_stale(
+                now=now,
+                error=split_error,
+            )
+            if used_stale_split:
+                self._heatpump_copy_daily_split_fields(snapshot, previous_snapshot)
+            else:
+                self._heatpump_clear_daily_split_fields(snapshot)
+                if not same_day:
+                    self._heatpump_daily_split_using_stale = False
+                    self._heatpump_daily_split_last_error = split_error
         snapshot["day_key"] = marker[0]
         snapshot["timezone"] = marker[1]
         self._heatpump_daily_consumption = snapshot
+        self._heatpump_mark_known_present()
         self._heatpump_daily_consumption_last_error = None
         self._heatpump_daily_consumption_using_stale = False
         self._heatpump_daily_consumption_last_success_mono = now
@@ -1340,6 +1604,16 @@ class HeatpumpRuntime:
     async def _async_refresh_heatpump_power(self, *, force: bool = False) -> None:
         now = time.monotonic()
         if not self.has_type("heatpump"):
+            if self.heatpump_entities_established():
+                self._heatpump_mark_power_stale(
+                    now=now,
+                    error="Heat pump type temporarily missing from inventory",
+                )
+                self._heatpump_power_cache_until = (
+                    now + HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL
+                )
+                self._heatpump_power_backoff_until = None
+                return
             self._heatpump_power_w = None
             self._heatpump_power_sample_utc = None
             self._heatpump_power_start_utc = None
@@ -1363,24 +1637,29 @@ class HeatpumpRuntime:
 
         await self._async_refresh_hems_support_preflight(force=force)
         if getattr(self.client, "hems_site_supported", None) is False:
-            self._heatpump_power_w = None
-            self._heatpump_power_sample_utc = None
-            self._heatpump_power_start_utc = None
-            self._heatpump_power_device_uid = None
-            self._heatpump_power_source = None
+            error = "HEMS power endpoint unavailable for this site"
+            self._heatpump_mark_power_stale(
+                now=now,
+                error=error,
+            )
             self._heatpump_power_snapshot = {
                 "site_date": self._site_local_current_date(),
                 "force": force,
                 "outcome": "unsupported_site",
-                "using_stale": False,
-                "last_success_utc": None,
+                "using_stale": bool(
+                    getattr(self, "_heatpump_power_using_stale", False)
+                ),
+                "last_success_utc": (
+                    self._heatpump_power_last_success_utc.isoformat()
+                    if isinstance(self._heatpump_power_last_success_utc, datetime)
+                    else None
+                ),
+                "last_error": error,
             }
             self._heatpump_power_cache_until = (
                 now + HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL
             )
             self._heatpump_power_backoff_until = None
-            self._heatpump_power_last_error = None
-            self._heatpump_power_using_stale = False
             self._heatpump_power_selection_marker = None
             return
 
@@ -1463,7 +1742,7 @@ class HeatpumpRuntime:
             return
 
         daily_last_error = coerce_optional_text(
-            getattr(self, "_heatpump_daily_consumption_last_error", None)
+            getattr(self, "_heatpump_daily_split_last_error", None)
         )
         power_summary = self._heatpump_power_summary_from_daily_snapshot(
             getattr(self, "_heatpump_daily_consumption", None),
@@ -1529,12 +1808,12 @@ class HeatpumpRuntime:
 
         snapshot = getattr(self, "_heatpump_daily_consumption", None)
         device_uid = (
-            coerce_optional_text(snapshot.get("device_uid"))
+            coerce_optional_text(snapshot.get("split_device_uid"))
             if isinstance(snapshot, dict)
             else None
         )
         endpoint_timestamp = (
-            parse_inverter_last_report(snapshot.get("endpoint_timestamp"))
+            parse_inverter_last_report(snapshot.get("split_endpoint_timestamp"))
             if isinstance(snapshot, dict)
             else None
         )
@@ -1543,8 +1822,8 @@ class HeatpumpRuntime:
         self._heatpump_power_start_utc = None
         self._heatpump_power_device_uid = device_uid
         self._heatpump_power_source = (
-            str(snapshot.get("source")).strip()
-            if isinstance(snapshot, dict) and snapshot.get("source") is not None
+            str(snapshot.get("split_source")).strip()
+            if isinstance(snapshot, dict) and snapshot.get("split_source") is not None
             else "hems_energy_consumption"
         )
         self._heatpump_power_cache_until = getattr(
@@ -1553,14 +1832,15 @@ class HeatpumpRuntime:
         self._heatpump_power_backoff_until = None
         self._heatpump_power_last_error = daily_last_error
         self._heatpump_power_using_stale = bool(
-            getattr(self, "_heatpump_daily_consumption_using_stale", False)
+            getattr(self, "_heatpump_daily_split_using_stale", False)
         )
         self._heatpump_power_last_success_mono = getattr(
-            self, "_heatpump_daily_consumption_last_success_mono", now
+            self, "_heatpump_daily_split_last_success_mono", now
         )
         self._heatpump_power_last_success_utc = getattr(
-            self, "_heatpump_daily_consumption_last_success_utc", dt_util.utcnow()
+            self, "_heatpump_daily_split_last_success_utc", dt_util.utcnow()
         )
+        self._heatpump_mark_known_present()
         self._heatpump_power_selection_marker = marker if device_uid else None
         power_snapshot["selected_payload"] = dict(power_summary)
         power_snapshot["selected_source"] = (
@@ -1656,6 +1936,9 @@ class HeatpumpRuntime:
             "runtime_state_last_error": getattr(
                 self, "_heatpump_runtime_state_last_error", None
             ),
+            "heatpump_known_present": bool(
+                getattr(self, "_heatpump_known_present", False)
+            ),
             "daily_consumption": self._copy_diagnostics_value(
                 getattr(self, "_heatpump_daily_consumption", None)
             ),
@@ -1674,6 +1957,22 @@ class HeatpumpRuntime:
             ),
             "daily_consumption_last_error": getattr(
                 self, "_heatpump_daily_consumption_last_error", None
+            ),
+            "daily_split_using_stale": bool(
+                getattr(self, "_heatpump_daily_split_using_stale", False)
+            ),
+            "daily_split_last_success_utc": (
+                getattr(
+                    self, "_heatpump_daily_split_last_success_utc", None
+                ).isoformat()
+                if isinstance(
+                    getattr(self, "_heatpump_daily_split_last_success_utc", None),
+                    datetime,
+                )
+                else None
+            ),
+            "daily_split_last_error": getattr(
+                self, "_heatpump_daily_split_last_error", None
             ),
             "show_livestream_payload": self._copy_diagnostics_value(
                 getattr(self, "_show_livestream_payload", None)
@@ -1750,6 +2049,26 @@ class HeatpumpRuntime:
     @property
     def heatpump_daily_consumption_last_success_utc(self) -> datetime | None:
         value = getattr(self, "_heatpump_daily_consumption_last_success_utc", None)
+        return value if isinstance(value, datetime) else None
+
+    @property
+    def heatpump_daily_split_last_error(self) -> str | None:
+        value = getattr(self, "_heatpump_daily_split_last_error", None)
+        if value is None:
+            return None
+        try:
+            text = str(value).strip()
+        except Exception:
+            return None
+        return text or None
+
+    @property
+    def heatpump_daily_split_using_stale(self) -> bool:
+        return bool(getattr(self, "_heatpump_daily_split_using_stale", False))
+
+    @property
+    def heatpump_daily_split_last_success_utc(self) -> datetime | None:
+        value = getattr(self, "_heatpump_daily_split_last_success_utc", None)
         return value if isinstance(value, datetime) else None
 
     @property

--- a/custom_components/enphase_ev/inventory_view.py
+++ b/custom_components/enphase_ev/inventory_view.py
@@ -109,6 +109,16 @@ class InventoryView:
             return True
         if self.has_type(normalized):
             return True
+        if normalized == "heatpump":
+            runtime = getattr(self.coordinator, "heatpump_runtime", None)
+            if bool(getattr(self.coordinator, "_heatpump_known_present", False)):
+                return True
+            helper = getattr(runtime, "heatpump_entities_established", None)
+            if callable(helper):
+                try:
+                    return bool(helper())
+                except Exception:  # noqa: BLE001
+                    return False
         if normalized == "encharge":
             return getattr(self.coordinator, "_battery_has_encharge", None) is True
         if normalized == "ac_battery":

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -739,6 +739,7 @@ async def async_setup_entry(
                     if inventory_ready
                     else (
                         heatpump_type_present
+                        or bool(getattr(coord, "_heatpump_known_present", False))
                         or _site_energy_channel_present(flow_key, "heatpump")
                     )
                 )
@@ -822,7 +823,9 @@ async def async_setup_entry(
                 "heat_pump_sg_ready_gateway",
                 EnphaseHeatPumpSgReadyGatewaySensor(coord),
             )
-        elif inventory_ready:
+        elif inventory_ready and not bool(
+            getattr(coord, "_heatpump_known_present", False)
+        ):
             for entity_key in heatpump_site_entity_keys:
                 _async_remove_site_sensor_entity(entity_key)
         if _grid_control_site_applicable(coord) and (
@@ -4794,15 +4797,20 @@ def _heatpump_daily_common_attrs(
         "sampled_at_utc": snapshot.get("sampled_at_utc"),
         "device_uid": snapshot.get("device_uid"),
         "device_name": snapshot.get("device_name"),
+        "split_device_uid": snapshot.get("split_device_uid"),
+        "split_device_name": snapshot.get("split_device_name"),
         "member_name": snapshot.get("member_name"),
         "member_device_type": snapshot.get("member_device_type"),
         "pairing_status": snapshot.get("pairing_status"),
         "device_state": snapshot.get("device_state"),
         "daily_endpoint_type": snapshot.get("endpoint_type"),
         "daily_endpoint_timestamp": snapshot.get("endpoint_timestamp"),
+        "split_endpoint_type": snapshot.get("split_endpoint_type"),
+        "split_endpoint_timestamp": snapshot.get("split_endpoint_timestamp"),
         "day_key": snapshot.get("day_key"),
         "timezone": snapshot.get("timezone"),
         "source": snapshot.get("source"),
+        "split_source": snapshot.get("split_source"),
         "using_stale": bool(
             getattr(coord, "heatpump_daily_consumption_using_stale", False)
         ),
@@ -7924,12 +7932,33 @@ class _EnphaseHeatPumpDailyEnergySensor(_SiteBaseEntity):
     def extra_state_attributes(self):
         snapshot = self._snapshot()
         attrs = _heatpump_daily_common_attrs(self._coord, snapshot)
+        if self._daily_key == "daily_energy_wh":
+            attrs["source"] = snapshot.get("source")
+            attrs["device_uid"] = snapshot.get("device_uid")
+            attrs["device_name"] = snapshot.get("device_name")
+        else:
+            attrs["source"] = snapshot.get("split_source") or snapshot.get("source")
+            attrs["device_uid"] = snapshot.get("split_device_uid")
+            attrs["device_name"] = snapshot.get("split_device_name")
+            attrs["using_stale"] = bool(
+                getattr(self._coord, "heatpump_daily_split_using_stale", False)
+            )
+            attrs["last_success_utc"] = (
+                self._coord.heatpump_daily_split_last_success_utc.isoformat()
+                if getattr(self._coord, "heatpump_daily_split_last_success_utc", None)
+                is not None
+                else None
+            )
+            attrs["last_error"] = getattr(
+                self._coord, "heatpump_daily_split_last_error", None
+            )
         attrs["details"] = (
             list(snapshot.get("details"))
             if isinstance(snapshot.get("details"), list)
             else []
         )
         attrs["daily_energy_wh"] = snapshot.get("daily_energy_wh")
+        attrs["split_daily_energy_wh"] = snapshot.get("split_daily_energy_wh")
         attrs["daily_grid_wh"] = snapshot.get("daily_grid_wh")
         attrs["daily_solar_wh"] = snapshot.get("daily_solar_wh")
         attrs["daily_battery_wh"] = snapshot.get("daily_battery_wh")

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -210,6 +210,7 @@ class HeatpumpState:
     _heatpump_runtime_state_last_success_mono: float | None = None
     _heatpump_runtime_state_last_success_utc: datetime | None = None
     _heatpump_runtime_state_using_stale: bool = False
+    _heatpump_known_present: bool = False
     _heatpump_daily_consumption: dict[str, object] | None = None
     _heatpump_daily_consumption_cache_until: float | None = None
     _heatpump_daily_consumption_backoff_until: float | None = None
@@ -218,6 +219,10 @@ class HeatpumpState:
     _heatpump_daily_consumption_last_success_mono: float | None = None
     _heatpump_daily_consumption_last_success_utc: datetime | None = None
     _heatpump_daily_consumption_using_stale: bool = False
+    _heatpump_daily_split_last_error: str | None = None
+    _heatpump_daily_split_last_success_mono: float | None = None
+    _heatpump_daily_split_last_success_utc: datetime | None = None
+    _heatpump_daily_split_using_stale: bool = False
     _current_power_consumption_w: float | None = None
     _current_power_consumption_sample_utc: datetime | None = None
     _current_power_consumption_reported_units: str | None = None

--- a/tests/components/enphase_ev/conftest.py
+++ b/tests/components/enphase_ev/conftest.py
@@ -388,6 +388,9 @@ def coordinator_factory(hass, mock_clientsession, mock_issue_registry, monkeypat
             )
         if not hasattr(coord.client, "set_storm_guard"):
             coord.client.set_storm_guard = AsyncMock(return_value={"status": "ok"})
+        coord.client.pv_system_today = AsyncMock(
+            return_value={"stats": [{"heatpump": [0.0]}]}
+        )
         if client is None:
             coord.client.battery_site_settings = AsyncMock(
                 return_value={

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -4697,6 +4697,64 @@ async def test_hems_energy_consumption_optional_and_reraise_variants() -> None:
 
 
 @pytest.mark.asyncio
+async def test_pv_system_today_normalization_and_headers() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        return_value={
+            "stats": [
+                {
+                    "heat_pump": [
+                        {"grid": "100.0", "solar": 20},
+                        {"battery": 5.5},
+                    ]
+                }
+            ],
+            "timestamp": "2026-03-20T08:00:00Z",
+        }
+    )
+
+    payload = await client.pv_system_today()
+
+    assert payload == {
+        "stats": [
+            {
+                "heat_pump": [
+                    {"grid": "100.0", "solar": 20},
+                    {"battery": 5.5},
+                ],
+                "heatpump": [
+                    {"grid": "100.0", "solar": 20},
+                    {"battery": 5.5},
+                ],
+            }
+        ],
+        "timestamp": "2026-03-20T08:00:00Z",
+    }
+    args, kwargs = client._json.await_args
+    assert args == ("GET", "https://enlighten.enphaseenergy.com/pv/systems/SITE/today")
+    headers = kwargs["headers"]()
+    assert headers["Accept"] == "application/json, text/javascript, */*; q=0.01"
+    assert "/web/SITE/today/graph/hours" in headers["Referer"]
+
+
+@pytest.mark.asyncio
+async def test_pv_system_today_optional_failures_return_none() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=_make_optional_payload_error("/pv/systems/SITE/today")
+    )
+    assert await client.pv_system_today() is None
+
+    client = _make_client()
+    client._json = AsyncMock(side_effect=api.Unauthorized())
+    assert await client.pv_system_today() is None
+
+    client = _make_client()
+    client._json = AsyncMock(side_effect=_make_cre(404))
+    assert await client.pv_system_today() is None
+
+
+@pytest.mark.asyncio
 async def test_hems_devices_uses_dedicated_endpoint_and_headers() -> None:
     client = _make_client()
     cookie_token = _make_token({"user_id": "user-123"})

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -4753,6 +4753,49 @@ async def test_pv_system_today_optional_failures_return_none() -> None:
     client._json = AsyncMock(side_effect=_make_cre(404))
     assert await client.pv_system_today() is None
 
+    client = _make_client()
+    client._json = AsyncMock(side_effect=_make_cre(403))
+    assert await client.pv_system_today() is None
+
+
+def test_normalize_pv_system_today_payload_edge_cases() -> None:
+    assert api.EnphaseEVClient._normalize_pv_system_today_payload(None) is None
+    assert api.EnphaseEVClient._normalize_pv_system_today_payload(
+        {
+            "stats": [
+                "skip-me",
+                {"other": 1},
+                {"heat-pump": [1, 2, 3]},
+            ]
+        }
+    ) == {
+        "stats": [
+            {"other": 1},
+            {"heat-pump": [1, 2, 3], "heatpump": [1, 2, 3]},
+        ]
+    }
+
+
+@pytest.mark.asyncio
+async def test_pv_system_today_reraises_non_optional_failures() -> None:
+    client = _make_client()
+    invalid_json = api.InvalidPayloadError(
+        "Invalid JSON response",
+        status=200,
+        content_type="application/json",
+        endpoint="/pv/systems/SITE/today",
+    )
+    client._json = AsyncMock(side_effect=invalid_json)
+
+    with pytest.raises(api.InvalidPayloadError):
+        await client.pv_system_today()
+
+    client = _make_client()
+    client._json = AsyncMock(side_effect=_make_cre(500))
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.pv_system_today()
+
 
 @pytest.mark.asyncio
 async def test_hems_devices_uses_dedicated_endpoint_and_headers() -> None:

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -917,9 +917,9 @@ def test_heatpump_sg_ready_active_binary_sensor_metadata(
                 "devices": [{"device_type": "HEAT_PUMP", "name": "Heat Pump"}],
             }
         },
-        ["heatpump"],
-    )
-    assert sensor.available is False
+            ["heatpump"],
+        )
+    assert sensor.available is True
 
 
 def test_heatpump_sg_ready_active_binary_sensor_uses_dedicated_hems_inventory(

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -917,8 +917,8 @@ def test_heatpump_sg_ready_active_binary_sensor_metadata(
                 "devices": [{"device_type": "HEAT_PUMP", "name": "Heat Pump"}],
             }
         },
-            ["heatpump"],
-        )
+        ["heatpump"],
+    )
     assert sensor.available is True
 
 

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2704,8 +2704,11 @@ def test_snapshot_helpers_and_discovery_capture_edge_paths(hass, monkeypatch) ->
     coord._inverter_data = {"INV-1": {"name": "Inverter 1"}}  # noqa: SLF001
     coord._battery_has_encharge = True  # noqa: SLF001
     coord._battery_has_enpower = False  # noqa: SLF001
+    coord._heatpump_known_present = True  # noqa: SLF001
+    coord._type_device_buckets["heatpump"] = {"count": 0, "devices": []}  # noqa: SLF001
 
     snapshot = coord.discovery_snapshot.capture()
+    assert snapshot["heatpump_known_present"] is True
     assert snapshot["site_energy_channels"] == ["heat_pump"]
     assert snapshot["gateway_iq_energy_router_records"] == [
         {"device-uid": "REST-1", "device-type": "IQ_ENERGY_ROUTER"}
@@ -2773,6 +2776,7 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
             },
             "battery_has_encharge": "enabled",
             "battery_has_enpower": "disabled",
+            "heatpump_known_present": "enabled",
             "site_energy_channels": ["", "heat_pump"],
             "gateway_iq_energy_router_records": [{"device-uid": "REST-1"}, "bad"],
         }
@@ -2789,6 +2793,7 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
     assert coord._restored_gateway_iq_energy_router_records == [  # noqa: SLF001
         {"device-uid": "REST-1"}
     ]
+    assert coord._heatpump_known_present is True  # noqa: SLF001
 
     coord = _make_coordinator(hass, monkeypatch)
     coord._devices_inventory_ready = True  # noqa: SLF001

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -317,6 +317,9 @@ async def test_coordinator_runtime_delegate_helpers_cover_direct_runtime_calls(
     ) == {  # noqa: SLF001
         "daily_energy_wh": 123.0
     }
+    assert coord._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
+        {"a": 1}, {"stats": [{"heatpump": [1.0]}]}
+    ) == {"daily_energy_wh": 123.0}
     assert coord._heatpump_power_candidate_device_uids() == [  # noqa: SLF001
         "HP-PRIMARY",
         None,
@@ -338,6 +341,16 @@ async def test_coordinator_runtime_delegate_helpers_cover_direct_runtime_calls(
     assert (
         coord._heatpump_power_candidate_is_recommended("HP-PRIMARY") is True
     )  # noqa: SLF001
+    coord._heatpump_daily_split_last_error = "split-error"  # noqa: SLF001
+    coord._heatpump_daily_split_using_stale = True  # noqa: SLF001
+    coord._heatpump_daily_split_last_success_utc = datetime(  # noqa: SLF001
+        2026, 1, 1, tzinfo=timezone.utc
+    )
+    assert coord.heatpump_daily_split_last_error == "split-error"
+    assert coord.heatpump_daily_split_using_stale is True
+    assert coord.heatpump_daily_split_last_success_utc == datetime(
+        2026, 1, 1, tzinfo=timezone.utc
+    )
 
     coord.heatpump_runtime.async_refresh_hems_support_preflight.assert_awaited_once_with(
         force=True

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -483,9 +483,12 @@ class DummyCoordinator(SimpleNamespace):
         )
         self._heatpump_runtime_state_last_error = None
         self._heatpump_daily_consumption = {
-            "device_uid": "HP-1",
+            "device_uid": None,
+            "split_device_uid": "HP-1",
             "daily_energy_wh": 230.0,
-            "source": "hems_energy_consumption:HP-1",
+            "split_daily_energy_wh": 230.0,
+            "source": "site_today_heatpump",
+            "split_source": "hems_energy_consumption:HP-1",
         }
         self._heatpump_daily_consumption_using_stale = False
         self._heatpump_daily_consumption_last_success_utc = datetime(

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -27,6 +27,17 @@ from custom_components.enphase_ev.parsing_helpers import (
 )
 
 
+def _site_today_payload(
+    total_wh: float, *, timestamp: str | None = None
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "stats": [{"heatpump": [total_wh]}],
+    }
+    if timestamp is not None:
+        payload["timestamp"] = timestamp
+    return payload
+
+
 @pytest.mark.asyncio
 async def test_heatpump_runtime_preflight_without_refresh_kw(
     coordinator_factory,
@@ -224,6 +235,9 @@ async def test_heatpump_runtime_power_logs_fetch_plan_and_selection_summary(
             },
         }
     )
+    coord.client.pv_system_today = AsyncMock(
+        return_value=_site_today_payload(275.0, timestamp="2026-03-20T08:00:00Z")
+    )
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"device_uid": primary_uid, "heatpump_status": "RUNNING"}
     )
@@ -286,7 +300,7 @@ async def test_heatpump_runtime_power_logs_when_no_candidate_payload_is_usable(
     assert power_snapshot["attempts"] == [
         {
             "source": "hems_energy_consumption",
-            "error": "No usable HEMS daily-consumption payload",
+            "error": "No usable HEMS daily split payload",
         }
     ]
 
@@ -440,7 +454,8 @@ async def test_heatpump_runtime_public_api_access(coordinator_factory) -> None:
         ("2026-03-27", "UTC"),
     )
     assert runtime._build_heatpump_daily_consumption_snapshot(
-        {"data": {}}
+        {"data": {}},
+        _site_today_payload(123.0),
     ) == {  # noqa: SLF001
         "daily_energy_wh": 123.0
     }
@@ -509,7 +524,8 @@ async def test_heatpump_runtime_public_api_access(coordinator_factory) -> None:
     runtime._heatpump_runtime_device_uid.assert_called_once_with()
     runtime._heatpump_daily_window.assert_called_once_with()
     runtime._build_heatpump_daily_consumption_snapshot.assert_called_once_with(
-        {"data": {}}
+        {"data": {}},
+        _site_today_payload(123.0),
     )
     runtime._heatpump_power_candidate_device_uids.assert_called_once_with()
     runtime._heatpump_member_for_uid.assert_called_once_with("HP-1")
@@ -968,7 +984,7 @@ async def test_heatpump_runtime_diagnostics_and_refresh_edge_branches(
     coord.client.hems_energy_consumption = AsyncMock(return_value=None)
     await runtime.async_refresh_heatpump_power(force=True)
     assert coord.heatpump_power_w is None
-    assert coord.heatpump_power_last_error == "No usable HEMS daily-consumption payload"
+    assert coord.heatpump_power_last_error == "No usable HEMS daily split payload"
 
     coord.client.hems_energy_consumption = AsyncMock(
         return_value={
@@ -1194,8 +1210,13 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
     await coord.heatpump_runtime._async_refresh_heatpump_power(
         force=True
     )  # noqa: SLF001
-    assert coord.heatpump_power_w is None
-    assert coord.heatpump_power_source is None
+    assert coord.heatpump_power_w == pytest.approx(500.5)
+    assert coord.heatpump_power_source == "hems_energy_consumption:HP-1"
+    assert coord.heatpump_power_using_stale is True
+    assert (
+        coord.heatpump_power_last_error
+        == "Heat pump type temporarily missing from inventory"
+    )
 
 
 @pytest.mark.asyncio
@@ -1387,8 +1408,19 @@ async def test_daily_consumption_preserves_stale_snapshot_on_unusable_payload(
         ["heatpump"],
     )
     coord._heatpump_daily_consumption = {
-        "device_uid": "HP-1",
+        "device_uid": None,
         "daily_energy_wh": 55.0,
+        "split_device_uid": "HP-1",
+        "split_device_name": "Heat Pump",
+        "split_daily_energy_wh": 55.0,
+        "daily_grid_wh": 50.0,
+        "daily_solar_wh": 5.0,
+        "daily_battery_wh": 0.0,
+        "details": [55.0],
+        "source": "site_today_heatpump",
+        "split_source": "hems_energy_consumption:HP-1",
+        "day_key": "2026-04-05",
+        "timezone": "UTC",
     }  # noqa: SLF001
     coord._heatpump_daily_consumption_last_success_mono = (
         time.monotonic() - 5
@@ -1396,21 +1428,32 @@ async def test_daily_consumption_preserves_stale_snapshot_on_unusable_payload(
     coord._heatpump_daily_consumption_last_success_utc = datetime(  # noqa: SLF001
         2026, 4, 5, 0, 0, tzinfo=timezone.utc
     )
+    coord._heatpump_daily_split_last_success_mono = time.monotonic() - 5  # noqa: SLF001
+    coord._heatpump_daily_split_last_success_utc = datetime(  # noqa: SLF001
+        2026, 4, 5, 0, 0, tzinfo=timezone.utc
+    )
     coord.client.hems_energy_consumption = AsyncMock(return_value=None)
+    coord.client.pv_system_today = AsyncMock(return_value=_site_today_payload(77.0))
 
     await coord.heatpump_runtime._async_refresh_heatpump_daily_consumption(
         force=True
     )  # noqa: SLF001
 
-    assert coord.heatpump_daily_consumption["daily_energy_wh"] == pytest.approx(55.0)
-    assert (
-        coord.heatpump_daily_consumption_last_error
-        == "No usable HEMS daily-consumption payload"
+    assert coord.heatpump_daily_consumption["daily_energy_wh"] == pytest.approx(77.0)
+    assert coord.heatpump_daily_consumption["split_daily_energy_wh"] == pytest.approx(
+        55.0
     )
-    assert coord.heatpump_runtime.heatpump_daily_consumption_using_stale is True
+    assert coord.heatpump_daily_consumption_last_error is None
+    assert coord.heatpump_runtime.heatpump_daily_consumption_using_stale is False
+    assert coord.heatpump_runtime.heatpump_daily_split_using_stale is True
+    assert (
+        coord.heatpump_runtime.heatpump_daily_split_last_error
+        == "No usable HEMS daily split payload"
+    )
     diag = coord.heatpump_runtime.heatpump_runtime_diagnostics()
-    assert diag["daily_consumption_using_stale"] is True
-    assert diag["daily_consumption_last_success_utc"] == "2026-04-05T00:00:00+00:00"
+    assert diag["daily_consumption_using_stale"] is False
+    assert diag["daily_split_using_stale"] is True
+    assert diag["daily_split_last_success_utc"] == "2026-04-05T00:00:00+00:00"
 
 
 @pytest.mark.asyncio
@@ -1569,7 +1612,10 @@ async def test_refresh_heatpump_runtime_state_covers_cache_and_error_paths(
         force=True
     )  # noqa: SLF001
     assert coord.heatpump_runtime_state == {}
-    assert coord.heatpump_runtime_state_last_error is None
+    assert (
+        coord.heatpump_runtime_state_last_error
+        == "HEMS runtime endpoint unavailable for this site"
+    )
 
     coord.client._hems_site_supported = None  # noqa: SLF001
     coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
@@ -1656,22 +1702,34 @@ async def test_refresh_heatpump_daily_consumption_tracks_site_day(
             },
         }
     )
+    coord.client.pv_system_today = AsyncMock(
+        return_value=_site_today_payload(275.0, timestamp="2026-03-20T08:00:00Z")
+    )
 
     await coord.heatpump_runtime._async_refresh_heatpump_daily_consumption(  # noqa: SLF001
         force=True
     )
 
     coord.client.hems_energy_consumption.assert_awaited_once()
+    coord.client.pv_system_today.assert_awaited_once()
     kwargs = coord.client.hems_energy_consumption.await_args.kwargs
     assert kwargs["timezone"] == "Europe/Berlin"
     assert kwargs["step"] == "P1D"
     assert kwargs["start_at"] == "2026-03-19T23:00:00.000Z"
     assert kwargs["end_at"] == "2026-03-20T22:59:59.999Z"
-    assert coord.heatpump_daily_consumption["daily_energy_wh"] == pytest.approx(230.0)
+    assert coord.heatpump_daily_consumption["daily_energy_wh"] == pytest.approx(275.0)
+    assert coord.heatpump_daily_consumption["split_daily_energy_wh"] == pytest.approx(
+        230.0
+    )
     assert coord.heatpump_daily_consumption["daily_grid_wh"] == pytest.approx(200.0)
-    assert coord.heatpump_daily_consumption["source"] == "hems_energy_consumption:HP-1"
-    assert coord.heatpump_daily_consumption["sampled_at_utc"].startswith(
-        "2026-03-20T07:53:00.739143"
+    assert coord.heatpump_daily_consumption["source"] == "site_today_heatpump"
+    assert (
+        coord.heatpump_daily_consumption["split_source"]
+        == "hems_energy_consumption:HP-1"
+    )
+    assert (
+        coord.heatpump_daily_consumption["sampled_at_utc"]
+        == "2026-03-20T08:00:00+00:00"
     )
 
 
@@ -1718,20 +1776,22 @@ def test_heatpump_daily_helper_and_property_edge_cases(
         3.5
     )  # noqa: SLF001
 
-    assert (
-        coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(["bad"])
-        is None
-    )  # noqa: SLF001
-    assert (
-        coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot({"data": []})
-        is None
-    )  # noqa: SLF001
-    assert (
-        coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
-            {"data": {"heat-pump": []}}
-        )
-        is None
+    snapshot = coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
+        ["bad"], _site_today_payload(10.0)
     )
+    assert snapshot["daily_energy_wh"] == pytest.approx(10.0)
+    assert snapshot["split_source"] is None
+    snapshot = coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
+        {"data": []}, _site_today_payload(10.0)
+    )
+    assert snapshot["daily_energy_wh"] == pytest.approx(10.0)
+    assert snapshot["split_source"] is None
+    snapshot = coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
+        {"data": {"heat-pump": []}},
+        _site_today_payload(10.0),
+    )
+    assert snapshot["daily_energy_wh"] == pytest.approx(10.0)
+    assert snapshot["split_source"] is None
 
     coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
         {
@@ -1763,9 +1823,11 @@ def test_heatpump_daily_helper_and_property_edge_cases(
                     },
                 ]
             }
-        }
+        },
+        _site_today_payload(10.0),
     )
-    assert snapshot is None
+    assert snapshot["daily_energy_wh"] == pytest.approx(10.0)
+    assert snapshot["split_source"] is None
 
     coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
         {
@@ -1795,23 +1857,30 @@ def test_heatpump_daily_helper_and_property_edge_cases(
                     }
                 ]
             }
-        }
+        },
+        _site_today_payload(10.0),
     )
     assert snapshot == {
-        "device_uid": "HP-2",
-        "device_name": "Backup",
+        "device_uid": None,
+        "device_name": None,
+        "split_device_uid": "HP-2",
+        "split_device_name": "Backup",
         "member_name": None,
         "member_device_type": "ENERGY_METER",
         "pairing_status": None,
         "device_state": None,
-        "daily_energy_wh": pytest.approx(4.0),
+        "daily_energy_wh": pytest.approx(10.0),
+        "split_daily_energy_wh": pytest.approx(4.0),
         "daily_solar_wh": pytest.approx(1.0),
         "daily_battery_wh": pytest.approx(2.0),
         "daily_grid_wh": pytest.approx(3.0),
         "details": [4.0, "bad", None],
-        "source": "hems_energy_consumption:HP-2",
+        "source": "site_today_heatpump",
+        "split_source": "hems_energy_consumption:HP-2",
         "endpoint_type": None,
         "endpoint_timestamp": None,
+        "split_endpoint_type": None,
+        "split_endpoint_timestamp": None,
         "sampled_at_utc": None,
     }
     snapshot = coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
@@ -1832,31 +1901,38 @@ def test_heatpump_daily_helper_and_property_edge_cases(
                     }
                 ]
             }
-        }
+        },
+        _site_today_payload(0.0),
     )
     assert snapshot == {
-        "device_uid": "HP-2",
-        "device_name": "Backup",
+        "device_uid": None,
+        "device_name": None,
+        "split_device_uid": "HP-2",
+        "split_device_name": "Backup",
         "member_name": None,
         "member_device_type": "ENERGY_METER",
         "pairing_status": None,
         "device_state": None,
         "daily_energy_wh": pytest.approx(0.0),
+        "split_daily_energy_wh": pytest.approx(0.0),
         "daily_solar_wh": pytest.approx(0.0),
         "daily_battery_wh": pytest.approx(0.0),
         "daily_grid_wh": pytest.approx(0.0),
         "details": [],
-        "source": "hems_energy_consumption:HP-2",
+        "source": "site_today_heatpump",
+        "split_source": "hems_energy_consumption:HP-2",
         "endpoint_type": None,
         "endpoint_timestamp": None,
+        "split_endpoint_type": None,
+        "split_endpoint_timestamp": None,
         "sampled_at_utc": None,
     }
-    assert (
-        coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
-            {"data": {"heat-pump": [{"device_uid": "HP-1", "consumption": ["bad"]}]}}
-        )
-        is None
+    snapshot = coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
+        {"data": {"heat-pump": [{"device_uid": "HP-1", "consumption": ["bad"]}]}},
+        _site_today_payload(10.0),
     )
+    assert snapshot["daily_energy_wh"] == pytest.approx(10.0)
+    assert snapshot["split_source"] is None
 
 
 def test_heatpump_event_summary_classifies_known_event_keys(
@@ -1891,12 +1967,12 @@ def test_heatpump_event_summary_classifies_known_event_keys(
         "known_event_counts": {},
         "unknown_event_keys": [],
     }
-    assert (
-        coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
-            {"data": {"heat-pump": ["skip-me"]}}
-        )
-        is None
+    snapshot = coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
+        {"data": {"heat-pump": ["skip-me"]}},
+        _site_today_payload(10.0),
     )
+    assert snapshot["daily_energy_wh"] == pytest.approx(10.0)
+    assert snapshot["split_source"] is None
 
     class BadString:
         def __str__(self) -> str:
@@ -1968,7 +2044,8 @@ async def test_refresh_heatpump_daily_consumption_covers_cache_and_error_paths(
     await coord.heatpump_runtime._async_refresh_heatpump_daily_consumption(
         force=True
     )  # noqa: SLF001
-    assert coord.heatpump_daily_consumption == {}
+    assert coord.heatpump_daily_consumption["source"] == "site_today_heatpump"
+    assert coord.heatpump_daily_consumption_last_error is None
 
 
 def test_heatpump_runtime_inventory_merge_and_helper_paths(
@@ -2294,24 +2371,34 @@ async def test_heatpump_runtime_power_and_diagnostics_paths(
         ["heatpump"],
     )
     coord.client._hems_site_supported = None  # noqa: SLF001
+    coord.client.pv_system_today = AsyncMock(return_value=_site_today_payload(88.0))
     coord.client.hems_energy_consumption = None
     await coord.heatpump_runtime._async_refresh_heatpump_daily_consumption(
         force=True
     )  # noqa: SLF001
+    assert coord.heatpump_daily_consumption["daily_energy_wh"] == pytest.approx(88.0)
+    assert coord.heatpump_daily_consumption["split_source"] is None
+    assert coord.heatpump_daily_consumption_last_error is None
+    assert coord.heatpump_runtime.heatpump_daily_split_last_error == (
+        "HEMS daily split endpoint unavailable"
+    )
 
     coord.client.hems_energy_consumption = AsyncMock(side_effect=RuntimeError("boom"))
     await coord.heatpump_runtime._async_refresh_heatpump_daily_consumption(
         force=True
     )  # noqa: SLF001
-    assert coord.heatpump_daily_consumption_last_error == "boom"
-    assert coord._heatpump_daily_consumption_backoff_until is not None  # noqa: SLF001
+    assert coord.heatpump_daily_consumption["daily_energy_wh"] == pytest.approx(88.0)
+    assert coord.heatpump_daily_consumption_last_error is None
+    assert coord.heatpump_runtime.heatpump_daily_split_last_error == "boom"
+    assert coord._heatpump_daily_consumption_backoff_until is None  # noqa: SLF001
 
     coord._heatpump_daily_consumption_backoff_until = None  # noqa: SLF001
     coord.client.hems_energy_consumption = AsyncMock(return_value=None)
     await coord.heatpump_runtime._async_refresh_heatpump_daily_consumption(
         force=True
     )  # noqa: SLF001
-    assert coord.heatpump_daily_consumption == {}
+    assert coord.heatpump_daily_consumption["daily_energy_wh"] == pytest.approx(88.0)
+    assert coord.heatpump_daily_consumption["split_source"] is None
 
 
 @pytest.mark.asyncio
@@ -2386,7 +2473,8 @@ async def test_heatpump_runtime_helper_branches_and_resets(coordinator_factory) 
     )  # noqa: SLF001
     await runtime._async_refresh_heatpump_runtime_state(force=True)  # noqa: SLF001
     assert coord.heatpump_runtime_state == {}
-    assert coord.heatpump_runtime_state_last_success_utc is None
+    assert coord.heatpump_runtime_state_using_stale is False
+    assert coord.heatpump_runtime_state_last_success_utc is not None
 
     coord._heatpump_daily_consumption = {"daily_energy_wh": 12.0}  # noqa: SLF001
     coord._heatpump_daily_consumption_last_success_mono = 1.0  # noqa: SLF001
@@ -2395,7 +2483,8 @@ async def test_heatpump_runtime_helper_branches_and_resets(coordinator_factory) 
     )  # noqa: SLF001
     await runtime._async_refresh_heatpump_daily_consumption(force=True)  # noqa: SLF001
     assert coord.heatpump_daily_consumption == {}
-    assert coord.heatpump_daily_consumption_last_success_utc is None
+    assert coord.heatpump_daily_consumption_using_stale is False
+    assert coord.heatpump_daily_consumption_last_success_utc is not None
 
 
 def test_heatpump_runtime_misc_helper_guards_and_properties(
@@ -2524,11 +2613,14 @@ async def test_heatpump_runtime_remaining_coverage_branches(
             "data": {"heat-pump": [{"device_uid": "HP-1", "consumption": []}]},
         }
     )
+    coord.client.pv_system_today = AsyncMock(return_value=_site_today_payload(91.0))
     await runtime._async_refresh_heatpump_daily_consumption(force=True)  # noqa: SLF001
-    assert coord.heatpump_daily_consumption == {}
+    assert coord.heatpump_daily_consumption["daily_energy_wh"] == pytest.approx(91.0)
+    assert coord.heatpump_daily_consumption["split_source"] is None
+    assert coord.heatpump_daily_consumption_last_error is None
     assert (
-        coord.heatpump_daily_consumption_last_error
-        == "No usable HEMS daily-consumption payload"
+        coord.heatpump_runtime.heatpump_daily_split_last_error
+        == "No usable HEMS daily split payload"
     )
 
     monkeypatch.setattr(

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -2604,8 +2604,11 @@ async def test_heatpump_runtime_helper_branches_and_resets(coordinator_factory) 
 
     runtime._type_device_buckets = {}  # noqa: SLF001
     runtime._type_device_order = []  # noqa: SLF001
+    now = time.monotonic()
     coord._heatpump_runtime_state = {"heatpump_status": "RUNNING"}  # noqa: SLF001
-    coord._heatpump_runtime_state_last_success_mono = 1.0  # noqa: SLF001
+    coord._heatpump_runtime_state_last_success_mono = (  # noqa: SLF001
+        now - heatpump_runtime_mod.HEATPUMP_RUNTIME_STATE_STALE_AFTER_S - 1.0
+    )
     coord._heatpump_runtime_state_last_success_utc = datetime.now(
         timezone.utc
     )  # noqa: SLF001
@@ -2615,7 +2618,9 @@ async def test_heatpump_runtime_helper_branches_and_resets(coordinator_factory) 
     assert coord.heatpump_runtime_state_last_success_utc is not None
 
     coord._heatpump_daily_consumption = {"daily_energy_wh": 12.0}  # noqa: SLF001
-    coord._heatpump_daily_consumption_last_success_mono = 1.0  # noqa: SLF001
+    coord._heatpump_daily_consumption_last_success_mono = (  # noqa: SLF001
+        now - heatpump_runtime_mod.HEATPUMP_DAILY_CONSUMPTION_STALE_AFTER_S - 1.0
+    )
     coord._heatpump_daily_consumption_last_success_utc = datetime.now(
         timezone.utc
     )  # noqa: SLF001

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -1986,6 +1986,112 @@ def test_heatpump_event_summary_classifies_known_event_keys(
     assert coord.heatpump_daily_consumption_last_error is None
 
 
+def test_heatpump_runtime_additional_helper_edge_cases(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.heatpump_runtime
+
+    assert runtime.heatpump_entities_established() is False
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 1,
+                "devices": [{"device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    assert runtime.heatpump_entities_established() is True
+    coord.inventory_runtime._set_type_device_buckets({}, [])
+
+    coord._heatpump_daily_consumption = {"daily_energy_wh": 12.0}  # noqa: SLF001
+    coord._heatpump_daily_consumption_last_success_mono = (
+        time.monotonic()
+    )  # noqa: SLF001
+    assert (
+        runtime._heatpump_mark_daily_consumption_stale(  # noqa: SLF001
+            now=time.monotonic(),
+            error="stale",
+        )
+        is True
+    )
+
+    assert (
+        runtime._heatpump_daily_split_available({"daily_grid_wh": 0.0})  # noqa: SLF001
+        is True
+    )
+    target = {"split_source": "keep"}
+    assert (
+        runtime._heatpump_copy_daily_split_fields(
+            target, {"details": []}
+        )  # noqa: SLF001
+        is False
+    )
+    assert target["split_source"] is None
+    assert target["details"] == []
+
+    assert (
+        runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
+            {"data": {"heat-pump": []}},
+            {"stats": []},
+        )
+        is None
+    )
+
+    assert runtime._site_today_heatpump_numeric_total(
+        {"a": {"b": 2}}
+    ) == pytest.approx(  # noqa: SLF001
+        2.0
+    )
+    assert (
+        runtime._site_today_heatpump_numeric_total({"a": "bad"}) is None
+    )  # noqa: SLF001
+    assert runtime._site_today_heatpump_numeric_total(
+        [1, {"a": 2}]
+    ) == pytest.approx(  # noqa: SLF001
+        3.0
+    )
+    assert (
+        runtime._site_today_heatpump_numeric_total([None, "bad"]) is None
+    )  # noqa: SLF001
+    assert runtime._site_today_heatpump_numeric_total("bad") is None  # noqa: SLF001
+    assert (
+        runtime._site_today_heatpump_numeric_total(float("inf")) is None
+    )  # noqa: SLF001
+    assert runtime._site_today_heatpump_total_wh(None) is None  # noqa: SLF001
+    assert runtime._site_today_heatpump_total_wh({"stats": []}) is None  # noqa: SLF001
+    assert (
+        runtime._site_today_heatpump_total_wh({"stats": ["bad"]}) is None
+    )  # noqa: SLF001
+    assert (
+        runtime._site_today_heatpump_total_wh({"stats": [{"other": 1}]}) is None
+    )  # noqa: SLF001
+
+    assert (
+        runtime._heatpump_power_summary_from_daily_snapshot(None) is None
+    )  # noqa: SLF001
+    assert (
+        runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+            {"daily_energy_wh": 10.0}
+        )
+        is None
+    )
+
+    assert runtime.heatpump_daily_split_last_error is None
+
+    class BadString:
+        def __str__(self) -> str:
+            raise ValueError("boom")
+
+    coord._heatpump_daily_consumption_last_error = "   "  # noqa: SLF001
+    assert coord.heatpump_daily_consumption_last_error is None
+    coord._heatpump_daily_split_last_error = BadString()  # noqa: SLF001
+    assert coord.heatpump_runtime.heatpump_daily_split_last_error is None
+
+
 @pytest.mark.asyncio
 async def test_refresh_heatpump_daily_consumption_covers_cache_and_error_paths(
     coordinator_factory, monkeypatch
@@ -2046,6 +2152,38 @@ async def test_refresh_heatpump_daily_consumption_covers_cache_and_error_paths(
     )  # noqa: SLF001
     assert coord.heatpump_daily_consumption["source"] == "site_today_heatpump"
     assert coord.heatpump_daily_consumption_last_error is None
+
+    coord.client._hems_site_supported = None  # noqa: SLF001
+    coord.client.pv_system_today = None  # type: ignore[assignment]
+    await coord.heatpump_runtime._async_refresh_heatpump_daily_consumption(
+        force=True
+    )  # noqa: SLF001
+
+    coord.client.pv_system_today = AsyncMock(side_effect=RuntimeError("site boom"))
+    await coord.heatpump_runtime._async_refresh_heatpump_daily_consumption(
+        force=True
+    )  # noqa: SLF001
+    assert coord.heatpump_daily_consumption_last_error == "site boom"
+    assert coord._heatpump_daily_consumption_backoff_until is not None  # noqa: SLF001
+
+    coord._heatpump_daily_consumption_backoff_until = None  # noqa: SLF001
+    coord.client.pv_system_today = AsyncMock(return_value="bad")
+    await coord.heatpump_runtime._async_refresh_heatpump_daily_consumption(
+        force=True
+    )  # noqa: SLF001
+    assert (
+        coord.heatpump_daily_consumption_last_error
+        == "No usable site today heat-pump payload"
+    )
+
+    coord.client.pv_system_today = AsyncMock(return_value={"stats": []})
+    await coord.heatpump_runtime._async_refresh_heatpump_daily_consumption(
+        force=True
+    )  # noqa: SLF001
+    assert (
+        coord.heatpump_daily_consumption_last_error
+        == "No usable site today heat-pump payload"
+    )
 
 
 def test_heatpump_runtime_inventory_merge_and_helper_paths(

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -4923,20 +4923,26 @@ def test_site_heat_pump_energy_sensor_uses_heatpump_device_info(
     coord._heatpump_power_w = 725.125  # noqa: SLF001
     coord._heatpump_daily_consumption = {  # noqa: SLF001
         "daily_energy_wh": 230.0,
+        "split_daily_energy_wh": 230.0,
         "daily_solar_wh": 10.0,
         "daily_battery_wh": 20.0,
         "daily_grid_wh": 200.0,
-        "device_uid": "HP-1",
-        "device_name": "Heat Pump",
+        "device_uid": None,
+        "device_name": None,
+        "split_device_uid": "HP-1",
+        "split_device_name": "Heat Pump",
         "member_name": "Primary Heat Pump",
         "member_device_type": "HEAT_PUMP",
         "pairing_status": "PAIRED",
         "device_state": "ACTIVE",
-        "endpoint_type": "hems-device-details",
-        "endpoint_timestamp": "2026-03-20T07:53:00.739143826Z",
+        "endpoint_type": "site-today",
+        "endpoint_timestamp": "2026-03-20T08:00:00Z",
+        "split_endpoint_type": "hems-device-details",
+        "split_endpoint_timestamp": "2026-03-20T07:53:00.739143826Z",
         "day_key": "2026-03-20",
         "timezone": "Europe/Berlin",
-        "source": "hems_energy_consumption:HP-1",
+        "source": "site_today_heatpump",
+        "split_source": "hems_energy_consumption:HP-1",
     }
     coord.energy.site_energy = {
         "heat_pump": {
@@ -4960,17 +4966,17 @@ def test_site_heat_pump_energy_sensor_uses_heatpump_device_info(
     assert attrs["heat_pump_power_w"] == pytest.approx(725.125)
     assert attrs["daily_energy_wh"] == pytest.approx(230.0)
     assert attrs["daily_grid_wh"] == pytest.approx(200.0)
-    assert attrs["daily_device_uid"] == "HP-1"
-    assert attrs["daily_device_name"] == "Heat Pump"
+    assert attrs["daily_device_uid"] is None
+    assert attrs["daily_device_name"] is None
     assert attrs["daily_member_name"] == "Primary Heat Pump"
     assert attrs["daily_member_device_type"] == "HEAT_PUMP"
     assert attrs["daily_pairing_status"] == "PAIRED"
     assert attrs["daily_device_state"] == "ACTIVE"
-    assert attrs["daily_endpoint_type"] == "hems-device-details"
-    assert attrs["daily_endpoint_timestamp"] == "2026-03-20T07:53:00.739143826Z"
+    assert attrs["daily_endpoint_type"] == "site-today"
+    assert attrs["daily_endpoint_timestamp"] == "2026-03-20T08:00:00Z"
     assert attrs["day_key"] == "2026-03-20"
     assert attrs["timezone"] == "Europe/Berlin"
-    assert attrs["daily_source"] == "hems_energy_consumption:HP-1"
+    assert attrs["daily_source"] == "site_today_heatpump"
 
 
 def test_heat_pump_daily_energy_and_sg_ready_gateway_sensors(
@@ -5014,22 +5020,38 @@ def test_heat_pump_daily_energy_and_sg_ready_gateway_sensors(
     )
     coord._heatpump_daily_consumption = {  # noqa: SLF001
         "daily_energy_wh": 230.0,
+        "split_daily_energy_wh": 230.0,
         "daily_solar_wh": 10.0,
         "daily_battery_wh": 20.0,
         "daily_grid_wh": 200.0,
-        "device_uid": "HP-1",
-        "device_name": "Heat Pump",
+        "device_uid": None,
+        "device_name": None,
+        "split_device_uid": "HP-1",
+        "split_device_name": "Heat Pump",
         "member_name": "Heat Pump",
         "member_device_type": "HEAT_PUMP",
         "pairing_status": "PAIRED",
         "device_state": "ACTIVE",
-        "endpoint_type": "hems-device-details",
-        "endpoint_timestamp": "2026-03-20T07:53:00.739143826Z",
+        "endpoint_type": "site-today",
+        "endpoint_timestamp": "2026-03-20T08:00:00Z",
+        "split_endpoint_type": "hems-device-details",
+        "split_endpoint_timestamp": "2026-03-20T07:53:00.739143826Z",
         "day_key": "2026-03-20",
         "timezone": "Europe/Berlin",
         "details": [230.0],
-        "source": "hems_energy_consumption:HP-1",
+        "source": "site_today_heatpump",
+        "split_source": "hems_energy_consumption:HP-1",
     }
+    coord._heatpump_daily_consumption_last_success_utc = datetime(  # noqa: SLF001
+        2026, 3, 20, 8, 0, tzinfo=timezone.utc
+    )
+    coord._heatpump_daily_split_last_success_utc = datetime(  # noqa: SLF001
+        2026, 3, 20, 7, 53, tzinfo=timezone.utc
+    )
+    coord._heatpump_daily_split_using_stale = True  # noqa: SLF001
+    coord._heatpump_daily_split_last_error = (
+        "No usable HEMS daily split payload"  # noqa: SLF001
+    )
 
     daily_sensor = EnphaseHeatPumpDailyEnergySensor(coord)
     grid_sensor = EnphaseHeatPumpDailyGridEnergySensor(coord)
@@ -5040,8 +5062,18 @@ def test_heat_pump_daily_energy_and_sg_ready_gateway_sensors(
     assert daily_sensor.available is True
     assert daily_sensor.state_class == SensorStateClass.TOTAL
     assert daily_sensor.native_value == pytest.approx(0.23)
-    assert daily_sensor.extra_state_attributes["daily_endpoint_timestamp"] == (
-        "2026-03-20T07:53:00.739143826Z"
+    assert daily_sensor.extra_state_attributes["source"] == "site_today_heatpump"
+    assert (
+        grid_sensor.extra_state_attributes["source"] == "hems_energy_consumption:HP-1"
+    )
+    assert grid_sensor.extra_state_attributes["using_stale"] is True
+    assert (
+        grid_sensor.extra_state_attributes["last_success_utc"]
+        == "2026-03-20T07:53:00+00:00"
+    )
+    assert (
+        grid_sensor.extra_state_attributes["last_error"]
+        == "No usable HEMS daily split payload"
     )
     assert grid_sensor.available is True
     assert grid_sensor.native_value == pytest.approx(0.2)

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -2359,6 +2359,32 @@ def test_heatpump_runtime_sensor_uid_fallback_and_error_paths(
     monkeypatch.setattr(meter_sensor, "_snapshot", lambda: {"member_count": 0})
     assert meter_sensor.available is False
 
+    monkeypatch.setattr(
+        coord.inventory_view,
+        "has_type_for_entities",
+        lambda _type_key: False,
+    )
+    assert meter_sensor.available is False
+    monkeypatch.setattr(
+        coord.inventory_view,
+        "has_type_for_entities",
+        lambda _type_key: True,
+    )
+
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 0,
+                "devices": [],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    assert meter_sensor.available is False
+
     coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
         {
             "heatpump": {


### PR DESCRIPTION
## Summary

Fix heat-pump daily energy semantics and availability handling by separating the primary daily total from HEMS split data. The user-facing `heat_pump_daily_energy` sensor now derives from `/pv/systems/<site>/today`, while split daily diagnostics remain HEMS-backed and stale-preserved independently. Fixes #443.

## Related Issues

- #443

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/heatpump_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/heatpump_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py tests/components/enphase_ev/test_diagnostics.py"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Primary heat-pump daily energy is now sourced from `/pv/systems/<site>/today`.
- HEMS split daily data is preserved independently for diagnostic split sensors and power derivation.
- Heat-pump entities remain available through short-lived inventory/runtime UID churn within the existing stale windows.
