### PR TITLE
Harden battery profile write compatibility for reserve changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Hardened BatteryConfig-backed battery reserve/profile writes by preserving the browser-style request path used by working sites and adding compatibility fallbacks for alternate auth and payload shapes observed on affected installs.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import time
 from datetime import time as dt_time, timedelta
@@ -12,6 +13,12 @@ import aiohttp
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import dt as dt_util
 
+from .api import (
+    BASE_URL,
+    _ENLIGHTEN_BROWSER_USER_AGENT,
+    _cookie_map_from_header,
+    _seed_cookie_jar,
+)
 from .ac_battery_runtime import AcBatteryRuntime
 from .const import (
     BATTERY_BACKUP_HISTORY_CACHE_TTL,
@@ -52,6 +59,24 @@ if TYPE_CHECKING:  # pragma: no cover
 
 _LOGGER = logging.getLogger(__name__)
 
+_BATTERY_PROFILE_WRITE_OFFICIAL_WEB_LEAN = "official_web_lean"
+_BATTERY_PROFILE_WRITE_EXTERNAL_COMPAT = "external_compatible"
+_BATTERY_PROFILE_MODERN_MARKERS: tuple[str, ...] = (
+    "IQBATTERY-5P",
+    "IQ BATTERY 5P",
+    "IQ-BAT-5P",
+    "B05-T02",
+    "5P FLEXPHASE",
+)
+_BATTERY_PROFILE_LEGACY_MARKERS: tuple[str, ...] = (
+    "IQ BATTERY 3T",
+    "IQ BATTERY 10T",
+    "IQ-BAT-3T",
+    "IQ-BAT-10T",
+    "ENCHARGE 3",
+    "ENCHARGE 10",
+)
+
 
 class BatteryRuntime:
     """Battery profile selection and pending-state helpers."""
@@ -59,6 +84,8 @@ class BatteryRuntime:
     def __init__(self, coordinator: EnphaseCoordinator) -> None:
         self.coordinator = coordinator
         self._ac_battery_runtime = AcBatteryRuntime(self)
+        self._battery_profile_write_mode_cache: str | None = None
+        self._battery_profile_write_without_devices_cache = False
 
     @property
     def battery_state(self) -> object:
@@ -1309,17 +1336,116 @@ class BatteryRuntime:
             and normalized_sub_type != SAVINGS_OPERATION_MODE_SUBTYPE
         ):
             normalized_sub_type = SAVINGS_OPERATION_MODE_SUBTYPE
+        devices_payload = coord.battery_profile_devices_payload()
+        preferred_devices_payload = (
+            None
+            if devices_payload and self._battery_profile_write_without_devices_cache
+            else devices_payload
+        )
         async with state._battery_profile_write_lock:
             state._battery_profile_last_write_mono = time.monotonic()
+            inventory_mode = self._battery_profile_write_mode_from_inventory()
+            preferred_mode = (
+                self._battery_profile_write_mode_cache
+                or inventory_mode
+                or _BATTERY_PROFILE_WRITE_OFFICIAL_WEB_LEAN
+            )
+            if preferred_mode == _BATTERY_PROFILE_WRITE_EXTERNAL_COMPAT:
+                preferred_debug_auth_source = (
+                    "external_compatible_profile_cached"
+                    if self._battery_profile_write_mode_cache
+                    == _BATTERY_PROFILE_WRITE_EXTERNAL_COMPAT
+                    else "external_compatible_profile_write"
+                )
+            else:
+                preferred_debug_auth_source = (
+                    "official_web_lean_cached"
+                    if self._battery_profile_write_mode_cache
+                    == _BATTERY_PROFILE_WRITE_OFFICIAL_WEB_LEAN
+                    else "official_web_lean"
+                )
             try:
