### PR TITLE
Fix heat pump power from cumulative HEMS readings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug fixes
 - Detect Enphase browser login-wall HTML responses on JSON/text API endpoints, surface a dedicated temporary-auth-block repair issue, and persist a 24-hour auth cooldown after a rejected stored-credential refresh so blocked sessions fail fast instead of repeatedly hammering the cloud API.
 - Improved BatteryConfig write compatibility for stubborn `403 Forbidden` sites by making schedule validation send `forceScheduleOpted` only for CFG, retrying rejected battery writes once with an external-client-style auth shape, and enriching DTG enable toggles to match the broader payload observed in a working third-party client.
+- Fixed heat-pump power reporting for issue `#443` by deriving the `heat_pump_power` sensor from the change in cumulative HEMS heat-pump energy over the reported sample window instead of exposing the cumulative energy bucket itself as watts.
 
 ### 🔧 Improvements
 - Expanded `docs/api/api_spec.md` with the additional BatteryConfig observations from a working third-party integration so the repository now records the alternate JWT bootstrap, user/site discovery, CFG disclaimer, and DTG toggle request shapes relevant to issue `#460`.

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -48,6 +48,8 @@ if TYPE_CHECKING:  # pragma: no cover
 _LOGGER = logging.getLogger(__name__)
 
 _HEATPUMP_IDLE_POWER_MAX_W = 20.0
+_HEATPUMP_POWER_DEFAULT_WINDOW_S = 300.0
+_HEATPUMP_POWER_MIN_DELTA_WH = 0.5
 
 
 class HeatpumpRuntime:
@@ -933,26 +935,98 @@ class HeatpumpRuntime:
             return None
         if not self._heatpump_daily_split_available(snapshot):
             return None
-        details = snapshot.get("details")
-        detail_value = self._first_optional_numeric_value(details)
         device_uid = coerce_optional_text(snapshot.get("split_device_uid"))
+        day_key = coerce_optional_text(snapshot.get("day_key"))
         runtime_mode = self._heatpump_runtime_mode(runtime_snapshot)
-        is_running = runtime_mode == "RUNNING"
         is_idle = runtime_mode in {"IDLE", "OFF", "STOPPED", "STANDBY"}
-        accepted_value = detail_value
-        validation = "accepted"
+        current_energy_wh = coerce_optional_float(snapshot.get("split_daily_energy_wh"))
+        current_sample_utc = parse_inverter_last_report(
+            snapshot.get("split_endpoint_timestamp")
+        )
+        previous_snapshot = getattr(self, "_heatpump_daily_consumption_previous", None)
+        previous_energy_wh = (
+            coerce_optional_float(previous_snapshot.get("split_daily_energy_wh"))
+            if isinstance(previous_snapshot, dict)
+            else None
+        )
+        previous_device_uid = (
+            coerce_optional_text(previous_snapshot.get("split_device_uid"))
+            if isinstance(previous_snapshot, dict)
+            else None
+        )
+        previous_day_key = (
+            coerce_optional_text(previous_snapshot.get("day_key"))
+            if isinstance(previous_snapshot, dict)
+            else None
+        )
+        previous_sample_utc = (
+            parse_inverter_last_report(
+                previous_snapshot.get("split_endpoint_timestamp")
+            )
+            if isinstance(previous_snapshot, dict)
+            else None
+        )
+        accepted_value = None
         rejected = False
+        validation = "accepted_delta"
+        window_s = None
+        series_start_utc = None
 
-        if detail_value is None or detail_value <= 0:
-            if is_running:
-                rejected = True
-                validation = "rejected_running_zero_or_missing"
-            else:
+        if current_energy_wh is None or current_sample_utc is None:
+            if is_idle:
                 accepted_value = 0.0
