### PR TITLE
Prepare release v2.7.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v2.7.11 - 2026-04-14
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Decoupled the charge-from-grid main toggle from schedule state so supported battery sites can update CFG enablement even when Enphase has not exposed a dedicated schedule payload yet.
+- Aligned BatteryConfig request handling and related API documentation with the current first-party Enphase web variants for issue `#460`, reducing drift from the browser client shape used by battery settings flows.
 - Relaxed EV charger manual and scheduled start strictness for issue `#544` so `start_charging` still prefers amp-bearing payloads but now falls back to no-level variants when older IQ 40 backends reject `chargingLevel` as invalid.
 - Fixed HEMS device lifetime sensors so zero-only primary EVSE, Heat Pump, and Water Heater placeholder buckets still trigger the dedicated HEMS fallback when needed, while zero-valued results copied from that fallback now report `0.0 kWh` instead of `Unavailable`.
 
@@ -18,7 +37,8 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🔄 Other changes
-- None
+- Bumped GitHub Actions dependencies by updating `actions/github-script` from v8 to v9 and `softprops/action-gh-release` from v2 to v3.
+- Bumped the integration manifest version to `2.7.11`.
 
 ## v2.7.10 - 2026-04-12
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.10"
+  "version": "2.7.11"
 }


### PR DESCRIPTION
## Summary

Prepare the `v2.7.11` release by bumping the integration manifest version and rolling the unreleased notes into a dated changelog entry that covers the PRs merged after `v2.7.10`.

## Related Issues

- PRs included in this release: #540, #542, #543, #545, #546, #547
- Related compatibility issues: #460, #544

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release preparation for `v2.7.11`.

## Testing

List the exact commands you ran.

```bash
docker-compose -f devtools/docker/docker-compose.yml build ha-dev
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev tests/components/enphase_ev"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker-compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Targeted coverage was not run because this PR only changes `CHANGELOG.md` and `custom_components/enphase_ev/manifest.json`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Local Docker on this machine exposes `docker-compose`, so the equivalent pinned `devtools/docker/` workflow was run with that command form.
