### PR TITLE
Improve BatteryConfig auth compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Detect Enphase browser login-wall HTML responses on JSON/text API endpoints, surface a dedicated temporary-auth-block repair issue, and persist a 24-hour auth cooldown after a rejected stored-credential refresh so blocked sessions fail fast instead of repeatedly hammering the cloud API.
+- Improved BatteryConfig write compatibility for stubborn `403 Forbidden` sites by making schedule validation send `forceScheduleOpted` only for CFG, retrying rejected battery writes once with an external-client-style auth shape, and enriching DTG enable toggles to match the broader payload observed in a working third-party client.
 
 ### 🔧 Improvements
-- None
+- Expanded `docs/api/api_spec.md` with the additional BatteryConfig observations from a working third-party integration so the repository now records the alternate JWT bootstrap, user/site discovery, CFG disclaimer, and DTG toggle request shapes relevant to issue `#460`.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -733,6 +733,19 @@ def _cookie_names_from_header(cookie_header: object) -> list[str]:
     return sorted(_cookie_map_from_header(cookie_header).keys())
 
 
+def _authorization_bearer_token(headers: dict[str, str]) -> str | None:
+    """Return the bearer token from an Authorization header when present."""
+
+    raw = headers.get("Authorization")
+    if not isinstance(raw, str):
+        return None
+    prefix = "Bearer "
+    if not raw.startswith(prefix):
+        return None
+    token = raw[len(prefix) :].strip()
+    return token or None
+
+
 def _request_failure_debug_family(method: object, path_or_url: object) -> str | None:
     """Return the debug-log label for curated opaque request failures."""
 
@@ -2246,6 +2259,66 @@ class EnphaseEVClient:
         _token, user_id = self._battery_config_auth_context()
         return user_id
 