-                validation = "accepted_zero"
-        elif is_idle and detail_value > _HEATPUMP_IDLE_POWER_MAX_W:
-            accepted_value = 0.0
-            validation = "coerced_idle_high_to_zero"
+                validation = "accepted_idle_without_delta"
+            else:
+                rejected = True
+                validation = "rejected_missing_energy_baseline"
+        elif (
+            previous_energy_wh is None
+            or previous_sample_utc is None
+            or previous_day_key != day_key
+            or previous_device_uid != device_uid
+        ):
+            if is_idle:
+                accepted_value = 0.0
+                validation = "accepted_idle_seeded"
+            else:
+                rejected = True
+                validation = "seeded_waiting_for_delta"
+        else:
+            window_s = (current_sample_utc - previous_sample_utc).total_seconds()
+            series_start_utc = previous_sample_utc
+            if window_s <= 0:
+                if is_idle:
+                    accepted_value = 0.0
+                    validation = "accepted_idle_repeated_sample"
+                else:
+                    rejected = True
+                    validation = "repeated_sample"
+            else:
+                delta_wh = current_energy_wh - previous_energy_wh
+                if delta_wh < 0:
+                    if is_idle:
+                        accepted_value = 0.0
+                        validation = "accepted_idle_reset"
+                    else:
+                        rejected = True
+                        validation = "rejected_energy_reset"
+                elif delta_wh <= _HEATPUMP_POWER_MIN_DELTA_WH:
+                    accepted_value = 0.0
+                    validation = (
+                        "accepted_idle_zero" if is_idle else "accepted_zero_delta"
+                    )
+                else:
+                    effective_window_s = (
+                        window_s if window_s > 0 else _HEATPUMP_POWER_DEFAULT_WINDOW_S
+                    )
+                    candidate_value = (delta_wh * 3600.0) / effective_window_s
+                    if is_idle and candidate_value > _HEATPUMP_IDLE_POWER_MAX_W:
+                        accepted_value = 0.0
+                        validation = "coerced_idle_high_to_zero"
+                    else:
+                        accepted_value = candidate_value
+                        if is_idle:
+                            validation = "accepted_idle_delta"
 
         summary: dict[str, object] = {
             "requested_device_ref": (
@@ -973,13 +1047,17 @@ class HeatpumpRuntime:
                 else None
             ),
             "recommended": self._heatpump_power_candidate_is_recommended(device_uid),
-            "detail_count": len(details) if isinstance(details, list) else 0,
+            "detail_count": 1 if current_energy_wh is not None else 0,
             "reported_detail_value": (
-                round(detail_value, 3) if detail_value is not None else None
+                round(current_energy_wh, 3) if current_energy_wh is not None else None
             ),
             "accepted_value_w": (
                 round(accepted_value, 3) if accepted_value is not None else None
             ),
+            "previous_detail_value": (
+                round(previous_energy_wh, 3) if previous_energy_wh is not None else None
+            ),
+            "window_seconds": round(window_s, 3) if window_s is not None else None,
             "daily_energy_wh": snapshot.get("daily_energy_wh"),
             "split_daily_energy_wh": snapshot.get("split_daily_energy_wh"),
             "daily_solar_wh": snapshot.get("daily_solar_wh"),
@@ -988,12 +1066,15 @@ class HeatpumpRuntime:
             "runtime_mode": runtime_mode,
             "validation": validation,
             "rejected": rejected,
+            "series_start_utc": (
+                series_start_utc.isoformat() if series_start_utc is not None else None
+            ),
             "endpoint_timestamp": snapshot.get("split_endpoint_timestamp"),
             "endpoint_type": snapshot.get("split_endpoint_type"),
             "source": (
-                f"hems_energy_consumption:{self._debug_truncate_identifier(device_uid)}"
+                f"hems_energy_consumption_delta:{self._debug_truncate_identifier(device_uid)}"
                 if device_uid
-                else "hems_energy_consumption"
+                else "hems_energy_consumption_delta"
             ),
         }
         return summary
