### PR TITLE
Lean BatteryConfig retry request shape

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v2.7.9 - 2026-04-12
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Trimmed the external-compatible BatteryConfig retry headers for issue `#460` so the fallback write path now omits extra browser defaults like `Accept`, `User-Agent`, and `X-Requested-With` while keeping the XSRF-only cookie retry path intact.
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `2.7.9`.
+
 ## v2.7.8 - 2026-04-12
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2372,7 +2372,12 @@ class EnphaseEVClient:
         token, _user_id = self._battery_config_auth_context()
         return token
 
-    def _battery_config_cookie(self, *, include_xsrf: bool = False) -> str | None:
+    def _battery_config_cookie(
+        self,
+        *,
+        include_xsrf: bool = False,
+        auth_style: str = "default",
+    ) -> str | None:
         """Return a normalized BatteryConfig cookie header value.
 
         BatteryConfig write endpoints reject stale duplicate ``BP-XSRF-Token``
@@ -2393,6 +2398,10 @@ class EnphaseEVClient:
         ]
         if include_xsrf:
             xsrf = self._xsrf_token()
+            if auth_style == "external_compatible":
+                if not xsrf:
+                    return None
+                return f"BP-XSRF-Token={xsrf}"
             if xsrf:
                 parts.append(f"BP-XSRF-Token={xsrf}")
         if not parts:
@@ -2412,8 +2421,11 @@ class EnphaseEVClient:
         if auth_style == "external_compatible":
             token = token_override or self._battery_config_single_auth_token()
             user_id = self._battery_config_user_id_for_token(token)
+            headers["Accept"] = None
             headers["Authorization"] = None
+            headers["User-Agent"] = None
             headers["X-CSRF-Token"] = None
+            headers["X-Requested-With"] = None
             if token:
                 headers["e-auth-token"] = token
             else:
@@ -2430,7 +2442,10 @@ class EnphaseEVClient:
             headers["Username"] = user_id
         headers["Origin"] = "https://battery-profile-ui.enphaseenergy.com"
         headers["Referer"] = "https://battery-profile-ui.enphaseenergy.com/"
-        cookie = self._battery_config_cookie(include_xsrf=include_xsrf)
+        cookie = self._battery_config_cookie(
+            include_xsrf=include_xsrf,
+            auth_style=auth_style,
+        )
         if cookie:
             headers["Cookie"] = cookie
         else:
@@ -2665,6 +2680,7 @@ class EnphaseEVClient:
                     headers=retry_headers,
                     params=retry_params,
                     debug_auth_source=retry_auth_source,
+                    skip_auto_headers={"Accept", "User-Agent"},
                 )
         finally:
             self._bp_xsrf_token = None

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.8"
+  "version": "2.7.9"
 }

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -738,10 +738,14 @@ def test_battery_config_headers_external_compatible_omit_authorization_and_x_csr
         token_override="legacy-token",
     )
 
+    assert headers["Accept"] is None
     assert headers["Authorization"] is None
     assert headers["e-auth-token"] == "legacy-token"
+    assert headers["User-Agent"] is None
+    assert headers["X-Requested-With"] is None
     assert headers["X-XSRF-Token"] == "raw-token"
     assert headers["X-CSRF-Token"] is None
+    assert headers["Cookie"] == "BP-XSRF-Token=raw-token"
 
 
 def test_battery_config_headers_external_compatible_drop_stale_eauth_when_missing() -> (
@@ -756,9 +760,25 @@ def test_battery_config_headers_external_compatible_drop_stale_eauth_when_missin
         auth_style="external_compatible"
     )
 
+    assert headers["Accept"] is None
     assert headers["Authorization"] is None
     assert headers["e-auth-token"] is None
+    assert headers["User-Agent"] is None
+    assert headers["X-Requested-With"] is None
     assert headers["X-CSRF-Token"] is None
+
+
+def test_battery_config_cookie_external_compatible_requires_xsrf() -> None:
+    client = _make_client()
+    client.update_credentials(cookie="session=1; other=2")
+
+    assert (
+        client._battery_config_cookie(  # noqa: SLF001
+            include_xsrf=True,
+            auth_style="external_compatible",
+        )
+        is None
+    )
 
 
 def test_battery_config_headers_drop_cookie_when_none_available() -> None:


### PR DESCRIPTION
## Summary

Lean the external-compatible BatteryConfig retry request shape so the fallback write path matches the accepted cloud headers more closely for issue #460.

This update removes extra browser-default headers from the retry request, keeps the XSRF-only retry cookie, and bumps the integration to 2.7.9.

## Related Issues

- #460

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py tests/components/enphase_ev/test_api_client_methods.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/api.py --fail-under=100"
```

Additional manual verification:

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_api_client_methods.py"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Local manual verification against the saved dev-site Enphase session confirmed the current branch still succeeds on a live `batterySettings` write.
- The external-compatible retry now collapses to the lean header set accepted by the working cloud-control request shape: `Cookie` with only `BP-XSRF-Token`, `Origin`, `Referer`, `Username`, `e-auth-token`, and `X-XSRF-Token`.