+    def _battery_config_single_auth_token(self) -> str | None:
+        """Return the single-token auth candidate used by external clients."""
+
+        return self._bearer() or self._eauth
+
+    def _battery_config_user_id_for_token(self, token: str | None = None) -> str | None:
+        """Return the preferred BatteryConfig user id for a specific token."""
+
+        if token:
+            user_id = _jwt_user_id(token)
+            if user_id:
+                return user_id
+        return self._battery_config_user_id()
+
+    def _battery_config_auth_source_label(self, token: str | None) -> str:
+        """Return a coarse label describing the selected BatteryConfig token source."""
+
+        if not token:
+            return "none"
+        bearer = self._bearer()
+        eauth = self._eauth
+        if bearer and eauth and token == bearer and token == eauth:
+            return "shared"
+        if bearer and eauth and token in {bearer, eauth} and bearer != eauth:
+            return "mixed"
+        if bearer and token == bearer:
+            return "manager_cookie"
+        if eauth and token == eauth:
+            return "access_token"
+        return "unknown"
+
+    def _battery_config_header_debug_flags(
+        self, headers: dict[str, str]
+    ) -> dict[str, object]:
+        """Return safe debug flags describing BatteryConfig auth-header shape."""
+
+        bearer = _authorization_bearer_token(headers)
+        eauth = headers.get("e-auth-token")
+        auth_mode = "none"
+        if bearer and eauth:
+            auth_mode = "dual_match" if bearer == eauth else "dual_mismatch"
+        elif bearer:
+            auth_mode = "authorization_only"
+        elif eauth:
+            auth_mode = "eauth_only"
+
+        auth_source = self._battery_config_auth_source_label(bearer or eauth)
+        if auth_mode == "dual_mismatch":
+            auth_source = "mixed"
+
+        return {
+            "has_authorization": "Authorization" in headers,
+            "has_e_auth_token": "e-auth-token" in headers,
+            "has_username": "Username" in headers,
+            "has_x_csrf_token": "X-CSRF-Token" in headers,
+            "has_x_xsrf_token": "X-XSRF-Token" in headers,
+            "auth_mode": auth_mode,
+            "auth_source": auth_source,
+        }
+
     def _battery_config_auth_context(self) -> tuple[str | None, str | None]:
         """Return preferred BatteryConfig auth token and resolved user id.
 
@@ -2308,17 +2381,29 @@ class EnphaseEVClient:
         self,
         *,
         include_xsrf: bool = False,
+        auth_style: str = "default",
+        token_override: str | None = None,
     ) -> dict[str, str]:
         """Return headers for BatteryConfig read/write calls."""
 
         headers = dict(self._h)
-        token, user_id = self._battery_config_auth_context()
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-        if self._eauth:
-            headers["e-auth-token"] = self._eauth
-        elif token:
-            headers["e-auth-token"] = token
+        if auth_style == "external_compatible":
+            token = token_override or self._battery_config_single_auth_token()
+            user_id = self._battery_config_user_id_for_token(token)
+            headers.pop("Authorization", None)
+            headers.pop("X-CSRF-Token", None)
+            if token:
+                headers["e-auth-token"] = token
+            else:
+                headers.pop("e-auth-token", None)
+        else:
+            token, user_id = self._battery_config_auth_context()
+            if token:
+                headers["Authorization"] = f"Bearer {token}"
+            if self._eauth:
+                headers["e-auth-token"] = self._eauth
+            elif token:
+                headers["e-auth-token"] = token
         if user_id:
             headers["Username"] = user_id
         headers["Origin"] = "https://battery-profile-ui.enphaseenergy.com"
@@ -2331,9 +2416,23 @@ class EnphaseEVClient:
         if include_xsrf:
             xsrf = self._xsrf_token()
             if xsrf:
-                headers["X-CSRF-Token"] = xsrf
                 headers["X-XSRF-Token"] = xsrf
+                if auth_style != "external_compatible":
+                    headers["X-CSRF-Token"] = xsrf
+                else:
+                    headers.pop("X-CSRF-Token", None)
         return headers
+
+    def _battery_schedule_validation_payload(
+        self, schedule_type: str = "cfg"
+    ) -> dict[str, object]:
+        """Return the XSRF bootstrap / validation payload for a schedule family."""
+
+        normalized = str(schedule_type).lower()
+        payload: dict[str, object] = {"scheduleType": normalized}
+        if normalized == "cfg":
+            payload["forceScheduleOpted"] = True
+        return payload
 
     def _battery_config_params(
         self,
@@ -2382,6 +2481,163 @@ class EnphaseEVClient:
                 return token
         return None
 
+    async def _fetch_legacy_battery_config_jwt(self) -> str | None:
+        """Fetch the legacy cookie-backed JWT used by some BatteryConfig clients."""
+
+        url = f"{BASE_URL}/app-api/jwt_token.json"
+        headers = {
+            "Accept": "application/json, text/plain, */*",
+            "Referer": f"{BASE_URL}/",
+            "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
+        }
+        if self._cookie:
+            headers["Cookie"] = self._cookie
+
+        try:
+            _seed_cookie_jar(self._s, _cookie_map_from_header(self._cookie))
+            async with asyncio.timeout(self._timeout):
+                async with self._s.request("GET", url, headers=headers) as r:
+                    if r.status >= 400:
+                        message = (await r.text()).strip()
+                        _LOGGER.debug(
+                            "Legacy BatteryConfig JWT bootstrap failed (%s): %s",
+                            r.status,
+                            redact_text(
+                                message or r.reason,
+                                site_ids=(self._site,),
+                                max_length=256,
+                            ),
+                        )
+                        return None
+                    try:
+                        payload = await r.json()
+                    except Exception as err:  # noqa: BLE001
+                        _LOGGER.debug(
+                            "Legacy BatteryConfig JWT bootstrap returned invalid JSON: %s",
+                            redact_text(err, site_ids=(self._site,), max_length=256),
+                        )
+                        return None
+        except aiohttp.ClientError as err:
+            _LOGGER.debug(
+                "Legacy BatteryConfig JWT bootstrap client error: %s",
+                redact_text(err, site_ids=(self._site,), max_length=256),
+            )
+            return None
+        except TimeoutError as err:
+            _LOGGER.debug(
+                "Legacy BatteryConfig JWT bootstrap timed out: %s",
+                redact_text(err, site_ids=(self._site,), max_length=256),
+            )
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+        token = payload.get("token") or payload.get("auth_token")
+        if not token:
+            return None
+        return str(token)
+
+    def _battery_config_retry_params(
+        self,
+        url: str,
+        params: dict[str, str] | None,
+        *,
+        retry_token: str | None = None,
+    ) -> dict[str, str] | None:
+        """Return adjusted params for an external-compatible BatteryConfig retry."""
+
+        if not isinstance(params, dict):
+            return params
+        try:
+            path = URL(url).path
+        except Exception:  # noqa: BLE001
+            path = str(url)
+        if "/service/batteryConfig/api/v1/batterySettings/" in path:
+            retry_params = dict(params)
+            retry_user_id = self._battery_config_user_id_for_token(retry_token)
+            if retry_user_id:
+                retry_params["userId"] = retry_user_id
+            return retry_params
+        retry_params = dict(params)
+        retry_user_id = self._battery_config_user_id_for_token(retry_token)
+        if retry_user_id:
+            retry_params["userId"] = retry_user_id
+        if "source" not in params:
+            return retry_params
+        retry_params.pop("source", None)
+        return retry_params
+
+    async def _battery_config_write_request(
+        self,
+        method: str,
+        url: str,
+        *,
+        json_body: dict[str, Any] | list[Any] | None = None,
+        params: dict[str, str] | None = None,
+        schedule_type: str = "cfg",
+    ) -> dict:
+        """Issue a BatteryConfig write with one external-compatible retry on 403."""
+
+        await self._acquire_xsrf_token(schedule_type)
+
+        try:
+            headers = self._battery_config_headers(include_xsrf=True)
+            if json_body is not None:
+                headers.setdefault("Content-Type", "application/json")
+            try:
+                return await self._json(
+                    method,
+                    url,
+                    json=json_body,
+                    headers=headers,
+                    params=params,
+                )
+            except aiohttp.ClientResponseError as err:
+                if err.status != 403:
+                    raise
+                legacy_token = await self._fetch_legacy_battery_config_jwt()
+                retry_headers = self._battery_config_headers(
+                    include_xsrf=True,
+                    auth_style="external_compatible",
+                    token_override=legacy_token,
+                )
+                if json_body is not None:
+                    retry_headers.setdefault("Content-Type", "application/json")
+                retry_token = (
+                    legacy_token
+                    or retry_headers.get("e-auth-token")
+                    or _authorization_bearer_token(retry_headers)
+                )
+                retry_params = self._battery_config_retry_params(
+                    url,
+                    params,
+                    retry_token=retry_token,
+                )
+                if retry_headers == headers and retry_params == params:
+                    raise
+                _LOGGER.debug(
+                    "Retrying BatteryConfig write for %s with external-compatible auth shape "
+                    "(auth_source=%s, has_authorization=%s, has_x_csrf_token=%s, params_changed=%s)",
+                    _request_label(method, url),
+                    (
+                        "legacy_jwt_token"
+                        if legacy_token
+                        else self._battery_config_auth_source_label(retry_token)
+                    ),
+                    "Authorization" in retry_headers,
+                    "X-CSRF-Token" in retry_headers,
+                    retry_params != params,
+                )
+                return await self._json(
+                    method,
+                    url,
+                    json=json_body,
+                    headers=retry_headers,
+                    params=retry_params,
+                )
+        finally:
+            self._bp_xsrf_token = None
+
     async def _acquire_xsrf_token(self, schedule_type: str = "cfg") -> str | None:
         """Acquire a BP-XSRF-Token by POSTing to the schedules isValid endpoint.
 
@@ -2410,10 +2666,7 @@ class EnphaseEVClient:
         cookie = self._battery_config_cookie()
         if cookie:
             headers["Cookie"] = cookie
-        payload = {
-            "scheduleType": str(schedule_type).lower(),
-            "forceScheduleOpted": True,
-        }
+        payload = self._battery_schedule_validation_payload(schedule_type)
 
         try:
             _seed_cookie_jar(self._s, _cookie_map_from_header(self._cookie))
@@ -2882,14 +3135,9 @@ class EnphaseEVClient:
                                             str(key) for key in data_payload.keys()
                                         )
                                     }
-                                header_flags = {
-                                    "has_authorization": "Authorization"
-                                    in base_headers,
-                                    "has_e_auth_token": "e-auth-token" in base_headers,
-                                    "has_username": "Username" in base_headers,
-                                    "has_x_csrf_token": "X-CSRF-Token" in base_headers,
-                                    "has_x_xsrf_token": "X-XSRF-Token" in base_headers,
-                                }
+                                header_flags = self._battery_config_header_debug_flags(
+                                    base_headers
+                                )
                                 _LOGGER.debug(
                                     "%s failed for %s: status=%s params=%s payload=%s "
                                     "header_flags=%s cookie_names=%s headers=%s response=%s",
@@ -3727,21 +3975,16 @@ class EnphaseEVClient:
         schedule_type: str = "cfg",
     ) -> dict:
         """Update BatteryConfig battery detail settings using a partial payload."""
