### PR TITLE
Fix HEMS lifetime zero-value device channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed HEMS device lifetime sensors so zero-only primary EVSE, Heat Pump, and Water Heater placeholder buckets still trigger the dedicated HEMS fallback when needed, while zero-valued results copied from that fallback now report `0.0 kWh` instead of `Unavailable`.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/energy.py
+++ b/custom_components/enphase_ev/energy.py
@@ -25,6 +25,7 @@ SITE_ENERGY_DEFAULT_INTERVAL_MIN = 5.0
 SITE_ENERGY_FAILURE_BACKOFF_S = 15 * 60
 HEMS_LIFETIME_FAILURE_BACKOFF_S = 60 * 60
 DEVICE_LIFETIME_CHANNELS: tuple[str, ...] = ("evse", "heatpump", "water_heater")
+HEMS_DEVICE_CHANNELS_META_KEY = "_hems_device_channels"
 
 
 @dataclass(slots=True)
@@ -466,6 +467,16 @@ class EnergyManager:
         flows: dict[str, SiteEnergyFlow] = {}
         interval_hours, interval_minutes = self._site_energy_interval_hours(payload)
         source_unit = "Wh"
+        hems_device_channels_raw = payload.get(HEMS_DEVICE_CHANNELS_META_KEY)
+        hems_device_channels = (
+            {
+                str(channel).strip()
+                for channel in hems_device_channels_raw
+                if str(channel).strip()
+            }
+            if isinstance(hems_device_channels_raw, (set, tuple, list))
+            else set()
+        )
 
         def _store(
             flow: str,
@@ -529,13 +540,25 @@ class EnergyManager:
         evse_total, evse_count = self._sum_energy_buckets(
             payload.get("evse"), interval_hours
         )
-        _store("evse_charging", evse_total, ["evse"], evse_count)
+        _store(
+            "evse_charging",
+            evse_total,
+            ["evse"],
+            evse_count,
+            allow_zero="evse" in hems_device_channels,
+        )
 
         # Heat pump lifetime consumption.
         heat_pump_total, heat_pump_count = self._sum_energy_buckets(
             payload.get("heatpump"), interval_hours
         )
-        _store("heat_pump", heat_pump_total, ["heatpump"], heat_pump_count)
+        _store(
+            "heat_pump",
+            heat_pump_total,
+            ["heatpump"],
+            heat_pump_count,
+            allow_zero="heatpump" in hems_device_channels,
+        )
 
         # Water heater lifetime consumption.
         water_heater_total, water_heater_count = self._sum_energy_buckets(
@@ -546,6 +569,7 @@ class EnergyManager:
             water_heater_total,
             ["water_heater"],
             water_heater_count,
+            allow_zero="water_heater" in hems_device_channels,
         )
 
         # Grid import (total site import).
@@ -666,6 +690,18 @@ class EnergyManager:
                     discharge_count,
                 )
 
+        raw_bucket_lengths = {
+            key: len(value) for key, value in payload.items() if isinstance(value, list)
+        }
+        bucket_lengths = dict(raw_bucket_lengths)
+        for channel in DEVICE_LIFETIME_CHANNELS:
+            if self._device_lifetime_channel_has_positive(payload, channel):
+                continue
+            if channel in hems_device_channels:
+                continue
+            if channel in bucket_lengths:
+                bucket_lengths[channel] = 0
+
         meta = {
             "start_date": start_date,
             "last_report_date": last_report_date,
@@ -673,11 +709,8 @@ class EnergyManager:
                 bool(update_pending) if update_pending is not None else None
             ),
             "interval_minutes": interval_minutes,
-            "bucket_lengths": {
-                key: len(value)
-                for key, value in payload.items()
-                if isinstance(value, list)
-            },
+            "bucket_lengths": bucket_lengths,
+            "raw_bucket_lengths": raw_bucket_lengths,
         }
         return flows, meta
 
@@ -694,6 +727,34 @@ class EnergyManager:
                 return False
         return True
 
