### PR TITLE
Prepare release 2.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,42 @@ All notable changes to this project will be documented in this file.
 - Clarified the README affiliation and API disclaimer to better distinguish the project from Enphase's official materials and support channels.
 - Bumped the integration manifest version to `2.7.6`.
 
+## v2.7.7 - 2026-04-11
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Detect Enphase browser login-wall HTML responses on JSON/text API endpoints, surface a dedicated temporary-auth-block repair issue, and persist a 24-hour auth cooldown after a rejected stored-credential refresh so blocked sessions fail fast instead of repeatedly hammering the cloud API.
+- Improved BatteryConfig write compatibility for stubborn `403 Forbidden` sites by making schedule validation send `forceScheduleOpted` only for CFG, retrying rejected battery writes once with an external-client-style auth shape, and enriching DTG enable toggles to match the broader payload observed in a working third-party client.
+
+### 🔧 Improvements
+- Expanded `docs/api/api_spec.md` with the additional BatteryConfig observations from a working third-party integration so the repository now records the alternate JWT bootstrap, user/site discovery, CFG disclaimer, and DTG toggle request shapes relevant to issue `#460`.
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `2.7.7`.
+
+## v2.7.6 - 2026-04-10
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Fixed heat-pump daily energy semantics by sourcing the primary `heat_pump_daily_energy` sensor from `/pv/systems/<site>/today`, preserving HEMS split daily values independently for diagnostics, and keeping heat-pump entities available through short-lived inventory/runtime UID churn and stale-data windows.
+- Added the `X-CSRF-Token` header alongside the existing XSRF token handling for BatteryConfig write requests so battery profile, settings, storm-guard, and schedule updates continue working when Enphase requires both CSRF header variants.
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `2.7.6`.
+
 ## v2.7.5 - 2026-04-09
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.6"
+  "version": "2.7.7"
 }

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -318,7 +318,8 @@ async def test_coordinator_runtime_delegate_helpers_cover_direct_runtime_calls(
         "daily_energy_wh": 123.0
     }
     assert coord._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
-        {"a": 1}, {"stats": [{"heatpump": [1.0]}]}
+        {"a": 1},
+        {"stats": [{"heatpump": [123.0]}]},
     ) == {"daily_energy_wh": 123.0}
     assert coord._heatpump_power_candidate_device_uids() == [  # noqa: SLF001
         "HP-PRIMARY",


### PR DESCRIPTION
## Summary

Prepare release `2.7.7` by promoting the post-`v2.7.6` unreleased notes into a dated changelog section and bumping the integration manifest version.

This branch was rebased onto `main` before publishing so the PR contains only the release-preparation commit on top of the already-merged `#529` and `#530` work.

## Related Issues

- Includes the changes from `#529`
- Includes the changes from `#530`

## Type of change

- [x] Documentation
- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

No Docker validation commands were rerun in this turn. Publishing work was limited to:

```bash
git fetch origin --tags
git rebase origin/main
git push --force-with-lease=refs/heads/bugfix/batteryconfig-x-csrf-header:466114e636a4d78c4612d7af97535b4541f4a209 -u origin HEAD:bugfix/batteryconfig-x-csrf-header
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Release prep only: `CHANGELOG.md` and `custom_components/enphase_ev/manifest.json` were updated for `v2.7.7`.
- The branch was rebased because the original branch tip predated `v2.7.6` and duplicated an already-merged commit.
- `tests/components/enphase_ev/test_coordinator_remaining_coverage.py` changed only as part of stash conflict resolution while rebasing this branch; no functional test intent changed.