-
-        await self._acquire_xsrf_token(schedule_type)
-
-        try:
-            url = (
-                f"{BASE_URL}/service/batteryConfig/api/v1/batterySettings/{self._site}"
-            )
-            params = self._battery_config_params(include_source=True)
-            headers = self._battery_config_headers(include_xsrf=True)
-            body = payload if isinstance(payload, dict) else {}
-            return await self._json(
-                "PUT", url, json=body, headers=headers, params=params
-            )
-        finally:
-            self._bp_xsrf_token = None
+        url = f"{BASE_URL}/service/batteryConfig/api/v1/batterySettings/{self._site}"
+        params = self._battery_config_params(include_source=True)
+        body = payload if isinstance(payload, dict) else {}
+        return await self._battery_config_write_request(
+            "PUT",
+            url,
+            json_body=body,
+            params=params,
+            schedule_type=schedule_type,
+        )
 
     async def set_battery_profile(
         self,
@@ -3752,62 +3995,51 @@ class EnphaseEVClient:
         devices: list[dict[str, Any]] | None = None,
     ) -> dict:
         """Update the site battery profile and reserve percentage."""
-
-        await self._acquire_xsrf_token()
-
-        try:
-            url = f"{BASE_URL}/service/batteryConfig/api/v1/profile/{self._site}"
-            params = self._battery_config_params(include_source=True)
-            headers = self._battery_config_headers(include_xsrf=True)
-            payload: dict[str, Any] = {
-                "profile": str(profile),
-                "batteryBackupPercentage": int(battery_backup_percentage),
-            }
-            if operation_mode_sub_type:
-                payload["operationModeSubType"] = str(operation_mode_sub_type)
-            if devices:
-                payload["devices"] = [
-                    item for item in devices if isinstance(item, dict)
-                ]
-            return await self._json(
-                "PUT", url, json=payload, headers=headers, params=params
-            )
-        finally:
-            self._bp_xsrf_token = None
+        url = f"{BASE_URL}/service/batteryConfig/api/v1/profile/{self._site}"
+        params = self._battery_config_params(include_source=True)
+        payload: dict[str, Any] = {
+            "profile": str(profile),
+            "batteryBackupPercentage": int(battery_backup_percentage),
+        }
+        if operation_mode_sub_type:
+            payload["operationModeSubType"] = str(operation_mode_sub_type)
+        if devices:
+            payload["devices"] = [item for item in devices if isinstance(item, dict)]
+        return await self._battery_config_write_request(
+            "PUT",
+            url,
+            json_body=payload,
+            params=params,
+        )
 
     async def cancel_battery_profile_update(self) -> dict:
         """Cancel a pending site battery profile change."""
-
-        await self._acquire_xsrf_token()
-
-        try:
-            url = f"{BASE_URL}/service/batteryConfig/api/v1/cancel/profile/{self._site}"
-            params = self._battery_config_params(include_source=True)
-            headers = self._battery_config_headers(include_xsrf=True)
-            return await self._json("PUT", url, json={}, headers=headers, params=params)
-        finally:
-            self._bp_xsrf_token = None
+        url = f"{BASE_URL}/service/batteryConfig/api/v1/cancel/profile/{self._site}"
+        params = self._battery_config_params(include_source=True)
+        return await self._battery_config_write_request(
+            "PUT",
+            url,
+            json_body={},
+            params=params,
+        )
 
     async def set_storm_guard(self, *, enabled: bool, evse_enabled: bool) -> dict:
         """Toggle Storm Guard and the EVSE charge-to-100% option.
 
         PUT /service/batteryConfig/api/v1/stormGuard/toggle/<site_id>?userId=<user_id>
         """
-        await self._acquire_xsrf_token()
-
-        try:
-            url = f"{BASE_URL}/service/batteryConfig/api/v1/stormGuard/toggle/{self._site}"
-            params = self._battery_config_params(include_source=True)
-            headers = self._battery_config_headers(include_xsrf=True)
-            payload = {
-                "stormGuardState": "enabled" if enabled else "disabled",
-                "evseStormEnabled": bool(evse_enabled),
-            }
-            return await self._json(
-                "PUT", url, json=payload, headers=headers, params=params
-            )
-        finally:
-            self._bp_xsrf_token = None
+        url = f"{BASE_URL}/service/batteryConfig/api/v1/stormGuard/toggle/{self._site}"
+        params = self._battery_config_params(include_source=True)
+        payload = {
+            "stormGuardState": "enabled" if enabled else "disabled",
+            "evseStormEnabled": bool(evse_enabled),
+        }
+        return await self._battery_config_write_request(
+            "PUT",
+            url,
+            json_body=payload,
+            params=params,
+        )
 
     # ------------------------------------------------------------------
     # Battery schedule CRUD (newer /battery/sites/{id}/schedules API)
@@ -3854,29 +4086,27 @@ class EnphaseEVClient:
             timezone: IANA timezone string.
         """
 
-        await self._acquire_xsrf_token(schedule_type)
-
-        try:
-            url = (
-                f"{BASE_URL}/service/batteryConfig/api/v1/battery/sites/"
-                f"{self._site}/schedules"
-            )
-            headers = self._battery_config_headers(include_xsrf=True)
-            headers["Content-Type"] = "application/json"
-            payload = {
-                "timezone": timezone,
-                "startTime": start_time[:5],
-                "endTime": end_time[:5],
-                "scheduleType": str(schedule_type).upper(),
-                "days": [int(d) for d in days],
-            }
-            if limit is not None:
-                payload["limit"] = int(limit)
-            if is_enabled is not None:
-                payload["isEnabled"] = bool(is_enabled)
-            return await self._json("POST", url, json=payload, headers=headers)
-        finally:
-            self._bp_xsrf_token = None
+        url = (
+            f"{BASE_URL}/service/batteryConfig/api/v1/battery/sites/"
+            f"{self._site}/schedules"
+        )
+        payload = {
+            "timezone": timezone,
+            "startTime": start_time[:5],
+            "endTime": end_time[:5],
+            "scheduleType": str(schedule_type).upper(),
+            "days": [int(d) for d in days],
+        }
+        if limit is not None:
+            payload["limit"] = int(limit)
+        if is_enabled is not None:
+            payload["isEnabled"] = bool(is_enabled)
+        return await self._battery_config_write_request(
+            "POST",
+            url,
+            json_body=payload,
+            schedule_type=schedule_type,
+        )
 
     async def update_battery_schedule(
         self,
@@ -3906,31 +4136,29 @@ class EnphaseEVClient:
             timezone: IANA timezone string.
         """
 