+    def _device_lifetime_channel_missing(
+        self, payload: dict[str, object], channel: str
+    ) -> bool:
+        """Treat zero-only device arrays as missing so HEMS can fill them."""
+
+        values = payload.get(channel)
+        if not isinstance(values, list) or len(values) == 0:
+            return True
+        for value in values:
+            numeric = self._coerce_energy_value(value)
+            if numeric is not None and numeric > 0:
+                return False
+        return True
+
+    def _device_lifetime_channel_has_positive(
+        self, payload: dict[str, object], channel: str
+    ) -> bool:
+        """Return True when a device channel contains a positive numeric sample."""
+
+        values = payload.get(channel)
+        if not isinstance(values, list) or len(values) == 0:
+            return False
+        for value in values:
+            numeric = self._coerce_energy_value(value)
+            if numeric is not None and numeric > 0:
+                return True
+        return False
+
     def _merge_device_lifetime_channels(
         self,
         primary: dict[str, object],
@@ -702,8 +763,18 @@ class EnergyManager:
         """Merge device lifetime channels from fallback when primary is missing."""
 
         merged = dict(primary)
+        hems_device_channels_raw = merged.get(HEMS_DEVICE_CHANNELS_META_KEY)
+        hems_device_channels = (
+            {
+                str(channel).strip()
+                for channel in hems_device_channels_raw
+                if str(channel).strip()
+            }
+            if isinstance(hems_device_channels_raw, (set, tuple, list))
+            else set()
+        )
         for channel in DEVICE_LIFETIME_CHANNELS:
-            if not self._lifetime_channel_missing(merged, channel):
+            if not self._device_lifetime_channel_missing(merged, channel):
                 continue
             fallback_values = fallback.get(channel)
             if (
@@ -712,6 +783,7 @@ class EnergyManager:
                 and not self._lifetime_channel_missing(fallback, channel)
             ):
                 merged[channel] = list(fallback_values)
+                hems_device_channels.add(channel)
 
         for metadata_key in (
             "start_date",
@@ -725,6 +797,8 @@ class EnergyManager:
                 and fallback.get(metadata_key) is not None
             ):
                 merged[metadata_key] = fallback.get(metadata_key)
+        if hems_device_channels:
+            merged[HEMS_DEVICE_CHANNELS_META_KEY] = hems_device_channels
         return merged
 
     def _hems_lifetime_backoff_active(self) -> bool:
@@ -790,7 +864,7 @@ class EnergyManager:
             missing_channels = [
                 channel
                 for channel in DEVICE_LIFETIME_CHANNELS
-                if self._lifetime_channel_missing(payload, channel)
+                if self._device_lifetime_channel_missing(payload, channel)
             ]
             if missing_channels:
                 hems_fetcher = getattr(client, "hems_consumption_lifetime", None)

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -11,7 +11,7 @@ import pytest
 from homeassistant.const import UnitOfPower
 
 from custom_components.enphase_ev.api import SiteEnergyUnavailable
-from custom_components.enphase_ev.energy import SiteEnergyFlow
+from custom_components.enphase_ev.energy import LifetimeGuardState, SiteEnergyFlow
 from custom_components.enphase_ev.sensor import (
     EnphaseBatteryPowerSensor,
     EnphaseGridPowerSensor,
@@ -91,6 +91,25 @@ def test_site_energy_aggregation_includes_additional_device_channels(
     assert flows["water_heater"].fields_used == ["water_heater"]
 
 
+def test_site_energy_aggregation_skips_zero_only_primary_device_channels(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    payload = {
+        "evse": [0, 0],
+        "heatpump": [0],
+        "water_heater": [0, 0, 0],
+        "start_date": "2024-01-01",
+        "interval_minutes": 60,
+    }
+
+    flows, _meta = coord.energy._aggregate_site_energy(payload)  # noqa: SLF001
+
+    assert "evse_charging" not in flows
+    assert "heat_pump" not in flows
+    assert "water_heater" not in flows
+
+
 def test_merge_device_lifetime_channels_keeps_present_primary_values(
     coordinator_factory,
 ) -> None:
@@ -115,6 +134,64 @@ def test_merge_device_lifetime_channels_keeps_present_primary_values(
     assert merged["heatpump"] == [20.0]
     assert merged["water_heater"] == [30.0]
     assert merged["last_report_date"] == 1_700_000_000
+
+
+def test_lifetime_channel_missing_accepts_zero_values(coordinator_factory) -> None:
+    coord = coordinator_factory()
+
+    assert coord.energy._lifetime_channel_missing({}, "evse") is True  # noqa: SLF001
+    assert (  # noqa: SLF001
+        coord.energy._lifetime_channel_missing({"evse": ["bad", None, -1]}, "evse")
+        is True
+    )
+    assert (
+        coord.energy._lifetime_channel_missing({"evse": [0]}, "evse") is False
+    )  # noqa: SLF001
+
+
+def test_device_lifetime_channel_missing_requires_positive_values(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    assert (
+        coord.energy._device_lifetime_channel_missing({"evse": [0, "0"]}, "evse")
+        is True
+    )  # noqa: SLF001
+    assert (
+        coord.energy._device_lifetime_channel_missing({"evse": [0, 25]}, "evse")
+        is False
+    )  # noqa: SLF001
+
+
+def test_aggregate_site_energy_supports_zero_device_channels_from_hems_fallback(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    payload = {
+        "evse": [0],
+        "heatpump": [0],
+        "water_heater": [0],
+        "interval_minutes": 60,
+        "_hems_device_channels": {"evse", "heatpump", "water_heater"},
+    }
+
+    flows, meta = coord.energy._aggregate_site_energy(payload)  # noqa: SLF001
+
+    assert flows["evse_charging"].value_kwh == pytest.approx(0.0)
+    assert flows["heat_pump"].value_kwh == pytest.approx(0.0)
+    assert flows["water_heater"].value_kwh == pytest.approx(0.0)
+    assert meta["bucket_lengths"]["water_heater"] == 1
+    assert meta["raw_bucket_lengths"]["water_heater"] == 1
+
+
+def test_apply_lifetime_guard_holds_small_backward_jitter(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.energy._lifetime_guard["sn"] = LifetimeGuardState(last=5.0)
+
+    assert coord.energy._apply_lifetime_guard("sn", 4.99, None) == pytest.approx(5.0)
 
 
 def test_site_energy_cache_age_and_invalidate(coordinator_factory, monkeypatch) -> None:
@@ -432,6 +509,19 @@ async def test_async_refresh_site_energy_marks_service_unavailable(coordinator_f
     await coord.energy._async_refresh_site_energy(force=True)  # noqa: SLF001
     assert coord.energy.service_available is False
     assert coord.energy.service_backoff_active is True
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_site_energy_handles_generic_fetch_failure(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.lifetime_energy = AsyncMock(side_effect=RuntimeError("boom"))
+
+    await coord.energy._async_refresh_site_energy(force=True)  # noqa: SLF001
+
+    assert coord.energy.site_energy == {}
+    assert coord.energy.service_available is True
 
 
 def test_site_energy_mark_service_available_resets_state(coordinator_factory) -> None:
@@ -3055,9 +3145,9 @@ async def test_site_energy_refresh_skips_hems_when_channels_present(
     coord.client.lifetime_energy = AsyncMock(
         return_value={
             "production": [1000],
-            "evse": [0],
-            "heatpump": [0],
-            "water_heater": [0],
+            "evse": [100],
+            "heatpump": [200],
+            "water_heater": [300],
             "start_date": "2024-01-01",
             "interval_minutes": 60,
         }
@@ -3073,9 +3163,74 @@ async def test_site_energy_refresh_skips_hems_when_channels_present(
     await coord.energy._async_refresh_site_energy()  # noqa: SLF001
 
     coord.client.hems_consumption_lifetime.assert_not_awaited()
-    assert "evse_charging" not in coord.energy.site_energy
-    assert "heat_pump" not in coord.energy.site_energy
-    assert "water_heater" not in coord.energy.site_energy
+    assert coord.energy.site_energy["evse_charging"].value_kwh == pytest.approx(0.1)
+    assert coord.energy.site_energy["heat_pump"].value_kwh == pytest.approx(0.2)
+    assert coord.energy.site_energy["water_heater"].value_kwh == pytest.approx(0.3)
+
+
+@pytest.mark.asyncio
+async def test_site_energy_refresh_uses_hems_when_device_channels_only_zero(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.lifetime_energy = AsyncMock(
+        return_value={
+            "production": [1000],
+            "evse": [0],
+            "heatpump": [0],
+            "water_heater": [0],
+            "start_date": "2024-01-01",
+            "interval_minutes": 60,
+        }
+    )
+    coord.client.hems_consumption_lifetime = AsyncMock(
+        return_value={
+            "evse": [100],
+            "heatpump": [200],
+            "water_heater": [300],
+            "interval_minutes": 60,
+        }
+    )
+
+    await coord.energy._async_refresh_site_energy()  # noqa: SLF001
+
+    assert coord.client.hems_consumption_lifetime.await_count == 1
+    assert coord.energy.site_energy["evse_charging"].value_kwh == pytest.approx(0.1)
+    assert coord.energy.site_energy["heat_pump"].value_kwh == pytest.approx(0.2)
+    assert coord.energy.site_energy["water_heater"].value_kwh == pytest.approx(0.3)
+
+
+@pytest.mark.asyncio
+async def test_site_energy_refresh_uses_zero_from_hems_when_primary_channel_missing(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.lifetime_energy = AsyncMock(
+        return_value={
+            "production": [1000],
+            "evse": [],
+            "heatpump": [],
+            "water_heater": [],
+            "start_date": "2024-01-01",
+            "interval_minutes": 60,
+        }
+    )
+    coord.client.hems_consumption_lifetime = AsyncMock(
+        return_value={
+            "evse": [0],
+            "heatpump": [0],
+            "water_heater": [0],
+            "interval_minutes": 60,
+        }
+    )
+
+    await coord.energy._async_refresh_site_energy()  # noqa: SLF001
+
+    assert coord.client.hems_consumption_lifetime.await_count == 1
+    assert coord.energy.site_energy["evse_charging"].value_kwh == pytest.approx(0.0)
+    assert coord.energy.site_energy["heat_pump"].value_kwh == pytest.approx(0.0)
+    assert coord.energy.site_energy["water_heater"].value_kwh == pytest.approx(0.0)
+    assert coord.energy.site_energy_meta["bucket_lengths"]["water_heater"] == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #541.

This change fixes HEMS device lifetime handling for EVSE, Heat Pump, and Water Heater channels when Enphase returns zero-only placeholder values in the primary lifetime payload.

Root cause:
- Zero-only primary device buckets were treated as missing for fallback purposes, but zero-valued device channels also needed to remain publishable when they came from the dedicated HEMS fallback.
- The fix keeps unsupported placeholder buckets suppressed while allowing authoritative zero-valued fallback results to publish as `0.0 kWh`.

User impact:
- Sites that receive a real zero-valued HEMS fallback for Water Heater, Heat Pump, or EVSE lifetime data now keep the entity available at `0.0 kWh` instead of `Unavailable`.
- Sites with unsupported zero-only placeholder channels in the primary payload do not incorrectly gain extra lifetime entities.

## Related Issues

- #541

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

List the exact commands you ran. Prefer the pinned Docker environment from `devtools/docker/`.

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black <changed-python-files> tests/components/enphase_ev/<changed-test-files>"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=<touched-module-paths-comma-separated> --fail-under=100"
```

Additional commands run for this change:

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/energy.py tests/components/enphase_ev/test_site_energy.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/energy.py tests/components/enphase_ev/test_site_energy.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev/test_site_energy.py tests/components/enphase_ev/test_lifetime_guard.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_remaining_coverage.py -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/energy.py --fail-under=100"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
python3 -m pre_commit run --all-files
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The `pre-commit` hook run was executed from the host checkout because the Docker container could not access a usable Git repository for Git-backed hooks.
