### PR TITLE
Align BatteryConfig with first-party web variants

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2317,6 +2317,7 @@ class EnphaseEVClient:
         return {
             "has_authorization": "Authorization" in headers,
             "has_e_auth_token": "e-auth-token" in headers,
+            "has_requestid": "requestid" in headers,
             "has_username": "Username" in headers,
             "has_x_csrf_token": "X-CSRF-Token" in headers,
             "has_x_xsrf_token": "X-XSRF-Token" in headers,
@@ -2366,95 +2367,40 @@ class EnphaseEVClient:
                 return token, user_id
         return fallback_token, None
 
-    def _battery_config_auth_token(self) -> str | None:
-        """Return bearer token to use for BatteryConfig requests."""
-
-        token, _user_id = self._battery_config_auth_context()
-        return token
-
-    def _battery_config_cookie(
-        self,
-        *,
-        include_xsrf: bool = False,
-        auth_style: str = "default",
-    ) -> str | None:
-        """Return a normalized BatteryConfig cookie header value.
-
-        BatteryConfig write endpoints reject stale duplicate ``BP-XSRF-Token``
-        cookies, so always strip any existing token from the base cookie string
-        before optionally appending the current one.
-        """
-
-        try:
-            cookie_str = str(self._cookie) if self._cookie else ""
-        except Exception:  # noqa: BLE001 - defensive parsing
-            cookie_str = ""
-
-        parts = [
-            part.strip()
-            for part in cookie_str.split(";")
-            if part.strip()
-            and part.strip().partition("=")[0].strip().lower() not in _XSRF_COOKIE_NAMES
-        ]
-        if include_xsrf:
-            xsrf = self._xsrf_token()
-            if auth_style == "external_compatible":
-                if not xsrf:
-                    return None
-                return f"BP-XSRF-Token={xsrf}"
-            if xsrf:
-                parts.append(f"BP-XSRF-Token={xsrf}")
-        if not parts:
-            return None
-        return "; ".join(parts)
-
     def _battery_config_headers(
         self,
         *,
         include_xsrf: bool = False,
-        auth_style: str = "default",
-        token_override: str | None = None,
+        include_eauth: bool = True,
+        include_requestid: bool = True,
     ) -> dict[str, str | None]:
         """Return headers for BatteryConfig read/write calls."""
 
-        headers: dict[str, str | None] = dict(self._h)
-        if auth_style == "external_compatible":
-            token = token_override or self._battery_config_single_auth_token()
-            user_id = self._battery_config_user_id_for_token(token)
-            headers["Authorization"] = None
-            headers["X-CSRF-Token"] = None
-            if token:
-                headers["e-auth-token"] = token
-            else:
-                headers["e-auth-token"] = None
-        else:
-            token, user_id = self._battery_config_auth_context()
-            if token:
-                headers["Authorization"] = f"Bearer {token}"
-            if self._eauth:
-                headers["e-auth-token"] = self._eauth
-            elif token:
-                headers["e-auth-token"] = token
+        headers: dict[str, str | None] = {
+            "Accept": "application/json, text/plain, */*",
+            "Origin": "https://battery-profile-ui.enphaseenergy.com",
+            "Referer": "https://battery-profile-ui.enphaseenergy.com/",
+            "User-Agent": (
+                "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/145.0.0.0 Safari/537.36"
+            ),
+            "Authorization": None,
+            "X-Requested-With": None,
+            "Cookie": None,
+            "e-auth-token": None,
+            "X-CSRF-Token": None,
+            "requestid": str(uuid.uuid4()) if include_requestid else None,
+        }
+        token, user_id = self._battery_config_auth_context()
+        if include_eauth and token:
+            headers["e-auth-token"] = token
         if user_id:
             headers["Username"] = user_id
-        headers["Origin"] = "https://battery-profile-ui.enphaseenergy.com"
-        headers["Referer"] = "https://battery-profile-ui.enphaseenergy.com/"
-        cookie = self._battery_config_cookie(
-            include_xsrf=include_xsrf,
-            auth_style=auth_style,
-        )
-        if cookie:
-            headers["Cookie"] = cookie
-        else:
-            headers.pop("Cookie", None)
         if include_xsrf:
             xsrf = self._xsrf_token()
             if xsrf:
                 headers["X-XSRF-Token"] = xsrf
-                if auth_style != "external_compatible":
-                    headers["X-CSRF-Token"] = xsrf
-                else:
-                    headers["X-CSRF-Token"] = None
         return headers
 
     def _battery_schedule_validation_payload(
@@ -2471,7 +2417,7 @@ class EnphaseEVClient:
     def _battery_config_params(
         self,
         *,
-        include_source: bool = False,
+        include_source: bool | str = False,
         locale: str | None = None,
     ) -> dict[str, str]:
         """Return query parameters for BatteryConfig calls."""
@@ -2481,7 +2427,9 @@ class EnphaseEVClient:
         if user_id:
             params["userId"] = user_id
         if include_source:
-            params["source"] = "enho"
+            params["source"] = (
+                str(include_source) if isinstance(include_source, str) else "enho"
+            )
         if locale:
             params["locale"] = locale
         return params
@@ -2515,92 +2463,6 @@ class EnphaseEVClient:
                 return token
         return None
 
-    async def _fetch_legacy_battery_config_jwt(self) -> str | None:
-        """Fetch the legacy cookie-backed JWT used by some BatteryConfig clients."""
-
-        url = f"{BASE_URL}/app-api/jwt_token.json"
-        headers = {
-            "Accept": "application/json, text/plain, */*",
-            "Referer": f"{BASE_URL}/",
-            "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
-        }
-        if self._cookie:
-            headers["Cookie"] = self._cookie
-
-        try:
-            _seed_cookie_jar(self._s, _cookie_map_from_header(self._cookie))
-            async with asyncio.timeout(self._timeout):
-                async with self._s.request("GET", url, headers=headers) as r:
-                    if r.status >= 400:
-                        message = (await r.text()).strip()
-                        _LOGGER.debug(
-                            "Legacy BatteryConfig JWT bootstrap failed (%s): %s",
-                            r.status,
-                            redact_text(
-                                message or r.reason,
-                                site_ids=(self._site,),
-                                max_length=256,
-                            ),
-                        )
-                        return None
-                    try:
-                        payload = await r.json()
-                    except Exception as err:  # noqa: BLE001
-                        _LOGGER.debug(
-                            "Legacy BatteryConfig JWT bootstrap returned invalid JSON: %s",
-                            redact_text(err, site_ids=(self._site,), max_length=256),
-                        )
-                        return None
-        except aiohttp.ClientError as err:
-            _LOGGER.debug(
-                "Legacy BatteryConfig JWT bootstrap client error: %s",
-                redact_text(err, site_ids=(self._site,), max_length=256),
-            )
-            return None
-        except TimeoutError as err:
-            _LOGGER.debug(
-                "Legacy BatteryConfig JWT bootstrap timed out: %s",
-                redact_text(err, site_ids=(self._site,), max_length=256),
-            )
-            return None
-
-        if not isinstance(payload, dict):
-            return None
-        token = payload.get("token") or payload.get("auth_token")
-        if not token:
-            return None
-        return str(token)
-
-    def _battery_config_retry_params(
-        self,
-        url: str,
-        params: dict[str, str] | None,
-        *,
-        retry_token: str | None = None,
-    ) -> dict[str, str] | None:
-        """Return adjusted params for an external-compatible BatteryConfig retry."""
-
-        if not isinstance(params, dict):
-            return params
-        try:
-            path = URL(url).path
-        except Exception:  # noqa: BLE001
-            path = str(url)
-        if "/service/batteryConfig/api/v1/batterySettings/" in path:
-            retry_params = dict(params)
-            retry_user_id = self._battery_config_user_id_for_token(retry_token)
-            if retry_user_id:
-                retry_params["userId"] = retry_user_id
-            return retry_params
-        retry_params = dict(params)
-        retry_user_id = self._battery_config_user_id_for_token(retry_token)
-        if retry_user_id:
-            retry_params["userId"] = retry_user_id
-        if "source" not in params:
-            return retry_params
-        retry_params.pop("source", None)
-        return retry_params
-
     async def _battery_config_write_request(
         self,
         method: str,
@@ -2610,78 +2472,69 @@ class EnphaseEVClient:
         params: dict[str, str] | None = None,
         schedule_type: str = "cfg",
     ) -> dict:
-        """Issue a BatteryConfig write with one external-compatible retry on 403."""
+        """Issue a BatteryConfig write with a narrow first-party fallback."""
 
         await self._acquire_xsrf_token(schedule_type)
 
         try:
-            headers = self._battery_config_headers(include_xsrf=True)
+            primary_headers = self._battery_config_headers(include_xsrf=True)
             if json_body is not None:
-                headers.setdefault("Content-Type", "application/json")
+                primary_headers.setdefault("Content-Type", "application/json")
             try:
                 return await self._json(
                     method,
                     url,
                     json=json_body,
-                    headers=headers,
+                    headers=primary_headers,
                     params=params,
                 )
             except aiohttp.ClientResponseError as err:
                 if err.status != 403:
                     raise
-                legacy_token = await self._fetch_legacy_battery_config_jwt()
-                retry_headers = self._battery_config_headers(
+                await self._acquire_xsrf_token(
+                    schedule_type,
+                    include_eauth=False,
+                    include_requestid=False,
+                )
+                fallback_headers = self._battery_config_headers(
                     include_xsrf=True,
-                    auth_style="external_compatible",
-                    token_override=legacy_token,
+                    include_eauth=False,
+                    include_requestid=False,
                 )
                 if json_body is not None:
-                    retry_headers.setdefault("Content-Type", "application/json")
-                retry_token = (
-                    legacy_token
-                    or retry_headers.get("e-auth-token")
-                    or _authorization_bearer_token(retry_headers)
+                    fallback_headers.setdefault("Content-Type", "application/json")
+                fallback_preview = self._merge_request_headers(
+                    self._h, fallback_headers
                 )
-                retry_auth_source = (
-                    "legacy_jwt_token"
-                    if legacy_token
-                    else self._battery_config_auth_source_label(retry_token)
-                )
-                retry_params = self._battery_config_retry_params(
-                    url,
-                    params,
-                    retry_token=retry_token,
-                )
-                if retry_headers == headers and retry_params == params:
-                    raise
-                merged_retry_headers = self._merge_request_headers(
-                    self._h, retry_headers
-                )
-                retry_header_flags = self._battery_config_header_debug_flags(
-                    merged_retry_headers,
-                    auth_source_override=retry_auth_source,
+                fallback_flags = self._battery_config_header_debug_flags(
+                    fallback_preview,
+                    auth_source_override="official_web_lean",
                 )
                 _LOGGER.debug(
-                    "Retrying BatteryConfig write for %s with external-compatible auth shape "
-                    "(auth_source=%s, has_authorization=%s, has_x_csrf_token=%s, params_changed=%s)",
+                    "Retrying BatteryConfig write for %s with lean official-web headers "
+                    "(has_e_auth_token=%s, has_requestid=%s)",
                     _request_label(method, url),
-                    retry_header_flags["auth_source"],
-                    retry_header_flags["has_authorization"],
-                    retry_header_flags["has_x_csrf_token"],
-                    retry_params != params,
+                    fallback_flags["has_e_auth_token"],
+                    "requestid" in fallback_preview,
                 )
                 return await self._json(
                     method,
                     url,
                     json=json_body,
-                    headers=retry_headers,
-                    params=retry_params,
-                    debug_auth_source=retry_auth_source,
+                    headers=fallback_headers,
+                    params=params,
+                    debug_auth_source="official_web_lean",
                 )
         finally:
             self._bp_xsrf_token = None
 
-    async def _acquire_xsrf_token(self, schedule_type: str = "cfg") -> str | None:
+    async def _acquire_xsrf_token(
+        self,
+        schedule_type: str = "cfg",
+        *,
+        include_eauth: bool = True,
+        include_requestid: bool = True,
+    ) -> str | None:
         """Acquire a BP-XSRF-Token by POSTing to the schedules isValid endpoint.
 
         The Enphase BatteryConfig API requires an XSRF token for write operations.
@@ -2693,22 +2546,13 @@ class EnphaseEVClient:
             f"{BASE_URL}/service/batteryConfig/api/v1/battery/sites/"
             f"{self._site}/schedules/isValid"
         )
-        token, user_id = self._battery_config_auth_context()
-        headers = {
-            "Accept": "application/json, text/plain, */*",
-            "Content-Type": "application/json",
-            "Origin": "https://battery-profile-ui.enphaseenergy.com",
-            "Referer": "https://battery-profile-ui.enphaseenergy.com/",
-        }
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-        if self._eauth:
-            headers["e-auth-token"] = self._eauth
-        if user_id:
-            headers["Username"] = user_id
-        cookie = self._battery_config_cookie()
-        if cookie:
-            headers["Cookie"] = cookie
+        headers = self._battery_config_headers(
+            include_xsrf=True,
+            include_eauth=include_eauth,
+            include_requestid=include_requestid,
+        )
+        headers["Content-Type"] = "application/json"
+        request_headers = self._merge_request_headers({}, headers)
         payload = self._battery_schedule_validation_payload(schedule_type)
 
         try:
@@ -2723,9 +2567,19 @@ class EnphaseEVClient:
 
             async with asyncio.timeout(self._timeout):
                 async with self._s.request(
-                    "POST", url, json=payload, headers=headers
+                    "POST", url, json=payload, headers=request_headers
                 ) as r:
-                    for value in r.headers.getall("Set-Cookie", []):
+                    header_values: list[str] = []
+                    getall = getattr(r.headers, "getall", None)
+                    if callable(getall):
+                        header_values = list(getall("Set-Cookie", []))
+                    else:
+                        header_value = getattr(
+                            r.headers, "get", lambda *_a, **_k: None
+                        )("Set-Cookie")
+                        if isinstance(header_value, str) and header_value:
+                            header_values = [header_value]
+                    for value in header_values:
                         match = re.search(
                             r"(?i)(?:^|;\s*)(?:bp-)?xsrf-token=([^;]+)", value
                         )
@@ -4007,7 +3861,7 @@ class EnphaseEVClient:
         """Return BatteryConfig battery details for charge-grid and shutdown controls."""
 
         url = f"{BASE_URL}/service/batteryConfig/api/v1/batterySettings/{self._site}"
-        params = self._battery_config_params(include_source=True)
+        params = self._battery_config_params(include_source="enlm")
         headers = self._battery_config_headers()
         return await self._json("GET", url, headers=headers, params=params)
 

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -6,7 +6,7 @@ _This reference consolidates observed Enlighten mobile/web APIs across EV chargi
 
 ## 1. Overview
 - **Base URL:** `https://enlighten.enphaseenergy.com`
-- **Auth:** The current implementation is cookie-first. Login establishes an Enlighten session cookie jar, then the client best-effort fetches an access token from Entrez and adds endpoint-specific headers on top. Many read endpoints work with cookies plus `e-auth-token`; scheduler, BatteryConfig, HEMS, and timeseries families prefer or require `Authorization: Bearer <jwt>`.
+- **Auth:** The current implementation is cookie-first. Login establishes an Enlighten session cookie jar, then the client best-effort fetches an access token from Entrez and adds endpoint-specific headers on top. Many read endpoints work with cookies plus `e-auth-token`; scheduler, HEMS, and timeseries families prefer or require `Authorization: Bearer <jwt>`. BatteryConfig is now the main exception: it follows the homeowner web app request shape instead of the bearer/e-auth/cookie overlay used elsewhere.
 - **Privacy:** Example identifiers, account details, LAN metadata, and credentials in this document use placeholders. Raw browser-export request headers often contain JWTs, cookies, email addresses, user IDs, LAN IPs, MAC addresses, and serial numbers; those values must be redacted before captures are shared or committed. When this spec lists "observed values", it intentionally preserves non-sensitive enum/flag values so newly seen behavior is not lost.
 - **Path Variables:**
   - `<site_id>` - numeric site identifier
@@ -131,15 +131,15 @@ Example response:
 | Stop charging | `PUT` | `/service/evse_controller/<site_id>/ev_chargers/<sn>/stop_charging` | `e-auth-token` + cookies | Yes |
 | EV charger config read/write | `POST/PUT` | `/service/evse_controller/api/v1/<site_id>/ev_chargers/<sn>/ev_charger_config` | `Authorization: Bearer <token>` overlay on top of session cookies / base EV headers | No (documented from web UI) |
 | Charge mode preference | `GET/PUT` | `/service/evse_scheduler/api/v1/iqevc/charging-mode/<site_id>/<sn>/preference` | bearer token + session headers | Yes |
-| BatteryConfig site settings | `GET` | `/service/batteryConfig/api/v1/siteSettings/<site_id>?userId=<user_id>` | bearer preferred + `e-auth-token` + normalized cookies; `Username` when user id can be decoded from JWT | Yes |
-| BatteryConfig MQTT authorizer bootstrap | `GET` | `/service/batteryConfig/api/v1/mqttSignedUrl/<site_id>` | bearer preferred + `e-auth-token` + normalized cookies; `Username` when available | No |
-| BatteryConfig third-party settings | `GET` | `/service/batteryConfig/api/v1/<site_id>/thirdPartyControlSettings` | bearer preferred + `e-auth-token` + normalized cookies; `Username` when available | No (documented from web UI) |
-| BatteryConfig schedules | `GET` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | bearer preferred + `e-auth-token` + normalized cookies; `Username` when available | No (documented from web UI) |
-| BatteryConfig schedule create | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | bearer preferred + `e-auth-token` + normalized cookies + `X-XSRF-Token`; `Username` when available | No |
-| BatteryConfig schedule validation | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid` | bearer preferred + `e-auth-token` + normalized cookies; `Username` when available | No (documented from web UI) |
-| BatteryConfig schedule update | `PUT` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>` | bearer preferred + `e-auth-token` + normalized cookies + `X-XSRF-Token`; `Username` when available | No (documented from web UI) |
-| BatteryConfig schedule legacy delete alias | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>/delete` | bearer preferred + `e-auth-token` + normalized cookies + `X-XSRF-Token`; `Username` when available | No |
-| BatteryConfig disclaimer accept | `POST` | `/service/batteryConfig/api/v1/batterySettings/acceptDisclaimer/<site_id>` | documented write pattern only: if implemented, use BatteryConfig write headers with fresh XSRF + bearer-preferred auth | No (not currently implemented) |
+| BatteryConfig site settings | `GET` | `/service/batteryConfig/api/v1/siteSettings/<site_id>?userId=<user_id>` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Chrome-style `User-Agent`, `Username`; suppress `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, `X-Requested-With` | Yes |
+| BatteryConfig MQTT authorizer bootstrap | `GET` | `/service/batteryConfig/api/v1/mqttSignedUrl/<site_id>` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Chrome-style `User-Agent`, `Username`; suppress `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, `X-Requested-With` | No |
+| BatteryConfig third-party settings | `GET` | `/service/batteryConfig/api/v1/<site_id>/thirdPartyControlSettings` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Chrome-style `User-Agent`, `Username`; suppress `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, `X-Requested-With` | No (documented from web UI) |
+| BatteryConfig schedules | `GET` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Chrome-style `User-Agent`, `Username`; suppress `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, `X-Requested-With` | No (documented from web UI) |
+| BatteryConfig schedule create | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | official-web BatteryConfig write shape plus `X-XSRF-Token`; suppress `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, `X-Requested-With` | No |
+| BatteryConfig schedule validation | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid` | official-web BatteryConfig write shape plus `X-XSRF-Token`; suppress `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, `X-Requested-With` | No (documented from web UI) |
+| BatteryConfig schedule update | `PUT` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>` | official-web BatteryConfig write shape plus `X-XSRF-Token`; suppress `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, `X-Requested-With` | No (documented from web UI) |
+| BatteryConfig schedule legacy delete alias | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>/delete` | official-web BatteryConfig write shape plus `X-XSRF-Token`; suppress `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, `X-Requested-With` | No |
+| BatteryConfig disclaimer accept | `POST` | `/service/batteryConfig/api/v1/batterySettings/acceptDisclaimer/<site_id>` | documented write pattern only: official-web BatteryConfig write shape plus `X-XSRF-Token`; suppress `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, `X-Requested-With` | No (not currently implemented) |
 | PES in-app banner/status | `GET` | `/service/pes_management/systems/<site_id>/inapp?type=<type>` | authenticated session cookies | No (documented from mobile/web HAR) |
 | Login | `POST` | `/login/login.json` | credentials; session/XSRF cookies are established by the response rather than pre-required | Yes |
 
@@ -3881,25 +3881,19 @@ Notes:
 The BatteryConfig service exposes system profile and EV charging mode endpoints.
 
 Observed shared requirements:
-- `Authorization: Bearer <jwt>` is preferred when a manager/access token is available.
-- `e-auth-token` is also sent; the implementation prefers the stored access token and otherwise falls back to the bearer token value.
-- Authenticated Enlighten cookies are still sent, but the client normalizes BatteryConfig cookies to avoid duplicate stale XSRF cookie values.
-- `Username: <user_id>` is sent when the JWT payload exposes a usable user id; it is not guaranteed for every token shape.
-- Browser-style `Origin`/`Referer` set to the battery profile UI host.
-- Write flows acquire a fresh `BP-XSRF-Token` first and then send `X-XSRF-Token`.
-
-External client source:
-- A working third-party custom integration uses a leaner BatteryConfig auth model:
-  - login via `GET /login` + `POST /login/login`
-  - JWT bootstrap via `GET /app-api/jwt_token.json`
-  - user/site discovery via `GET /app-api/<site_id>/data.json?app=1&device_status=non_retired&is_mobile=0`
-  - BatteryConfig requests authenticated with that JWT in `e-auth-token`, plus `username`, cookies, and `X-XSRF-Token`
-  - no explicit `Authorization` header documented
-  - no explicit `X-CSRF-Token` header documented
-- This is important for issue `#460`: users report that the third-party client can successfully change BatteryConfig settings on sites where the current integration still receives `403 Forbidden`.
-
-Inference:
-- The current implementation can send different token values in `Authorization` and `e-auth-token` (`Authorization` may come from the manager JWT cookie while `e-auth-token` comes from the Entrez access token). The external client source does not do this, so header/token divergence is now a plausible remaining compatibility variable.
+- Reads and writes follow the official homeowner web app request shape rather than the bearer/e-auth/cookie overlay used by other endpoint families.
+- Shared BatteryConfig baseline headers are:
+  - `Accept: application/json, text/plain, */*`
+  - `Origin: https://battery-profile-ui.enphaseenergy.com`
+  - `Referer: https://battery-profile-ui.enphaseenergy.com/`
+  - `User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36`
+  - `Username: <user_id>` when the active auth context exposes a usable user id
+- Observed successful first-party variants are:
+  - primary variant: baseline headers plus `e-auth-token` and `requestid`
+  - lean fallback variant: baseline headers without `e-auth-token` and `requestid`
+- The current implementation explicitly suppresses inherited `Authorization`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` on BatteryConfig requests so those headers do not leak in from the general Enlighten client state.
+- Write flows acquire a fresh `BP-XSRF-Token` first, then send `X-XSRF-Token` on both the `isValid` preflight and the follow-up write.
+- `GET /batterySettings/<site_id>` uses `source=enlm`; writes still use `source=enho`.
 
 ### 5.0 AC Battery cloud UI routes
 
@@ -4223,7 +4217,8 @@ Updates the system profile and reserve percentage. Observed profile keys include
 
 Implementation auth notes:
 - The current client first acquires a fresh `BP-XSRF-Token` by POSTing to `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid`.
-- It then sends the write with bearer-preferred BatteryConfig headers plus `X-XSRF-Token`.
+- It then sends the official-web BatteryConfig shape plus `X-XSRF-Token`: `Accept`, `Username`, battery-profile `Origin`/`Referer`, and a Chrome-style `User-Agent`.
+- The current implementation explicitly suppresses inherited `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` on this write path.
 - The current implementation also appends `source=enho` to profile writes, even though the first-party write capture documented for this spec only confirmed `userId=<user_id>`.
 
 Example payloads observed:
@@ -4313,7 +4308,8 @@ Body: {}
 Cancels a pending profile change. The request body is an empty JSON object.
 
 Implementation auth notes:
-- The current client treats this as another BatteryConfig write: acquire fresh XSRF first, then send bearer-preferred BatteryConfig headers plus `X-XSRF-Token`.
+- The current client treats this as another official-web-style BatteryConfig write: acquire fresh XSRF first, then send the BatteryConfig `Accept`/`Username`/`Origin`/`Referer`/Chrome-`User-Agent` shape plus `X-XSRF-Token`.
+- Inherited `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` are explicitly suppressed here as well.
 
 Example response:
 ```json
@@ -4322,7 +4318,7 @@ Example response:
 
 ### 5.5 Battery Settings (Battery Details)
 ```
-GET /service/batteryConfig/api/v1/batterySettings/<site_id>?source=enho&userId=<user_id>
+GET /service/batteryConfig/api/v1/batterySettings/<site_id>?source=enlm&userId=<user_id>
 ```
 Returns battery configuration details for the Battery page (battery mode, charge-from-grid settings, shutdown level).
 
@@ -4396,16 +4392,20 @@ Example response (anonymized):
 ```
 
 ```
-PUT /service/batteryConfig/api/v1/batterySettings/<site_id>?userId=<user_id>
+PUT /service/batteryConfig/api/v1/batterySettings/<site_id>?userId=<user_id>&source=enho
 Headers:
-  X-CSRF-Token: <token>
+  Username: <user_id>
   X-XSRF-Token: <token>
+  Origin: https://battery-profile-ui.enphaseenergy.com
+  Referer: https://battery-profile-ui.enphaseenergy.com/
+  User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36
 ```
 Updates battery settings. Captured requests used partial payloads to change individual controls.
 
 Implementation auth notes:
 - The current client first acquires a fresh `BP-XSRF-Token` via `/battery/sites/<site_id>/schedules/isValid`.
-- It then sends bearer-preferred BatteryConfig headers, normalized cookies, `X-CSRF-Token`, and `X-XSRF-Token`.
+- It then sends the official-web BatteryConfig shape: `Username`, `X-XSRF-Token`, browser `Origin`/`Referer`, and a Chrome-style `User-Agent`.
+- The current implementation explicitly suppresses inherited `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` for BatteryConfig reads and writes.
 
 Example payloads observed:
 ```json
@@ -4457,6 +4457,7 @@ Notes:
 - Two equivalent write variants were observed:
   - REST-only flows use `PUT /batterySettings/<site_id>?source=enho&userId=<user_id>`.
   - MQTT-backed RBD flows on `supportsMqtt=true` systems use `PUT /batterySettings/<site_id>?userId=<user_id>` after opening the MQTT response stream.
+- In the official homeowner web capture used to guide the current implementation, the successful `PUT /batterySettings/<site_id>?userId=<user_id>&source=enho` request did not include `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, or `X-Requested-With`.
 - Additional partial payloads were observed on the same endpoint for DTG/RBD enablement toggles:
   - `{"dtgControl":{"enabled":true}}`
   - `{"dtgControl":{"enabled":false}}`
@@ -4513,7 +4514,8 @@ Body: {
 Opts out of a specific active Storm Guard alert.
 
 Implementation auth notes:
-- The current client treats this as a BatteryConfig write: fresh XSRF acquisition first, then bearer-preferred headers plus `X-XSRF-Token`.
+- The current client treats this as an official-web-style BatteryConfig write: fresh XSRF acquisition first, then send the BatteryConfig `Accept`/`Username`/`Origin`/`Referer`/Chrome-`User-Agent` shape plus `X-XSRF-Token`.
+- Inherited `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` are explicitly suppressed on this path.
 
 Example response:
 ```json
@@ -4655,7 +4657,8 @@ Body: {
 Creates a new battery schedule entry. The same endpoint is used for CFG, DTG, and RBD schedule creation and schedule restore flows.
 
 Implementation auth notes:
-- The current client acquires fresh XSRF first, then sends bearer-preferred BatteryConfig headers plus `X-XSRF-Token`.
+- The current client acquires fresh XSRF first, then sends the official-web BatteryConfig shape plus `X-XSRF-Token`.
+- Inherited `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` are explicitly suppressed on this path.
 
 Observed behavior:
 - `scheduleType` is sent uppercase (`CFG`, `DTG`, `RBD`).
@@ -4720,7 +4723,7 @@ Observed behavior:
 - The request used lowercase schedule-family values (`cfg`, `dtg`, `rbd`) even though stored schedule objects used uppercase `scheduleType` values.
 - `forceScheduleOpted: true` was only observed for CFG validation; DTG/RBD validation calls omitted that field.
 - In the current client, this validation route also serves as the XSRF bootstrap mechanism for later BatteryConfig writes.
-- Unlike later writes, the validation request is sent without `X-XSRF-Token`; the token is learned from the response `Set-Cookie` / cookie jar update.
+- The official homeowner web capture sent `X-XSRF-Token` on the validation request as well; the current implementation mirrors that behavior while still learning fresh `BP-XSRF-Token` from `Set-Cookie` / the updated cookie jar.
 - External client source matches the CFG-only `forceScheduleOpted` rule: it documents `forceScheduleOpted` only for CFG validation and omits it for DTG validation.
 - Compatibility note: the current integration should not treat `forceScheduleOpted` as a universal BatteryConfig validation field.
 
@@ -4739,16 +4742,16 @@ Body: {
 Updates an existing battery schedule in place.  This is the endpoint used by
 the Enlighten battery profile UI when the user modifies a CFG schedule.
 
-**Headers** (same as other batteryConfig calls):
-- `Authorization: Bearer <jwt>` preferred
-- `e-auth-token`: stored access token when present, otherwise bearer token
-- `Username`: Enphase user ID when decodable from JWT
-- normalized BatteryConfig `Cookie` header, optionally including `BP-XSRF-Token`
-- `X-CSRF-Token`: freshly acquired XSRF token echoed in request header
+**Headers** (same as other BatteryConfig calls in the current implementation):
+- `Username`: Enphase user ID when decodable from the active auth context
 - `X-XSRF-Token`: freshly acquired XSRF token echoed in request header
+- `Origin: https://battery-profile-ui.enphaseenergy.com`
+- `Referer: https://battery-profile-ui.enphaseenergy.com/`
+- Chrome-style `User-Agent`
 
 Implementation auth notes:
 - The current client acquires fresh XSRF via `/schedules/isValid` immediately before issuing this `PUT`.
+- The current client explicitly suppresses `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` on this BatteryConfig schedule write path to align with the official homeowner web capture.
 
 Example response (anonymized):
 ```json
@@ -4995,8 +4998,8 @@ There is no single universal header set; the implementation varies headers by en
 | Session history + EVSE timeseries | `Authorization: Bearer <jwt>`; `e-auth-token` set to JWT `session_id`; `username` set to JWT `user_id`; `requestid` UUID |
 | System dashboard reads | authenticated cookies; may also include bearer auth opportunistically |
 | HEMS | bearer-preferred auth plus cookies/base headers; `username` and `requestId` when available |
-| BatteryConfig reads | bearer-preferred auth, `e-auth-token`, normalized cookies, `Username` when decodable, battery-profile `Origin`/`Referer` |
-| BatteryConfig writes | acquire fresh XSRF via `/battery/sites/<site_id>/schedules/isValid`, then send bearer-preferred BatteryConfig headers plus `X-CSRF-Token` and `X-XSRF-Token` |
+| BatteryConfig reads | official-web BatteryConfig shape: `Username`, battery-profile `Origin`/`Referer`, Chrome-style `User-Agent`; suppress `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` |
+| BatteryConfig writes | acquire fresh XSRF via `/battery/sites/<site_id>/schedules/isValid`, then send official-web BatteryConfig headers plus `X-XSRF-Token`; suppress `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` |
 
 - Base Enlighten reads:
   - `Cookie: <serialized cookie jar>`
@@ -5015,12 +5018,12 @@ There is no single universal header set; the implementation varies headers by en
   - `username: <jwt user_id claim>` when present
   - `requestid: <uuid>`
 - BatteryConfig:
-  - `Authorization: Bearer <jwt>` preferred
-  - `e-auth-token`
-  - normalized `Cookie`
-  - `Username: <user_id>` when decodable from JWT
+  - `Accept: application/json, text/plain, */*`
+  - `Username: <user_id>` when decodable from the active auth context
   - `Origin` / `Referer` for the battery-profile UI
-  - `X-XSRF-Token` for writes after token acquisition
+  - Chrome-style `User-Agent`
+  - `X-XSRF-Token` for `isValid` preflight and writes after token acquisition
+  - inherited `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` are explicitly suppressed
 
 ---
 

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -563,9 +563,6 @@ def test_xsrf_helpers_accept_lower_case_cookie_names() -> None:
     client.update_credentials(cookie="bp-xsrf-token=bp%3Dtoken; other=1")
 
     assert client._xsrf_token() == "bp=token"
-    assert client._battery_config_cookie(include_xsrf=True) == (
-        "other=1; BP-XSRF-Token=bp=token"
-    )
 
 
 def test_system_dashboard_should_fallback_rejects_unexpected_errors() -> None:
@@ -582,13 +579,16 @@ def test_battery_config_auth_helpers_cover_token_and_cookie_fallback() -> None:
     client._bp_xsrf_token = "dynamic-token"  # noqa: SLF001
 
     headers = client._battery_config_headers(include_xsrf=True)  # noqa: SLF001
+    auth_token, user_id = client._battery_config_auth_context()  # noqa: SLF001
 
-    assert client._battery_config_auth_token() == token  # noqa: SLF001
+    assert auth_token == token
+    assert user_id == "77"
     assert client._xsrf_token() == "dynamic-token"  # noqa: SLF001
     assert headers["e-auth-token"] == token
-    assert headers["X-CSRF-Token"] == "dynamic-token"
+    assert headers["X-CSRF-Token"] is None
     assert headers["X-XSRF-Token"] == "dynamic-token"
-    assert headers["Cookie"] == "BP-XSRF-Token=dynamic-token"
+    assert headers["Cookie"] is None
+    assert "requestid" in headers
 
 
 def test_authorization_bearer_token_helper() -> None:
@@ -616,14 +616,12 @@ def test_battery_config_headers_preserve_original_eauth_and_replace_stale_xsrf()
 
     headers = client._battery_config_headers(include_xsrf=True)  # noqa: SLF001
 
-    assert headers["Authorization"] == f"Bearer {bearer}"
-    assert headers["e-auth-token"] == "session-token"
-    assert headers["X-CSRF-Token"] == "fresh-token"
+    assert headers["Authorization"] is None
+    assert headers["e-auth-token"] == bearer
+    assert headers["X-CSRF-Token"] is None
     assert headers["X-XSRF-Token"] == "fresh-token"
-    assert headers["Cookie"] == (
-        "session=1; other=1; "
-        f"enlighten_manager_token_production={bearer}; BP-XSRF-Token=fresh-token"
-    )
+    assert headers["Cookie"] is None
+    assert headers["Username"] == "77"
 
 
 def test_battery_config_header_debug_flags_cover_auth_modes() -> None:
@@ -715,13 +713,13 @@ def test_battery_config_headers_use_bearer_cookie_for_eauth_when_missing() -> No
 
     headers = client._battery_config_headers()  # noqa: SLF001
 
-    assert headers["Authorization"] == f"Bearer {bearer}"
+    assert headers["Authorization"] is None
     assert headers["e-auth-token"] == bearer
+    assert headers["X-CSRF-Token"] is None
+    assert headers["Username"] == "77"
 
 
-def test_battery_config_headers_external_compatible_omit_authorization_and_x_csrf() -> (
-    None
-):
+def test_battery_config_headers_match_official_web_shape() -> None:
     bearer = _make_token({"user_id": "77"})
     client = _make_client()
     client.update_credentials(
@@ -732,53 +730,48 @@ def test_battery_config_headers_external_compatible_omit_authorization_and_x_csr
         ),
     )
 
-    headers = client._battery_config_headers(  # noqa: SLF001
-        include_xsrf=True,
-        auth_style="external_compatible",
-        token_override="legacy-token",
-    )
+    headers = client._battery_config_headers(include_xsrf=True)  # noqa: SLF001
 
     assert headers["Accept"] == "application/json, text/plain, */*"
-    assert headers["Authorization"] is None
-    assert headers["e-auth-token"] == "legacy-token"
-    assert headers["User-Agent"] == api._ENLIGHTEN_BROWSER_USER_AGENT
-    assert headers["X-Requested-With"] == "XMLHttpRequest"
+    assert headers["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
+    assert headers["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
+    assert (
+        headers["User-Agent"] == "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) "
+        "Chrome/145.0.0.0 Safari/537.36"
+    )
+    assert headers["X-Requested-With"] is None
     assert headers["X-XSRF-Token"] == "raw-token"
+    assert headers["Authorization"] is None
+    assert headers["e-auth-token"] == bearer
     assert headers["X-CSRF-Token"] is None
-    assert headers["Cookie"] == "BP-XSRF-Token=raw-token"
+    assert headers["Cookie"] is None
+    assert headers["Username"] == "77"
+    assert "requestid" in headers
 
 
-def test_battery_config_headers_external_compatible_drop_stale_eauth_when_missing() -> (
-    None
-):
+def test_battery_config_headers_can_build_lean_fallback_shape() -> None:
+    bearer = _make_token({"user_id": "77"})
     client = _make_client()
-    client._eauth = None  # noqa: SLF001
-    client._cookie = ""  # noqa: SLF001
-    client._h["e-auth-token"] = "stale"
-
-    headers = client._battery_config_headers(  # noqa: SLF001
-        auth_style="external_compatible"
+    client.update_credentials(
+        eauth="access-token",
+        cookie=(
+            "session=1; XSRF-TOKEN=raw-token; "
+            f"enlighten_manager_token_production={bearer}"
+        ),
     )
 
-    assert headers["Accept"] == "application/json, text/plain, */*"
+    headers = client._battery_config_headers(
+        include_xsrf=True,
+        include_eauth=False,
+        include_requestid=False,
+    )  # noqa: SLF001
+
     assert headers["Authorization"] is None
     assert headers["e-auth-token"] is None
-    assert headers["User-Agent"] == api._ENLIGHTEN_BROWSER_USER_AGENT
-    assert headers["X-Requested-With"] == "XMLHttpRequest"
-    assert headers["X-CSRF-Token"] is None
-
-
-def test_battery_config_cookie_external_compatible_requires_xsrf() -> None:
-    client = _make_client()
-    client.update_credentials(cookie="session=1; other=2")
-
-    assert (
-        client._battery_config_cookie(  # noqa: SLF001
-            include_xsrf=True,
-            auth_style="external_compatible",
-        )
-        is None
-    )
+    assert headers["requestid"] is None
+    assert headers["Username"] == "77"
+    assert headers["X-XSRF-Token"] == "raw-token"
 
 
 def test_battery_config_headers_drop_cookie_when_none_available() -> None:
@@ -788,44 +781,7 @@ def test_battery_config_headers_drop_cookie_when_none_available() -> None:
 
     headers = client._battery_config_headers()  # noqa: SLF001
 
-    assert "Cookie" not in headers
-
-
-def test_battery_config_retry_params_cover_profile_and_battery_settings() -> None:
-    token = _make_token({"user_id": "99"})
-    client = _make_client()
-    client.update_credentials(
-        eauth="access-token",
-        cookie="session=1; enlighten_manager_token_production=manager-token",
-    )
-
-    assert (
-        client._battery_config_retry_params(  # noqa: SLF001
-            "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
-            "userId=1&source=enho",
-        )
-        == "userId=1&source=enho"
-    )
-    assert client._battery_config_retry_params(  # noqa: SLF001
-        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/batterySettings/SITE",
-        {"userId": "1", "source": "enho"},
-        retry_token=token,
-    ) == {"userId": "99", "source": "enho"}
-    assert client._battery_config_retry_params(  # noqa: SLF001
-        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
-        {"userId": "1", "source": "enho"},
-        retry_token=token,
-    ) == {"userId": "99"}
-    assert client._battery_config_retry_params(  # noqa: SLF001
-        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
-        {"userId": "1"},
-        retry_token=token,
-    ) == {"userId": "99"}
-    assert client._battery_config_retry_params(  # noqa: SLF001
-        123,
-        {"userId": "1", "source": "enho"},
-        retry_token=token,
-    ) == {"userId": "99"}
+    assert headers["Cookie"] is None
 
 
 def test_merge_request_headers_returns_base_for_non_dict_overrides() -> None:
@@ -1721,6 +1677,7 @@ async def test_json_logs_batteryconfig_write_failure_details(caplog) -> None:
     assert "cookie_names=['bp-xsrf-token', 'other', 'session']" in caplog.text
     assert "'has_authorization': True" in caplog.text
     assert "'has_e_auth_token': True" in caplog.text
+    assert "'has_requestid': False" in caplog.text
     assert "'has_username': True" in caplog.text
     assert "'has_x_csrf_token': True" in caplog.text
     assert "'has_x_xsrf_token': True" in caplog.text
@@ -3493,12 +3450,14 @@ async def test_storm_guard_alert_passes_headers() -> None:
     args, kwargs = client._json.await_args
     assert args[0] == "GET"
     assert "stormGuard" in args[1]
-    assert kwargs["headers"]["Authorization"] == f"Bearer {token}"
+    assert kwargs["headers"]["Authorization"] is None
+    assert kwargs["headers"]["e-auth-token"] == token
     assert kwargs["headers"]["Username"] == "42"
     assert kwargs["headers"]["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
     assert (
         kwargs["headers"]["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
     )
+    assert "requestid" in kwargs["headers"]
 
 
 @pytest.mark.asyncio
@@ -3535,9 +3494,11 @@ async def test_battery_site_settings_passes_params_and_headers() -> None:
     assert args[0] == "GET"
     assert "siteSettings" in args[1]
     assert kwargs["params"]["userId"] == "77"
-    assert kwargs["headers"]["Authorization"] == f"Bearer {token}"
+    assert kwargs["headers"]["Authorization"] is None
+    assert kwargs["headers"]["e-auth-token"] == token
     assert kwargs["headers"]["Username"] == "77"
     assert kwargs["headers"]["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
+    assert "requestid" in kwargs["headers"]
 
 
 @pytest.mark.asyncio
@@ -3553,9 +3514,41 @@ async def test_battery_settings_details_passes_params_and_headers() -> None:
     args, kwargs = client._json.await_args
     assert args[0] == "GET"
     assert "batterySettings" in args[1]
-    assert kwargs["params"]["source"] == "enho"
+    assert kwargs["params"]["source"] == "enlm"
     assert kwargs["params"]["userId"] == "99"
     assert kwargs["headers"]["Username"] == "99"
+    assert kwargs["headers"]["Authorization"] is None
+    assert kwargs["headers"]["e-auth-token"] == token
+    assert "requestid" in kwargs["headers"]
+
+
+@pytest.mark.asyncio
+async def test_battery_settings_details_wire_headers_match_official_web_shape() -> None:
+    response = _FakeResponse(status=200, json_body={"data": {"chargeFromGrid": True}})
+    session = _FakeSession([response])
+    client = _make_client(session)
+    client.update_credentials(
+        eauth="access-token",
+        cookie=(
+            "session=1; XSRF-TOKEN=base-xsrf; "
+            f"enlighten_manager_token_production={_make_token({'user_id': '99'})}"
+        ),
+    )
+
+    out = await client.battery_settings_details()
+
+    assert out == {"data": {"chargeFromGrid": True}}
+    headers = session.calls[0][2]["headers"]
+    assert headers["Accept"] == "application/json, text/plain, */*"
+    assert headers["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
+    assert headers["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
+    assert headers["Username"] == "99"
+    assert "Authorization" not in headers
+    assert headers["e-auth-token"] == _make_token({"user_id": "99"})
+    assert "Cookie" not in headers
+    assert "X-CSRF-Token" not in headers
+    assert "X-Requested-With" not in headers
+    assert "requestid" in headers
 
 
 @pytest.mark.asyncio
@@ -3563,6 +3556,8 @@ async def test_set_battery_settings_payload_and_xsrf() -> None:
     token = _make_token({"user_id": "88"})
     client = _make_client()
     client.update_credentials(eauth=token, cookie="XSRF-TOKEN=xsrf%3Dtoken; other=1")
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf=token")  # noqa: SLF001
+    client._bp_xsrf_token = "xsrf=token"  # noqa: SLF001
     client._json = AsyncMock(return_value={"message": "success"})
 
     out = await client.set_battery_settings({"veryLowSoc": 15})
@@ -3572,8 +3567,11 @@ async def test_set_battery_settings_payload_and_xsrf() -> None:
     assert args[0] == "PUT"
     assert "batterySettings" in args[1]
     assert kwargs["params"]["userId"] == "88"
-    assert kwargs["headers"]["X-CSRF-Token"] == "xsrf=token"
     assert kwargs["headers"]["X-XSRF-Token"] == "xsrf=token"
+    assert kwargs["headers"]["e-auth-token"] == token
+    assert "requestid" in kwargs["headers"]
+    assert kwargs["headers"]["Cookie"] is None
+    assert kwargs["headers"]["X-CSRF-Token"] is None
     assert kwargs["json"] == {"veryLowSoc": 15}
 
 
@@ -3594,18 +3592,18 @@ async def test_set_battery_settings_uses_requested_schedule_type_for_xsrf() -> N
     )
 
     client._acquire_xsrf_token.assert_awaited_once_with("dtg")
-    assert client._json.await_args.kwargs["headers"]["X-CSRF-Token"] == "dtg-token"
     assert client._json.await_args.kwargs["headers"]["X-XSRF-Token"] == "dtg-token"
+    assert client._json.await_args.kwargs["headers"]["Cookie"] is None
+    assert client._json.await_args.kwargs["headers"]["e-auth-token"] == "EAUTH"
+    assert "requestid" in client._json.await_args.kwargs["headers"]
 
 
 @pytest.mark.asyncio
-async def test_set_battery_settings_retries_with_external_compatible_auth_shape(
+async def test_set_battery_settings_retries_403_with_lean_official_web_variant(
     caplog,
 ) -> None:
-    bearer = _make_token({"user_id": "88"})
-    legacy = _make_token({"user_id": "99"})
-    validate = _FakeResponse(status=200, json_body={"isValid": True})
-    validate.headers = CIMultiDict(
+    validate_primary = _FakeResponse(status=200, json_body={"isValid": True})
+    validate_primary.headers = CIMultiDict(
         [("Set-Cookie", "BP-XSRF-Token=cfg-token; Path=/; Secure")]
     )
     initial_write = _FakeResponse(
@@ -3613,19 +3611,25 @@ async def test_set_battery_settings_retries_with_external_compatible_auth_shape(
         json_body={},
         text_body='{"timestamp":"2026-04-11T06:15:59.504+00:00","status":403}',
     )
-    legacy_jwt = _FakeResponse(status=200, json_body={"token": legacy})
-    retry_write = _FakeResponse(
+    validate_fallback = _FakeResponse(status=200, json_body={"isValid": True})
+    validate_fallback.headers = CIMultiDict(
+        [("Set-Cookie", "BP-XSRF-Token=cfg-token-lean; Path=/; Secure")]
+    )
+    fallback_write = _FakeResponse(
         status=403,
         json_body={},
         text_body='{"timestamp":"2026-04-11T06:16:00.098+00:00","status":403}',
     )
-    session = _FakeSession([validate, initial_write, legacy_jwt, retry_write])
+    session = _FakeSession(
+        [validate_primary, initial_write, validate_fallback, fallback_write]
+    )
+    primary_token = _make_token({"user_id": "88"})
     client = _make_client(session)
     client.update_credentials(
-        eauth=bearer,
+        eauth=primary_token,
         cookie=(
             "session=1; XSRF-TOKEN=base-xsrf; "
-            f"enlighten_manager_token_production={bearer}"
+            f"enlighten_manager_token_production={primary_token}"
         ),
     )
 
@@ -3637,42 +3641,29 @@ async def test_set_battery_settings_retries_with_external_compatible_auth_shape(
     assert len(session.calls) == 4
     assert session.calls[0][0] == "POST"
     assert session.calls[1][0] == "PUT"
-    assert session.calls[2][0] == "GET"
+    assert session.calls[2][0] == "POST"
     assert session.calls[3][0] == "PUT"
-
-    first_headers = session.calls[1][2]["headers"]
-    retry_headers = session.calls[3][2]["headers"]
-    assert first_headers["Authorization"] == f"Bearer {bearer}"
-    assert first_headers["e-auth-token"] == bearer
-    assert first_headers["X-CSRF-Token"] == "cfg-token"
-    assert first_headers["X-XSRF-Token"] == "cfg-token"
-
-    assert "Authorization" not in retry_headers
-    assert retry_headers["Accept"] == "application/json, text/plain, */*"
-    assert retry_headers["e-auth-token"] == legacy
-    assert retry_headers["User-Agent"] == api._ENLIGHTEN_BROWSER_USER_AGENT
-    assert retry_headers["Username"] == "99"
-    assert retry_headers["X-Requested-With"] == "XMLHttpRequest"
-    assert retry_headers["X-XSRF-Token"] == "cfg-token"
-    assert "X-CSRF-Token" not in retry_headers
-    assert retry_headers["Cookie"].endswith("BP-XSRF-Token=cfg-token")
-
-    assert session.calls[3][2]["params"]["userId"] == "99"
-    assert session.calls[3][2]["params"]["source"] == "enho"
-    assert "skip_auto_headers" not in session.calls[3][2]
-    assert "Retrying BatteryConfig write for PUT" in caplog.text
-    assert "auth_source=legacy_jwt_token" in caplog.text
-    assert "has_authorization=False" in caplog.text
-    assert "has_x_csrf_token=False" in caplog.text
-    assert "'auth_source': 'legacy_jwt_token'" in caplog.text
-    assert "'has_x_csrf_token': False" in caplog.text
-    assert caplog.text.count("'Authorization': '[redacted]'") == 1
-    assert caplog.text.count("'X-CSRF-Token': '[redacted]'") == 1
+    primary_headers = session.calls[1][2]["headers"]
+    fallback_headers = session.calls[3][2]["headers"]
+    assert "Authorization" not in primary_headers
+    assert primary_headers["e-auth-token"] == primary_token
+    assert "requestid" in primary_headers
+    assert primary_headers["Username"] == "88"
+    assert primary_headers["X-XSRF-Token"] == "cfg-token"
+    assert "Cookie" not in primary_headers
+    assert "X-CSRF-Token" not in primary_headers
+    assert "Authorization" not in fallback_headers
+    assert "e-auth-token" not in fallback_headers
+    assert "requestid" not in fallback_headers
+    assert fallback_headers["Username"] == "88"
+    assert fallback_headers["X-XSRF-Token"] == "cfg-token-lean"
+    assert "Retrying BatteryConfig write" in caplog.text
+    assert "official_web_lean" in caplog.text
     assert client._bp_xsrf_token is None  # noqa: SLF001
 
 
 @pytest.mark.asyncio
-async def test_set_battery_profile_retry_drops_source_param() -> None:
+async def test_set_battery_profile_keeps_source_param_without_retry() -> None:
     token = _make_token({"user_id": "100"})
     client = _make_client()
     client.update_credentials(eauth=token, cookie="XSRF-TOKEN=xsrf-token; other=1")
@@ -3682,12 +3673,7 @@ async def test_set_battery_profile_retry_drops_source_param() -> None:
         return "xsrf-token"
 
     client._acquire_xsrf_token = AsyncMock(side_effect=_acquire)  # noqa: SLF001
-    client._fetch_legacy_battery_config_jwt = AsyncMock(
-        return_value=None
-    )  # noqa: SLF001
-    client._json = AsyncMock(
-        side_effect=[_make_cre(403, "Forbidden"), {"message": "success"}]
-    )
+    client._json = AsyncMock(return_value={"message": "success"})
 
     out = await client.set_battery_profile(
         profile="self-consumption",
@@ -3695,9 +3681,13 @@ async def test_set_battery_profile_retry_drops_source_param() -> None:
     )
 
     assert out == {"message": "success"}
-    first_call, second_call = client._json.await_args_list
-    assert first_call.kwargs["params"] == {"userId": "100", "source": "enho"}
-    assert second_call.kwargs["params"] == {"userId": "100"}
+    assert client._json.await_count == 1
+    assert client._json.await_args.kwargs["params"] == {
+        "userId": "100",
+        "source": "enho",
+    }
+    assert client._json.await_args.kwargs["headers"]["e-auth-token"] == token
+    assert "requestid" in client._json.await_args.kwargs["headers"]
 
 
 @pytest.mark.asyncio
@@ -3705,9 +3695,6 @@ async def test_battery_config_write_request_reraises_non_403_errors() -> None:
     client = _make_client()
     client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
     client._json = AsyncMock(side_effect=_make_cre(401, "Unauthorized"))
-    client._fetch_legacy_battery_config_jwt = AsyncMock(
-        return_value="legacy-token"
-    )  # noqa: SLF001
 
     with pytest.raises(aiohttp.ClientResponseError):
         await client._battery_config_write_request(  # noqa: SLF001
@@ -3717,31 +3704,15 @@ async def test_battery_config_write_request_reraises_non_403_errors() -> None:
             params={"userId": "88", "source": "enho"},
         )
 
-    client._fetch_legacy_battery_config_jwt.assert_not_awaited()  # noqa: SLF001
+    assert client._json.await_count == 1
     assert client._bp_xsrf_token is None  # noqa: SLF001
 
 
 @pytest.mark.asyncio
-async def test_battery_config_write_request_skips_identical_retry_shape(
-    monkeypatch,
-) -> None:
+async def test_battery_config_write_request_reraises_403_after_fallback() -> None:
     client = _make_client()
     client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
     client._json = AsyncMock(side_effect=_make_cre(403, "Forbidden"))
-    client._fetch_legacy_battery_config_jwt = AsyncMock(
-        return_value=None
-    )  # noqa: SLF001
-    identical_headers = {"Accept": "application/json"}
-    monkeypatch.setattr(
-        client,
-        "_battery_config_headers",
-        lambda **_kwargs: dict(identical_headers),
-    )
-    monkeypatch.setattr(
-        client,
-        "_battery_config_retry_params",
-        lambda _url, params, **_kwargs: params,
-    )
 
     with pytest.raises(aiohttp.ClientResponseError):
         await client._battery_config_write_request(  # noqa: SLF001
@@ -3751,7 +3722,14 @@ async def test_battery_config_write_request_skips_identical_retry_shape(
             params={"userId": "88"},
         )
 
-    assert client._json.await_count == 1
+    assert client._json.await_count == 2
+    assert client._acquire_xsrf_token.await_count == 2
+    assert client._acquire_xsrf_token.await_args_list[0].args == ("cfg",)
+    assert client._acquire_xsrf_token.await_args_list[1].args == ("cfg",)
+    assert client._acquire_xsrf_token.await_args_list[1].kwargs == {
+        "include_eauth": False,
+        "include_requestid": False,
+    }
 
 
 @pytest.mark.asyncio
@@ -3777,8 +3755,11 @@ async def test_acquire_xsrf_token_uses_requested_validation_payload() -> None:
         "/service/batteryConfig/api/v1/battery/sites/SITE/schedules/isValid"
     )
     assert kwargs["json"] == {"scheduleType": "dtg"}
-    assert kwargs["headers"]["Cookie"] == "session=1; other=1"
     assert kwargs["headers"]["Username"] == "88"
+    assert kwargs["headers"]["X-XSRF-Token"] == "stale-token"
+    assert kwargs["headers"]["e-auth-token"] == token
+    assert "requestid" in kwargs["headers"]
+    assert "Cookie" not in kwargs["headers"]
 
 
 @pytest.mark.asyncio
@@ -3798,7 +3779,7 @@ async def test_validate_battery_schedule_cfg_payload_keeps_force_schedule_opted(
 
 
 @pytest.mark.asyncio
-async def test_acquire_xsrf_token_preserves_original_eauth_header() -> None:
+async def test_acquire_xsrf_token_uses_official_web_headers() -> None:
     bearer = _make_token({"user_id": "88"})
     response = _FakeResponse(status=200, json_body={"isValid": True})
     response.headers = CIMultiDict(
@@ -3813,8 +3794,13 @@ async def test_acquire_xsrf_token_preserves_original_eauth_header() -> None:
 
     await client._acquire_xsrf_token()  # noqa: SLF001
 
-    assert session.calls[0][2]["headers"]["Authorization"] == f"Bearer {bearer}"
-    assert session.calls[0][2]["headers"]["e-auth-token"] == "session-token"
+    headers = session.calls[0][2]["headers"]
+    assert "Authorization" not in headers
+    assert headers["e-auth-token"] == bearer
+    assert headers["Username"] == "88"
+    assert headers["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
+    assert headers["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
+    assert "requestid" in headers
 
 
 @pytest.mark.asyncio
@@ -3847,6 +3833,18 @@ async def test_acquire_xsrf_token_uses_getall_fallback_and_handles_bad_cookie() 
 
 
 @pytest.mark.asyncio
+async def test_acquire_xsrf_token_uses_plain_header_get_fallback() -> None:
+    response = _FakeResponse(status=200, json_body={"isValid": True})
+    response.headers = {"Set-Cookie": "BP-XSRF-Token=plain-header-token; Path=/;"}
+    session = _FakeSession([response])
+    client = _make_client(session)
+
+    out = await client._acquire_xsrf_token()  # noqa: SLF001
+
+    assert out == "plain-header-token"
+
+
+@pytest.mark.asyncio
 async def test_acquire_xsrf_token_returns_none_when_cookie_missing() -> None:
     response = _FakeResponse(status=200, json_body={"isValid": True})
     response.headers = CIMultiDict()
@@ -3854,6 +3852,20 @@ async def test_acquire_xsrf_token_returns_none_when_cookie_missing() -> None:
     client = _make_client(session)
 
     assert await client._acquire_xsrf_token() is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_acquire_xsrf_token_returns_none_when_request_raises(caplog) -> None:
+    class _BoomSession(_DefaultSession):
+        def request(self, method: str, url: str, **kwargs):
+            raise RuntimeError("boom")
+
+    client = _make_client(_BoomSession())
+
+    with caplog.at_level(logging.WARNING):
+        assert await client._acquire_xsrf_token() is None  # noqa: SLF001
+
+    assert "Failed to acquire XSRF token" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -3903,10 +3915,7 @@ async def test_acquire_xsrf_token_falls_back_to_session_cookie_jar() -> None:
         client._cookie
         == "session=1; other=1; enlighten_manager_token_production=bearer"
     )  # noqa: SLF001
-    assert client._battery_config_headers(include_xsrf=True)["Cookie"] == (
-        "session=1; other=1; enlighten_manager_token_production=bearer; "
-        "BP-XSRF-Token=jar-token"
-    )
+    assert client._battery_config_headers(include_xsrf=True)["Cookie"] is None
 
 
 @pytest.mark.asyncio
@@ -4069,15 +4078,17 @@ async def test_update_battery_schedule_builds_request_and_clears_xsrf() -> None:
         "scheduleType": "DTG",
         "days": [2, 6],
     }
-    assert kwargs["headers"]["Authorization"] == "Bearer EAUTH"
-    assert kwargs["headers"]["X-CSRF-Token"] == "fresh-token"
+    assert kwargs["headers"]["Authorization"] is None
+    assert kwargs["headers"]["e-auth-token"] == "EAUTH"
+    assert "requestid" in kwargs["headers"]
+    assert kwargs["headers"]["X-CSRF-Token"] is None
     assert kwargs["headers"]["X-XSRF-Token"] == "fresh-token"
     assert kwargs["headers"]["Content-Type"] == "application/json"
     assert kwargs["headers"]["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
     assert (
         kwargs["headers"]["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
     )
-    assert kwargs["headers"]["Cookie"] == "COOKIE; BP-XSRF-Token=fresh-token"
+    assert kwargs["headers"]["Cookie"] is None
     assert client._bp_xsrf_token is None  # noqa: SLF001
 
 
@@ -4103,6 +4114,8 @@ async def test_set_battery_settings_reacquires_xsrf_for_each_write() -> None:
     first_call, second_call = client._json.await_args_list
     assert first_call.kwargs["headers"]["X-XSRF-Token"] == "cfg-fresh-token-1"
     assert second_call.kwargs["headers"]["X-XSRF-Token"] == "cfg-fresh-token-2"
+    assert "requestid" in first_call.kwargs["headers"]
+    assert "requestid" in second_call.kwargs["headers"]
     assert client._acquire_xsrf_token.await_count == 2
     assert client._acquire_xsrf_token.await_args_list[0].args == ("cfg",)
     assert client._acquire_xsrf_token.await_args_list[1].args == ("cfg",)
@@ -4128,6 +4141,8 @@ async def test_set_battery_profile_payload_variants_and_xsrf() -> None:
         eauth=token,
         cookie="XSRF-TOKEN=xsrf-token; other=1",
     )
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
+    client._bp_xsrf_token = "xsrf-token"  # noqa: SLF001
     client._json = AsyncMock(return_value={"message": "success"})
 
     out = await client.set_battery_profile(
@@ -4142,8 +4157,10 @@ async def test_set_battery_profile_payload_variants_and_xsrf() -> None:
     assert args[0] == "PUT"
     assert "api/v1/profile" in args[1]
     assert kwargs["params"]["userId"] == "100"
-    assert kwargs["headers"]["X-CSRF-Token"] == "xsrf-token"
     assert kwargs["headers"]["X-XSRF-Token"] == "xsrf-token"
+    assert kwargs["headers"]["X-CSRF-Token"] is None
+    assert kwargs["headers"]["e-auth-token"] == token
+    assert "requestid" in kwargs["headers"]
     assert kwargs["json"] == {
         "profile": "cost_savings",
         "batteryBackupPercentage": 25,
@@ -4153,105 +4170,12 @@ async def test_set_battery_profile_payload_variants_and_xsrf() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fetch_legacy_battery_config_jwt_success() -> None:
-    response = _FakeResponse(status=200, json_body={"token": "legacy-token"})
-    session = _FakeSession([response])
-    client = _make_client(session)
-    client.update_credentials(cookie="session=1; other=1")
-
-    out = await client._fetch_legacy_battery_config_jwt()  # noqa: SLF001
-
-    assert out == "legacy-token"
-    method, url, kwargs = session.calls[0]
-    assert method == "GET"
-    assert url.endswith("/app-api/jwt_token.json")
-    assert kwargs["headers"]["Cookie"] == "session=1; other=1"
-    assert "Authorization" not in kwargs["headers"]
-
-
-@pytest.mark.asyncio
-async def test_fetch_legacy_battery_config_jwt_handles_http_error(caplog) -> None:
-    response = _FakeResponse(status=400, json_body={}, text_body="bad request")
-    session = _FakeSession([response])
-    client = _make_client(session)
-
-    with caplog.at_level(logging.DEBUG):
-        out = await client._fetch_legacy_battery_config_jwt()  # noqa: SLF001
-
-    assert out is None
-    assert "Legacy BatteryConfig JWT bootstrap failed (400)" in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_fetch_legacy_battery_config_jwt_handles_invalid_json(caplog) -> None:
-    response = _FakeResponse(status=200, json_body=ValueError("bad json"))
-    session = _FakeSession([response])
-    client = _make_client(session)
-
-    with caplog.at_level(logging.DEBUG):
-        out = await client._fetch_legacy_battery_config_jwt()  # noqa: SLF001
-
-    assert out is None
-    assert "Legacy BatteryConfig JWT bootstrap returned invalid JSON" in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_fetch_legacy_battery_config_jwt_handles_non_dict_payload() -> None:
-    response = _FakeResponse(status=200, json_body=["not", "a", "dict"])
-    session = _FakeSession([response])
-    client = _make_client(session)
-
-    assert await client._fetch_legacy_battery_config_jwt() is None  # noqa: SLF001
-
-
-@pytest.mark.asyncio
-async def test_fetch_legacy_battery_config_jwt_handles_missing_token() -> None:
-    response = _FakeResponse(status=200, json_body={})
-    session = _FakeSession([response])
-    client = _make_client(session)
-
-    assert await client._fetch_legacy_battery_config_jwt() is None  # noqa: SLF001
-
-
-@pytest.mark.asyncio
-async def test_fetch_legacy_battery_config_jwt_handles_client_error(caplog) -> None:
-    class _ClientErrorSession:
-        cookie_jar = SimpleNamespace(filter_cookies=lambda _url: {})
-
-        def request(self, *_args, **_kwargs):
-            raise aiohttp.ClientError("boom")
-
-    client = _make_client(_ClientErrorSession())
-
-    with caplog.at_level(logging.DEBUG):
-        out = await client._fetch_legacy_battery_config_jwt()  # noqa: SLF001
-
-    assert out is None
-    assert "Legacy BatteryConfig JWT bootstrap client error" in caplog.text
-
-
-@pytest.mark.asyncio
-async def test_fetch_legacy_battery_config_jwt_handles_timeout(caplog) -> None:
-    class _TimeoutSession:
-        cookie_jar = SimpleNamespace(filter_cookies=lambda _url: {})
-
-        def request(self, *_args, **_kwargs):
-            raise TimeoutError("too slow")
-
-    client = _make_client(_TimeoutSession())
-
-    with caplog.at_level(logging.DEBUG):
-        out = await client._fetch_legacy_battery_config_jwt()  # noqa: SLF001
-
-    assert out is None
-    assert "Legacy BatteryConfig JWT bootstrap timed out" in caplog.text
-
-
-@pytest.mark.asyncio
 async def test_cancel_battery_profile_update_uses_empty_body() -> None:
     token = _make_token({"user_id": "44"})
     client = _make_client()
     client.update_credentials(eauth=token, cookie="XSRF-TOKEN=t; other=1")
+    client._acquire_xsrf_token = AsyncMock(return_value="t")  # noqa: SLF001
+    client._bp_xsrf_token = "t"  # noqa: SLF001
     client._json = AsyncMock(return_value={"message": "success"})
 
     out = await client.cancel_battery_profile_update()
@@ -4262,8 +4186,10 @@ async def test_cancel_battery_profile_update_uses_empty_body() -> None:
     assert "cancel/profile" in args[1]
     assert kwargs["json"] == {}
     assert kwargs["params"]["userId"] == "44"
-    assert kwargs["headers"]["X-CSRF-Token"] == "t"
     assert kwargs["headers"]["X-XSRF-Token"] == "t"
+    assert kwargs["headers"]["X-CSRF-Token"] is None
+    assert kwargs["headers"]["e-auth-token"] == token
+    assert "requestid" in kwargs["headers"]
 
 
 @pytest.mark.asyncio
@@ -4274,6 +4200,8 @@ async def test_set_storm_guard_passes_payload_and_xsrf() -> None:
         eauth=token,
         cookie="XSRF-TOKEN=xsrf-token; other=1",
     )
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
+    client._bp_xsrf_token = "xsrf-token"  # noqa: SLF001
     client._json = AsyncMock(return_value={"message": "success"})
     out = await client.set_storm_guard(enabled=True, evse_enabled=False)
     assert out == {"message": "success"}
@@ -4285,8 +4213,10 @@ async def test_set_storm_guard_passes_payload_and_xsrf() -> None:
         "evseStormEnabled": False,
     }
     assert kwargs["params"]["userId"] == "99"
-    assert kwargs["headers"]["X-CSRF-Token"] == "xsrf-token"
     assert kwargs["headers"]["X-XSRF-Token"] == "xsrf-token"
+    assert kwargs["headers"]["X-CSRF-Token"] is None
+    assert kwargs["headers"]["e-auth-token"] == token
+    assert "requestid" in kwargs["headers"]
 
 
 @pytest.mark.asyncio
@@ -4312,6 +4242,8 @@ async def test_opt_out_storm_alert_passes_payload_and_xsrf() -> None:
         ]
     }
     assert kwargs["headers"]["X-XSRF-Token"] == "xsrf-token"
+    assert kwargs["headers"]["e-auth-token"] == token
+    assert "requestid" in kwargs["headers"]
     assert "params" not in kwargs
 
 
@@ -4325,6 +4257,7 @@ async def test_opt_out_storm_alert_handles_missing_xsrf() -> None:
 
     _args, kwargs = client._json.await_args
     assert "X-XSRF-Token" not in kwargs["headers"]
+    assert kwargs["headers"]["requestid"]
 
 
 @pytest.mark.asyncio
@@ -4339,13 +4272,17 @@ async def test_battery_config_prefers_cookie_bearer_when_it_has_user_id() -> Non
             f"{cookie_token}; XSRF-TOKEN=token; other=1"
         ),
     )
+    client._acquire_xsrf_token = AsyncMock(return_value="token")  # noqa: SLF001
+    client._bp_xsrf_token = "token"  # noqa: SLF001
     client._json = AsyncMock(return_value={"message": "success"})
 
     await client.set_storm_guard(enabled=True, evse_enabled=True)
 
     _args, kwargs = client._json.await_args
-    assert kwargs["headers"]["Authorization"] == f"Bearer {cookie_token}"
+    assert kwargs["headers"]["Authorization"] is None
+    assert kwargs["headers"]["e-auth-token"] == cookie_token
     assert kwargs["headers"]["Username"] == "123"
+    assert "requestid" in kwargs["headers"]
     assert kwargs["params"]["userId"] == "123"
 
 
@@ -4359,6 +4296,7 @@ async def test_set_storm_guard_handles_missing_xsrf() -> None:
 
     _args, kwargs = client._json.await_args
     assert "X-XSRF-Token" not in kwargs["headers"]
+    assert "requestid" in kwargs["headers"]
 
 
 @pytest.mark.asyncio
@@ -4371,6 +4309,7 @@ async def test_set_storm_guard_uses_bp_xsrf_cookie_fallback() -> None:
 
     _args, kwargs = client._json.await_args
     assert kwargs["headers"]["X-XSRF-Token"] == "bp=token"
+    assert "requestid" in kwargs["headers"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Align BatteryConfig requests with the observed first-party Enphase web variants used for issue #460.

This change keeps the official-web BatteryConfig baseline, sends `e-auth-token` and `requestid` on the primary path, and retries once with a lean first-party variant that drops those two headers on `403`. It also updates the BatteryConfig API spec and debug logging to reflect the final request model.

Fixes #460

## Related Issues

- Ongoing BatteryConfig 403 investigation in #460

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py tests/components/enphase_ev/test_api_client_methods.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_api_client_methods.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/api.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
```

Manual validation:
- Restarted the local Home Assistant runtime mounted from this branch.
- Verified local Enphase battery writes still succeed against the live saved session after adding the primary `e-auth-token` + `requestid` variant and the lean fallback.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- BatteryConfig debug logging now reports whether `requestid` was present in the failed request header set.
- The updated API spec now records the two observed first-party BatteryConfig variants:
  - primary official-web shape with `e-auth-token` and `requestid`
  - lean fallback without those two headers