-        await self._acquire_xsrf_token(schedule_type)
-
-        try:
-            url = (
-                f"{BASE_URL}/service/batteryConfig/api/v1/battery/sites/"
-                f"{self._site}/schedules/{schedule_id}"
-            )
-            headers = self._battery_config_headers(include_xsrf=True)
-            headers["Content-Type"] = "application/json"
-            payload = {
-                "timezone": timezone,
-                "startTime": start_time[:5],
-                "endTime": end_time[:5],
-                "scheduleType": str(schedule_type).upper(),
-                "days": [int(d) for d in days],
-            }
-            if limit is not None:
-                payload["limit"] = int(limit)
-            if is_enabled is not None:
-                payload["isEnabled"] = bool(is_enabled)
-            if is_deleted is not None:
-                payload["isDeleted"] = bool(is_deleted)
-            return await self._json("PUT", url, json=payload, headers=headers)
-        finally:
-            self._bp_xsrf_token = None
+        url = (
+            f"{BASE_URL}/service/batteryConfig/api/v1/battery/sites/"
+            f"{self._site}/schedules/{schedule_id}"
+        )
+        payload = {
+            "timezone": timezone,
+            "startTime": start_time[:5],
+            "endTime": end_time[:5],
+            "scheduleType": str(schedule_type).upper(),
+            "days": [int(d) for d in days],
+        }
+        if limit is not None:
+            payload["limit"] = int(limit)
+        if is_enabled is not None:
+            payload["isEnabled"] = bool(is_enabled)
+        if is_deleted is not None:
+            payload["isDeleted"] = bool(is_deleted)
+        return await self._battery_config_write_request(
+            "PUT",
+            url,
+            json_body=payload,
+            schedule_type=schedule_type,
+        )
 
     async def delete_battery_schedule(
         self,
@@ -3943,18 +4171,16 @@ class EnphaseEVClient:
         POST /service/batteryConfig/api/v1/battery/sites/{site_id}/schedules/{id}/delete
         """
 
-        await self._acquire_xsrf_token(schedule_type)
-
-        try:
-            url = (
-                f"{BASE_URL}/service/batteryConfig/api/v1/battery/sites/"
-                f"{self._site}/schedules/{schedule_id}/delete"
-            )
-            headers = self._battery_config_headers(include_xsrf=True)
-            headers["Content-Type"] = "application/json"
-            return await self._json("POST", url, json={}, headers=headers)
-        finally:
-            self._bp_xsrf_token = None
+        url = (
+            f"{BASE_URL}/service/batteryConfig/api/v1/battery/sites/"
+            f"{self._site}/schedules/{schedule_id}/delete"
+        )
+        return await self._battery_config_write_request(
+            "POST",
+            url,
+            json_body={},
+            schedule_type=schedule_type,
+        )
 
     async def validate_battery_schedule(self, schedule_type: str = "cfg") -> dict:
         """Validate a battery schedule configuration.
@@ -3970,10 +4196,7 @@ class EnphaseEVClient:
         )
         headers = self._battery_config_headers()
         headers["Content-Type"] = "application/json"
-        payload = {
-            "scheduleType": schedule_type,
-            "forceScheduleOpted": True,
-        }
+        payload = self._battery_schedule_validation_payload(schedule_type)
         return await self._json("POST", url, json=payload, headers=headers)
 
     async def charger_auth_settings(self, sn: str) -> list[dict[str, Any]]:

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -3317,7 +3317,12 @@ class BatteryRuntime:
             schedule_id is not None or not enabled
         ):
             control_key = f"{normalized_schedule_type}Control"
-            payload = {control_key: {"enabled": bool(enabled)}}
+            control_payload: dict[str, object] = {"enabled": bool(enabled)}
+            if normalized_schedule_type == "dtg" and enabled:
+                control_payload["scheduleSupported"] = True
+                control_payload["startTime"] = current_start
+                control_payload["endTime"] = current_end
+            payload = {control_key: control_payload}
             async with state._battery_settings_write_lock:
                 state._battery_settings_last_write_mono = time.monotonic()
                 try:

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -16,6 +16,7 @@ _This reference consolidates observed Enlighten mobile/web APIs across EV chargi
 - **Evidence labels used below:**
   - `Implementation:` describes behavior verified in the current integration code.
   - `Observed:` describes behavior seen in browser/mobile captures.
+  - `External client source:` describes behavior inferred from another public custom integration source; useful for comparison, but weaker than a first-party browser/mobile capture.
   - `Inference:` describes reasoned interpretation that is plausible but not yet directly confirmed.
 
 ---
@@ -73,7 +74,7 @@ Example response:
 | --- | --- | --- | --- | --- |
 | Site discovery | `GET` | `/app-api/search_sites.json` | authenticated session cookies; implementation also sends `X-CSRF-Token` and, when available, `Authorization: Bearer <token>` + `e-auth-token: <token>` | Yes |
 | Entrez token bootstrap | `POST` | `https://entrez.enphaseenergy.com/tokens` | authenticated session cookies + JSON body `{session_id,email}` | Yes |
-| JWT token bootstrap (legacy / documented capture) | `GET` | `/app-api/jwt_token.json` | authenticated Enlighten session cookies | No |
+| JWT token bootstrap (legacy / documented capture) | `GET` | `/app-api/jwt_token.json` | authenticated Enlighten session cookies | No (current integration); Yes in external client source |
 | JWT token fallback (legacy / documented capture) | `GET` | `/service/auth_ms_enho/api/v1/session/token` | session cookies + `_enlighten_4_session` echoed as `e-auth-token` | No |
 | Mobile/web shared constants | `GET` | `https://enlighten-mobile-38d22.firebaseio.com/enho_constants.json` | none observed | No (documented from web UI) |
 | EV runtime status | `GET` | `/service/evse_controller/<site_id>/ev_chargers/status` | `e-auth-token` + cookies | Yes |
