### PR TITLE
Fix BatteryConfig retry header suppression

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2291,7 +2291,10 @@ class EnphaseEVClient:
         return "unknown"
 
     def _battery_config_header_debug_flags(
-        self, headers: dict[str, str]
+        self,
+        headers: dict[str, str],
+        *,
+        auth_source_override: str | None = None,
     ) -> dict[str, object]:
         """Return safe debug flags describing BatteryConfig auth-header shape."""
 
@@ -2305,7 +2308,9 @@ class EnphaseEVClient:
         elif eauth:
             auth_mode = "eauth_only"
 
-        auth_source = self._battery_config_auth_source_label(bearer or eauth)
+        auth_source = auth_source_override or self._battery_config_auth_source_label(
+            bearer or eauth
+        )
         if auth_mode == "dual_mismatch":
             auth_source = "mixed"
 
@@ -2318,6 +2323,23 @@ class EnphaseEVClient:
             "auth_mode": auth_mode,
             "auth_source": auth_source,
         }
+
+    @staticmethod
+    def _merge_request_headers(
+        base_headers: dict[str, str],
+        extra_headers: dict[str, str | None] | None,
+    ) -> dict[str, str]:
+        """Merge request headers, treating ``None`` values as explicit removals."""
+
+        merged = dict(base_headers)
+        if not isinstance(extra_headers, dict):
+            return merged
+        for header_key, header_value in extra_headers.items():
+            if header_value is None:
+                merged.pop(header_key, None)
+            else:
+                merged[header_key] = header_value
+        return merged
 
     def _battery_config_auth_context(self) -> tuple[str | None, str | None]:
         """Return preferred BatteryConfig auth token and resolved user id.
@@ -2383,19 +2405,19 @@ class EnphaseEVClient:
         include_xsrf: bool = False,
         auth_style: str = "default",
         token_override: str | None = None,
-    ) -> dict[str, str]:
+    ) -> dict[str, str | None]:
         """Return headers for BatteryConfig read/write calls."""
 
-        headers = dict(self._h)
+        headers: dict[str, str | None] = dict(self._h)
         if auth_style == "external_compatible":
             token = token_override or self._battery_config_single_auth_token()
             user_id = self._battery_config_user_id_for_token(token)
-            headers.pop("Authorization", None)
-            headers.pop("X-CSRF-Token", None)
+            headers["Authorization"] = None
+            headers["X-CSRF-Token"] = None
             if token:
                 headers["e-auth-token"] = token
             else:
-                headers.pop("e-auth-token", None)
+                headers["e-auth-token"] = None
         else:
             token, user_id = self._battery_config_auth_context()
             if token:
@@ -2420,7 +2442,7 @@ class EnphaseEVClient:
                 if auth_style != "external_compatible":
                     headers["X-CSRF-Token"] = xsrf
                 else:
-                    headers.pop("X-CSRF-Token", None)
+                    headers["X-CSRF-Token"] = None
         return headers
 
     def _battery_schedule_validation_payload(
@@ -2608,6 +2630,11 @@ class EnphaseEVClient:
                     or retry_headers.get("e-auth-token")
                     or _authorization_bearer_token(retry_headers)
                 )
+                retry_auth_source = (
+                    "legacy_jwt_token"
+                    if legacy_token
+                    else self._battery_config_auth_source_label(retry_token)
+                )
                 retry_params = self._battery_config_retry_params(
                     url,
                     params,
@@ -2615,17 +2642,20 @@ class EnphaseEVClient:
                 )
                 if retry_headers == headers and retry_params == params:
                     raise
+                merged_retry_headers = self._merge_request_headers(
+                    self._h, retry_headers
+                )
+                retry_header_flags = self._battery_config_header_debug_flags(
+                    merged_retry_headers,
+                    auth_source_override=retry_auth_source,
+                )
                 _LOGGER.debug(
                     "Retrying BatteryConfig write for %s with external-compatible auth shape "
                     "(auth_source=%s, has_authorization=%s, has_x_csrf_token=%s, params_changed=%s)",
                     _request_label(method, url),
-                    (
-                        "legacy_jwt_token"
-                        if legacy_token
-                        else self._battery_config_auth_source_label(retry_token)
-                    ),
-                    "Authorization" in retry_headers,
-                    "X-CSRF-Token" in retry_headers,
+                    retry_header_flags["auth_source"],
+                    retry_header_flags["has_authorization"],
+                    retry_header_flags["has_x_csrf_token"],
                     retry_params != params,
                 )
                 return await self._json(
@@ -2634,6 +2664,7 @@ class EnphaseEVClient:
                     json=json_body,
                     headers=retry_headers,
                     params=retry_params,
+                    debug_auth_source=retry_auth_source,
                 )
         finally:
             self._bp_xsrf_token = None
@@ -3023,6 +3054,7 @@ class EnphaseEVClient:
         auth-sensitive headers after a successful reauthentication callback.
         """
         extra_headers = kwargs.pop("headers", None)
