### PR TITLE
Decouple CFG toggle from schedule state

### DIFF
--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -1065,6 +1065,75 @@ class BatteryRuntime:
             end = 300
         return begin, end
 
+    def clear_cfg_settings_pending(self) -> None:
+        state = self.battery_state
+        state._battery_cfg_pending_charge_from_grid = None
+        state._battery_cfg_pending_schedule_enabled = None
+        state._battery_cfg_pending_begin_time = None
+        state._battery_cfg_pending_end_time = None
+        state._battery_cfg_pending_expires_mono = None
+
+    def set_cfg_settings_pending_from_payload(self, payload: dict[str, object]) -> None:
+        if not isinstance(payload, dict):
+            return
+        state = self.battery_state
+        pending = False
+        if "chargeFromGrid" in payload:
+            state._battery_cfg_pending_charge_from_grid = self._coerce_optional_bool(
+                payload.get("chargeFromGrid")
+            )
+            pending = True
+        if "chargeFromGridScheduleEnabled" in payload:
+            state._battery_cfg_pending_schedule_enabled = self._coerce_optional_bool(
+                payload.get("chargeFromGridScheduleEnabled")
+            )
+            pending = True
+        if "chargeBeginTime" in payload:
+            state._battery_cfg_pending_begin_time = self._normalize_minutes_of_day(
+                payload.get("chargeBeginTime")
+            )
+            pending = True
+        if "chargeEndTime" in payload:
+            state._battery_cfg_pending_end_time = self._normalize_minutes_of_day(
+                payload.get("chargeEndTime")
+            )
+            pending = True
+        if pending:
+            state._battery_cfg_pending_expires_mono = (
+                time.monotonic() + FAST_TOGGLE_POLL_HOLD_S
+            )
+        else:
+            self.clear_cfg_settings_pending()
+
+    def sync_cfg_settings_pending(self) -> None:
+        state = self.battery_state
+        expires_at = getattr(state, "_battery_cfg_pending_expires_mono", None)
+        if expires_at is None:
+            return
+        if time.monotonic() >= float(expires_at):
+            self.clear_cfg_settings_pending()
+            return
+
+        pending_pairs = (
+            ("_battery_cfg_pending_charge_from_grid", "_battery_charge_from_grid"),
+            (
+                "_battery_cfg_pending_schedule_enabled",
+                "_battery_charge_from_grid_schedule_enabled",
+            ),
+            ("_battery_cfg_pending_begin_time", "_battery_charge_begin_time"),
+            ("_battery_cfg_pending_end_time", "_battery_charge_end_time"),
+        )
+        all_match = True
+        for pending_attr, state_attr in pending_pairs:
+            pending_value = getattr(state, pending_attr, None)
+            if pending_value is None:
+                continue
+            if getattr(state, state_attr, None) != pending_value:
+                setattr(state, state_attr, pending_value)
+                all_match = False
+        if all_match:
+            self.clear_cfg_settings_pending()
+
     @staticmethod
     def _battery_schedule_label(schedule_type: str) -> str:
         labels = {
@@ -1302,6 +1371,7 @@ class BatteryRuntime:
             clear_missing_schedule_times=False,
             clear_missing_reserve_bounds=False,
         )
+        self.set_cfg_settings_pending_from_payload(payload)
         state._battery_settings_cache_until = None
         coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
         await coord.async_request_refresh()
@@ -2515,6 +2585,7 @@ class BatteryRuntime:
             payload,
             clear_missing_schedule_times=True,
         )
+        self.sync_cfg_settings_pending()
         state._battery_settings_cache_until = now + BATTERY_SETTINGS_CACHE_TTL
         coord._note_endpoint_family_success(family)
 
@@ -2974,15 +3045,10 @@ class BatteryRuntime:
         )
         if not coord.charge_from_grid_control_available:
             raise ServiceValidationError("Charge from grid setting is unavailable.")
-        payload: dict[str, object] = {"chargeFromGrid": bool(enabled)}
-        if enabled:
-            start, end = self.current_charge_from_grid_schedule_window()
-            payload["acceptedItcDisclaimer"] = self.battery_itc_disclaimer_value()
-            payload["chargeBeginTime"] = start
-            payload["chargeEndTime"] = end
-            payload["chargeFromGridScheduleEnabled"] = bool(
-                getattr(coord, "_battery_charge_from_grid_schedule_enabled", None)
-            )
+        payload: dict[str, object] = {
+            "chargeFromGrid": bool(enabled),
+            "acceptedItcDisclaimer": self.battery_itc_disclaimer_value(),
+        }
         await self.async_apply_battery_settings(payload)
 
     async def async_set_charge_from_grid_schedule_enabled(self, enabled: bool) -> None:

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -368,6 +368,11 @@ class BatteryState:
     _battery_settings_write_lock: Any = None
     _battery_settings_last_write_mono: float | None = None
     _battery_settings_cache_until: float | None = None
+    _battery_cfg_pending_charge_from_grid: bool | None = None
+    _battery_cfg_pending_schedule_enabled: bool | None = None
+    _battery_cfg_pending_begin_time: int | None = None
+    _battery_cfg_pending_end_time: int | None = None
+    _battery_cfg_pending_expires_mono: float | None = None
     _battery_grid_mode: str | None = None
     _battery_hide_charge_from_grid: bool | None = None
     _battery_envoy_supports_vls: bool | None = None

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -549,6 +549,39 @@ async def test_refresh_battery_settings_caches_and_redacts(coordinator_factory) 
 
 
 @pytest.mark.asyncio