@@ -3887,6 +3888,19 @@ Observed shared requirements:
 - Browser-style `Origin`/`Referer` set to the battery profile UI host.
 - Write flows acquire a fresh `BP-XSRF-Token` first and then send `X-XSRF-Token`.
 
+External client source:
+- A working third-party custom integration uses a leaner BatteryConfig auth model:
+  - login via `GET /login` + `POST /login/login`
+  - JWT bootstrap via `GET /app-api/jwt_token.json`
+  - user/site discovery via `GET /app-api/<site_id>/data.json?app=1&device_status=non_retired&is_mobile=0`
+  - BatteryConfig requests authenticated with that JWT in `e-auth-token`, plus `username`, cookies, and `X-XSRF-Token`
+  - no explicit `Authorization` header documented
+  - no explicit `X-CSRF-Token` header documented
+- This is important for issue `#460`: users report that the third-party client can successfully change BatteryConfig settings on sites where the current integration still receives `403 Forbidden`.
+
+Inference:
+- The current implementation can send different token values in `Authorization` and `e-auth-token` (`Authorization` may come from the manager JWT cookie while `e-auth-token` comes from the Entrez access token). The external client source does not do this, so header/token divergence is now a plausible remaining compatibility variable.
+
 ### 5.0 AC Battery cloud UI routes
 
 Legacy AC Battery systems expose runtime discovery, telemetry, and sleep-mode control through the Enlighten web UI rather than the JSON BatteryConfig service.
@@ -4210,6 +4224,7 @@ Updates the system profile and reserve percentage. Observed profile keys include
 Implementation auth notes:
 - The current client first acquires a fresh `BP-XSRF-Token` by POSTing to `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid`.
 - It then sends the write with bearer-preferred BatteryConfig headers plus `X-XSRF-Token`.
+- The current implementation also appends `source=enho` to profile writes, even though the first-party write capture documented for this spec only confirmed `userId=<user_id>`.
 
 Example payloads observed:
 ```json
@@ -4431,7 +4446,8 @@ Notes:
 - Observed `chargeFromGrid` values so far: `true`, `false`.
 - The schedule checkbox ("Also up to 100% during this schedule") is represented by `chargeFromGridScheduleEnabled`; `chargeBeginTime`/`chargeEndTime` are minutes after midnight (local). Observed values so far: `chargeFromGridScheduleEnabled=true`, `chargeBeginTime=120`, `chargeEndTime=300`.
 - When the schedule is enabled, the status payload reports `chargeFromGridScheduleEnabled: true` and `cfgControl.forceScheduleOpted: true`.
-- Captured writes used `acceptedItcDisclaimer: true`, while subsequent reads returned a timestamp string; the backend normalizes the acknowledgement state internally.
+- First-party browser captures documented for this repository used `acceptedItcDisclaimer: true`, while subsequent reads returned a timestamp string; the backend normalizes the acknowledgement state internally.
+- External client source uses a current UTC timestamp string for `acceptedItcDisclaimer` when enabling CFG. The current integration follows this timestamp-style payload today.
 - `veryLowSoc` drives the "Battery shutdown level" slider, clamped between `veryLowSocMin` and `veryLowSocMax`. Observed values so far: `veryLowSoc=5` and `15`, `veryLowSocMin=5` and `10`, `veryLowSocMax=25`.
 - `dtgControl`, `cfgControl`, and `rbdControl` are per-feature UI capability blocks. In the homeowner capture they each exposed `show`, `enabled`, `locked`, and schedule-support fields even though the corresponding toggles were off. Observed booleans so far: `show=true`, `showDaySchedule=true`, `enabled=false`, `locked=false`, `scheduleSupported=true`, plus `cfgControl.forceScheduleSupported=true` and `cfgControl.forceScheduleOpted=true`.
 - Later captures showed `dtgControl.enabled=true` and `rbdControl.enabled=true` while `dtgControl.forceScheduleSupported` / `rbdControl.forceScheduleSupported` remained absent or `null`; schedule-family toggles should not assume CFG-style `forceScheduleSupported` metadata is present for DTG/RBD.
@@ -4446,6 +4462,10 @@ Notes:
   - `{"dtgControl":{"enabled":false}}`
   - `{"rbdControl":{"enabled":true}}`
   - `{"rbdControl":{"enabled":false}}`
+- External client source sends a richer DTG enable payload:
+  - `{"dtgControl":{"enabled":true,"scheduleSupported":true,"startTime":<minutes>,"endTime":<minutes>}}`
+  - `startTime` / `endTime` are minute-of-day integers derived from the current DTG control window
+- This is another concrete comparison point for issue `#460`: the current integration only sends the minimal `enabled` toggle for DTG/RBD BatterySettings writes.
 
 ### 5.6 Storm Guard Alert Status, Opt-Out, and Toggle
 ```
@@ -4701,6 +4721,8 @@ Observed behavior:
 - `forceScheduleOpted: true` was only observed for CFG validation; DTG/RBD validation calls omitted that field.
 - In the current client, this validation route also serves as the XSRF bootstrap mechanism for later BatteryConfig writes.
 - Unlike later writes, the validation request is sent without `X-XSRF-Token`; the token is learned from the response `Set-Cookie` / cookie jar update.
+- External client source matches the CFG-only `forceScheduleOpted` rule: it documents `forceScheduleOpted` only for CFG validation and omits it for DTG validation.
+- Compatibility note: the current integration should not treat `forceScheduleOpted` as a universal BatteryConfig validation field.
 
 ### 5.10 Update Battery Schedule (In-Place PUT)
 ```

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -591,6 +591,15 @@ def test_battery_config_auth_helpers_cover_token_and_cookie_fallback() -> None:
     assert headers["Cookie"] == "BP-XSRF-Token=dynamic-token"
 
 
+def test_authorization_bearer_token_helper() -> None:
+    assert api._authorization_bearer_token({}) is None
+    assert api._authorization_bearer_token({"Authorization": "Basic abc"}) is None
+    assert (
+        api._authorization_bearer_token({"Authorization": "Bearer secret-token"})
+        == "secret-token"
+    )
+
+
 def test_battery_config_headers_preserve_original_eauth_and_replace_stale_xsrf() -> (
     None
 ):
@@ -617,6 +626,85 @@ def test_battery_config_headers_preserve_original_eauth_and_replace_stale_xsrf()
     )
 
 