-                await coord.client.set_battery_profile(
+                if not await self._async_write_battery_profile(
                     profile=normalized_profile,
-                    battery_backup_percentage=normalized_reserve,
-                    operation_mode_sub_type=normalized_sub_type,
-                    devices=coord.battery_profile_devices_payload(),
+                    reserve=normalized_reserve,
+                    sub_type=normalized_sub_type,
+                    devices=preferred_devices_payload,
+                    mode=preferred_mode,
+                    debug_auth_source=preferred_debug_auth_source,
+                ):
+                    raise aiohttp.ClientResponseError(
+                        request_info=None,
+                        history=(),
+                        status=HTTPStatus.FORBIDDEN,
+                        message="Forbidden",
+                    )
+                self._cache_battery_profile_write_mode(
+                    preferred_mode, inventory_mode=inventory_mode
+                )
+                self._battery_profile_write_without_devices_cache = bool(
+                    devices_payload and preferred_devices_payload is None
                 )
             except aiohttp.ClientResponseError as err:
-                if err.status == HTTPStatus.FORBIDDEN:
+                fallback_devices_payload = preferred_devices_payload
+                if (
+                    err.status == HTTPStatus.FORBIDDEN
+                    and devices_payload
+                    and preferred_devices_payload is not None
+                ):
+                    try:
+                        if await self._async_write_battery_profile(
+                            profile=normalized_profile,
+                            reserve=normalized_reserve,
+                            sub_type=normalized_sub_type,
+                            devices=None,
+                            mode=preferred_mode,
+                            debug_auth_source=(
+                                f"{preferred_debug_auth_source}_without_devices"
+                            ),
+                        ):
+                            err = None
+                            fallback_devices_payload = None
+                            self._cache_battery_profile_write_mode(
+                                preferred_mode, inventory_mode=inventory_mode
+                            )
+                            self._battery_profile_write_without_devices_cache = True
+                    except aiohttp.ClientResponseError as retry_err:
+                        err = retry_err
+                        fallback_devices_payload = None
+                if err is None:
+                    pass
+                elif err.status == HTTPStatus.FORBIDDEN:
+                    fallback_mode = (
+                        _BATTERY_PROFILE_WRITE_OFFICIAL_WEB_LEAN
+                        if preferred_mode == _BATTERY_PROFILE_WRITE_EXTERNAL_COMPAT
+                        else _BATTERY_PROFILE_WRITE_EXTERNAL_COMPAT
+                    )
+                    try:
+                        if await self._async_write_battery_profile(
+                            profile=normalized_profile,
+                            reserve=normalized_reserve,
+                            sub_type=normalized_sub_type,
+                            devices=fallback_devices_payload,
+                            mode=fallback_mode,
+                            debug_auth_source=(
+                                "external_compatible_profile_retry"
+                                if fallback_mode
+                                == _BATTERY_PROFILE_WRITE_EXTERNAL_COMPAT
+                                else "official_web_lean_retry"
+                            ),
+                        ):
+                            err = None
+                            self._cache_battery_profile_write_mode(
+                                fallback_mode, inventory_mode=inventory_mode
+                            )
+                            self._battery_profile_write_without_devices_cache = bool(
+                                devices_payload and fallback_devices_payload is None
+                            )
+                    except aiohttp.ClientResponseError as retry_err:
+                        err = retry_err
+                if err is None:
+                    pass
+                elif err.status == HTTPStatus.FORBIDDEN:
                     owner = coord.battery_user_is_owner
                     installer = coord.battery_user_is_installer
                     if owner is False and installer is False:
@@ -1329,11 +1455,12 @@ class BatteryRuntime:
                     raise ServiceValidationError(
                         "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
                     ) from err
-                if err.status == HTTPStatus.UNAUTHORIZED:
+                elif err.status == HTTPStatus.UNAUTHORIZED:
                     raise ServiceValidationError(
                         "Battery profile update could not be authenticated. Reauthenticate and try again."
                     ) from err
-                raise
+                else:
+                    raise
         self.remember_battery_reserve(normalized_profile, normalized_reserve)
         self.set_battery_pending(
             profile=normalized_profile,
@@ -1345,6 +1472,341 @@ class BatteryRuntime:
         state._battery_settings_cache_until = None
         coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
         await coord.async_request_refresh()
+
+    @staticmethod
+    def _battery_profile_write_payload(
+        *,
+        profile: str,
+        reserve: int,
+        sub_type: str | None,
+        devices: list[dict[str, object]] | None,
+    ) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "profile": str(profile),
+            "batteryBackupPercentage": int(reserve),
+        }
+        if sub_type:
+            payload["operationModeSubType"] = str(sub_type)
+        if devices:
+            payload["devices"] = [item for item in devices if isinstance(item, dict)]
+        return payload
+
+    @staticmethod
+    def _battery_profile_marker_match(text: str, markers: tuple[str, ...]) -> bool:
+        normalized = text.upper()
+        return any(marker in normalized for marker in markers)
+
+    def _battery_profile_write_mode_from_inventory(self) -> str | None:
+        inventory_view = getattr(self.coordinator, "inventory_view", None)
+        type_bucket = getattr(inventory_view, "type_bucket", None)
+        if not callable(type_bucket):
+            return None
+        bucket = type_bucket("encharge")
+        if not isinstance(bucket, dict):
+            return None
+        devices = bucket.get("devices")
+        if not isinstance(devices, list) or not devices:
+            return None
+
+        saw_modern = False
+        saw_legacy = False
+        for member in devices:
+            if not isinstance(member, dict):
+                continue
+            member_modern = False
+            member_legacy = False
+            for key in ("sku_id", "model_id", "model", "name"):
+                text = self._coerce_optional_text(member.get(key))
+                if not text:
+                    continue
+                if self._battery_profile_marker_match(
+                    text, _BATTERY_PROFILE_MODERN_MARKERS
+                ):
+                    member_modern = True
+                if self._battery_profile_marker_match(
+                    text, _BATTERY_PROFILE_LEGACY_MARKERS
+                ):
+                    member_legacy = True
+            if member_modern and member_legacy:
+                return None
+            if member_modern:
+                saw_modern = True
+            elif member_legacy:
+                saw_legacy = True
+
+        if saw_modern and not saw_legacy:
+            return _BATTERY_PROFILE_WRITE_OFFICIAL_WEB_LEAN
+        if saw_legacy and not saw_modern:
+            return _BATTERY_PROFILE_WRITE_EXTERNAL_COMPAT
+        return None
+
+    def _cache_battery_profile_write_mode(
+        self, mode: str, *, inventory_mode: str | None
+    ) -> None:
+        if inventory_mode == mode:
+            self._battery_profile_write_mode_cache = None
+            return
+        self._battery_profile_write_mode_cache = mode
+
+    def _battery_profile_write_override(self):
+        client_dict = getattr(self.coordinator.client, "__dict__", None)
+        if not isinstance(client_dict, dict):
+            return None
+        override = client_dict.get("set_battery_profile")
+        if callable(override):
+            return override
+        return None
+
+    async def _async_write_battery_profile(
+        self,
+        *,
+        profile: str,
+        reserve: int,
+        sub_type: str | None,
+        devices: list[dict[str, object]] | None,
+        mode: str,
+        debug_auth_source: str,
+    ) -> bool:
+        if mode == _BATTERY_PROFILE_WRITE_EXTERNAL_COMPAT:
+            return await self._async_write_battery_profile_external_compat(
+                profile=profile,
+                reserve=reserve,
+                sub_type=sub_type,
+                devices=devices,
+                debug_auth_source=debug_auth_source,
+            )
+        await self._async_write_battery_profile_official_web_lean(
+            profile=profile,
+            reserve=reserve,
+            sub_type=sub_type,
+            devices=devices,
+            debug_auth_source=debug_auth_source,
+        )
+        return True
+
+    async def _async_write_battery_profile_official_web_lean(
+        self,
+        *,
+        profile: str,
+        reserve: int,
+        sub_type: str | None,
+        devices: list[dict[str, object]] | None,
+        debug_auth_source: str,
+    ) -> None:
+        override = self._battery_profile_write_override()
+        if override is not None:
+            await override(
+                profile=profile,
+                battery_backup_percentage=reserve,
+                operation_mode_sub_type=sub_type,
+                devices=devices,
+            )
+            return
+
+        coord = self.coordinator
+        client = coord.client
+        acquire_xsrf = getattr(client, "_acquire_xsrf_token", None)
+        auth_context_factory = getattr(client, "_battery_config_auth_context", None)
+        params_factory = getattr(client, "_battery_config_params", None)
+        request_json = getattr(client, "_json", None)
+        xsrf_token_factory = getattr(client, "_xsrf_token", None)
+        if not all(
+            callable(func)
+            for func in (
+                acquire_xsrf,
+                auth_context_factory,
+                params_factory,
+                request_json,
+                xsrf_token_factory,
+            )
+        ):
+            await client.set_battery_profile(
+                profile=profile,
+                battery_backup_percentage=reserve,
+                operation_mode_sub_type=sub_type,
+                devices=devices,
+            )
+            return
+
+        await acquire_xsrf("cfg")
+        headers = dict(getattr(client, "_h", {}) or {})
+        token, user_id = auth_context_factory()
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        if getattr(client, "_eauth", None):
+            headers["e-auth-token"] = getattr(client, "_eauth")
+        elif token:
+            headers["e-auth-token"] = token
+        if user_id:
+            headers["Username"] = user_id
+        headers["Accept"] = "application/json, text/plain, */*"
+        headers["Origin"] = "https://battery-profile-ui.enphaseenergy.com"
+        headers["Referer"] = "https://battery-profile-ui.enphaseenergy.com/"
+        headers["Content-Type"] = "application/json"
+        xsrf = xsrf_token_factory()
+        if xsrf:
+            headers["X-XSRF-Token"] = xsrf
+            headers["X-CSRF-Token"] = xsrf
+            cookie_map = _cookie_map_from_header(getattr(client, "_cookie", None))
+            cookie_parts = [
+                f"{key}={value}"
+                for key, value in cookie_map.items()
+                if str(key).strip().lower() not in {"xsrf-token", "bp-xsrf-token"}
+            ]
+            cookie_parts.append(f"BP-XSRF-Token={xsrf}")
+            headers["Cookie"] = "; ".join(cookie_parts)
+        params = params_factory(include_source=True)
+        if isinstance(params, dict):
+            params = dict(params)
+
+        await request_json(
+            "PUT",
+            f"{BASE_URL}/service/batteryConfig/api/v1/profile/{coord.site_id}",
+            json=self._battery_profile_write_payload(
+                profile=profile,
+                reserve=reserve,
+                sub_type=sub_type,
+                devices=devices,
+            ),
+            headers=headers,
+            params=params,
+            debug_auth_source=debug_auth_source,
+        )
+
+    async def _async_fetch_legacy_battery_config_jwt(self) -> str | None:
+        client = self.coordinator.client
+        session = getattr(client, "_s", None)
+        request = getattr(session, "request", None)
+        if not callable(request):
+            return None
+
+        headers = {
+            "Accept": "application/json, text/plain, */*",
+            "Referer": f"{BASE_URL}/",
+            "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
+        }
+        cookie = getattr(client, "_cookie", None)
+        if cookie:
+            headers["Cookie"] = str(cookie)
+
+        timeout = getattr(client, "_timeout", None) or 15
+        url = f"{BASE_URL}/app-api/jwt_token.json"
+        try:
+            _seed_cookie_jar(session, _cookie_map_from_header(cookie))
+            async with asyncio.timeout(timeout):
+                async with request("GET", url, headers=headers) as response:
+                    if response.status >= HTTPStatus.BAD_REQUEST:
+                        return None
+                    payload = await response.json()
+        except (aiohttp.ClientError, TimeoutError, TypeError, ValueError):
+            return None
+
+        if not isinstance(payload, dict):
+            return None
+        token = payload.get("token") or payload.get("auth_token")
+        if not token:
+            return None
+        return str(token)
+
+    async def _async_write_battery_profile_external_compat(
+        self,
+        *,
+        profile: str,
+        reserve: int,
+        sub_type: str | None,
+        devices: list[dict[str, object]] | None,
+        debug_auth_source: str,
+    ) -> bool:
+        override = self._battery_profile_write_override()
+        if override is not None:
+            await override(
+                profile=profile,
+                battery_backup_percentage=reserve,
+                operation_mode_sub_type=sub_type,
+                devices=devices,
+            )
+            return True
+
+        coord = self.coordinator
+        client = coord.client
+        acquire_xsrf = getattr(client, "_acquire_xsrf_token", None)
+        headers_factory = getattr(client, "_battery_config_headers", None)
+        params_factory = getattr(client, "_battery_config_params", None)
+        auth_token_factory = getattr(client, "_battery_config_single_auth_token", None)
+        user_id_factory = getattr(client, "_battery_config_user_id_for_token", None)
+        request_json = getattr(client, "_json", None)
+        if not all(
+            callable(func)
+            for func in (
+                acquire_xsrf,
+                params_factory,
+                auth_token_factory,
+                user_id_factory,
+                request_json,
+            )
+        ):
+            return False
+
+        await acquire_xsrf("cfg", include_eauth=False, include_requestid=False)
+        headers = dict(getattr(client, "_h", {}) or {})
+        retry_token = await self._async_fetch_legacy_battery_config_jwt()
+        if not retry_token:
+            retry_token = auth_token_factory()
+        xsrf = headers.get("X-XSRF-Token")
+        if not xsrf and callable(
+            headers_factory := getattr(client, "_battery_config_headers", None)
+        ):
+            fallback_headers = headers_factory(
+                include_xsrf=True,
+                include_eauth=False,
+                include_requestid=False,
+            )
+            if isinstance(fallback_headers, dict):
+                xsrf = self._coerce_optional_text(fallback_headers.get("X-XSRF-Token"))
+        if not retry_token or not xsrf:
+            return False
+
+        user_id = user_id_factory(retry_token)
+        headers["Accept"] = "application/json, text/plain, */*"
+        headers["Origin"] = "https://battery-profile-ui.enphaseenergy.com"
+        headers["Referer"] = "https://battery-profile-ui.enphaseenergy.com/"
+        headers["Authorization"] = None
+        headers["Content-Type"] = "application/json"
+        headers["Cookie"] = f"BP-XSRF-Token={xsrf}"
+        headers["X-Requested-With"] = "XMLHttpRequest"
+        headers["e-auth-token"] = retry_token
+        headers["X-CSRF-Token"] = None
+        headers["X-XSRF-Token"] = xsrf
+        if user_id:
+            headers["Username"] = user_id
+        else:
+            headers.pop("Username", None)
+
+        params = params_factory(include_source=True)
+        if isinstance(params, dict):
+            params = dict(params)
+            params.pop("source", None)
+            if user_id:
+                params["userId"] = user_id
+
+        _LOGGER.debug(
+            "Retrying BatteryConfig profile write for site %s with external-compatible headers",
+            redact_site_id(coord.site_id),
+        )
+        await request_json(
+            "PUT",
+            f"{BASE_URL}/service/batteryConfig/api/v1/profile/{coord.site_id}",
+            json=self._battery_profile_write_payload(
+                profile=profile,
+                reserve=reserve,
+                sub_type=sub_type,
+                devices=devices,
+            ),
+            headers=headers,
+            params=params,
+            debug_auth_source=debug_auth_source,
+        )
+        return True
 
     async def async_apply_battery_settings(self, payload: dict[str, object]) -> None:
         coord = self.coordinator

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from datetime import datetime, timedelta, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, call
 
 import aiohttp
 import pytest
@@ -518,6 +518,1191 @@ async def test_battery_profile_forbidden_after_permission_change_returns_permiss
             profile="self-consumption",
             reserve=30,
         )
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_modern_inventory_uses_official_web_lean_shape(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "encharge": {
+                "type_key": "encharge",
+                "type_label": "Battery",
+                "count": 1,
+                "devices": [
+                    {
+                        "serial_number": "BAT-5P",
+                        "name": "IQ Battery 5P",
+                        "sku_id": "B05-T02-US00-1-3",
+                    }
+                ],
+            }
+        },
+        ["encharge"],
+    )
+    coord.client._acquire_xsrf_token = AsyncMock(return_value="cfg-token")
+    coord.client._battery_config_auth_context = MagicMock(
+        return_value=("bearer-token", "88")
+    )
+    coord.client._battery_config_params = MagicMock(
+        return_value={"userId": "88", "source": "enho"}
+    )
+    coord.client._xsrf_token = MagicMock(return_value="cfg-token")
+    coord.client._h = {"User-Agent": "Mozilla/5.0"}
+    coord.client._cookie = "session=abc; BP-XSRF-Token=stale"
+    coord.client._json = AsyncMock(return_value={"message": "success"})
+
+    await coord.async_set_battery_reserve(30)
+
+    coord.client._acquire_xsrf_token.assert_awaited_once_with("cfg")
+    coord.client._json.assert_awaited_once()
+    args, kwargs = coord.client._json.await_args
+    assert args[0] == "PUT"
+    assert "batteryConfig/api/v1/profile/" in args[1]
+    assert kwargs["params"] == {"userId": "88", "source": "enho"}
+    assert kwargs["headers"]["Authorization"] == "Bearer bearer-token"
+    assert kwargs["headers"]["e-auth-token"] == "EAUTH"
+    assert kwargs["headers"]["Username"] == "88"
+    assert kwargs["headers"]["X-XSRF-Token"] == "cfg-token"
+    assert kwargs["headers"]["X-CSRF-Token"] == "cfg-token"
+    assert kwargs["headers"]["Cookie"] == "session=abc; BP-XSRF-Token=cfg-token"
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+    assert kwargs["debug_auth_source"] == "official_web_lean"
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_legacy_inventory_uses_external_compatible_shape(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "encharge": {
+                "type_key": "encharge",
+                "type_label": "Battery",
+                "count": 1,
+                "devices": [
+                    {
+                        "serial_number": "BAT-3T",
+                        "name": "IQ Battery 3T",
+                        "sku_id": "IQ-BAT-3T",
+                    }
+                ],
+            }
+        },
+        ["encharge"],
+    )
+    coord.client._acquire_xsrf_token = AsyncMock(return_value="cfg-token")
+    coord.client._battery_config_headers = MagicMock(
+        return_value={
+            "Accept": "application/json, text/plain, */*",
+            "Origin": "https://battery-profile-ui.enphaseenergy.com",
+            "Referer": "https://battery-profile-ui.enphaseenergy.com/",
+            "User-Agent": "Mozilla/5.0",
+            "Authorization": None,
+            "X-Requested-With": None,
+            "Cookie": None,
+            "e-auth-token": None,
+            "X-CSRF-Token": None,
+            "requestid": None,
+            "X-XSRF-Token": "cfg-token",
+        }
+    )
+    coord.client._battery_config_params = MagicMock(
+        return_value={"userId": "88", "source": "enho"}
+    )
+    coord.client._battery_config_single_auth_token = MagicMock(
+        return_value="retry-token"
+    )
+    coord.client._battery_config_user_id_for_token = MagicMock(return_value="88")
+    coord.client._json = AsyncMock(return_value={"message": "success"})
+
+    await coord.async_set_battery_reserve(30)
+
+    coord.client._json.assert_awaited_once()
+    args, kwargs = coord.client._json.await_args
+    assert args[0] == "PUT"
+    assert "batteryConfig/api/v1/profile/" in args[1]
+    assert kwargs["params"] == {"userId": "88"}
+    assert kwargs["headers"]["Cookie"] == "BP-XSRF-Token=cfg-token"
+    assert kwargs["headers"]["X-Requested-With"] == "XMLHttpRequest"
+    assert kwargs["headers"]["e-auth-token"] == "retry-token"
+    assert kwargs["headers"]["Username"] == "88"
+    assert "source" not in kwargs["params"]
+    assert kwargs["debug_auth_source"] == "external_compatible_profile_write"
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_unknown_inventory_fallbacks_and_caches_external_compat(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord.client._acquire_xsrf_token = AsyncMock(return_value="cfg-token")
+    coord.client._battery_config_headers = MagicMock(
+        return_value={
+            "Accept": "application/json, text/plain, */*",
+            "Origin": "https://battery-profile-ui.enphaseenergy.com",
+            "Referer": "https://battery-profile-ui.enphaseenergy.com/",
+            "User-Agent": "Mozilla/5.0",
+            "Authorization": None,
+            "X-Requested-With": None,
+            "Cookie": None,
+            "e-auth-token": None,
+            "X-CSRF-Token": None,
+            "requestid": None,
+            "X-XSRF-Token": "cfg-token",
+        }
+    )
+    coord.client._battery_config_params = MagicMock(
+        return_value={"userId": "88", "source": "enho"}
+    )
+    coord.client._battery_config_single_auth_token = MagicMock(
+        return_value="retry-token"
+    )
+    coord.client._battery_config_user_id_for_token = MagicMock(return_value="88")
+    calls: list[str] = []
+
+    async def _json_side_effect(*_args, **kwargs):
+        calls.append(kwargs["debug_auth_source"])
+        if kwargs["debug_auth_source"] == "official_web_lean" and len(calls) == 1:
+            raise aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=403,
+                message="Forbidden",
+            )
+        return {"message": "success"}
+
+    coord.client._json = AsyncMock(side_effect=_json_side_effect)
+
+    await coord.async_set_battery_reserve(30)
+
+    assert calls == [
+        "official_web_lean",
+        "external_compatible_profile_retry",
+    ]
+    assert (
+        coord.battery_runtime._battery_profile_write_mode_cache == "external_compatible"
+    )
+
+    coord._battery_profile_last_write_mono = time.monotonic() - 10  # noqa: SLF001
+    await coord.async_set_battery_reserve(31)
+
+    assert calls == [
+        "official_web_lean",
+        "external_compatible_profile_retry",
+        "external_compatible_profile_cached",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_modern_inventory_fallbacks_and_caches_external_compat(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "encharge": {
+                "type_key": "encharge",
+                "type_label": "Battery",
+                "count": 1,
+                "devices": [
+                    {
+                        "serial_number": "BAT-5P",
+                        "name": "IQ Battery 5P",
+                        "sku_id": "B05-T02-ROW00-1-2",
+                    }
+                ],
+            }
+        },
+        ["encharge"],
+    )
+    coord.client._acquire_xsrf_token = AsyncMock(return_value="cfg-token")
+    coord.client._battery_config_headers = MagicMock(
+        return_value={
+            "Accept": "application/json, text/plain, */*",
+            "Origin": "https://battery-profile-ui.enphaseenergy.com",
+            "Referer": "https://battery-profile-ui.enphaseenergy.com/",
+            "User-Agent": "Mozilla/5.0",
+            "Authorization": None,
+            "X-Requested-With": None,
+            "Cookie": None,
+            "e-auth-token": None,
+            "X-CSRF-Token": None,
+            "requestid": None,
+            "X-XSRF-Token": "cfg-token",
+        }
+    )
+    coord.client._battery_config_params = MagicMock(
+        return_value={"userId": "88", "source": "enho"}
+    )
+    coord.client._battery_config_single_auth_token = MagicMock(
+        return_value="retry-token"
+    )
+    coord.client._battery_config_user_id_for_token = MagicMock(return_value="88")
+    calls: list[str] = []
+
+    async def _json_side_effect(*_args, **kwargs):
+        calls.append(kwargs["debug_auth_source"])
+        if kwargs["debug_auth_source"] == "official_web_lean":
+            raise aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=403,
+                message="Forbidden",
+            )
+        return {"message": "success"}
+
+    coord.client._json = AsyncMock(side_effect=_json_side_effect)
+
+    await coord.async_set_battery_reserve(30)
+
+    assert calls == [
+        "official_web_lean",
+        "external_compatible_profile_retry",
+    ]
+    assert (
+        coord.battery_runtime._battery_profile_write_mode_cache == "external_compatible"
+    )
+
+    coord._battery_profile_last_write_mono = time.monotonic() - 10  # noqa: SLF001
+    await coord.async_set_battery_reserve(31)
+
+    assert calls == [
+        "official_web_lean",
+        "external_compatible_profile_retry",
+        "external_compatible_profile_cached",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_legacy_inventory_fallbacks_and_caches_official_web_lean(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "encharge": {
+                "type_key": "encharge",
+                "type_label": "Battery",
+                "count": 1,
+                "devices": [{"name": "IQ Battery 3T", "sku_id": "IQ-BAT-3T"}],
+            }
+        },
+        ["encharge"],
+    )
+    coord.client._acquire_xsrf_token = AsyncMock(return_value="cfg-token")
+    coord.client._battery_config_headers = MagicMock(
+        return_value={
+            "Accept": "application/json, text/plain, */*",
+            "Origin": "https://battery-profile-ui.enphaseenergy.com",
+            "Referer": "https://battery-profile-ui.enphaseenergy.com/",
+            "User-Agent": "Mozilla/5.0",
+            "Authorization": None,
+            "X-Requested-With": None,
+            "Cookie": None,
+            "e-auth-token": None,
+            "X-CSRF-Token": None,
+            "requestid": None,
+            "X-XSRF-Token": "cfg-token",
+        }
+    )
+    coord.client._battery_config_params = MagicMock(
+        return_value={"userId": "88", "source": "enho"}
+    )
+    coord.client._battery_config_single_auth_token = MagicMock(
+        return_value="retry-token"
+    )
+    coord.client._battery_config_user_id_for_token = MagicMock(return_value="88")
+    calls: list[str] = []
+
+    async def _json_side_effect(*_args, **kwargs):
+        calls.append(kwargs["debug_auth_source"])
+        if kwargs["debug_auth_source"] == "external_compatible_profile_write":
+            raise aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=403,
+                message="Forbidden",
+            )
+        return {"message": "success"}
+
+    coord.client._json = AsyncMock(side_effect=_json_side_effect)
+
+    await coord.async_set_battery_reserve(30)
+
+    assert calls == [
+        "external_compatible_profile_write",
+        "official_web_lean_retry",
+    ]
+    assert (
+        coord.battery_runtime._battery_profile_write_mode_cache == "official_web_lean"
+    )
+
+    coord._battery_profile_last_write_mono = time.monotonic() - 10  # noqa: SLF001
+    await coord.async_set_battery_reserve(31)
+
+    assert calls == [
+        "external_compatible_profile_write",
+        "official_web_lean_retry",
+        "official_web_lean_cached",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_false_result_from_preferred_mode_triggers_fallback(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "encharge": {
+                "type_key": "encharge",
+                "type_label": "Battery",
+                "count": 1,
+                "devices": [{"name": "IQ Battery 3T", "sku_id": "IQ-BAT-3T"}],
+            }
+        },
+        ["encharge"],
+    )
+    coord.battery_runtime._async_write_battery_profile = AsyncMock(  # noqa: SLF001
+        side_effect=[False, True]
+    )
+
+    await coord.async_set_battery_reserve(30)
+
+    assert (
+        coord.battery_runtime._async_write_battery_profile.await_args_list
+        == [  # noqa: SLF001
+            call(
+                profile="self-consumption",
+                reserve=30,
+                sub_type=None,
+                devices=None,
+                mode="external_compatible",
+                debug_auth_source="external_compatible_profile_write",
+            ),
+            call(
+                profile="self-consumption",
+                reserve=30,
+                sub_type=None,
+                devices=None,
+                mode="official_web_lean",
+                debug_auth_source="official_web_lean_retry",
+            ),
+        ]
+    )
+    assert (
+        coord.battery_runtime._battery_profile_write_mode_cache == "official_web_lean"
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_retries_without_devices_before_switching_modes(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord._battery_profile_devices = [  # noqa: SLF001
+        {"uuid": "evse-1", "enable": False, "chargeMode": "MANUAL"}
+    ]
+    coord.battery_runtime._async_write_battery_profile = AsyncMock(  # noqa: SLF001
+        side_effect=[
+            aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=403,
+                message="Forbidden",
+            ),
+            True,
+        ]
+    )
+
+    await coord.async_set_battery_reserve(30)
+
+    assert (
+        coord.battery_runtime._async_write_battery_profile.await_args_list
+        == [  # noqa: SLF001
+            call(
+                profile="self-consumption",
+                reserve=30,
+                sub_type=None,
+                devices=[
+                    {
+                        "uuid": "evse-1",
+                        "deviceType": "iqEvse",
+                        "enable": False,
+                        "chargeMode": "MANUAL",
+                    }
+                ],
+                mode="official_web_lean",
+                debug_auth_source="official_web_lean",
+            ),
+            call(
+                profile="self-consumption",
+                reserve=30,
+                sub_type=None,
+                devices=None,
+                mode="official_web_lean",
+                debug_auth_source="official_web_lean_without_devices",
+            ),
+        ]
+    )
+    assert coord.battery_runtime._battery_profile_write_without_devices_cache is True
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_cached_without_devices_skips_device_payload(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord._battery_profile_devices = [  # noqa: SLF001
+        {"uuid": "evse-1", "enable": False, "chargeMode": "MANUAL"}
+    ]
+    coord.battery_runtime._battery_profile_write_without_devices_cache = (
+        True  # noqa: SLF001
+    )
+    coord.battery_runtime._async_write_battery_profile = AsyncMock(  # noqa: SLF001
+        return_value=True
+    )
+
+    await coord.async_set_battery_reserve(30)
+
+    assert (
+        coord.battery_runtime._async_write_battery_profile.await_args_list
+        == [  # noqa: SLF001
+            call(
+                profile="self-consumption",
+                reserve=30,
+                sub_type=None,
+                devices=None,
+                mode="official_web_lean",
+                debug_auth_source="official_web_lean",
+            )
+        ]
+    )
+    assert coord.battery_runtime._battery_profile_write_without_devices_cache is True
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_uses_fallback_mode_without_devices_after_retry_failure(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord._battery_profile_devices = [  # noqa: SLF001
+        {"uuid": "evse-1", "enable": False, "chargeMode": "MANUAL"}
+    ]
+    coord.battery_runtime._async_write_battery_profile = AsyncMock(  # noqa: SLF001
+        side_effect=[
+            aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=403,
+                message="Forbidden",
+            ),
+            aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=403,
+                message="Forbidden",
+            ),
+            True,
+        ]
+    )
+
+    await coord.async_set_battery_reserve(30)
+
+    assert (
+        coord.battery_runtime._async_write_battery_profile.await_args_list
+        == [  # noqa: SLF001
+            call(
+                profile="self-consumption",
+                reserve=30,
+                sub_type=None,
+                devices=[
+                    {
+                        "uuid": "evse-1",
+                        "deviceType": "iqEvse",
+                        "enable": False,
+                        "chargeMode": "MANUAL",
+                    }
+                ],
+                mode="official_web_lean",
+                debug_auth_source="official_web_lean",
+            ),
+            call(
+                profile="self-consumption",
+                reserve=30,
+                sub_type=None,
+                devices=None,
+                mode="official_web_lean",
+                debug_auth_source="official_web_lean_without_devices",
+            ),
+            call(
+                profile="self-consumption",
+                reserve=30,
+                sub_type=None,
+                devices=None,
+                mode="external_compatible",
+                debug_auth_source="external_compatible_profile_retry",
+            ),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_forbidden_without_compat_prereqs_still_raises(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord.client._acquire_xsrf_token = AsyncMock(return_value="cfg-token")
+    coord.client._battery_config_headers = MagicMock(
+        return_value={"X-XSRF-Token": "cfg-token"}
+    )
+    coord.client._battery_config_single_auth_token = MagicMock(return_value=None)
+    coord.client._battery_config_user_id_for_token = MagicMock(return_value=None)
+    coord.client._battery_config_params = MagicMock(
+        return_value={"userId": "88", "source": "enho"}
+    )
+    coord.client._json = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=403,
+            message="Forbidden",
+        )
+    )
+
+    with pytest.raises(ServiceValidationError, match="HTTP 403 Forbidden"):
+        await coord.async_set_battery_reserve(30)
+
+    coord.client._json.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_legacy_mode_without_compat_helpers_raises(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "encharge": {
+                "type_key": "encharge",
+                "type_label": "Battery",
+                "count": 1,
+                "devices": [{"name": "IQ Battery 3T", "sku_id": "IQ-BAT-3T"}],
+            }
+        },
+        ["encharge"],
+    )
+    coord.client._json = None
+    coord.client.set_battery_profile = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=403,
+            message="Forbidden",
+        )
+    )
+
+    with pytest.raises(ServiceValidationError, match="HTTP 403 Forbidden"):
+        await coord.async_set_battery_reserve(30)
+
+
+def test_battery_profile_write_mode_from_inventory_handles_invalid_shapes(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    coord.inventory_view.type_bucket = None
+    assert coord.battery_runtime._battery_profile_write_mode_from_inventory() is None
+
+    coord.inventory_view.type_bucket = lambda *_args: ["bad"]
+    assert coord.battery_runtime._battery_profile_write_mode_from_inventory() is None
+
+    coord.inventory_view.type_bucket = lambda *_args: {"devices": []}
+    assert coord.battery_runtime._battery_profile_write_mode_from_inventory() is None
+
+    coord.inventory_view.type_bucket = lambda *_args: {"devices": [None]}
+    assert coord.battery_runtime._battery_profile_write_mode_from_inventory() is None
+
+
+def test_battery_profile_write_mode_from_inventory_returns_none_for_mixed_markers(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.inventory_view.type_bucket = lambda *_args: {
+        "devices": [
+            {"name": "IQ Battery 5P", "sku_id": "IQ-BAT-3T"},
+        ]
+    }
+
+    assert coord.battery_runtime._battery_profile_write_mode_from_inventory() is None
+
+
+def test_cache_battery_profile_write_mode_clears_when_it_matches_inventory(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.battery_runtime._battery_profile_write_mode_cache = "external_compatible"
+
+    coord.battery_runtime._cache_battery_profile_write_mode(
+        "official_web_lean", inventory_mode="official_web_lean"
+    )
+
+    assert coord.battery_runtime._battery_profile_write_mode_cache is None
+
+
+def test_cache_battery_profile_write_mode_keeps_override_when_it_differs_from_inventory(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    coord.battery_runtime._cache_battery_profile_write_mode(
+        "external_compatible", inventory_mode="official_web_lean"
+    )
+
+    assert (
+        coord.battery_runtime._battery_profile_write_mode_cache == "external_compatible"
+    )
+
+
+def test_battery_profile_write_override_returns_none_without_instance_dict(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    class SlotClient:
+        __slots__ = ()
+
+    coord.client = SlotClient()
+
+    assert coord.battery_runtime._battery_profile_write_override() is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_legacy_battery_config_jwt_returns_token(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    class CookieJar:
+        def __init__(self) -> None:
+            self.cookies: dict[str, str] | None = None
+
+        def update_cookies(self, cookies, response_url=None) -> None:
+            self.cookies = dict(cookies)
+
+    class Response:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def json(self):
+            return {"token": "legacy-token"}
+
+    class Session:
+        def __init__(self) -> None:
+            self.cookie_jar = CookieJar()
+            self.calls: list[tuple[str, str, dict[str, str]]] = []
+
+        def request(self, method, url, headers=None):
+            self.calls.append((method, url, dict(headers or {})))
+            return Response()
+
+    coord.client._s = Session()
+    coord.client._cookie = "session=abc; BP-XSRF-Token=cfg-token"
+    coord.client._timeout = 1
+
+    token = await coord.battery_runtime._async_fetch_legacy_battery_config_jwt()
+
+    assert token == "legacy-token"
+    assert coord.client._s.calls == [
+        (
+            "GET",
+            "https://enlighten.enphaseenergy.com/app-api/jwt_token.json",
+            {
+                "Accept": "application/json, text/plain, */*",
+                "Referer": "https://enlighten.enphaseenergy.com/",
+                "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3.1 Safari/605.1.15",
+                "Cookie": "session=abc; BP-XSRF-Token=cfg-token",
+            },
+        )
+    ]
+    assert coord.client._s.cookie_jar.cookies == {
+        "session": "abc",
+        "BP-XSRF-Token": "cfg-token",
+    }
+
+
+@pytest.mark.asyncio
+async def test_fetch_legacy_battery_config_jwt_returns_none_for_http_error(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    class Response:
+        status = 403
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def json(self):
+            raise AssertionError("json should not be called")
+
+    class Session:
+        cookie_jar = None
+
+        def request(self, *_args, **_kwargs):
+            return Response()
+
+    coord.client._s = Session()
+    coord.client._cookie = None
+    coord.client._timeout = 1
+
+    token = await coord.battery_runtime._async_fetch_legacy_battery_config_jwt()
+
+    assert token is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_legacy_battery_config_jwt_returns_none_on_request_error(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    class Session:
+        cookie_jar = None
+
+        def request(self, *_args, **_kwargs):
+            raise TypeError("boom")
+
+    coord.client._s = Session()
+    coord.client._cookie = None
+    coord.client._timeout = 1
+
+    token = await coord.battery_runtime._async_fetch_legacy_battery_config_jwt()
+
+    assert token is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_legacy_battery_config_jwt_returns_none_for_non_dict_payload(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    class Response:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def json(self):
+            return []
+
+    class Session:
+        cookie_jar = None
+
+        def request(self, *_args, **_kwargs):
+            return Response()
+
+    coord.client._s = Session()
+    coord.client._cookie = None
+    coord.client._timeout = 1
+
+    token = await coord.battery_runtime._async_fetch_legacy_battery_config_jwt()
+
+    assert token is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_legacy_battery_config_jwt_returns_none_without_token(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    class Response:
+        status = 200
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def json(self):
+            return {}
+
+    class Session:
+        cookie_jar = None
+
+        def request(self, *_args, **_kwargs):
+            return Response()
+
+    coord.client._s = Session()
+    coord.client._cookie = None
+    coord.client._timeout = 1
+
+    token = await coord.battery_runtime._async_fetch_legacy_battery_config_jwt()
+
+    assert token is None
+
+
+@pytest.mark.asyncio
+async def test_write_battery_profile_external_compat_returns_false_without_helpers(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client._json = None
+
+    result = await coord.battery_runtime._async_write_battery_profile_external_compat(
+        profile="self-consumption",
+        reserve=30,
+        sub_type=None,
+        devices=None,
+        debug_auth_source="external_compatible_profile_write",
+    )
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_write_battery_profile_official_web_lean_falls_back_to_client_method(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    calls: list[dict[str, object]] = []
+
+    class Client:
+        _acquire_xsrf_token = None
+        _battery_config_headers = None
+        _battery_config_params = None
+        _json = None
+
+        async def set_battery_profile(self, **kwargs):
+            calls.append(dict(kwargs))
+            return {"message": "success"}
+
+    coord.client = Client()
+
+    await coord.battery_runtime._async_write_battery_profile_official_web_lean(
+        profile="self-consumption",
+        reserve=30,
+        sub_type=None,
+        devices=None,
+        debug_auth_source="official_web_lean",
+    )
+
+    assert calls == [
+        {
+            "profile": "self-consumption",
+            "battery_backup_percentage": 30,
+            "operation_mode_sub_type": None,
+            "devices": None,
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_write_battery_profile_official_web_lean_uses_bearer_when_eauth_missing(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    class Client:
+        _h = {"User-Agent": "Mozilla/5.0"}
+        _cookie = "session=abc; BP-XSRF-Token=stale"
+        _eauth = None
+        _acquire_xsrf_token = AsyncMock(return_value="cfg-token")
+        _battery_config_auth_context = MagicMock(return_value=("bearer-token", "88"))
+        _battery_config_params = MagicMock(
+            return_value={"userId": "88", "source": "enho"}
+        )
+        _xsrf_token = MagicMock(return_value="cfg-token")
+        _json = AsyncMock(return_value={"message": "success"})
+
+    coord.client = Client()
+
+    await coord.battery_runtime._async_write_battery_profile_official_web_lean(
+        profile="self-consumption",
+        reserve=30,
+        sub_type=None,
+        devices=None,
+        debug_auth_source="official_web_lean",
+    )
+
+    kwargs = coord.client._json.await_args.kwargs
+    assert kwargs["headers"]["Authorization"] == "Bearer bearer-token"
+    assert kwargs["headers"]["e-auth-token"] == "bearer-token"
+
+
+@pytest.mark.asyncio
+async def test_write_battery_profile_external_compat_uses_instance_override(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.set_battery_profile = AsyncMock(return_value={"message": "success"})
+
+    result = await coord.battery_runtime._async_write_battery_profile_external_compat(
+        profile="self-consumption",
+        reserve=30,
+        sub_type=None,
+        devices=None,
+        debug_auth_source="external_compatible_profile_write",
+    )
+
+    assert result is True
+    coord.client.set_battery_profile.assert_awaited_once_with(
+        profile="self-consumption",
+        battery_backup_percentage=30,
+        operation_mode_sub_type=None,
+        devices=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_battery_profile_external_compat_includes_subtype_and_devices(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client._acquire_xsrf_token = AsyncMock(return_value="cfg-token")
+    coord.client._battery_config_headers = MagicMock(
+        return_value={
+            "Accept": "application/json, text/plain, */*",
+            "Origin": "https://battery-profile-ui.enphaseenergy.com",
+            "Referer": "https://battery-profile-ui.enphaseenergy.com/",
+            "User-Agent": "Mozilla/5.0",
+            "Authorization": None,
+            "X-Requested-With": None,
+            "Cookie": None,
+            "e-auth-token": None,
+            "X-CSRF-Token": None,
+            "requestid": None,
+            "X-XSRF-Token": "cfg-token",
+        }
+    )
+    coord.client._battery_config_params = MagicMock(
+        return_value={"userId": "88", "source": "enho"}
+    )
+    coord.client._battery_config_single_auth_token = MagicMock(
+        return_value="retry-token"
+    )
+    coord.client._battery_config_user_id_for_token = MagicMock(return_value="88")
+    coord.client._json = AsyncMock(return_value={"message": "success"})
+
+    result = await coord.battery_runtime._async_write_battery_profile_external_compat(
+        profile="cost_savings",
+        reserve=15,
+        sub_type="prioritize-energy",
+        devices=[{"uuid": "battery-1"}],
+        debug_auth_source="external_compatible_profile_write",
+    )
+
+    assert result is True
+    payload = coord.client._json.await_args.kwargs["json"]
+    assert payload["operationModeSubType"] == "prioritize-energy"
+    assert payload["devices"] == [{"uuid": "battery-1"}]
+
+
+@pytest.mark.asyncio
+async def test_write_battery_profile_external_compat_prefers_legacy_jwt_token(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client._h = {"User-Agent": "Mozilla/5.0"}
+    coord.client._acquire_xsrf_token = AsyncMock(return_value="cfg-token")
+    coord.client._battery_config_headers = MagicMock(
+        return_value={"X-XSRF-Token": "cfg-token"}
+    )
+    coord.client._battery_config_params = MagicMock(
+        return_value={"userId": "88", "source": "enho"}
+    )
+    coord.client._battery_config_single_auth_token = MagicMock(
+        return_value="retry-token"
+    )
+    coord.client._battery_config_user_id_for_token = MagicMock(
+        return_value="legacy-user"
+    )
+    coord.client._json = AsyncMock(return_value={"message": "success"})
+    coord.battery_runtime._async_fetch_legacy_battery_config_jwt = AsyncMock(
+        return_value="legacy-token"
+    )  # noqa: SLF001
+
+    result = await coord.battery_runtime._async_write_battery_profile_external_compat(
+        profile="self-consumption",
+        reserve=30,
+        sub_type=None,
+        devices=None,
+        debug_auth_source="external_compatible_profile_retry",
+    )
+
+    assert result is True
+    coord.client._battery_config_single_auth_token.assert_not_called()
+    coord.client._battery_config_user_id_for_token.assert_called_once_with(
+        "legacy-token"
+    )
+    kwargs = coord.client._json.await_args.kwargs
+    assert kwargs["headers"]["e-auth-token"] == "legacy-token"
+    assert kwargs["params"] == {"userId": "legacy-user"}
+
+
+@pytest.mark.asyncio
+async def test_write_battery_profile_external_compat_omits_username_without_user_id(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client._h = {"User-Agent": "Mozilla/5.0", "Username": "stale-user"}
+    coord.client._acquire_xsrf_token = AsyncMock(return_value="cfg-token")
+    coord.client._battery_config_headers = MagicMock(
+        return_value={"X-XSRF-Token": "cfg-token"}
+    )
+    coord.client._battery_config_params = MagicMock(
+        return_value={"userId": "88", "source": "enho"}
+    )
+    coord.client._battery_config_single_auth_token = MagicMock(
+        return_value="retry-token"
+    )
+    coord.client._battery_config_user_id_for_token = MagicMock(return_value=None)
+    coord.client._json = AsyncMock(return_value={"message": "success"})
+    coord.battery_runtime._async_fetch_legacy_battery_config_jwt = AsyncMock(
+        return_value=None
+    )  # noqa: SLF001
+
+    result = await coord.battery_runtime._async_write_battery_profile_external_compat(
+        profile="self-consumption",
+        reserve=30,
+        sub_type=None,
+        devices=None,
+        debug_auth_source="external_compatible_profile_retry",
+    )
+
+    assert result is True
+    headers = coord.client._json.await_args.kwargs["headers"]
+    assert "Username" not in headers
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_forbidden_retry_error_still_translates(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord.client._acquire_xsrf_token = AsyncMock(return_value="cfg-token")
+    coord.client._battery_config_headers = MagicMock(
+        return_value={
+            "X-XSRF-Token": "cfg-token",
+            "Cookie": None,
+            "X-Requested-With": None,
+            "e-auth-token": None,
+        }
+    )
+    coord.client._battery_config_single_auth_token = MagicMock(
+        return_value="retry-token"
+    )
+    coord.client._battery_config_user_id_for_token = MagicMock(return_value="88")
+    coord.client._battery_config_params = MagicMock(
+        return_value={"userId": "88", "source": "enho"}
+    )
+    coord.client._json = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=403,
+            message="Forbidden",
+        )
+    )
+
+    with pytest.raises(ServiceValidationError, match="HTTP 403 Forbidden"):
+        await coord.async_set_battery_reserve(30)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Harden BatteryConfig-backed battery reserve/profile writes by preserving the browser-style write path used by working sites and adding compatibility fallbacks for alternate auth and payload shapes.

Fixes #549.

## Related Issues

- #544

## Type of change

- [x] Bugfix
- [x] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_battery_profile.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger:/Users/james/Documents/GitHub/ha-enphase-ev-charger ha-dev bash -lc "pre-commit run --all-files"
```

Manual validation:
- Local HA dev env: battery reserve changed successfully via Home Assistant service call `35 -> 36 -> 35` on a live site.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The reserve/profile write path now prefers the browser-style BatteryConfig request shape used by working sites, then falls back across alternate auth and payload variants when the backend rejects a write.
- Live validation showed Home Assistant-initiated battery reserve writes succeeding on a previously failing site after these compatibility changes.
