### PR TITLE
Restore browser headers for BatteryConfig retry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v2.7.10 - 2026-04-12
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Restored the standard Enlighten browser-style `Accept`, `User-Agent`, and `X-Requested-With` headers on the external-compatible BatteryConfig retry path for issue `#460` so the fallback write flow no longer trips Enphase `406 Not Acceptable` checks while still suppressing the rejected auth headers.
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `2.7.10`.
+
 ## v2.7.9 - 2026-04-12
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2421,11 +2421,8 @@ class EnphaseEVClient:
         if auth_style == "external_compatible":
             token = token_override or self._battery_config_single_auth_token()
             user_id = self._battery_config_user_id_for_token(token)
-            headers["Accept"] = None
             headers["Authorization"] = None
-            headers["User-Agent"] = None
             headers["X-CSRF-Token"] = None
-            headers["X-Requested-With"] = None
             if token:
                 headers["e-auth-token"] = token
             else:
@@ -2680,7 +2677,6 @@ class EnphaseEVClient:
                     headers=retry_headers,
                     params=retry_params,
                     debug_auth_source=retry_auth_source,
-                    skip_auto_headers={"Accept", "User-Agent"},
                 )
         finally:
             self._bp_xsrf_token = None

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.9"
+  "version": "2.7.10"
 }

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -738,11 +738,11 @@ def test_battery_config_headers_external_compatible_omit_authorization_and_x_csr
         token_override="legacy-token",
     )
 
-    assert headers["Accept"] is None
+    assert headers["Accept"] == "application/json, text/plain, */*"
     assert headers["Authorization"] is None
     assert headers["e-auth-token"] == "legacy-token"
-    assert headers["User-Agent"] is None
-    assert headers["X-Requested-With"] is None
+    assert headers["User-Agent"] == api._ENLIGHTEN_BROWSER_USER_AGENT
+    assert headers["X-Requested-With"] == "XMLHttpRequest"
     assert headers["X-XSRF-Token"] == "raw-token"
     assert headers["X-CSRF-Token"] is None
     assert headers["Cookie"] == "BP-XSRF-Token=raw-token"
@@ -760,11 +760,11 @@ def test_battery_config_headers_external_compatible_drop_stale_eauth_when_missin
         auth_style="external_compatible"
     )
 
-    assert headers["Accept"] is None
+    assert headers["Accept"] == "application/json, text/plain, */*"
     assert headers["Authorization"] is None
     assert headers["e-auth-token"] is None
-    assert headers["User-Agent"] is None
-    assert headers["X-Requested-With"] is None
+    assert headers["User-Agent"] == api._ENLIGHTEN_BROWSER_USER_AGENT
+    assert headers["X-Requested-With"] == "XMLHttpRequest"
     assert headers["X-CSRF-Token"] is None
 
 
@@ -3648,14 +3648,18 @@ async def test_set_battery_settings_retries_with_external_compatible_auth_shape(
     assert first_headers["X-XSRF-Token"] == "cfg-token"
 
     assert "Authorization" not in retry_headers
+    assert retry_headers["Accept"] == "application/json, text/plain, */*"
     assert retry_headers["e-auth-token"] == legacy
+    assert retry_headers["User-Agent"] == api._ENLIGHTEN_BROWSER_USER_AGENT
     assert retry_headers["Username"] == "99"
+    assert retry_headers["X-Requested-With"] == "XMLHttpRequest"
     assert retry_headers["X-XSRF-Token"] == "cfg-token"
     assert "X-CSRF-Token" not in retry_headers
     assert retry_headers["Cookie"].endswith("BP-XSRF-Token=cfg-token")
 
     assert session.calls[3][2]["params"]["userId"] == "99"
     assert session.calls[3][2]["params"]["source"] == "enho"
+    assert "skip_auto_headers" not in session.calls[3][2]
     assert "Retrying BatteryConfig write for PUT" in caplog.text
     assert "auth_source=legacy_jwt_token" in caplog.text
     assert "has_authorization=False" in caplog.text


### PR DESCRIPTION
## Summary

Restore the integration's standard browser-style BatteryConfig headers on the external-compatible retry path while still suppressing the auth headers Enphase rejects. Bump the release version to `2.7.10`.

This change follows the new `406 Not Acceptable` reports in issue #460, which show the fallback request is now getting past the earlier `403` mismatch and being blocked by missing browser-style request headers.

## Related Issues

- #460

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py tests/components/enphase_ev/test_api_client_methods.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/api.py --fail-under=100"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The new user-reported `406 Not Acceptable` response indicates the fallback request is now being processed by Enphase, but requires the same browser-style `Accept`, `User-Agent`, and `X-Requested-With` headers already used across the rest of the integration.
- The retry still suppresses `Authorization` and `X-CSRF-Token` and keeps the XSRF-only retry cookie.