+        debug_auth_source = kwargs.pop("debug_auth_source", None)
         attempt = 0
         request_label = _request_label(method, url)
         endpoint = ""
@@ -3037,11 +3069,9 @@ class EnphaseEVClient:
             else:
                 attempt_headers = extra_headers
             if isinstance(attempt_headers, dict):
-                for header_key, header_value in attempt_headers.items():
-                    if header_value is None:
-                        base_headers.pop(header_key, None)
-                    else:
-                        base_headers[header_key] = header_value
+                base_headers = self._merge_request_headers(
+                    base_headers, attempt_headers
+                )
 
             async with _enlighten_read_request_guard(method, url):
                 async with asyncio.timeout(self._timeout):
@@ -3136,7 +3166,8 @@ class EnphaseEVClient:
                                         )
                                     }
                                 header_flags = self._battery_config_header_debug_flags(
-                                    base_headers
+                                    base_headers,
+                                    auth_source_override=debug_auth_source,
                                 )
                                 _LOGGER.debug(
                                     "%s failed for %s: status=%s params=%s payload=%s "

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -738,10 +738,10 @@ def test_battery_config_headers_external_compatible_omit_authorization_and_x_csr
         token_override="legacy-token",
     )
 
-    assert "Authorization" not in headers
+    assert headers["Authorization"] is None
     assert headers["e-auth-token"] == "legacy-token"
     assert headers["X-XSRF-Token"] == "raw-token"
-    assert "X-CSRF-Token" not in headers
+    assert headers["X-CSRF-Token"] is None
 
 
 def test_battery_config_headers_external_compatible_drop_stale_eauth_when_missing() -> (
@@ -756,7 +756,9 @@ def test_battery_config_headers_external_compatible_drop_stale_eauth_when_missin
         auth_style="external_compatible"
     )
 
-    assert "e-auth-token" not in headers
+    assert headers["Authorization"] is None
+    assert headers["e-auth-token"] is None
+    assert headers["X-CSRF-Token"] is None
 
 
 def test_battery_config_headers_drop_cookie_when_none_available() -> None:
@@ -804,6 +806,20 @@ def test_battery_config_retry_params_cover_profile_and_battery_settings() -> Non
         {"userId": "1", "source": "enho"},
         retry_token=token,
     ) == {"userId": "99"}
+
+
+def test_merge_request_headers_returns_base_for_non_dict_overrides() -> None:
+    client = _make_client()
+
+    assert client._merge_request_headers(
+        {"Accept": "application/json"}, None
+    ) == {  # noqa: SLF001
+        "Accept": "application/json"
+    }
+    assert client._merge_request_headers(  # noqa: SLF001
+        {"Accept": "application/json"},
+        "invalid",
+    ) == {"Accept": "application/json"}
 
 
 def test_system_dashboard_query_type_helper_branches() -> None:
@@ -3568,39 +3584,66 @@ async def test_set_battery_settings_retries_with_external_compatible_auth_shape(
 ) -> None:
     bearer = _make_token({"user_id": "88"})
     legacy = _make_token({"user_id": "99"})
-    client = _make_client()
+    validate = _FakeResponse(status=200, json_body={"isValid": True})
+    validate.headers = CIMultiDict(
+        [("Set-Cookie", "BP-XSRF-Token=cfg-token; Path=/; Secure")]
+    )
+    initial_write = _FakeResponse(
+        status=403,
+        json_body={},
+        text_body='{"timestamp":"2026-04-11T06:15:59.504+00:00","status":403}',
+    )
+    legacy_jwt = _FakeResponse(status=200, json_body={"token": legacy})
+    retry_write = _FakeResponse(
+        status=403,
+        json_body={},
+        text_body='{"timestamp":"2026-04-11T06:16:00.098+00:00","status":403}',
+    )
+    session = _FakeSession([validate, initial_write, legacy_jwt, retry_write])
+    client = _make_client(session)
     client.update_credentials(
-        eauth="access-token",
-        cookie=f"session=1; enlighten_manager_token_production={bearer}",
-    )
-
-    async def _acquire(schedule_type: str = "cfg") -> str:
-        client._bp_xsrf_token = f"{schedule_type}-token"  # noqa: SLF001
-        return client._bp_xsrf_token  # noqa: SLF001
-
-    client._acquire_xsrf_token = AsyncMock(side_effect=_acquire)  # noqa: SLF001
-    client._fetch_legacy_battery_config_jwt = AsyncMock(  # noqa: SLF001
-        return_value=legacy
-    )
-    client._json = AsyncMock(
-        side_effect=[_make_cre(403, "Forbidden"), {"message": "success"}]
+        eauth=bearer,
+        cookie=(
+            "session=1; XSRF-TOKEN=base-xsrf; "
+            f"enlighten_manager_token_production={bearer}"
+        ),
     )
 
     with caplog.at_level(logging.DEBUG):