+async def test_refresh_battery_settings_preserves_pending_cfg_values_when_backend_stale(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.battery_runtime
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_hide_charge_from_grid = False  # noqa: SLF001
+    coord._battery_charge_from_grid = False  # noqa: SLF001
+    coord._battery_charge_from_grid_schedule_enabled = False  # noqa: SLF001
+    coord._battery_charge_begin_time = None  # noqa: SLF001
+    coord._battery_charge_end_time = None  # noqa: SLF001
+
+    monotonic_now = 100.0
+    monkeypatch.setattr(time, "monotonic", lambda: monotonic_now)
+    runtime.set_cfg_settings_pending_from_payload({"chargeFromGrid": True})
+
+    coord.client.battery_settings_details = AsyncMock(
+        return_value={"data": {"chargeFromGrid": False}}
+    )
+
+    await runtime.async_refresh_battery_settings(force=True)
+
+    assert coord.battery_charge_from_grid_enabled is True
+    assert (
+        coord.battery_state._battery_cfg_pending_expires_mono == 160.0
+    )  # noqa: SLF001
+
+    monotonic_now = 200.0
+    runtime.sync_cfg_settings_pending()
+    assert coord.battery_state._battery_cfg_pending_expires_mono is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_refresh_battery_settings_bypasses_cache_when_profile_pending(
     coordinator_factory,
 ) -> None:
@@ -636,11 +669,91 @@ async def test_set_charge_from_grid_enable_autostamps_and_defaults(
     payload = args[0]
     assert payload["chargeFromGrid"] is True
     assert payload["acceptedItcDisclaimer"] == fixed_now.isoformat()
-    assert payload["chargeBeginTime"] == 120
-    assert payload["chargeEndTime"] == 300
-    assert payload["chargeFromGridScheduleEnabled"] is False
+    assert "chargeBeginTime" not in payload
+    assert "chargeEndTime" not in payload
+    assert "chargeFromGridScheduleEnabled" not in payload
     assert coord.battery_charge_from_grid_enabled is True
     coord.async_request_refresh.assert_awaited_once()
+
+
+def test_cfg_settings_pending_helpers_overlay_and_clear(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.battery_runtime
+
+    monkeypatch.setattr(time, "monotonic", lambda: 100.0)
+    runtime.set_cfg_settings_pending_from_payload(
+        {
+            "chargeFromGrid": True,
+            "chargeFromGridScheduleEnabled": False,
+            "chargeBeginTime": 120,
+            "chargeEndTime": 300,
+        }
+    )
+
+    coord._battery_charge_from_grid = False  # noqa: SLF001
+    coord._battery_charge_from_grid_schedule_enabled = True  # noqa: SLF001
+    coord._battery_charge_begin_time = None  # noqa: SLF001
+    coord._battery_charge_end_time = None  # noqa: SLF001
+
+    runtime.sync_cfg_settings_pending()
+
+    assert coord.battery_charge_from_grid_enabled is True
+    assert coord.battery_charge_from_grid_schedule_enabled is False
+    assert coord._battery_charge_begin_time == 120  # noqa: SLF001
+    assert coord._battery_charge_end_time == 300  # noqa: SLF001
+    assert (
+        coord.battery_state._battery_cfg_pending_expires_mono == 160.0
+    )  # noqa: SLF001
+
+    runtime.sync_cfg_settings_pending()
+
+    assert (
+        coord.battery_state._battery_cfg_pending_charge_from_grid is None
+    )  # noqa: SLF001
+    assert (
+        coord.battery_state._battery_cfg_pending_schedule_enabled is None
+    )  # noqa: SLF001
+    assert coord.battery_state._battery_cfg_pending_begin_time is None  # noqa: SLF001
+    assert coord.battery_state._battery_cfg_pending_end_time is None  # noqa: SLF001
+    assert coord.battery_state._battery_cfg_pending_expires_mono is None  # noqa: SLF001
+
+
+def test_cfg_settings_pending_helpers_clear_on_empty_payload_and_expiry(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.battery_runtime
+
+    monkeypatch.setattr(time, "monotonic", lambda: 50.0)
+    runtime.set_cfg_settings_pending_from_payload({"chargeFromGrid": True})
+    assert (
+        coord.battery_state._battery_cfg_pending_charge_from_grid is True
+    )  # noqa: SLF001
+
+    runtime.set_cfg_settings_pending_from_payload({})
+    assert (
+        coord.battery_state._battery_cfg_pending_charge_from_grid is None
+    )  # noqa: SLF001
+
+    runtime.set_cfg_settings_pending_from_payload({"chargeFromGrid": False})
+    monkeypatch.setattr(time, "monotonic", lambda: 200.0)
+    runtime.sync_cfg_settings_pending()
+    assert coord.battery_state._battery_cfg_pending_expires_mono is None  # noqa: SLF001
+
+
+def test_cfg_settings_pending_helpers_ignore_non_dict_payload(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.battery_runtime
+
+    runtime.set_cfg_settings_pending_from_payload(None)  # type: ignore[arg-type]
+
+    assert (
+        coord.battery_state._battery_cfg_pending_charge_from_grid is None
+    )  # noqa: SLF001
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix the CFG main toggle so it no longer implicitly mutates CFG schedule state, and preserve the just-written CFG values locally until Enphase catches up on the next battery settings refresh. Related to #460.

## Related Issues

- #460

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_runtime_settings.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/state_models.py --fail-under=100"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Local live validation against a real Enphase site in the dev runtime confirmed that turning the main Charge From Grid switch on/off no longer flips `chargeFromGridScheduleEnabled` on the cloud side, and that Home Assistant now keeps the main CFG entity in sync while backend battery settings lag briefly after the write.
