### PR TITLE
Relax EV charger start fallback for IQ 40 backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Relaxed EV charger manual and scheduled start strictness for issue `#544` so `start_charging` still prefers amp-bearing payloads but now falls back to no-level variants when older IQ 40 backends reject `chargingLevel` as invalid.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -9,6 +9,8 @@ from datetime import timedelta
 from datetime import timezone as _tz
 from typing import TYPE_CHECKING, Iterable
 
+import aiohttp
+
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import dt as dt_util
 
@@ -312,6 +314,7 @@ class EvseRuntime:
             "last_set_amps",
             "_operating_v",
             "_charge_mode_cache",
+            "_start_without_level_fallback",
             "_green_battery_cache",
             "_charger_config_cache",
             "_charger_config_backoff_until",
@@ -427,11 +430,11 @@ class EvseRuntime:
         amps = coord.pick_start_amps(sn_str)
         prefs = coord._charge_mode_start_preferences(sn_str)
         try:
-            result = await coord.client.start_charging(
+            result = await self.async_issue_start_charging(
                 sn_str,
                 amps,
-                include_level=prefs.include_level,
-                strict_preference=prefs.strict,
+                prefs,
+                requested_amps=None,
             )
         except Exception as err:  # noqa: BLE001
             _LOGGER.debug(
@@ -574,14 +577,13 @@ class EvseRuntime:
             )
         fallback = fallback_amps if fallback_amps is not None else 32
         amps = coord.pick_start_amps(sn_str, requested_amps, fallback=fallback)
-        connector = connector_id if connector_id is not None else 1
         prefs = coord._charge_mode_start_preferences(sn_str)
-        result = await coord.client.start_charging(
+        result = await self.async_issue_start_charging(
             sn_str,
             amps,
-            connector,
-            include_level=prefs.include_level,
-            strict_preference=prefs.strict,
+            prefs,
+            connector_id=connector_id,
+            requested_amps=requested_amps,
         )
         coord.set_last_set_amps(sn_str, amps)
         if isinstance(result, dict) and result.get("status") == "not_ready":
@@ -596,6 +598,68 @@ class EvseRuntime:
         if prefs.enforce_mode:
             await coord._ensure_charge_mode(sn_str, prefs.enforce_mode)
         await coord.async_request_refresh()
+        return result
+
+    async def async_issue_start_charging(
+        self,
+        sn: str,
+        amps: int,
+        prefs: ChargeModeStartPreferences,
+        *,
+        connector_id: int | None = 1,
+        requested_amps: int | float | str | None = None,
+    ) -> object:
+        coord = self.coordinator
+        sn_str = str(sn)
+        connector = connector_id if connector_id is not None else 1
+        fallback_cache = getattr(coord, "_start_without_level_fallback", None)
+        degraded = bool(
+            requested_amps is None
+            and prefs.include_level is True
+            and not prefs.strict
+            and isinstance(fallback_cache, dict)
+            and fallback_cache.get(sn_str)
+        )
+        include_level = False if degraded else prefs.include_level
+        # Keep explicit setpoint requests strict so service/action calls do not
+        # silently fall back to a no-level start and misreport the applied amps.
+        strict_preference = prefs.strict or (
+            requested_amps is not None and prefs.include_level is True
+        )
+        if degraded:
+            strict_preference = True
+        try:
+            result = await coord.client.start_charging(
+                sn_str,
+                amps,
+                connector,
+                include_level=include_level,
+                strict_preference=strict_preference,
+            )
+        except aiohttp.ClientResponseError as err:
+            if (
+                requested_amps is None
+                and include_level is True
+                and not strict_preference
+                and err.status == 500
+                and "invalid charge level" in str(err.message or "").lower()
+            ):
+                result = await coord.client.start_charging(
+                    sn_str,
+                    amps,
+                    connector,
+                    include_level=False,
+                    strict_preference=True,
+                )
+                if not isinstance(fallback_cache, dict):
+                    fallback_cache = {}
+                    coord._start_without_level_fallback = fallback_cache
+                fallback_cache[sn_str] = True
+                return result
+            raise
+        if include_level is True and prefs.include_level is True:
+            if isinstance(fallback_cache, dict):
+                fallback_cache.pop(sn_str, None)
         return result
 
     async def async_stop_charging(
@@ -1544,10 +1608,8 @@ class EvseRuntime:
         enforce_mode: str | None = None
         if mode == "MANUAL_CHARGING":
             include_level = True
-            strict = True
         elif mode == "SCHEDULED_CHARGING":
             include_level = True
-            strict = True
             enforce_mode = "SCHEDULED_CHARGING"
         elif mode in {"GREEN_CHARGING", "SMART_CHARGING"}:
             include_level = False

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3106,7 +3106,6 @@ async def test_start_charging_includes_fallback_variants(monkeypatch) -> None:
     assert client._start_variant_idx == 0
 
 
-@pytest.mark.asyncio
 async def test_start_charging_excludes_level_variants_when_requested(
     monkeypatch,
 ) -> None:

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -1589,12 +1589,13 @@ async def test_async_auto_resume_respects_preferences(coordinator_factory, monke
     )
     coord._charge_mode_start_preferences = MagicMock(return_value=prefs)
     coord._ensure_charge_mode = AsyncMock()
+    coord.async_request_refresh = AsyncMock()
     coord.data = {sn: {"plugged": True}}
 
     await coord._async_auto_resume(sn, {"plugged": True})
 
     coord.client.start_charging.assert_awaited_once_with(
-        sn, 24, include_level=True, strict_preference=True
+        sn, 24, 1, include_level=True, strict_preference=True
     )
     coord._ensure_charge_mode.assert_awaited_once_with(sn, "SCHEDULED_CHARGING")
 
@@ -2323,7 +2324,7 @@ def test_charge_mode_preference_helpers(coordinator_factory):
     coord.data[sn]["charge_mode_pref"] = "MANUAL_CHARGING"
     prefs = coord._charge_mode_start_preferences(sn)
     assert prefs.include_level is True
-    assert prefs.strict is True
+    assert prefs.strict is False
     assert prefs.enforce_mode is None
 
     coord.data[sn]["charge_mode_pref"] = "SCHEDULED_CHARGING"

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1974,7 +1974,41 @@ async def test_async_start_charging_manual_mode_sends_requested_amps(hass, monke
     await coord.async_start_charging(RANDOM_SERIAL)
 
     coord.client.start_charging.assert_awaited_once_with(
-        RANDOM_SERIAL, 26, 1, include_level=True, strict_preference=True
+        RANDOM_SERIAL, 26, 1, include_level=True, strict_preference=False
+    )
+    coord.client.set_charge_mode.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_start_charging_manual_mode_explicit_request_stays_strict(
+    hass, monkeypatch
+):
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.serials = {RANDOM_SERIAL}
+    coord.data = {
+        RANDOM_SERIAL: {
+            "plugged": True,
+            "charging_level": 26,
+            "charge_mode_pref": "MANUAL_CHARGING",
+        }
+    }
+    coord.last_set_amps = {}
+    coord.set_charging_expectation = MagicMock()
+    coord.kick_fast = MagicMock()
+    coord.client = SimpleNamespace(
+        start_charging=AsyncMock(return_value={"status": "ok"}),
+        stop_charging=AsyncMock(return_value=None),
+        set_charge_mode=AsyncMock(return_value={"status": "ok"}),
+        start_live_stream=AsyncMock(
+            return_value={"status": "accepted", "duration_s": 900}
+        ),
+    )
+    coord.async_request_refresh = AsyncMock()
+
+    await coord.async_start_charging(RANDOM_SERIAL, requested_amps=24)
+
+    coord.client.start_charging.assert_awaited_once_with(
+        RANDOM_SERIAL, 24, 1, include_level=True, strict_preference=True
     )
     coord.client.set_charge_mode.assert_not_awaited()
 
@@ -2005,7 +2039,7 @@ async def test_async_start_and_stop_preserve_scheduled_mode(hass, monkeypatch):
 
     await coord.async_start_charging(RANDOM_SERIAL)
     coord.client.start_charging.assert_awaited_once_with(
-        RANDOM_SERIAL, 18, 1, include_level=True, strict_preference=True
+        RANDOM_SERIAL, 18, 1, include_level=True, strict_preference=False
     )
     coord.client.set_charge_mode.assert_awaited_once_with(
         RANDOM_SERIAL, "SCHEDULED_CHARGING"
@@ -2013,6 +2047,42 @@ async def test_async_start_and_stop_preserve_scheduled_mode(hass, monkeypatch):
 
     coord.client.set_charge_mode.reset_mock()
     await coord.async_stop_charging(RANDOM_SERIAL)
+    coord.client.set_charge_mode.assert_awaited_once_with(
+        RANDOM_SERIAL, "SCHEDULED_CHARGING"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_start_charging_scheduled_mode_explicit_request_stays_strict(
+    hass, monkeypatch
+):
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.serials = {RANDOM_SERIAL}
+    coord.data = {
+        RANDOM_SERIAL: {
+            "plugged": True,
+            "charging_level": 18,
+            "charge_mode_pref": "SCHEDULED_CHARGING",
+        }
+    }
+    coord.last_set_amps = {}
+    coord.set_charging_expectation = MagicMock()
+    coord.kick_fast = MagicMock()
+    coord.client = SimpleNamespace(
+        start_charging=AsyncMock(return_value={"status": "ok"}),
+        stop_charging=AsyncMock(return_value={"status": "ok"}),
+        set_charge_mode=AsyncMock(return_value={"status": "ok"}),
+        start_live_stream=AsyncMock(
+            return_value={"status": "accepted", "duration_s": 900}
+        ),
+    )
+    coord.async_request_refresh = AsyncMock()
+
+    await coord.async_start_charging(RANDOM_SERIAL, requested_amps=24)
+
+    coord.client.start_charging.assert_awaited_once_with(
+        RANDOM_SERIAL, 24, 1, include_level=True, strict_preference=True
+    )
     coord.client.set_charge_mode.assert_awaited_once_with(
         RANDOM_SERIAL, "SCHEDULED_CHARGING"
     )

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import asyncio
 from datetime import UTC, datetime
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, MagicMock, Mock
+from unittest.mock import AsyncMock, MagicMock, Mock, call
 
+import aiohttp
 import pytest
 
 from homeassistant.exceptions import ServiceValidationError
@@ -22,6 +23,22 @@ from custom_components.enphase_ev.evse_runtime import (
 @pytest.fixture(autouse=True)
 def _force_utc_timezone() -> None:
     dt_util.set_default_time_zone(UTC)
+
+
+def _client_response_error(status: int, *, message: str = "", headers=None):
+    req = aiohttp.RequestInfo(
+        url=aiohttp.client.URL("https://example"),
+        method="GET",
+        headers={},
+        real_url=aiohttp.client.URL("https://example"),
+    )
+    return aiohttp.ClientResponseError(
+        request_info=req,
+        history=(),
+        status=status,
+        message=message,
+        headers=headers or {},
+    )
 
 
 def test_evse_runtime_helper_paths(coordinator_factory) -> None:
@@ -57,7 +74,7 @@ def test_evse_runtime_helper_paths(coordinator_factory) -> None:
     assert prefs == ChargeModeStartPreferences(
         mode="SCHEDULED_CHARGING",
         include_level=True,
-        strict=True,
+        strict=False,
         enforce_mode="SCHEDULED_CHARGING",
     )
 
@@ -238,6 +255,138 @@ async def test_evse_runtime_start_stop_and_auto_resume_use_coordinator_hooks(
     )
     coord._ensure_charge_mode.assert_awaited()
     assert coord.async_request_refresh.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_evse_runtime_start_charging_invalid_level_falls_back_and_caches(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    runtime = coord.evse_runtime
+    coord.data = {"EV1": {"plugged": True, "charge_mode_pref": "MANUAL_CHARGING"}}
+    coord.pick_start_amps = MagicMock(return_value=28)
+    coord.set_last_set_amps = MagicMock()
+    coord.set_desired_charging = MagicMock()
+    coord.set_charging_expectation = MagicMock()
+    coord.kick_fast = MagicMock()
+    coord.async_start_streaming = AsyncMock()
+    coord.async_request_refresh = AsyncMock()
+    coord.require_plugged = MagicMock()
+    coord.client.start_charging = AsyncMock(
+        side_effect=[
+            _client_response_error(
+                500,
+                message='{"error":{"displayMessage":"Invalid charge level","code":"500"}}',
+            ),
+            {"status": "ok"},
+        ]
+    )
+
+    await runtime.async_start_charging("EV1")
+
+    assert coord.client.start_charging.await_args_list[0] == call(
+        "EV1",
+        28,
+        1,
+        include_level=True,
+        strict_preference=False,
+    )
+    assert coord.client.start_charging.await_args_list[1] == call(
+        "EV1",
+        28,
+        1,
+        include_level=False,
+        strict_preference=True,
+    )
+    assert coord._start_without_level_fallback == {"EV1": True}  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_evse_runtime_start_charging_uses_cached_no_level_fallback(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    runtime = coord.evse_runtime
+    coord.data = {"EV1": {"plugged": True, "charge_mode_pref": "MANUAL_CHARGING"}}
+    coord.pick_start_amps = MagicMock(return_value=28)
+    coord.set_last_set_amps = MagicMock()
+    coord.set_desired_charging = MagicMock()
+    coord.set_charging_expectation = MagicMock()
+    coord.kick_fast = MagicMock()
+    coord.async_start_streaming = AsyncMock()
+    coord.async_request_refresh = AsyncMock()
+    coord.require_plugged = MagicMock()
+    coord._start_without_level_fallback = {"EV1": True}  # noqa: SLF001
+    coord.client.start_charging = AsyncMock(return_value={"status": "ok"})
+
+    await runtime.async_start_charging("EV1")
+
+    coord.client.start_charging.assert_awaited_once_with(
+        "EV1",
+        28,
+        1,
+        include_level=False,
+        strict_preference=True,
+    )
+    assert coord._start_without_level_fallback == {"EV1": True}  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_evse_runtime_explicit_start_clears_cached_no_level_fallback(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    runtime = coord.evse_runtime
+    coord.data = {"EV1": {"plugged": True, "charge_mode_pref": "MANUAL_CHARGING"}}
+    coord.pick_start_amps = MagicMock(return_value=24)
+    coord.set_last_set_amps = MagicMock()
+    coord.set_desired_charging = MagicMock()
+    coord.set_charging_expectation = MagicMock()
+    coord.kick_fast = MagicMock()
+    coord.async_start_streaming = AsyncMock()
+    coord.async_request_refresh = AsyncMock()
+    coord.require_plugged = MagicMock()
+    coord._start_without_level_fallback = {"EV1": True}  # noqa: SLF001
+    coord.client.start_charging = AsyncMock(return_value={"status": "ok"})
+
+    await runtime.async_start_charging("EV1", requested_amps=24)
+
+    coord.client.start_charging.assert_awaited_once_with(
+        "EV1",
+        24,
+        1,
+        include_level=True,
+        strict_preference=True,
+    )
+    assert coord._start_without_level_fallback == {}  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_evse_runtime_start_charging_reraises_non_fallback_errors(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    runtime = coord.evse_runtime
+    coord.data = {"EV1": {"plugged": True, "charge_mode_pref": "MANUAL_CHARGING"}}
+    coord.pick_start_amps = MagicMock(return_value=28)
+    coord.require_plugged = MagicMock()
+    coord.client.start_charging = AsyncMock(
+        side_effect=_client_response_error(
+            500,
+            message='{"error":{"displayMessage":"Backend unavailable","code":"500"}}',
+        )
+    )
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await runtime.async_start_charging("EV1")
+
+    coord.client.start_charging.assert_awaited_once_with(
+        "EV1",
+        28,
+        1,
+        include_level=True,
+        strict_preference=False,
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #544 by relaxing EV charger start strictness for manual and scheduled starts only when no explicit charging level was requested.

Root cause: older IQ 40 backends can reject `chargingLevel` during `start_charging` with `500 Invalid charge level`, and the manual/scheduled runtime path previously forced strict level-bearing variants with no no-level fallback.

Behavior after this change:
- button-style starts without an explicit amp request still prefer level-bearing payloads first, but now retry once without a charging level when the backend rejects the level as invalid
- explicit `charging_level` service and device-action requests remain strict, so they do not silently start at a stale charger limit
- successful degraded starts are cached per charger in runtime state so future button-style starts go straight to the working no-level variant

## Related Issues

- #544

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Commands run:

```bash
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/evse_runtime.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_api_client_methods.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev/evse_runtime.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_api_client_methods.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_api_client_methods.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/evse_runtime.py --fail-under=100"
docker-compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger:/Users/james/Documents/GitHub/ha-enphase-ev-charger ha-dev bash -lc "git rev-parse --show-toplevel && pre-commit run --all-files"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- `pre-commit` required mounting the parent repository path inside Docker because this checkout is a Git worktree and the `.git` file points at host worktree metadata outside `/workspace`.