-        out = await client.set_battery_settings({"veryLowSoc": 15})
+        with pytest.raises(aiohttp.ClientResponseError) as err:
+            await client.set_battery_settings({"veryLowSoc": 15})
 
-    assert out == {"message": "success"}
-    first_call, second_call = client._json.await_args_list
-    assert first_call.kwargs["headers"]["Authorization"] == f"Bearer {bearer}"
-    assert first_call.kwargs["headers"]["e-auth-token"] == "access-token"
-    assert first_call.kwargs["headers"]["X-CSRF-Token"] == "cfg-token"
-    assert "Authorization" not in second_call.kwargs["headers"]
-    assert second_call.kwargs["headers"]["e-auth-token"] == legacy
-    assert second_call.kwargs["headers"]["Username"] == "99"
-    assert second_call.kwargs["headers"]["X-XSRF-Token"] == "cfg-token"
-    assert "X-CSRF-Token" not in second_call.kwargs["headers"]
-    assert second_call.kwargs["params"]["userId"] == "99"
+    assert err.value.status == 403
+    assert len(session.calls) == 4
+    assert session.calls[0][0] == "POST"
+    assert session.calls[1][0] == "PUT"
+    assert session.calls[2][0] == "GET"
+    assert session.calls[3][0] == "PUT"
+
+    first_headers = session.calls[1][2]["headers"]
+    retry_headers = session.calls[3][2]["headers"]
+    assert first_headers["Authorization"] == f"Bearer {bearer}"
+    assert first_headers["e-auth-token"] == bearer
+    assert first_headers["X-CSRF-Token"] == "cfg-token"
+    assert first_headers["X-XSRF-Token"] == "cfg-token"
+
+    assert "Authorization" not in retry_headers
+    assert retry_headers["e-auth-token"] == legacy
+    assert retry_headers["Username"] == "99"
+    assert retry_headers["X-XSRF-Token"] == "cfg-token"
+    assert "X-CSRF-Token" not in retry_headers
+    assert retry_headers["Cookie"].endswith("BP-XSRF-Token=cfg-token")
+
+    assert session.calls[3][2]["params"]["userId"] == "99"
+    assert session.calls[3][2]["params"]["source"] == "enho"
     assert "Retrying BatteryConfig write for PUT" in caplog.text
+    assert "auth_source=legacy_jwt_token" in caplog.text
+    assert "has_authorization=False" in caplog.text
+    assert "has_x_csrf_token=False" in caplog.text
+    assert "'auth_source': 'legacy_jwt_token'" in caplog.text
+    assert "'has_x_csrf_token': False" in caplog.text
+    assert caplog.text.count("'Authorization': '[redacted]'") == 1
+    assert caplog.text.count("'X-CSRF-Token': '[redacted]'") == 1
     assert client._bp_xsrf_token is None  # noqa: SLF001
 
 


### PR DESCRIPTION
## Summary

Fix the external-compatible BatteryConfig retry path for issue #460 by making header suppression explicit in the merged request, so retry attempts actually omit `Authorization` and `X-CSRF-Token` instead of only dropping them from the pre-merge header dict.

## Related Issues

- Related: #460

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_api_client_methods.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/api.py --fail-under=100"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
python3 -m pre_commit run --all-files
```

Notes:
- `pre-commit` was run on the host checkout because the Docker container cannot resolve this Git worktree as a repository for `pre-commit`, even though the same files and branch were validated there for pytest/coverage.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The issue surfaced in `v2.7.7` logs where the retry debug line reported `has_x_csrf_token=False`, but the subsequent BatteryConfig failure log still showed `X-CSRF-Token` in the retried request headers.
- This PR makes the retry suppression use explicit `None` deletions through the shared `_json()` header merge path and adds an end-to-end regression test that inspects the actual merged retry request.