+def test_battery_config_header_debug_flags_cover_auth_modes() -> None:
+    client = _make_client()
+
+    assert client._battery_config_auth_source_label(None) == "none"  # noqa: SLF001
+    assert (
+        client._battery_config_auth_source_label("other") == "unknown"
+    )  # noqa: SLF001
+
+    client.update_credentials(
+        eauth="shared-token",
+        cookie="session=1; enlighten_manager_token_production=shared-token",
+    )
+    shared_flags = client._battery_config_header_debug_flags(  # noqa: SLF001
+        {
+            "Authorization": "Bearer shared-token",
+            "e-auth-token": "shared-token",
+        }
+    )
+    assert shared_flags["auth_mode"] == "dual_match"
+    assert shared_flags["auth_source"] == "shared"
+
+    client.update_credentials(
+        eauth="access-token",
+        cookie="session=1; enlighten_manager_token_production=manager-token",
+    )
+    mismatch_flags = client._battery_config_header_debug_flags(  # noqa: SLF001
+        {
+            "Authorization": "Bearer manager-token",
+            "e-auth-token": "access-token",
+        }
+    )
+    assert mismatch_flags["auth_mode"] == "dual_mismatch"
+    assert mismatch_flags["auth_source"] == "mixed"
+
+    client.update_credentials(eauth="access-only", cookie="session=1")
+    assert (
+        client._battery_config_auth_source_label("access-only") == "access_token"
+    )  # noqa: SLF001
+    access_only_flags = client._battery_config_header_debug_flags(  # noqa: SLF001
+        {"e-auth-token": "access-only"}
+    )
+    assert access_only_flags["auth_mode"] == "eauth_only"
+    assert access_only_flags["auth_source"] == "access_token"
+
+    client.update_credentials(
+        eauth="",
+        cookie="session=1; enlighten_manager_token_production=manager-token",
+    )
+    bearer_only_flags = client._battery_config_header_debug_flags(  # noqa: SLF001
+        {"Authorization": "Bearer manager-token"}
+    )
+    assert bearer_only_flags["auth_mode"] == "authorization_only"
+    assert bearer_only_flags["auth_source"] == "manager_cookie"
+
+
+def test_battery_config_single_auth_token_prefers_manager_cookie() -> None:
+    bearer = _make_token({"user_id": "77"})
+    client = _make_client()
+    client.update_credentials(
+        eauth="access-token",
+        cookie=f"session=1; enlighten_manager_token_production={bearer}",
+    )
+
+    assert client._battery_config_single_auth_token() == bearer  # noqa: SLF001
+
+
+def test_battery_config_user_id_for_token_prefers_override_then_context() -> None:
+    bearer = _make_token({"user_id": "77"})
+    override = _make_token({"user_id": "88"})
+    client = _make_client()
+    client.update_credentials(
+        eauth="access-token",
+        cookie=f"session=1; enlighten_manager_token_production={bearer}",
+    )
+
+    assert client._battery_config_user_id_for_token(override) == "88"  # noqa: SLF001
+    assert client._battery_config_user_id_for_token(None) == "77"  # noqa: SLF001
+
+
 def test_battery_config_headers_use_bearer_cookie_for_eauth_when_missing() -> None:
     bearer = _make_token({"user_id": "77"})
     client = _make_client()
@@ -631,6 +719,46 @@ def test_battery_config_headers_use_bearer_cookie_for_eauth_when_missing() -> No
     assert headers["e-auth-token"] == bearer
 
 
+def test_battery_config_headers_external_compatible_omit_authorization_and_x_csrf() -> (
+    None
+):
+    bearer = _make_token({"user_id": "77"})
+    client = _make_client()
+    client.update_credentials(
+        eauth="access-token",
+        cookie=(
+            "session=1; XSRF-TOKEN=raw-token; "
+            f"enlighten_manager_token_production={bearer}"
+        ),
+    )
+
+    headers = client._battery_config_headers(  # noqa: SLF001
+        include_xsrf=True,
+        auth_style="external_compatible",
+        token_override="legacy-token",
+    )
+
+    assert "Authorization" not in headers
+    assert headers["e-auth-token"] == "legacy-token"
+    assert headers["X-XSRF-Token"] == "raw-token"
+    assert "X-CSRF-Token" not in headers
+
+
+def test_battery_config_headers_external_compatible_drop_stale_eauth_when_missing() -> (
+    None
+):
+    client = _make_client()
+    client._eauth = None  # noqa: SLF001
+    client._cookie = ""  # noqa: SLF001
+    client._h["e-auth-token"] = "stale"
+
+    headers = client._battery_config_headers(  # noqa: SLF001
+        auth_style="external_compatible"
+    )
+
+    assert "e-auth-token" not in headers
+
+
 def test_battery_config_headers_drop_cookie_when_none_available() -> None:
     client = _make_client()
     client.update_credentials(cookie="session=1")
@@ -639,6 +767,43 @@ def test_battery_config_headers_drop_cookie_when_none_available() -> None:
     headers = client._battery_config_headers()  # noqa: SLF001
 
     assert "Cookie" not in headers
+
+
+def test_battery_config_retry_params_cover_profile_and_battery_settings() -> None:
+    token = _make_token({"user_id": "99"})
+    client = _make_client()
+    client.update_credentials(
+        eauth="access-token",
+        cookie="session=1; enlighten_manager_token_production=manager-token",
+    )
+
+    assert (
+        client._battery_config_retry_params(  # noqa: SLF001
+            "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
+            "userId=1&source=enho",
+        )
+        == "userId=1&source=enho"
+    )
+    assert client._battery_config_retry_params(  # noqa: SLF001
+        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/batterySettings/SITE",
+        {"userId": "1", "source": "enho"},
+        retry_token=token,
+    ) == {"userId": "99", "source": "enho"}
+    assert client._battery_config_retry_params(  # noqa: SLF001
+        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
+        {"userId": "1", "source": "enho"},
+        retry_token=token,
+    ) == {"userId": "99"}
+    assert client._battery_config_retry_params(  # noqa: SLF001
+        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
+        {"userId": "1"},
+        retry_token=token,
+    ) == {"userId": "99"}
+    assert client._battery_config_retry_params(  # noqa: SLF001
+        123,
+        {"userId": "1", "source": "enho"},
+        retry_token=token,
+    ) == {"userId": "99"}
 
 
 def test_system_dashboard_query_type_helper_branches() -> None:
@@ -1523,6 +1688,8 @@ async def test_json_logs_batteryconfig_write_failure_details(caplog) -> None:
     assert "'has_username': True" in caplog.text
     assert "'has_x_csrf_token': True" in caplog.text
     assert "'has_x_xsrf_token': True" in caplog.text
+    assert "'auth_mode': 'dual_mismatch'" in caplog.text
+    assert "'auth_source': 'mixed'" in caplog.text
     assert "'source': 'enho'" in caplog.text
     assert "'userId': '[redacted]'" in caplog.text
     assert "headers={'Accept': 'application/json, text/plain, */*'" in caplog.text
@@ -3396,6 +3563,131 @@ async def test_set_battery_settings_uses_requested_schedule_type_for_xsrf() -> N
 
 
 @pytest.mark.asyncio
+async def test_set_battery_settings_retries_with_external_compatible_auth_shape(
+    caplog,
+) -> None:
+    bearer = _make_token({"user_id": "88"})
+    legacy = _make_token({"user_id": "99"})
+    client = _make_client()
+    client.update_credentials(
+        eauth="access-token",
+        cookie=f"session=1; enlighten_manager_token_production={bearer}",
+    )
+
+    async def _acquire(schedule_type: str = "cfg") -> str:
+        client._bp_xsrf_token = f"{schedule_type}-token"  # noqa: SLF001
+        return client._bp_xsrf_token  # noqa: SLF001
+
+    client._acquire_xsrf_token = AsyncMock(side_effect=_acquire)  # noqa: SLF001
+    client._fetch_legacy_battery_config_jwt = AsyncMock(  # noqa: SLF001
+        return_value=legacy
+    )
+    client._json = AsyncMock(
+        side_effect=[_make_cre(403, "Forbidden"), {"message": "success"}]
+    )
+
+    with caplog.at_level(logging.DEBUG):
+        out = await client.set_battery_settings({"veryLowSoc": 15})
+
+    assert out == {"message": "success"}
+    first_call, second_call = client._json.await_args_list
+    assert first_call.kwargs["headers"]["Authorization"] == f"Bearer {bearer}"
+    assert first_call.kwargs["headers"]["e-auth-token"] == "access-token"
+    assert first_call.kwargs["headers"]["X-CSRF-Token"] == "cfg-token"
+    assert "Authorization" not in second_call.kwargs["headers"]
+    assert second_call.kwargs["headers"]["e-auth-token"] == legacy
+    assert second_call.kwargs["headers"]["Username"] == "99"
+    assert second_call.kwargs["headers"]["X-XSRF-Token"] == "cfg-token"
+    assert "X-CSRF-Token" not in second_call.kwargs["headers"]
+    assert second_call.kwargs["params"]["userId"] == "99"
+    assert "Retrying BatteryConfig write for PUT" in caplog.text
+    assert client._bp_xsrf_token is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_set_battery_profile_retry_drops_source_param() -> None:
+    token = _make_token({"user_id": "100"})
+    client = _make_client()
+    client.update_credentials(eauth=token, cookie="XSRF-TOKEN=xsrf-token; other=1")
+
+    async def _acquire(schedule_type: str = "cfg") -> str:
+        client._bp_xsrf_token = "xsrf-token"  # noqa: SLF001
+        return "xsrf-token"
+
+    client._acquire_xsrf_token = AsyncMock(side_effect=_acquire)  # noqa: SLF001
+    client._fetch_legacy_battery_config_jwt = AsyncMock(
+        return_value=None
+    )  # noqa: SLF001
+    client._json = AsyncMock(
+        side_effect=[_make_cre(403, "Forbidden"), {"message": "success"}]
+    )
+
+    out = await client.set_battery_profile(
+        profile="self-consumption",
+        battery_backup_percentage=10,
+    )
+
+    assert out == {"message": "success"}
+    first_call, second_call = client._json.await_args_list
+    assert first_call.kwargs["params"] == {"userId": "100", "source": "enho"}
+    assert second_call.kwargs["params"] == {"userId": "100"}
+
+
+@pytest.mark.asyncio
+async def test_battery_config_write_request_reraises_non_403_errors() -> None:
+    client = _make_client()
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
+    client._json = AsyncMock(side_effect=_make_cre(401, "Unauthorized"))
+    client._fetch_legacy_battery_config_jwt = AsyncMock(
+        return_value="legacy-token"
+    )  # noqa: SLF001
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client._battery_config_write_request(  # noqa: SLF001
+            "PUT",
+            "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/batterySettings/SITE",
+            json_body={"veryLowSoc": 15},
+            params={"userId": "88", "source": "enho"},
+        )
+
+    client._fetch_legacy_battery_config_jwt.assert_not_awaited()  # noqa: SLF001
+    assert client._bp_xsrf_token is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_battery_config_write_request_skips_identical_retry_shape(
+    monkeypatch,
+) -> None:
+    client = _make_client()
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
+    client._json = AsyncMock(side_effect=_make_cre(403, "Forbidden"))
+    client._fetch_legacy_battery_config_jwt = AsyncMock(
+        return_value=None
+    )  # noqa: SLF001
+    identical_headers = {"Accept": "application/json"}
+    monkeypatch.setattr(
+        client,
+        "_battery_config_headers",
+        lambda **_kwargs: dict(identical_headers),
+    )
+    monkeypatch.setattr(
+        client,
+        "_battery_config_retry_params",
+        lambda _url, params, **_kwargs: params,
+    )
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client._battery_config_write_request(  # noqa: SLF001
+            "PUT",
+            "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
+            json_body={"profile": "self-consumption"},
+            params={"userId": "88"},
+        )
+
+    assert client._json.await_count == 1
+
+
+@pytest.mark.asyncio
 async def test_acquire_xsrf_token_uses_requested_validation_payload() -> None:
     token = _make_token({"user_id": "88"})
     response = _FakeResponse(status=200, json_body={"isValid": True})
@@ -3417,12 +3709,25 @@ async def test_acquire_xsrf_token_uses_requested_validation_payload() -> None:
     assert url.endswith(
         "/service/batteryConfig/api/v1/battery/sites/SITE/schedules/isValid"
     )
-    assert kwargs["json"] == {
-        "scheduleType": "dtg",
-        "forceScheduleOpted": True,
-    }
+    assert kwargs["json"] == {"scheduleType": "dtg"}
     assert kwargs["headers"]["Cookie"] == "session=1; other=1"
     assert kwargs["headers"]["Username"] == "88"