@@ -1112,6 +1193,7 @@ class HeatpumpRuntime:
             )
             return
 
+        previous_snapshot = getattr(self, "_heatpump_daily_consumption", None)
         snapshot = self._build_heatpump_daily_consumption_snapshot(
             split_payload,
             site_today_payload,
@@ -1149,6 +1231,9 @@ class HeatpumpRuntime:
                     self._heatpump_daily_split_last_error = split_error
         snapshot["day_key"] = marker[0]
         snapshot["timezone"] = marker[1]
+        self._heatpump_daily_consumption_previous = (
+            dict(previous_snapshot) if isinstance(previous_snapshot, dict) else None
+        )
         self._heatpump_daily_consumption = snapshot
         self._heatpump_mark_known_present()
         self._heatpump_daily_consumption_last_error = None
@@ -1785,7 +1870,9 @@ class HeatpumpRuntime:
             return
 
         if bool(power_summary.get("rejected")):
-            error = str(power_summary.get("validation") or "rejected_bad_power_value")
+            error = daily_last_error or str(
+                power_summary.get("validation") or "rejected_bad_power_value"
+            )
             power_snapshot["last_error"] = error
             power_snapshot["outcome"] = "rejected_value"
             self._heatpump_mark_power_stale(
@@ -1819,12 +1906,14 @@ class HeatpumpRuntime:
         )
         self._heatpump_power_w = float(power_summary.get("accepted_value_w") or 0.0)
         self._heatpump_power_sample_utc = endpoint_timestamp
-        self._heatpump_power_start_utc = None
+        self._heatpump_power_start_utc = parse_inverter_last_report(
+            power_summary.get("series_start_utc")
+        )
         self._heatpump_power_device_uid = device_uid
         self._heatpump_power_source = (
-            str(snapshot.get("split_source")).strip()
-            if isinstance(snapshot, dict) and snapshot.get("split_source") is not None
-            else "hems_energy_consumption"
+            f"hems_energy_consumption_delta:{device_uid}"
+            if device_uid
+            else "hems_energy_consumption_delta"
         )
         self._heatpump_power_cache_until = getattr(
             self, "_heatpump_daily_consumption_cache_until", None
@@ -1844,9 +1933,9 @@ class HeatpumpRuntime:
         self._heatpump_power_selection_marker = marker if device_uid else None
         power_snapshot["selected_payload"] = dict(power_summary)
         power_snapshot["selected_source"] = (
-            f"hems_energy_consumption:{self._debug_truncate_identifier(device_uid)}"
+            f"hems_energy_consumption_delta:{self._debug_truncate_identifier(device_uid)}"
             if device_uid
-            else "hems_energy_consumption"
+            else "hems_energy_consumption_delta"
         )
         power_snapshot["selected_sample_at_utc"] = (
             endpoint_timestamp.isoformat() if endpoint_timestamp is not None else None

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -38,6 +38,68 @@ def _site_today_payload(
     return payload
 
 
+def _seed_previous_heatpump_daily_snapshot(
+    coord,
+    *,
+    energy_wh: float,
+    timestamp: str,
+    day_key: str,
+    timezone_name: str,
+    device_uid: str | None = "HP-1",
+    device_name: str = "Waermepumpe",
+) -> None:
+    coord._heatpump_daily_consumption = {  # noqa: SLF001
+        "split_device_uid": device_uid,
+        "split_device_name": device_name,
+        "member_name": device_name,
+        "member_device_type": "HEAT_PUMP",
+        "pairing_status": "PAIRED",
+        "device_state": None,
+        "daily_energy_wh": energy_wh,
+        "split_daily_energy_wh": energy_wh,
+        "daily_solar_wh": 0.0,
+        "daily_battery_wh": 0.0,
+        "daily_grid_wh": 0.0,
+        "details": [energy_wh],
+        "source": "site_today_heatpump",
+        "split_source": (
+            f"hems_energy_consumption:{device_uid}"
+            if device_uid is not None
+            else "hems_energy_consumption"
+        ),
+        "split_endpoint_type": "hems-device-details",
+        "split_endpoint_timestamp": timestamp,
+        "day_key": day_key,
+        "timezone": timezone_name,
+    }
+
+
+def _heatpump_daily_snapshot(
+    *,
+    energy_wh: float | None,
+    timestamp: str | None,
+    day_key: str = "2026-04-02",
+    timezone_name: str = "UTC",
+    device_uid: str | None = "HP-1",
+) -> dict[str, object]:
+    return {
+        "split_device_uid": device_uid,
+        "member_device_type": "HEAT_PUMP",
+        "pairing_status": "PAIRED",
+        "device_state": None,
+        "daily_energy_wh": energy_wh,
+        "split_daily_energy_wh": energy_wh,
+        "daily_solar_wh": 0.0,
+        "daily_battery_wh": 0.0,
+        "daily_grid_wh": 0.0,
+        "details": [energy_wh],
+        "split_endpoint_type": "hems-device-details",
+        "split_endpoint_timestamp": timestamp,
+        "day_key": day_key,
+        "timezone": timezone_name,
+    }
+
+
 @pytest.mark.asyncio
 async def test_heatpump_runtime_preflight_without_refresh_kw(
     coordinator_factory,
@@ -106,6 +168,76 @@ async def test_heatpump_runtime_public_async_wrappers(
     runtime._async_refresh_heatpump_power.assert_awaited_once_with(  # noqa: SLF001
         force=True
     )
+
+
+@pytest.mark.parametrize(
+    ("current_snapshot", "previous_snapshot", "expected_validation"),
+    [
+        (
+            _heatpump_daily_snapshot(energy_wh=None, timestamp=None),
+            None,
+            "accepted_idle_without_delta",
+        ),
+        (
+            _heatpump_daily_snapshot(
+                energy_wh=10.0,
+                timestamp="2026-04-02T00:05:00Z",
+            ),
+            None,
+            "accepted_idle_seeded",
+        ),
+        (
+            _heatpump_daily_snapshot(
+                energy_wh=10.0,
+                timestamp="2026-04-02T00:05:00Z",
+            ),
+            _heatpump_daily_snapshot(
+                energy_wh=9.0,
+                timestamp="2026-04-02T00:05:00Z",
+            ),
+            "accepted_idle_repeated_sample",
+        ),
+        (
+            _heatpump_daily_snapshot(
+                energy_wh=8.0,
+                timestamp="2026-04-02T00:10:00Z",
+            ),
+            _heatpump_daily_snapshot(
+                energy_wh=9.0,
+                timestamp="2026-04-02T00:05:00Z",
+            ),
+            "accepted_idle_reset",
+        ),
+        (
+            _heatpump_daily_snapshot(
+                energy_wh=9.2,
+                timestamp="2026-04-02T00:10:00Z",
+            ),
+            _heatpump_daily_snapshot(
+                energy_wh=9.0,
+                timestamp="2026-04-02T00:05:00Z",
+            ),
+            "accepted_idle_zero",
+        ),
+    ],
+)
+def test_heatpump_power_summary_covers_idle_delta_edge_paths(
+    coordinator_factory,
+    current_snapshot,
+    previous_snapshot,
+    expected_validation,
+):
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_daily_consumption_previous = previous_snapshot  # noqa: SLF001
+
+    summary = runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        current_snapshot,
+        runtime_snapshot={"heatpump_status": "IDLE"},
+    )
+
+    assert summary is not None
+    assert summary["accepted_value_w"] == pytest.approx(0.0)
+    assert summary["validation"] == expected_validation
 
 
 @pytest.mark.asyncio
@@ -241,6 +373,15 @@ async def test_heatpump_runtime_power_logs_fetch_plan_and_selection_summary(
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"device_uid": primary_uid, "heatpump_status": "RUNNING"}
     )
+    _seed_previous_heatpump_daily_snapshot(
+        coord,
+        device_uid=primary_uid,
+        energy_wh=504.1666666667,
+        timestamp="2026-03-13T00:00:00Z",
+        day_key="2026-03-13",
+        timezone_name="UTC",
+        device_name="Primary",
+    )
 
     with caplog.at_level(logging.DEBUG):
         await coord.heatpump_runtime._async_refresh_heatpump_power(  # noqa: SLF001
@@ -260,7 +401,9 @@ async def test_heatpump_runtime_power_logs_fetch_plan_and_selection_summary(
     assert power_snapshot["compare_all"] is False
     assert power_snapshot["previous_device_ref"] is None
     assert power_snapshot["outcome"] == "selected_sample"
-    assert power_snapshot["selected_source"] == "hems_energy_consumption:DEVI...6789"
+    assert (
+        power_snapshot["selected_source"] == "hems_energy_consumption_delta:DEVI...6789"
+    )
     assert power_snapshot["selected_payload"]["resolved_device_ref"] == "DEVI...6789"
     assert power_snapshot["selected_payload"]["accepted_value_w"] == pytest.approx(
         550.0
@@ -331,6 +474,15 @@ async def test_heatpump_runtime_power_snapshot_handles_selected_payload_without_
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"heatpump_status": "RUNNING"}
     )
+    _seed_previous_heatpump_daily_snapshot(
+        coord,
+        device_uid=None,
+        energy_wh=114.5833333333,
+        timestamp="2026-03-13T00:00:00Z",
+        day_key="2026-03-13",
+        timezone_name="UTC",
+        device_name="Heat Pump",
+    )
 
     await coord.heatpump_runtime._async_refresh_heatpump_power(
         force=True
@@ -338,11 +490,11 @@ async def test_heatpump_runtime_power_snapshot_handles_selected_payload_without_
 
     assert coord.heatpump_power_w == pytest.approx(125.0)
     assert coord.heatpump_power_device_uid is None
-    assert coord.heatpump_power_source == "hems_energy_consumption"
+    assert coord.heatpump_power_source == "hems_energy_consumption_delta"
     power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
         "power_snapshot"
     ]
-    assert power_snapshot["selected_source"] == "hems_energy_consumption"
+    assert power_snapshot["selected_source"] == "hems_energy_consumption_delta"
 
 
 @pytest.mark.asyncio
@@ -998,8 +1150,8 @@ async def test_heatpump_runtime_diagnostics_and_refresh_edge_branches(
         }
     )
     await runtime.async_refresh_heatpump_power(force=True)
-    assert coord.heatpump_power_w == pytest.approx(0.0)
-    assert coord.heatpump_power_last_error is None
+    assert coord.heatpump_power_w is None
+    assert coord.heatpump_power_last_error == "rejected_missing_energy_baseline"
     assert coord.heatpump_power_sample_utc is None
 
     class BadFloat:
@@ -1176,6 +1328,13 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"device_uid": "HP-1", "heatpump_status": "RUNNING"}
     )
+    _seed_previous_heatpump_daily_snapshot(
+        coord,
+        energy_wh=458.7916666667,
+        timestamp="2026-02-27T00:05:00Z",
+        day_key="2026-03-13",
+        timezone_name="UTC",
+    )
 
     await coord.heatpump_runtime._async_refresh_heatpump_power(
         force=True
@@ -1183,9 +1342,13 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
 
     assert coord.heatpump_power_w == pytest.approx(500.5)
     assert coord.heatpump_power_device_uid == "HP-1"
-    assert coord.heatpump_power_source == "hems_energy_consumption:HP-1"
-    assert coord.heatpump_power_start_utc is None
-    assert coord.heatpump_power_sample_utc is not None
+    assert coord.heatpump_power_source == "hems_energy_consumption_delta:HP-1"
+    assert coord.heatpump_power_start_utc == datetime(
+        2026, 2, 27, 0, 5, tzinfo=timezone.utc
+    )
+    assert coord.heatpump_power_sample_utc == datetime(
+        2026, 2, 27, 0, 10, tzinfo=timezone.utc
+    )
     assert coord.heatpump_power_last_error is None
     assert coord._heatpump_power_cache_until is not None  # noqa: SLF001
     assert (
@@ -1211,7 +1374,7 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
         force=True
     )  # noqa: SLF001
     assert coord.heatpump_power_w == pytest.approx(500.5)
-    assert coord.heatpump_power_source == "hems_energy_consumption:HP-1"
+    assert coord.heatpump_power_source == "hems_energy_consumption_delta:HP-1"
     assert coord.heatpump_power_using_stale is True
     assert (
         coord.heatpump_power_last_error
@@ -1267,6 +1430,13 @@ async def test_refresh_heatpump_power_validates_energy_consumption_payload(
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"device_uid": "HP-1", "heatpump_status": "IDLE"}
     )
+    _seed_previous_heatpump_daily_snapshot(
+        coord,
+        energy_wh=45.8333333333,
+        timestamp="2026-04-01T22:26:12.407610009Z",
+        day_key="2026-04-02",
+        timezone_name="Europe/Berlin",
+    )
 
     with caplog.at_level(logging.DEBUG):
         await coord.heatpump_runtime._async_refresh_heatpump_power(
@@ -1275,15 +1445,18 @@ async def test_refresh_heatpump_power_validates_energy_consumption_payload(
 
     assert coord.heatpump_power_w == pytest.approx(0.0)
     assert coord.heatpump_power_device_uid == "HP-1"
-    assert coord.heatpump_power_source == "hems_energy_consumption:HP-1"
+    assert coord.heatpump_power_source == "hems_energy_consumption_delta:HP-1"
     assert coord.heatpump_power_sample_utc == datetime(
         2026, 4, 1, 22, 31, 12, 407610, tzinfo=timezone.utc
+    )
+    assert coord.heatpump_power_start_utc == datetime(
+        2026, 4, 1, 22, 26, 12, 407610, tzinfo=timezone.utc
     )
     power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
         "power_snapshot"
     ]
     assert power_snapshot["outcome"] == "selected_sample"
-    assert power_snapshot["selected_source"] == "hems_energy_consumption:H...1"
+    assert power_snapshot["selected_source"] == "hems_energy_consumption_delta:H...1"
     assert power_snapshot["selected_payload"]["accepted_value_w"] == pytest.approx(0.0)
     assert (
         power_snapshot["selected_payload"]["validation"] == "coerced_idle_high_to_zero"
@@ -1339,6 +1512,13 @@ async def test_refresh_heatpump_power_preserves_small_idle_value(
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"device_uid": "HP-1", "heatpump_status": "IDLE"}
     )
+    _seed_previous_heatpump_daily_snapshot(
+        coord,
+        energy_wh=3.0,
+        timestamp="2026-04-01T22:16:12.407610009Z",
+        day_key="2026-04-02",
+        timezone_name="Europe/Berlin",
+    )
 
     await coord.heatpump_runtime._async_refresh_heatpump_power(
         force=True
@@ -1349,7 +1529,7 @@ async def test_refresh_heatpump_power_preserves_small_idle_value(
         "power_snapshot"
     ]
     assert power_snapshot["selected_payload"]["accepted_value_w"] == pytest.approx(4.0)
-    assert power_snapshot["selected_payload"]["validation"] == "accepted"
+    assert power_snapshot["selected_payload"]["validation"] == "accepted_idle_delta"
 
 
 @pytest.mark.asyncio
@@ -1474,7 +1654,7 @@ async def test_heatpump_power_preserves_stale_sample_on_no_usable_payload(
     )
     coord._heatpump_power_w = 520.0  # noqa: SLF001
     coord._heatpump_power_device_uid = "HP-1"  # noqa: SLF001
-    coord._heatpump_power_source = "hems_energy_consumption:HP-1"  # noqa: SLF001
+    coord._heatpump_power_source = "hems_energy_consumption_delta:HP-1"  # noqa: SLF001
     coord._heatpump_power_last_success_mono = time.monotonic() - 5  # noqa: SLF001
     coord._heatpump_power_last_success_utc = datetime(  # noqa: SLF001
         2026, 4, 5, 0, 0, tzinfo=timezone.utc
@@ -1499,7 +1679,7 @@ async def test_heatpump_power_preserves_stale_sample_on_no_usable_payload(
     )  # noqa: SLF001
 
     assert coord.heatpump_power_w == pytest.approx(520.0)
-    assert coord.heatpump_power_last_error == "rejected_running_zero_or_missing"
+    assert coord.heatpump_power_last_error == "seeded_waiting_for_delta"
     assert coord.heatpump_runtime.heatpump_power_using_stale is True
     power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
         "power_snapshot"
@@ -2409,6 +2589,15 @@ async def test_heatpump_runtime_power_and_diagnostics_paths(
     )
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"device_uid": "HP-CTRL", "heatpump_status": "RUNNING"}
+    )
+    _seed_previous_heatpump_daily_snapshot(
+        coord,
+        device_uid="HP-CTRL",
+        energy_wh=559.1666666667,
+        timestamp="2026-03-13T00:00:00Z",
+        day_key="2026-03-13",
+        timezone_name="UTC",
+        device_name="Primary",
     )
     await runtime._async_refresh_heatpump_power(force=True)  # noqa: SLF001
     assert coord.heatpump_power_w == pytest.approx(610.0)

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -1977,7 +1977,7 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
         2026, 2, 27, 0, 0, tzinfo=timezone.utc
     )  # noqa: SLF001
     coord._heatpump_power_device_uid = "HP-1"  # noqa: SLF001
-    coord._heatpump_power_source = "hems_energy_consumption:HP-1"  # noqa: SLF001
+    coord._heatpump_power_source = "hems_energy_consumption_delta:HP-1"  # noqa: SLF001
     coord._heatpump_power_last_error = None  # noqa: SLF001
     coord.heatpump_runtime._heatpump_power_last_success_utc = datetime(  # noqa: SLF001
         2026, 2, 27, 9, 16, tzinfo=timezone.utc
@@ -2064,7 +2064,7 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
     assert power_sensor.native_value == pytest.approx(863.2)
     power_attrs = power_sensor.extra_state_attributes
     assert power_attrs["device_uid"] == "HP-1"
-    assert power_attrs["source"] == "hems_energy_consumption:HP-1"
+    assert power_attrs["source"] == "hems_energy_consumption_delta:HP-1"
     assert "using_stale" in power_attrs
     assert "last_success_utc" in power_attrs
 


### PR DESCRIPTION
## Summary

Derive `heat_pump_power` from the change in cumulative HEMS heat-pump energy over the reported sample window instead of exposing the cumulative bucket value itself as watts. This fixes the regression reported in `#443`, where the heat-pump power sensor climbed like energy and no longer matched the expected 500-600 W operating range.

## Related Issues

Fixes #443

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py"
docker-compose -f devtools/docker/docker-compose.yml run -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git -v /Users/james/.codex/worktrees/fd23/ha-enphase-ev-charger:/Users/james/.codex/worktrees/fd23/ha-enphase-ev-charger --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/heatpump_runtime.py --fail-under=100"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The heat-pump power fix is intentionally an interval-average derivation based on cumulative HEMS split energy plus endpoint timestamps. It no longer treats the cumulative `details[0]` energy bucket as a watt value, which was the direct cause of the regression in issue #443.