+
+
+@pytest.mark.asyncio
+async def test_validate_battery_schedule_cfg_payload_keeps_force_schedule_opted() -> (
+    None
+):
+    client = _make_client()
+    client._json = AsyncMock(return_value={"isValid": True})
+
+    out = await client.validate_battery_schedule("CFG")
+
+    assert out == {"isValid": True}
+    assert client._json.await_args.kwargs["json"] == {
+        "scheduleType": "cfg",
+        "forceScheduleOpted": True,
+    }
 
 
 @pytest.mark.asyncio
@@ -3584,10 +3889,7 @@ async def test_battery_schedule_crud_methods_build_requests() -> None:
         "POST",
         "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/battery/sites/SITE/schedules/isValid",
     )
-    assert validate_call.kwargs["json"] == {
-        "scheduleType": "dtg",
-        "forceScheduleOpted": True,
-    }
+    assert validate_call.kwargs["json"] == {"scheduleType": "dtg"}
     assert client._acquire_xsrf_token.await_count == 2
 
 
@@ -3781,6 +4083,101 @@ async def test_set_battery_profile_payload_variants_and_xsrf() -> None:
         "operationModeSubType": "prioritize-energy",
         "devices": [{"uuid": "abc", "deviceType": "iqEvse", "enable": False}],
     }
+
+
+@pytest.mark.asyncio
+async def test_fetch_legacy_battery_config_jwt_success() -> None:
+    response = _FakeResponse(status=200, json_body={"token": "legacy-token"})
+    session = _FakeSession([response])
+    client = _make_client(session)
+    client.update_credentials(cookie="session=1; other=1")
+
+    out = await client._fetch_legacy_battery_config_jwt()  # noqa: SLF001
+
+    assert out == "legacy-token"
+    method, url, kwargs = session.calls[0]
+    assert method == "GET"
+    assert url.endswith("/app-api/jwt_token.json")
+    assert kwargs["headers"]["Cookie"] == "session=1; other=1"
+    assert "Authorization" not in kwargs["headers"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_legacy_battery_config_jwt_handles_http_error(caplog) -> None:
+    response = _FakeResponse(status=400, json_body={}, text_body="bad request")
+    session = _FakeSession([response])
+    client = _make_client(session)
+
+    with caplog.at_level(logging.DEBUG):
+        out = await client._fetch_legacy_battery_config_jwt()  # noqa: SLF001
+
+    assert out is None
+    assert "Legacy BatteryConfig JWT bootstrap failed (400)" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_fetch_legacy_battery_config_jwt_handles_invalid_json(caplog) -> None:
+    response = _FakeResponse(status=200, json_body=ValueError("bad json"))
+    session = _FakeSession([response])
+    client = _make_client(session)
+
+    with caplog.at_level(logging.DEBUG):
+        out = await client._fetch_legacy_battery_config_jwt()  # noqa: SLF001
+
+    assert out is None
+    assert "Legacy BatteryConfig JWT bootstrap returned invalid JSON" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_fetch_legacy_battery_config_jwt_handles_non_dict_payload() -> None:
+    response = _FakeResponse(status=200, json_body=["not", "a", "dict"])
+    session = _FakeSession([response])
+    client = _make_client(session)
+
+    assert await client._fetch_legacy_battery_config_jwt() is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_fetch_legacy_battery_config_jwt_handles_missing_token() -> None:
+    response = _FakeResponse(status=200, json_body={})
+    session = _FakeSession([response])
+    client = _make_client(session)
+
+    assert await client._fetch_legacy_battery_config_jwt() is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_fetch_legacy_battery_config_jwt_handles_client_error(caplog) -> None:
+    class _ClientErrorSession:
+        cookie_jar = SimpleNamespace(filter_cookies=lambda _url: {})
+
+        def request(self, *_args, **_kwargs):
+            raise aiohttp.ClientError("boom")
+
+    client = _make_client(_ClientErrorSession())
+
+    with caplog.at_level(logging.DEBUG):
+        out = await client._fetch_legacy_battery_config_jwt()  # noqa: SLF001
+
+    assert out is None
+    assert "Legacy BatteryConfig JWT bootstrap client error" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_fetch_legacy_battery_config_jwt_handles_timeout(caplog) -> None:
+    class _TimeoutSession:
+        cookie_jar = SimpleNamespace(filter_cookies=lambda _url: {})
+
+        def request(self, *_args, **_kwargs):
+            raise TimeoutError("too slow")
+
+    client = _make_client(_TimeoutSession())
+
+    with caplog.at_level(logging.DEBUG):
+        out = await client._fetch_legacy_battery_config_jwt()  # noqa: SLF001
+
+    assert out is None
+    assert "Legacy BatteryConfig JWT bootstrap timed out" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -2273,6 +2273,31 @@ async def test_dtg_schedule_enabled_uses_in_place_put(
 
 
 @pytest.mark.asyncio
+async def test_dtg_schedule_enabled_true_uses_richer_battery_settings_payload(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_schedule_family(coord, "dtg")
+    coord.client.set_battery_settings = AsyncMock(return_value={})
+
+    await coord.async_set_discharge_to_grid_schedule_enabled(True)
+
+    coord.client.update_battery_schedule.assert_not_awaited()
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "dtgControl": {
+                "enabled": True,
+                "scheduleSupported": True,
+                "startTime": 1080,
+                "endTime": 1380,
+            }
+        },
+        schedule_type="dtg",
+    )
+    assert coord._battery_dtg_schedule_enabled is True  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_dtg_schedule_time_update_omits_enabled_flag(
     coordinator_factory,
 ) -> None:


### PR DESCRIPTION
## Summary

Improve BatteryConfig write compatibility for issue #460 by making the XSRF bootstrap payload family-aware, retrying rejected BatteryConfig writes once with an external-client-style auth shape, and enriching DTG enable toggles to better match a working third-party client.

## Related Issues

- Related: #460

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_battery_runtime_settings.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_battery_runtime_settings.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_battery_runtime_settings.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/battery_runtime.py --fail-under=100"
python3 -m pre_commit run --all-files
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- This PR is driven by issue #460 and compares the project BatteryConfig flow against a reported working third-party client.
- The retry path now realigns `e-auth-token`, `Username`, and `userId` around a single retry token and prefers the legacy browser JWT source when available.
- `docs/api/api_spec.md` now stores the useful third-party observations relevant to this issue so the repo record stays aligned with the remaining failure analysis.
