### PR TITLE
Fix BatteryConfig bootstrap XSRF handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Stabilized derived EV charger power around suspend and resume transitions by treating `SUSPENDED_EV` as non-charging for power purposes and reseeding the lifetime baseline when charging starts again, preventing stale non-zero readings after pauses and inflated first values after a resume.
 - Fixed stuck `System Profile Status` updates by only clearing local battery-profile pending state after Enphase reports the change is no longer pending and the request has either settled locally or exceeded a post-write grace window.
 - Reduced external battery profile refresh latency by aligning BatteryConfig profile/settings cache TTLs to the active poll cadence instead of holding stale data for a fixed five minutes.
+- Fixed BatteryConfig bootstrap handling so failed `isValid` preflights keep the existing `BP-XSRF-Token` instead of poisoning subsequent battery settings/profile writes with a bad token.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -3,16 +3,13 @@ from __future__ import annotations
 import asyncio
 import base64
 import hashlib
-import http.cookiejar
 import json
 import logging
 import re
 from contextlib import asynccontextmanager
 from datetime import date, datetime, timedelta, timezone
 from http import HTTPStatus
-from urllib.parse import urlencode, unquote
-import urllib.error
-import urllib.request
+from urllib.parse import unquote
 import uuid
 from dataclasses import dataclass
 from typing import Any, Awaitable, Callable, Iterable
@@ -45,6 +42,8 @@ _ENLIGHTEN_BROWSER_USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
     "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3.1 Safari/605.1.15"
 )
+_BATTERY_CONFIG_VARIANT_PRIMARY = "official_web_primary"
+_BATTERY_CONFIG_VARIANT_LEAN = "official_web_lean"
 _ENLIGHTEN_READ_CONCURRENCY_LIMIT = 2
 _enlighten_read_semaphore: asyncio.Semaphore | None = None
 
@@ -1874,6 +1873,7 @@ class EnphaseEVClient:
         self._start_variant_idx_no_level: int | None = None
         self._stop_variant_idx: int | None = None
         self._bp_xsrf_token: str | None = None
+        self._battery_config_variant_cache: dict[tuple[str, str, str], str] = {}
         self._cookie = cookie or ""
         self._eauth = eauth or None
         self._hems_site_supported: bool | None = None
@@ -2375,8 +2375,7 @@ class EnphaseEVClient:
         self,
         *,
         include_xsrf: bool = False,
-        include_eauth: bool = True,
-        include_requestid: bool = True,
+        variant: str = _BATTERY_CONFIG_VARIANT_PRIMARY,
     ) -> dict[str, str | None]:
         """Return headers for BatteryConfig read/write calls."""
 
@@ -2384,13 +2383,15 @@ class EnphaseEVClient:
         headers["Accept"] = "application/json, text/plain, */*"
         headers["Origin"] = "https://battery-profile-ui.enphaseenergy.com"
         headers["Referer"] = "https://battery-profile-ui.enphaseenergy.com/"
-        headers["requestid"] = str(uuid.uuid4()) if include_requestid else None
+        headers["Authorization"] = None
+        headers["X-Requested-With"] = None
+        headers["Cookie"] = None
+        headers["X-CSRF-Token"] = None
+        headers["requestid"] = (
+            str(uuid.uuid4()) if variant == _BATTERY_CONFIG_VARIANT_PRIMARY else None
+        )
         token, user_id = self._battery_config_auth_context()
-        if token:
-            headers["Authorization"] = f"Bearer {token}"
-        else:
-            headers["Authorization"] = None
-        if include_eauth:
+        if variant == _BATTERY_CONFIG_VARIANT_PRIMARY:
             if self._eauth:
                 headers["e-auth-token"] = self._eauth
             elif token:
@@ -2403,26 +2404,10 @@ class EnphaseEVClient:
             headers["Username"] = user_id
         else:
             headers.pop("Username", None)
-        cookie_map = _cookie_map_from_header(self._cookie)
-        cookie_parts = [
-            f"{key}={value}"
-            for key, value in cookie_map.items()
-            if str(key).strip().lower() not in _XSRF_COOKIE_NAMES
-        ]
         if include_xsrf:
             xsrf = self._xsrf_token()
             if xsrf:
                 headers["X-XSRF-Token"] = xsrf
-                headers["X-CSRF-Token"] = xsrf
-                cookie_parts.append(f"BP-XSRF-Token={xsrf}")
-            else:
-                headers["X-CSRF-Token"] = None
-        else:
-            headers["X-CSRF-Token"] = None
-        if cookie_parts:
-            headers["Cookie"] = "; ".join(cookie_parts)
-        else:
-            headers["Cookie"] = None
         return headers
 
     def _battery_schedule_validation_payload(
@@ -2456,6 +2441,51 @@ class EnphaseEVClient:
             params["locale"] = locale
         return params
 
+    def _battery_config_endpoint_family(self, url: str) -> str:
+        """Return the cache family for a BatteryConfig endpoint URL."""
+
+        if "/batterySettings/" in url:
+            return "battery_settings"
+        if "/battery/sites/" in url and "/schedules" in url:
+            return "schedules"
+        return "profile"
+
+    def _battery_config_variant_cache_key(
+        self, endpoint_family: str
+    ) -> tuple[str, str, str]:
+        """Return the cache key for BatteryConfig request variants."""
+
+        user_id = self._battery_config_user_id() or "<unknown>"
+        return (str(self._site), user_id, str(endpoint_family))
+
+    def _battery_config_cached_variant(self, endpoint_family: str) -> str | None:
+        """Return the cached request variant for a BatteryConfig family."""
+
+        key = self._battery_config_variant_cache_key(endpoint_family)
+        return self._battery_config_variant_cache.get(key)
+
+    def _cache_battery_config_variant(self, endpoint_family: str, variant: str) -> None:
+        """Remember the working request variant for a BatteryConfig family."""
+
+        key = self._battery_config_variant_cache_key(endpoint_family)
+        self._battery_config_variant_cache[key] = variant
+
+    def _battery_config_variant_order(self, endpoint_family: str) -> list[str]:
+        """Return the ordered variants to try for a BatteryConfig family."""
+
+        cached = self._battery_config_cached_variant(endpoint_family)
+        variants = [
+            cached,
+            _BATTERY_CONFIG_VARIANT_PRIMARY,
+            _BATTERY_CONFIG_VARIANT_LEAN,
+        ]
+        return [
+            variant
+            for variant in dict.fromkeys(variants)
+            if variant
+            in {_BATTERY_CONFIG_VARIANT_PRIMARY, _BATTERY_CONFIG_VARIANT_LEAN}
+        ]
+
     def _xsrf_token(self) -> str | None:
         """Return the XSRF token value.
 
@@ -2485,178 +2515,64 @@ class EnphaseEVClient:
                 return token
         return None
 
-    async def _battery_config_profile_write_request(
+    async def _battery_config_request(
         self,
-        *,
+        method: str,
         url: str,
-        payload: dict[str, Any],
-        params: dict[str, str] | None,
+        *,
+        json_body: dict[str, Any] | list[Any] | None = None,
+        params: dict[str, str] | None = None,
         schedule_type: str = "cfg",
+        endpoint_family: str | None = None,
+        bootstrap_xsrf: bool = False,
+        cache_on_success: bool = False,
     ) -> dict:
-        """Issue a profile write using the mixed browser-plus-legacy auth flow."""
+        """Issue a BatteryConfig request using the observed first-party variants."""
 
-        def _request_once(body: dict[str, Any]) -> dict:
-            auth_token, user_id = self._battery_config_auth_context()
-            cookie_map = _cookie_map_from_header(self._cookie)
-            if not auth_token or not user_id or not cookie_map:
-                raise aiohttp.ClientResponseError(
-                    request_info=None,
-                    history=(),
-                    status=HTTPStatus.FORBIDDEN,
-                    message="Forbidden",
-                )
-
-            cookie_jar = http.cookiejar.CookieJar()
-            opener = urllib.request.build_opener(
-                urllib.request.HTTPCookieProcessor(cookie_jar)
-            )
-            for key, value in cookie_map.items():
-                cookie_jar.set_cookie(
-                    http.cookiejar.Cookie(
-                        version=0,
-                        name=str(key),
-                        value=str(value),
-                        port=None,
-                        port_specified=False,
-                        domain=".enphaseenergy.com",
-                        domain_specified=True,
-                        domain_initial_dot=True,
-                        path="/",
-                        path_specified=True,
-                        secure=False,
-                        expires=None,
-                        discard=False,
-                        comment=None,
-                        comment_url=None,
-                        rest={},
-                    )
-                )
-
-            try:
-                legacy_request = urllib.request.Request(
-                    f"{BASE_URL}/app-api/jwt_token.json",
-                    headers={
-                        "Accept": "application/json, text/plain, */*",
-                        "Referer": f"{BASE_URL}/",
-                        "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
-                    },
-                )
-                with opener.open(legacy_request, timeout=self._timeout) as response:
-                    legacy_payload = json.loads(response.read().decode())
-            except (OSError, ValueError, urllib.error.HTTPError) as err:
-                raise aiohttp.ClientResponseError(
-                    request_info=None,
-                    history=(),
-                    status=HTTPStatus.FORBIDDEN,
-                    message=str(err),
-                ) from err
-
-            legacy_token = legacy_payload.get("token") or legacy_payload.get(
-                "auth_token"
-            )
-            if not legacy_token:
-                raise aiohttp.ClientResponseError(
-                    request_info=None,
-                    history=(),
-                    status=HTTPStatus.FORBIDDEN,
-                    message="Forbidden",
-                )
-
-            is_valid_headers = {
-                "Accept": "application/json, text/plain, */*",
-                "Origin": "https://battery-profile-ui.enphaseenergy.com",
-                "Referer": "https://battery-profile-ui.enphaseenergy.com/",
-                "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
-                "Authorization": f"Bearer {auth_token}",
-                "e-auth-token": str(legacy_token),
-                "Username": str(user_id),
-                "X-Requested-With": "XMLHttpRequest",
-                "Content-Type": "application/json",
-            }
-            is_valid_url = (
-                f"{BASE_URL}/service/batteryConfig/api/v1/battery/sites/"
-                f"{self._site}/schedules/isValid?userId={user_id}&source=enho"
-            )
-            try:
-                opener.open(
-                    urllib.request.Request(
-                        is_valid_url,
-                        data=json.dumps(
-                            self._battery_schedule_validation_payload(schedule_type)
-                        ).encode(),
-                        headers=is_valid_headers,
-                        method="POST",
-                    ),
-                    timeout=self._timeout,
-                )
-            except urllib.error.HTTPError:
-                pass
-
-            xsrf = None
-            fallback_xsrf = None
-            for cookie in cookie_jar:
-                cookie_name = cookie.name.lower()
-                if cookie_name == "bp-xsrf-token":
-                    xsrf = cookie.value
-                    break
-                if cookie_name in _XSRF_COOKIE_NAMES and fallback_xsrf is None:
-                    fallback_xsrf = cookie.value
-            if xsrf is None:
-                xsrf = fallback_xsrf
-
-            request_headers = {
-                "Accept": "application/json, text/plain, */*",
-                "Origin": "https://battery-profile-ui.enphaseenergy.com",
-                "Referer": "https://battery-profile-ui.enphaseenergy.com/",
-                "User-Agent": _ENLIGHTEN_BROWSER_USER_AGENT,
-                "Authorization": f"Bearer {auth_token}",
-                "e-auth-token": str(legacy_token),
-                "Username": str(user_id),
-                "X-Requested-With": "XMLHttpRequest",
-                "Content-Type": "application/json",
-                "requestid": str(uuid.uuid4()),
-            }
-            if xsrf:
-                request_headers["X-XSRF-Token"] = xsrf
-                request_headers["X-CSRF-Token"] = xsrf
-
-            request_url = url
-            if params:
-                request_url = f"{url}?{urlencode(params)}"
-
-            try:
-                with opener.open(
-                    urllib.request.Request(
-                        request_url,
-                        data=json.dumps(body).encode(),
-                        headers=request_headers,
-                        method="PUT",
-                    ),
-                    timeout=self._timeout,
-                ) as response:
-                    response_text = response.read().decode()
-            except urllib.error.HTTPError as err:
-                body_text = err.read().decode()
-                raise aiohttp.ClientResponseError(
-                    request_info=None,
-                    history=(),
-                    status=err.code,
-                    message=body_text or str(err),
-                    headers=err.headers,
-                ) from err
-
-            if not response_text.strip():
-                return {}
-            return json.loads(response_text)
+        family = endpoint_family or self._battery_config_endpoint_family(url)
+        variants = self._battery_config_variant_order(family)
 
         try:
-            return await asyncio.to_thread(_request_once, dict(payload))
-        except aiohttp.ClientResponseError as err:
-            if err.status != HTTPStatus.FORBIDDEN or "devices" not in payload:
-                raise
-        fallback_payload = dict(payload)
-        fallback_payload.pop("devices", None)
-        return await asyncio.to_thread(_request_once, fallback_payload)
+            for index, variant in enumerate(variants):
+                try:
+                    if bootstrap_xsrf:
+                        await self._acquire_xsrf_token(schedule_type, variant=variant)
+                    headers = self._battery_config_headers(
+                        include_xsrf=bootstrap_xsrf,
+                        variant=variant,
+                    )
+                    if json_body is not None:
+                        headers.setdefault("Content-Type", "application/json")
+                    result = await self._json(
+                        method,
+                        url,
+                        json=json_body,
+                        headers=headers,
+                        params=params,
+                        debug_auth_source=variant,
+                    )
+                except aiohttp.ClientResponseError as err:
+                    if err.status == HTTPStatus.UNAUTHORIZED:
+                        raise
+                    if err.status != HTTPStatus.FORBIDDEN or index == len(variants) - 1:
+                        raise
+                    _LOGGER.debug(
+                        "Retrying BatteryConfig %s for %s with %s variant "
+                        "(cached_variant=%s)",
+                        "write" if bootstrap_xsrf else "request",
+                        _request_label(method, url),
+                        variants[index + 1],
+                        self._battery_config_cached_variant(family),
+                    )
+                    continue
+                if cache_on_success:
+                    self._cache_battery_config_variant(family, variant)
+                return result
+        finally:
+            if bootstrap_xsrf:
+                self._bp_xsrf_token = None
+
+        raise aiohttp.ClientError("BatteryConfig request exhausted variants")
 
     async def _battery_config_write_request(
         self,
@@ -2666,69 +2582,26 @@ class EnphaseEVClient:
         json_body: dict[str, Any] | list[Any] | None = None,
         params: dict[str, str] | None = None,
         schedule_type: str = "cfg",
+        endpoint_family: str | None = None,
     ) -> dict:
-        """Issue a BatteryConfig write with a narrow first-party fallback."""
+        """Issue a BatteryConfig write with centralized variant selection."""
 
-        await self._acquire_xsrf_token(schedule_type)
-
-        try:
-            primary_headers = self._battery_config_headers(include_xsrf=True)
-            if json_body is not None:
-                primary_headers.setdefault("Content-Type", "application/json")
-            try:
-                return await self._json(
-                    method,
-                    url,
-                    json=json_body,
-                    headers=primary_headers,
-                    params=params,
-                )
-            except aiohttp.ClientResponseError as err:
-                if err.status != 403:
-                    raise
-                await self._acquire_xsrf_token(
-                    schedule_type,
-                    include_eauth=False,
-                    include_requestid=False,
-                )
-                fallback_headers = self._battery_config_headers(
-                    include_xsrf=True,
-                    include_eauth=False,
-                    include_requestid=False,
-                )
-                if json_body is not None:
-                    fallback_headers.setdefault("Content-Type", "application/json")
-                fallback_preview = self._merge_request_headers(
-                    self._h, fallback_headers
-                )
-                fallback_flags = self._battery_config_header_debug_flags(
-                    fallback_preview,
-                    auth_source_override="official_web_lean",
-                )
-                _LOGGER.debug(
-                    "Retrying BatteryConfig write for %s with lean official-web headers "
-                    "(has_e_auth_token=%s, has_requestid=%s)",
-                    _request_label(method, url),
-                    fallback_flags["has_e_auth_token"],
-                    "requestid" in fallback_preview,
-                )
-                return await self._json(
-                    method,
-                    url,
-                    json=json_body,
-                    headers=fallback_headers,
-                    params=params,
-                    debug_auth_source="official_web_lean",
-                )
-        finally:
-            self._bp_xsrf_token = None
+        return await self._battery_config_request(
+            method,
+            url,
+            json_body=json_body,
+            params=params,
+            schedule_type=schedule_type,
+            endpoint_family=endpoint_family,
+            bootstrap_xsrf=True,
+            cache_on_success=True,
+        )
 
     async def _acquire_xsrf_token(
         self,
         schedule_type: str = "cfg",
         *,
-        include_eauth: bool = True,
-        include_requestid: bool = True,
+        variant: str = _BATTERY_CONFIG_VARIANT_PRIMARY,
     ) -> str | None:
         """Acquire a BP-XSRF-Token by POSTing to the schedules isValid endpoint.
 
@@ -2743,8 +2616,7 @@ class EnphaseEVClient:
         )
         headers = self._battery_config_headers(
             include_xsrf=True,
-            include_eauth=include_eauth,
-            include_requestid=include_requestid,
+            variant=variant,
         )
         headers["Content-Type"] = "application/json"
         request_headers = self._merge_request_headers({}, headers)
@@ -2764,6 +2636,15 @@ class EnphaseEVClient:
                 async with self._s.request(
                     "POST", url, json=payload, headers=request_headers
                 ) as r:
+                    if r.status >= HTTPStatus.BAD_REQUEST:
+                        _LOGGER.debug(
+                            "BatteryConfig bootstrap returned %s for %s; "
+                            "keeping existing XSRF token",
+                            r.status,
+                            _request_label("POST", url),
+                        )
+                        return None
+
                     header_values: list[str] = []
                     getall = getattr(r.headers, "getall", None)
                     if callable(getall):
@@ -4003,8 +3884,7 @@ class EnphaseEVClient:
         GET /service/batteryConfig/api/v1/stormGuard/<site_id>/stormAlert
         """
         url = f"{BASE_URL}/service/batteryConfig/api/v1/stormGuard/{self._site}/stormAlert"
-        headers = self._battery_config_headers()
-        return await self._json("GET", url, headers=headers)
+        return await self._battery_config_request("GET", url)
 
     async def opt_out_storm_alert(self, *, alert_id: str, name: str) -> dict:
         """Opt out of a specific Storm Guard alert.
@@ -4041,24 +3921,31 @@ class EnphaseEVClient:
 
         url = f"{BASE_URL}/service/batteryConfig/api/v1/siteSettings/{self._site}"
         params = self._battery_config_params()
-        headers = self._battery_config_headers()
-        return await self._json("GET", url, headers=headers, params=params)
+        return await self._battery_config_request("GET", url, params=params)
 
     async def battery_profile_details(self, *, locale: str | None = None) -> dict:
         """Return BatteryConfig profile details for system + EVSE settings."""
 
         url = f"{BASE_URL}/service/batteryConfig/api/v1/profile/{self._site}"
         params = self._battery_config_params(include_source=True, locale=locale)
-        headers = self._battery_config_headers()
-        return await self._json("GET", url, headers=headers, params=params)
+        return await self._battery_config_request(
+            "GET",
+            url,
+            params=params,
+            endpoint_family="profile",
+        )
 
     async def battery_settings_details(self) -> dict:
         """Return BatteryConfig battery details for charge-grid and shutdown controls."""
 
         url = f"{BASE_URL}/service/batteryConfig/api/v1/batterySettings/{self._site}"
         params = self._battery_config_params(include_source="enlm")
-        headers = self._battery_config_headers()
-        return await self._json("GET", url, headers=headers, params=params)
+        return await self._battery_config_request(
+            "GET",
+            url,
+            params=params,
+            endpoint_family="battery_settings",
+        )
 
     async def set_battery_settings(
         self,
@@ -4097,23 +3984,12 @@ class EnphaseEVClient:
             payload["operationModeSubType"] = str(operation_mode_sub_type)
         if devices:
             payload["devices"] = [item for item in devices if isinstance(item, dict)]
-        try:
-            return await self._battery_config_profile_write_request(
-                url=url,
-                payload=payload,
-                params=params,
-            )
-        except aiohttp.ClientResponseError as err:
-            if err.status != HTTPStatus.FORBIDDEN:
-                raise
-        if "devices" in payload:
-            payload = dict(payload)
-            payload.pop("devices", None)
         return await self._battery_config_write_request(
             "PUT",
             url,
             json_body=payload,
             params=params,
+            endpoint_family="profile",
         )
 
     async def cancel_battery_profile_update(self) -> dict:
@@ -4125,6 +4001,7 @@ class EnphaseEVClient:
             url,
             json_body={},
             params=params,
+            endpoint_family="profile",
         )
 
     async def set_storm_guard(self, *, enabled: bool, evse_enabled: bool) -> dict:
@@ -4143,6 +4020,7 @@ class EnphaseEVClient:
             url,
             json_body=payload,
             params=params,
+            endpoint_family="profile",
         )
 
     # ------------------------------------------------------------------
@@ -4162,8 +4040,11 @@ class EnphaseEVClient:
             f"{BASE_URL}/service/batteryConfig/api/v1/battery/sites/"
             f"{self._site}/schedules"
         )
-        headers = self._battery_config_headers()
-        return await self._json("GET", url, headers=headers)
+        return await self._battery_config_request(
+            "GET",
+            url,
+            endpoint_family="schedules",
+        )
 
     async def create_battery_schedule(
         self,
@@ -4210,6 +4091,7 @@ class EnphaseEVClient:
             url,
             json_body=payload,
             schedule_type=schedule_type,
+            endpoint_family="schedules",
         )
 
     async def update_battery_schedule(
@@ -4262,6 +4144,7 @@ class EnphaseEVClient:
             url,
             json_body=payload,
             schedule_type=schedule_type,
+            endpoint_family="schedules",
         )
 
     async def delete_battery_schedule(
@@ -4284,6 +4167,7 @@ class EnphaseEVClient:
             url,
             json_body={},
             schedule_type=schedule_type,
+            endpoint_family="schedules",
         )
 
     async def validate_battery_schedule(self, schedule_type: str = "cfg") -> dict:
@@ -4298,10 +4182,14 @@ class EnphaseEVClient:
             f"{BASE_URL}/service/batteryConfig/api/v1/battery/sites/"
             f"{self._site}/schedules/isValid"
         )
-        headers = self._battery_config_headers()
-        headers["Content-Type"] = "application/json"
         payload = self._battery_schedule_validation_payload(schedule_type)
-        return await self._json("POST", url, json=payload, headers=headers)
+        return await self._battery_config_request(
+            "POST",
+            url,
+            json_body=payload,
+            schedule_type=schedule_type,
+            endpoint_family="schedules",
+        )
 
     async def charger_auth_settings(self, sn: str) -> list[dict[str, Any]]:
         """Return authentication settings for the charger.

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import base64
 import datetime
 import hashlib
-import io
 import json
 import logging
 from types import SimpleNamespace
@@ -608,11 +607,12 @@ def test_battery_config_auth_helpers_cover_token_and_cookie_fallback() -> None:
     assert auth_token == token
     assert user_id == "77"
     assert client._xsrf_token() == "dynamic-token"  # noqa: SLF001
-    assert headers["Authorization"] == f"Bearer {token}"
     assert headers["e-auth-token"] == token
-    assert headers["X-CSRF-Token"] == "dynamic-token"
     assert headers["X-XSRF-Token"] == "dynamic-token"
-    assert headers["Cookie"] == "BP-XSRF-Token=dynamic-token"
+    assert headers["Authorization"] is None
+    assert headers["X-CSRF-Token"] is None
+    assert headers["Cookie"] is None
+    assert headers["X-Requested-With"] is None
     assert "requestid" in headers
 
 
@@ -641,15 +641,11 @@ def test_battery_config_headers_preserve_original_eauth_and_replace_stale_xsrf()
 
     headers = client._battery_config_headers(include_xsrf=True)  # noqa: SLF001
 
-    assert headers["Authorization"] == f"Bearer {bearer}"
     assert headers["e-auth-token"] == "session-token"
-    assert headers["X-CSRF-Token"] == "fresh-token"
     assert headers["X-XSRF-Token"] == "fresh-token"
-    assert headers["Cookie"] == (
-        "session=1; other=1; "
-        "enlighten_manager_token_production="
-        f"{bearer}; BP-XSRF-Token=fresh-token"
-    )
+    assert headers["Authorization"] is None
+    assert headers["X-CSRF-Token"] is None
+    assert headers["Cookie"] is None
     assert headers["Username"] == "77"
 
 
@@ -742,7 +738,7 @@ def test_battery_config_headers_use_bearer_cookie_for_eauth_when_missing() -> No
 
     headers = client._battery_config_headers()  # noqa: SLF001
 
-    assert headers["Authorization"] == f"Bearer {bearer}"
+    assert headers["Authorization"] is None
     assert headers["e-auth-token"] == bearer
     assert headers["X-CSRF-Token"] is None
     assert headers["Username"] == "77"
@@ -765,15 +761,12 @@ def test_battery_config_headers_match_official_web_shape() -> None:
     assert headers["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
     assert headers["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
     assert headers["User-Agent"] == api._ENLIGHTEN_BROWSER_USER_AGENT
-    assert headers["X-Requested-With"] == "XMLHttpRequest"
+    assert headers["X-Requested-With"] is None
     assert headers["X-XSRF-Token"] == "raw-token"
-    assert headers["X-CSRF-Token"] == "raw-token"
-    assert headers["Authorization"] == f"Bearer {bearer}"
+    assert headers["X-CSRF-Token"] is None
+    assert headers["Authorization"] is None
     assert headers["e-auth-token"] == "access-token"
-    assert headers["Cookie"] == (
-        "session=1; enlighten_manager_token_production="
-        f"{bearer}; BP-XSRF-Token=raw-token"
-    )
+    assert headers["Cookie"] is None
     assert headers["Username"] == "77"
     assert "requestid" in headers
 
@@ -789,22 +782,18 @@ def test_battery_config_headers_can_build_lean_fallback_shape() -> None:
         ),
     )
 
-    headers = client._battery_config_headers(
+    headers = client._battery_config_headers(  # noqa: SLF001
         include_xsrf=True,
-        include_eauth=False,
-        include_requestid=False,
-    )  # noqa: SLF001
+        variant=api._BATTERY_CONFIG_VARIANT_LEAN,
+    )
 
-    assert headers["Authorization"] == f"Bearer {bearer}"
+    assert headers["Authorization"] is None
     assert headers["e-auth-token"] is None
     assert headers["requestid"] is None
     assert headers["Username"] == "77"
     assert headers["X-XSRF-Token"] == "raw-token"
-    assert headers["X-CSRF-Token"] == "raw-token"
-    assert headers["Cookie"] == (
-        "session=1; enlighten_manager_token_production="
-        f"{bearer}; BP-XSRF-Token=raw-token"
-    )
+    assert headers["X-CSRF-Token"] is None
+    assert headers["Cookie"] is None
 
 
 def test_battery_config_headers_drop_cookie_when_none_available() -> None:
@@ -3523,13 +3512,16 @@ async def test_storm_guard_alert_passes_headers() -> None:
     args, kwargs = client._json.await_args
     assert args[0] == "GET"
     assert "stormGuard" in args[1]
-    assert kwargs["headers"]["Authorization"] == f"Bearer {token}"
     assert kwargs["headers"]["e-auth-token"] == token
     assert kwargs["headers"]["Username"] == "42"
     assert kwargs["headers"]["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
     assert (
         kwargs["headers"]["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
     )
+    assert kwargs["headers"]["Authorization"] is None
+    assert kwargs["headers"]["Cookie"] is None
+    assert kwargs["headers"]["X-CSRF-Token"] is None
+    assert kwargs["headers"]["X-Requested-With"] is None
     assert "requestid" in kwargs["headers"]
 
 
@@ -3567,10 +3559,13 @@ async def test_battery_site_settings_passes_params_and_headers() -> None:
     assert args[0] == "GET"
     assert "siteSettings" in args[1]
     assert kwargs["params"]["userId"] == "77"
-    assert kwargs["headers"]["Authorization"] == f"Bearer {token}"
     assert kwargs["headers"]["e-auth-token"] == token
     assert kwargs["headers"]["Username"] == "77"
     assert kwargs["headers"]["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
+    assert kwargs["headers"]["Authorization"] is None
+    assert kwargs["headers"]["Cookie"] is None
+    assert kwargs["headers"]["X-CSRF-Token"] is None
+    assert kwargs["headers"]["X-Requested-With"] is None
     assert "requestid" in kwargs["headers"]
 
 
@@ -3590,8 +3585,11 @@ async def test_battery_settings_details_passes_params_and_headers() -> None:
     assert kwargs["params"]["source"] == "enlm"
     assert kwargs["params"]["userId"] == "99"
     assert kwargs["headers"]["Username"] == "99"
-    assert kwargs["headers"]["Authorization"] == f"Bearer {token}"
     assert kwargs["headers"]["e-auth-token"] == token
+    assert kwargs["headers"]["Authorization"] is None
+    assert kwargs["headers"]["Cookie"] is None
+    assert kwargs["headers"]["X-CSRF-Token"] is None
+    assert kwargs["headers"]["X-Requested-With"] is None
     assert "requestid" in kwargs["headers"]
 
 
@@ -3616,14 +3614,11 @@ async def test_battery_settings_details_wire_headers_match_official_web_shape() 
     assert headers["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
     assert headers["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
     assert headers["Username"] == "99"
-    assert headers["Authorization"] == f"Bearer {_make_token({'user_id': '99'})}"
+    assert "Authorization" not in headers
     assert headers["e-auth-token"] == "access-token"
-    assert headers["Cookie"] == (
-        "session=1; enlighten_manager_token_production="
-        f"{_make_token({'user_id': '99'})}"
-    )
+    assert "Cookie" not in headers
     assert "X-CSRF-Token" not in headers
-    assert headers["X-Requested-With"] == "XMLHttpRequest"
+    assert "X-Requested-With" not in headers
     assert "requestid" in headers
 
 
@@ -3645,10 +3640,10 @@ async def test_set_battery_settings_payload_and_xsrf() -> None:
     assert kwargs["params"]["userId"] == "88"
     assert kwargs["headers"]["X-XSRF-Token"] == "xsrf=token"
     assert kwargs["headers"]["e-auth-token"] == token
-    assert kwargs["headers"]["Authorization"] == f"Bearer {token}"
+    assert kwargs["headers"]["Authorization"] is None
     assert "requestid" in kwargs["headers"]
-    assert kwargs["headers"]["Cookie"] == "other=1; BP-XSRF-Token=xsrf=token"
-    assert kwargs["headers"]["X-CSRF-Token"] == "xsrf=token"
+    assert kwargs["headers"]["Cookie"] is None
+    assert kwargs["headers"]["X-CSRF-Token"] is None
     assert kwargs["json"] == {"veryLowSoc": 15}
 
 
@@ -3657,7 +3652,12 @@ async def test_set_battery_settings_uses_requested_schedule_type_for_xsrf() -> N
     client = _make_client()
     client._json = AsyncMock(return_value={"message": "success"})
 
-    async def _acquire(schedule_type: str = "cfg") -> str:
+    async def _acquire(
+        schedule_type: str = "cfg",
+        *,
+        variant: str = api._BATTERY_CONFIG_VARIANT_PRIMARY,
+    ) -> str:
+        assert variant == api._BATTERY_CONFIG_VARIANT_PRIMARY
         client._bp_xsrf_token = f"{schedule_type}-token"  # noqa: SLF001
         return client._bp_xsrf_token  # noqa: SLF001
 
@@ -3668,13 +3668,14 @@ async def test_set_battery_settings_uses_requested_schedule_type_for_xsrf() -> N
         schedule_type="dtg",
     )
 
-    client._acquire_xsrf_token.assert_awaited_once_with("dtg")
-    assert client._json.await_args.kwargs["headers"]["X-XSRF-Token"] == "dtg-token"
-    assert client._json.await_args.kwargs["headers"]["Cookie"] == (
-        "BP-XSRF-Token=dtg-token"
+    client._acquire_xsrf_token.assert_awaited_once_with(
+        "dtg", variant=api._BATTERY_CONFIG_VARIANT_PRIMARY
     )
+    assert client._json.await_args.kwargs["headers"]["X-XSRF-Token"] == "dtg-token"
     assert client._json.await_args.kwargs["headers"]["e-auth-token"] == "EAUTH"
-    assert client._json.await_args.kwargs["headers"]["Authorization"] == "Bearer EAUTH"
+    assert client._json.await_args.kwargs["headers"]["Authorization"] is None
+    assert client._json.await_args.kwargs["headers"]["Cookie"] is None
+    assert client._json.await_args.kwargs["headers"]["X-CSRF-Token"] is None
     assert "requestid" in client._json.await_args.kwargs["headers"]
 
 
@@ -3725,344 +3726,91 @@ async def test_set_battery_settings_retries_403_with_lean_official_web_variant(
     assert session.calls[3][0] == "PUT"
     primary_headers = session.calls[1][2]["headers"]
     fallback_headers = session.calls[3][2]["headers"]
-    assert primary_headers["Authorization"] == f"Bearer {primary_token}"
+    assert "Authorization" not in primary_headers
     assert primary_headers["e-auth-token"] == primary_token
     assert "requestid" in primary_headers
     assert primary_headers["Username"] == "88"
     assert primary_headers["X-XSRF-Token"] == "cfg-token"
-    assert primary_headers["Cookie"] == (
-        "session=1; enlighten_manager_token_production="
-        f"{primary_token}; BP-XSRF-Token=cfg-token"
-    )
-    assert primary_headers["X-CSRF-Token"] == "cfg-token"
-    assert fallback_headers["Authorization"] == f"Bearer {primary_token}"
+    assert "Cookie" not in primary_headers
+    assert "X-CSRF-Token" not in primary_headers
+    assert "Authorization" not in fallback_headers
     assert "e-auth-token" not in fallback_headers
     assert "requestid" not in fallback_headers
     assert fallback_headers["Username"] == "88"
     assert fallback_headers["X-XSRF-Token"] == "cfg-token-lean"
-    assert fallback_headers["X-CSRF-Token"] == "cfg-token-lean"
+    assert "X-CSRF-Token" not in fallback_headers
     assert "Retrying BatteryConfig write" in caplog.text
     assert "official_web_lean" in caplog.text
     assert client._bp_xsrf_token is None  # noqa: SLF001
 
 
 @pytest.mark.asyncio
-async def test_set_battery_profile_uses_mixed_legacy_cookie_jar_path(
-    monkeypatch,
-) -> None:
+async def test_set_battery_profile_uses_canonical_batteryconfig_write_path() -> None:
     token = _make_token({"user_id": "100"})
     client = _make_client()
     client.update_credentials(
-        eauth="session-token",
-        cookie=(
-            "session=1; locale=en-AU; XSRF-TOKEN=stale-xsrf; "
-            f"enlighten_manager_token_production={token}"
-        ),
+        eauth=token,
+        cookie=f"XSRF-TOKEN=fresh-xsrf; enlighten_manager_token_production={token}",
     )
-    client._timeout = 1  # noqa: SLF001
-
-    async def _to_thread(func, *args, **kwargs):
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(api.asyncio, "to_thread", _to_thread)
-
-    class _FakeOpener:
-        def __init__(self, cookie_jar):
-            self.cookie_jar = cookie_jar
-            self.calls: list[tuple[str, str, dict[str, str], str | None]] = []
-
-        def open(self, request, timeout=None):
-            del timeout
-            body = request.data.decode() if request.data else None
-            headers = {key.lower(): value for key, value in request.header_items()}
-            self.calls.append((request.get_method(), request.full_url, headers, body))
-            if request.full_url.endswith("/app-api/jwt_token.json"):
-                return _FakeUrlLibResponse(status=200, body='{"token":"legacy-token"}')
-            if request.full_url.endswith("/schedules/isValid?userId=100&source=enho"):
-                self.cookie_jar.set_cookie(
-                    api.http.cookiejar.Cookie(
-                        version=0,
-                        name="BP-XSRF-Token",
-                        value="fresh-xsrf",
-                        port=None,
-                        port_specified=False,
-                        domain=".enphaseenergy.com",
-                        domain_specified=True,
-                        domain_initial_dot=True,
-                        path="/",
-                        path_specified=True,
-                        secure=False,
-                        expires=None,
-                        discard=False,
-                        comment=None,
-                        comment_url=None,
-                        rest={},
-                    )
-                )
-                return _FakeUrlLibResponse(status=200, body='{"isValid":true}')
-            return _FakeUrlLibResponse(status=200, body='{"message":"success"}')
-
-    openers: list[_FakeOpener] = []
-
-    def _build_opener(processor):
-        opener = _FakeOpener(processor.cookiejar)
-        openers.append(opener)
-        return opener
-
-    monkeypatch.setattr(api.urllib.request, "build_opener", _build_opener)
+    client._acquire_xsrf_token = AsyncMock(return_value="fresh-xsrf")  # noqa: SLF001
+    client._bp_xsrf_token = "fresh-xsrf"  # noqa: SLF001
+    client._json = AsyncMock(return_value={"message": "success"})
 
     out = await client.set_battery_profile(
         profile="self-consumption",
         battery_backup_percentage=10,
+        operation_mode_sub_type="prioritize-energy",
+        devices=[
+            {"uuid": "abc", "deviceType": "iqEvse", "enable": False},
+            "skip",
+        ],
     )
 
     assert out == {"message": "success"}
-    opener = openers[0]
-    assert [call[0] for call in opener.calls] == ["GET", "POST", "PUT"]
-    put_method, put_url, put_headers, put_body = opener.calls[-1]
-    assert put_method == "PUT"
-    assert put_url.endswith(
-        "/service/batteryConfig/api/v1/profile/SITE?userId=100&source=enho"
+    args, kwargs = client._json.await_args
+    assert args == (
+        "PUT",
+        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
     )
-    assert put_headers["authorization"] == f"Bearer {token}"
-    assert put_headers["e-auth-token"] == "legacy-token"
-    assert put_headers["username"] == "100"
-    assert put_headers["x-csrf-token"] == "fresh-xsrf"
-    assert put_headers["x-xsrf-token"] == "fresh-xsrf"
-    assert "requestid" in {key.lower() for key in put_headers}
-    assert json.loads(put_body) == {
+    assert kwargs["params"] == {"userId": "100", "source": "enho"}
+    assert kwargs["json"] == {
         "profile": "self-consumption",
         "batteryBackupPercentage": 10,
+        "operationModeSubType": "prioritize-energy",
+        "devices": [{"uuid": "abc", "deviceType": "iqEvse", "enable": False}],
     }
+    assert kwargs["headers"]["e-auth-token"] == token
+    assert kwargs["headers"]["Username"] == "100"
+    assert kwargs["headers"]["X-XSRF-Token"] == "fresh-xsrf"
+    assert kwargs["headers"]["requestid"]
+    assert kwargs["headers"]["Authorization"] is None
+    assert kwargs["headers"]["Cookie"] is None
+    assert kwargs["headers"]["X-CSRF-Token"] is None
+    assert kwargs["headers"]["X-Requested-With"] is None
 
 
-@pytest.mark.asyncio
-async def test_battery_config_profile_write_request_requires_auth_context() -> None:
+def test_battery_config_endpoint_family_identifies_schedule_routes() -> None:
     client = _make_client()
-    client.update_credentials(eauth="", cookie="")
 
-    with pytest.raises(aiohttp.ClientResponseError) as err:
-        await client._battery_config_profile_write_request(  # noqa: SLF001
-            url="https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
-            payload={"profile": "self-consumption", "batteryBackupPercentage": 10},
-            params={"userId": "100", "source": "enho"},
+    assert (
+        client._battery_config_endpoint_family(  # noqa: SLF001
+            "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/"
+            "battery/sites/SITE/schedules/sched-1"
         )
-
-    assert err.value.status == 403
+        == "schedules"
+    )
 
 
 @pytest.mark.asyncio
-async def test_battery_config_profile_write_request_reraises_legacy_token_fetch_errors(
-    monkeypatch,
-) -> None:
-    token = _make_token({"user_id": "100"})
+async def test_battery_config_request_raises_when_no_variants_are_available() -> None:
     client = _make_client()
-    client.update_credentials(
-        eauth="session-token",
-        cookie=f"session=1; enlighten_manager_token_production={token}",
-    )
-    client._timeout = 1  # noqa: SLF001
+    client._battery_config_variant_order = MagicMock(return_value=[])  # noqa: SLF001
 
-    async def _to_thread(func, *args, **kwargs):
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(api.asyncio, "to_thread", _to_thread)
-
-    class _FakeOpener:
-        def open(self, request, timeout=None):
-            del timeout
-            raise api.urllib.error.HTTPError(
-                request.full_url,
-                403,
-                "Forbidden",
-                hdrs={},
-                fp=io.BytesIO(b'{"status":403}'),
-            )
-
-    monkeypatch.setattr(
-        api.urllib.request,
-        "build_opener",
-        lambda _processor: _FakeOpener(),
-    )
-
-    with pytest.raises(aiohttp.ClientResponseError) as err:
-        await client._battery_config_profile_write_request(  # noqa: SLF001
-            url="https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
-            payload={"profile": "self-consumption", "batteryBackupPercentage": 10},
-            params={"userId": "100", "source": "enho"},
+    with pytest.raises(aiohttp.ClientError, match="exhausted variants"):
+        await client._battery_config_request(  # noqa: SLF001
+            "GET",
+            "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
         )
-
-    assert err.value.status == 403
-
-
-@pytest.mark.asyncio
-async def test_battery_config_profile_write_request_returns_empty_dict_for_blank_body(
-    monkeypatch,
-) -> None:
-    token = _make_token({"user_id": "100"})
-    client = _make_client()
-    client.update_credentials(
-        eauth="session-token",
-        cookie=(
-            "session=1; XSRF-TOKEN=stale-xsrf; "
-            f"enlighten_manager_token_production={token}"
-        ),
-    )
-    client._timeout = 1  # noqa: SLF001
-
-    async def _to_thread(func, *args, **kwargs):
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(api.asyncio, "to_thread", _to_thread)
-
-    class _FakeOpener:
-        def __init__(self, cookie_jar):
-            self.cookie_jar = cookie_jar
-
-        def open(self, request, timeout=None):
-            del timeout
-            if request.full_url.endswith("/app-api/jwt_token.json"):
-                return _FakeUrlLibResponse(status=200, body='{"token":"legacy-token"}')
-            if request.full_url.endswith("/schedules/isValid?userId=100&source=enho"):
-                self.cookie_jar.set_cookie(
-                    api.http.cookiejar.Cookie(
-                        version=0,
-                        name="BP-XSRF-Token",
-                        value="fresh-xsrf",
-                        port=None,
-                        port_specified=False,
-                        domain=".enphaseenergy.com",
-                        domain_specified=True,
-                        domain_initial_dot=True,
-                        path="/",
-                        path_specified=True,
-                        secure=False,
-                        expires=None,
-                        discard=False,
-                        comment=None,
-                        comment_url=None,
-                        rest={},
-                    )
-                )
-                return _FakeUrlLibResponse(status=200, body='{"isValid":true}')
-            return _FakeUrlLibResponse(status=200, body="   ")
-
-    monkeypatch.setattr(
-        api.urllib.request,
-        "build_opener",
-        lambda processor: _FakeOpener(processor.cookiejar),
-    )
-
-    out = await client._battery_config_profile_write_request(  # noqa: SLF001
-        url="https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
-        payload={"profile": "self-consumption", "batteryBackupPercentage": 10},
-        params={"userId": "100", "source": "enho"},
-    )
-
-    assert out == {}
-
-
-@pytest.mark.asyncio
-async def test_battery_config_profile_write_request_rejects_missing_legacy_token(
-    monkeypatch,
-) -> None:
-    token = _make_token({"user_id": "100"})
-    client = _make_client()
-    client.update_credentials(
-        eauth="session-token",
-        cookie=f"session=1; enlighten_manager_token_production={token}",
-    )
-    client._timeout = 1  # noqa: SLF001
-
-    async def _to_thread(func, *args, **kwargs):
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(api.asyncio, "to_thread", _to_thread)
-
-    class _FakeOpener:
-        def __init__(self, cookie_jar):
-            self.cookie_jar = cookie_jar
-
-        def open(self, request, timeout=None):
-            del timeout
-            if request.full_url.endswith("/app-api/jwt_token.json"):
-                return _FakeUrlLibResponse(status=200, body="{}")
-            return _FakeUrlLibResponse(status=200, body='{"isValid":true}')
-
-    monkeypatch.setattr(
-        api.urllib.request,
-        "build_opener",
-        lambda processor: _FakeOpener(processor.cookiejar),
-    )
-
-    with pytest.raises(aiohttp.ClientResponseError) as err:
-        await client._battery_config_profile_write_request(  # noqa: SLF001
-            url="https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
-            payload={"profile": "self-consumption", "batteryBackupPercentage": 10},
-            params={"userId": "100", "source": "enho"},
-        )
-
-    assert err.value.status == 403
-
-
-@pytest.mark.asyncio
-async def test_battery_config_profile_write_request_uses_fallback_xsrf_cookie(
-    monkeypatch,
-) -> None:
-    token = _make_token({"user_id": "100"})
-    client = _make_client()
-    client.update_credentials(
-        eauth="session-token",
-        cookie=(
-            "session=1; XSRF-TOKEN=stale-xsrf; "
-            f"enlighten_manager_token_production={token}"
-        ),
-    )
-    client._timeout = 1  # noqa: SLF001
-
-    async def _to_thread(func, *args, **kwargs):
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(api.asyncio, "to_thread", _to_thread)
-
-    seen_headers: dict[str, str] = {}
-
-    class _FakeOpener:
-        def __init__(self, cookie_jar):
-            self.cookie_jar = cookie_jar
-
-        def open(self, request, timeout=None):
-            del timeout
-            if request.full_url.endswith("/app-api/jwt_token.json"):
-                return _FakeUrlLibResponse(status=200, body='{"token":"legacy-token"}')
-            if request.full_url.endswith("/schedules/isValid?userId=100&source=enho"):
-                raise api.urllib.error.HTTPError(
-                    request.full_url,
-                    403,
-                    "Forbidden",
-                    hdrs={},
-                    fp=io.BytesIO(b'{"status":403}'),
-                )
-            seen_headers.update(
-                {key.lower(): value for key, value in request.header_items()}
-            )
-            return _FakeUrlLibResponse(status=200, body='{"message":"success"}')
-
-    monkeypatch.setattr(
-        api.urllib.request,
-        "build_opener",
-        lambda processor: _FakeOpener(processor.cookiejar),
-    )
-
-    out = await client._battery_config_profile_write_request(  # noqa: SLF001
-        url="https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
-        payload={"profile": "self-consumption", "batteryBackupPercentage": 10},
-        params={"userId": "100", "source": "enho"},
-    )
-
-    assert out == {"message": "success"}
-    assert seen_headers["x-csrf-token"] == "stale-xsrf"
-    assert seen_headers["x-xsrf-token"] == "stale-xsrf"
 
 
 @pytest.mark.asyncio
@@ -4100,11 +3848,101 @@ async def test_battery_config_write_request_reraises_403_after_fallback() -> Non
     assert client._json.await_count == 2
     assert client._acquire_xsrf_token.await_count == 2
     assert client._acquire_xsrf_token.await_args_list[0].args == ("cfg",)
+    assert client._acquire_xsrf_token.await_args_list[0].kwargs == {
+        "variant": api._BATTERY_CONFIG_VARIANT_PRIMARY
+    }
     assert client._acquire_xsrf_token.await_args_list[1].args == ("cfg",)
     assert client._acquire_xsrf_token.await_args_list[1].kwargs == {
-        "include_eauth": False,
-        "include_requestid": False,
+        "variant": api._BATTERY_CONFIG_VARIANT_LEAN
     }
+
+
+@pytest.mark.asyncio
+async def test_battery_config_write_request_caches_successful_fallback_variant() -> (
+    None
+):
+    client = _make_client()
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
+    client._json = AsyncMock(
+        side_effect=[
+            _make_cre(403, "Forbidden"),
+            {"message": "success"},
+            {"message": "success"},
+        ]
+    )
+
+    first = await client._battery_config_write_request(  # noqa: SLF001
+        "PUT",
+        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/batterySettings/SITE",
+        json_body={"veryLowSoc": 15},
+        params={"userId": "88", "source": "enho"},
+    )
+    second = await client._battery_config_write_request(  # noqa: SLF001
+        "PUT",
+        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/batterySettings/SITE",
+        json_body={"veryLowSoc": 20},
+        params={"userId": "88", "source": "enho"},
+    )
+
+    assert first == {"message": "success"}
+    assert second == {"message": "success"}
+    first_call = client._json.await_args_list[0]
+    fallback_call = client._json.await_args_list[1]
+    cached_call = client._json.await_args_list[2]
+    assert first_call.kwargs["headers"]["requestid"]
+    assert "e-auth-token" in first_call.kwargs["headers"]
+    assert fallback_call.kwargs["headers"]["requestid"] is None
+    assert fallback_call.kwargs["headers"]["e-auth-token"] is None
+    assert cached_call.kwargs["headers"]["requestid"] is None
+    assert cached_call.kwargs["headers"]["e-auth-token"] is None
+
+
+@pytest.mark.asyncio
+async def test_battery_config_write_request_updates_cached_variant_after_403() -> None:
+    client = _make_client()
+    client._cache_battery_config_variant(  # noqa: SLF001
+        "battery_settings", api._BATTERY_CONFIG_VARIANT_PRIMARY
+    )
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
+    client._json = AsyncMock(
+        side_effect=[_make_cre(403, "Forbidden"), {"message": "success"}]
+    )
+
+    out = await client._battery_config_write_request(  # noqa: SLF001
+        "PUT",
+        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/batterySettings/SITE",
+        json_body={"veryLowSoc": 15},
+        params={"userId": "88", "source": "enho"},
+    )
+
+    assert out == {"message": "success"}
+    assert (
+        client._battery_config_cached_variant("battery_settings")  # noqa: SLF001
+        == api._BATTERY_CONFIG_VARIANT_LEAN
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_config_write_request_does_not_cache_on_401() -> None:
+    client = _make_client()
+    client._cache_battery_config_variant(  # noqa: SLF001
+        "battery_settings", api._BATTERY_CONFIG_VARIANT_PRIMARY
+    )
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
+    client._json = AsyncMock(side_effect=_make_cre(401, "Unauthorized"))
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client._battery_config_write_request(  # noqa: SLF001
+            "PUT",
+            "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/batterySettings/SITE",
+            json_body={"veryLowSoc": 15},
+            params={"userId": "88", "source": "enho"},
+        )
+
+    assert (
+        client._battery_config_cached_variant("battery_settings")  # noqa: SLF001
+        == api._BATTERY_CONFIG_VARIANT_PRIMARY
+    )
 
 
 @pytest.mark.asyncio
@@ -4133,11 +3971,9 @@ async def test_acquire_xsrf_token_uses_requested_validation_payload() -> None:
     assert kwargs["headers"]["Username"] == "88"
     assert kwargs["headers"]["X-XSRF-Token"] == "stale-token"
     assert kwargs["headers"]["e-auth-token"] == token
-    assert kwargs["headers"]["Authorization"] == f"Bearer {token}"
+    assert "Authorization" not in kwargs["headers"]
     assert "requestid" in kwargs["headers"]
-    assert (
-        kwargs["headers"]["Cookie"] == "session=1; other=1; BP-XSRF-Token=stale-token"
-    )
+    assert "Cookie" not in kwargs["headers"]
 
 
 @pytest.mark.asyncio
@@ -4173,14 +4009,12 @@ async def test_acquire_xsrf_token_uses_official_web_headers() -> None:
     await client._acquire_xsrf_token()  # noqa: SLF001
 
     headers = session.calls[0][2]["headers"]
-    assert headers["Authorization"] == f"Bearer {bearer}"
+    assert "Authorization" not in headers
     assert headers["e-auth-token"] == "session-token"
     assert headers["Username"] == "88"
     assert headers["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
     assert headers["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
-    assert (
-        headers["Cookie"] == f"session=1; enlighten_manager_token_production={bearer}"
-    )
+    assert "Cookie" not in headers
     assert "requestid" in headers
 
 
@@ -4296,10 +4130,33 @@ async def test_acquire_xsrf_token_falls_back_to_session_cookie_jar() -> None:
         client._cookie
         == "session=1; other=1; enlighten_manager_token_production=bearer"
     )  # noqa: SLF001
-    assert client._battery_config_headers(include_xsrf=True)["Cookie"] == (
-        "session=1; other=1; enlighten_manager_token_production=bearer; "
-        "BP-XSRF-Token=jar-token"
+    assert client._battery_config_headers(include_xsrf=True)["Cookie"] is None
+
+
+@pytest.mark.asyncio
+async def test_acquire_xsrf_token_keeps_existing_token_on_bootstrap_403() -> None:
+    response = _FakeResponse(status=403, json_body={"error": "Forbidden"})
+    response.headers = CIMultiDict()
+    session = _FakeSession([response])
+    request_url = URL(
+        f"{api.BASE_URL}/service/batteryConfig/api/v1/battery/sites/SITE/schedules/isValid"
     )
+    session.cookie_jar.update_cookies(
+        {"bp-xsrf-token": "jar-token"},
+        response_url=request_url,
+    )
+    client = _make_client(session)
+    client.update_credentials(
+        cookie=(
+            "session=1; BP-XSRF-Token=stale-token; other=1; "
+            "enlighten_manager_token_production=bearer"
+        )
+    )
+    client._bp_xsrf_token = "existing-token"  # noqa: SLF001
+
+    assert await client._acquire_xsrf_token() is None  # noqa: SLF001
+    assert client._bp_xsrf_token == "existing-token"  # noqa: SLF001
+    assert client._xsrf_token() == "existing-token"  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -4307,7 +4164,7 @@ async def test_battery_schedule_crud_methods_build_requests() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"message": "success"})
 
-    async def _acquire(*_args: object) -> str:
+    async def _acquire(*_args: object, **_kwargs: object) -> str:
         client._bp_xsrf_token = "fresh-token"  # noqa: SLF001
         return "fresh-token"
 
@@ -4339,12 +4196,18 @@ async def test_battery_schedule_crud_methods_build_requests() -> None:
         "days": [1, 7],
     }
     assert client._acquire_xsrf_token.await_args_list[0].args == ("cfg",)
+    assert client._acquire_xsrf_token.await_args_list[0].kwargs == {
+        "variant": api._BATTERY_CONFIG_VARIANT_PRIMARY
+    }
     assert delete_call.args == (
         "POST",
         "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/battery/sites/SITE/schedules/sched-1/delete",
     )
     assert delete_call.kwargs["json"] == {}
     assert client._acquire_xsrf_token.await_args_list[1].args == ("rbd",)
+    assert client._acquire_xsrf_token.await_args_list[1].kwargs == {
+        "variant": api._BATTERY_CONFIG_VARIANT_PRIMARY
+    }
     assert validate_call.args == (
         "POST",
         "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/battery/sites/SITE/schedules/isValid",
@@ -4360,7 +4223,7 @@ async def test_create_battery_schedule_omits_optional_limit_and_sets_is_enabled(
     client = _make_client()
     client._json = AsyncMock(return_value={"message": "success"})
 
-    async def _acquire(*_args: object) -> str:
+    async def _acquire(*_args: object, **_kwargs: object) -> str:
         client._bp_xsrf_token = "fresh-token"  # noqa: SLF001
         return "fresh-token"
 
@@ -4377,7 +4240,9 @@ async def test_create_battery_schedule_omits_optional_limit_and_sets_is_enabled(
     )
 
     call = client._json.await_args
-    client._acquire_xsrf_token.assert_awaited_once_with("rbd")
+    client._acquire_xsrf_token.assert_awaited_once_with(
+        "rbd", variant=api._BATTERY_CONFIG_VARIANT_PRIMARY
+    )
     assert call.kwargs["json"] == {
         "timezone": "Europe/London",
         "startTime": "01:00",
@@ -4395,7 +4260,7 @@ async def test_update_battery_schedule_sets_optional_is_enabled_and_is_deleted()
     client = _make_client()
     client._json = AsyncMock(return_value={"message": "success"})
 
-    async def _acquire(*_args: object) -> str:
+    async def _acquire(*_args: object, **_kwargs: object) -> str:
         client._bp_xsrf_token = "fresh-token"  # noqa: SLF001
         return "fresh-token"
 
@@ -4414,7 +4279,9 @@ async def test_update_battery_schedule_sets_optional_is_enabled_and_is_deleted()
     )
 
     call = client._json.await_args
-    client._acquire_xsrf_token.assert_awaited_once_with("rbd")
+    client._acquire_xsrf_token.assert_awaited_once_with(
+        "rbd", variant=api._BATTERY_CONFIG_VARIANT_PRIMARY
+    )
     assert call.kwargs["json"] == {
         "timezone": "Europe/London",
         "startTime": "01:00",
@@ -4431,7 +4298,7 @@ async def test_update_battery_schedule_builds_request_and_clears_xsrf() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"message": "success"})
 
-    async def _acquire(*_args: object) -> str:
+    async def _acquire(*_args: object, **_kwargs: object) -> str:
         client._bp_xsrf_token = "fresh-token"  # noqa: SLF001
         return "fresh-token"
 
@@ -4448,7 +4315,9 @@ async def test_update_battery_schedule_builds_request_and_clears_xsrf() -> None:
     )
 
     assert out == {"message": "success"}
-    client._acquire_xsrf_token.assert_awaited_once_with("dtg")
+    client._acquire_xsrf_token.assert_awaited_once_with(
+        "dtg", variant=api._BATTERY_CONFIG_VARIANT_PRIMARY
+    )
     args, kwargs = client._json.await_args
     assert args == (
         "PUT",
@@ -4462,17 +4331,17 @@ async def test_update_battery_schedule_builds_request_and_clears_xsrf() -> None:
         "scheduleType": "DTG",
         "days": [2, 6],
     }
-    assert kwargs["headers"]["Authorization"] == "Bearer EAUTH"
+    assert kwargs["headers"]["Authorization"] is None
     assert kwargs["headers"]["e-auth-token"] == "EAUTH"
     assert "requestid" in kwargs["headers"]
-    assert kwargs["headers"]["X-CSRF-Token"] == "fresh-token"
+    assert kwargs["headers"]["X-CSRF-Token"] is None
     assert kwargs["headers"]["X-XSRF-Token"] == "fresh-token"
     assert kwargs["headers"]["Content-Type"] == "application/json"
     assert kwargs["headers"]["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
     assert (
         kwargs["headers"]["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
     )
-    assert kwargs["headers"]["Cookie"] == "BP-XSRF-Token=fresh-token"
+    assert kwargs["headers"]["Cookie"] is None
     assert client._bp_xsrf_token is None  # noqa: SLF001
 
 
@@ -4482,8 +4351,13 @@ async def test_set_battery_settings_reacquires_xsrf_for_each_write() -> None:
     client._json = AsyncMock(return_value={"message": "success"})
     call_number = 0
 
-    async def _acquire(schedule_type: str = "cfg") -> str:
+    async def _acquire(
+        schedule_type: str = "cfg",
+        *,
+        variant: str = api._BATTERY_CONFIG_VARIANT_PRIMARY,
+    ) -> str:
         nonlocal call_number
+        assert variant == api._BATTERY_CONFIG_VARIANT_PRIMARY
         call_number += 1
         client._bp_xsrf_token = (  # noqa: SLF001
             f"{schedule_type}-fresh-token-{call_number}"
@@ -4502,7 +4376,13 @@ async def test_set_battery_settings_reacquires_xsrf_for_each_write() -> None:
     assert "requestid" in second_call.kwargs["headers"]
     assert client._acquire_xsrf_token.await_count == 2
     assert client._acquire_xsrf_token.await_args_list[0].args == ("cfg",)
+    assert client._acquire_xsrf_token.await_args_list[0].kwargs == {
+        "variant": api._BATTERY_CONFIG_VARIANT_PRIMARY
+    }
     assert client._acquire_xsrf_token.await_args_list[1].args == ("cfg",)
+    assert client._acquire_xsrf_token.await_args_list[1].kwargs == {
+        "variant": api._BATTERY_CONFIG_VARIANT_PRIMARY
+    }
     assert client._bp_xsrf_token is None  # noqa: SLF001
 
 
@@ -4518,122 +4398,9 @@ async def test_storm_guard_profile_delegates_to_battery_profile_details() -> Non
 
 
 @pytest.mark.asyncio
-async def test_set_battery_profile_retries_without_devices_on_mixed_auth_403(
-    monkeypatch,
-) -> None:
-    token = _make_token({"user_id": "100"})
+async def test_set_battery_profile_reraises_non_403_errors() -> None:
     client = _make_client()
-    client.update_credentials(
-        eauth="session-token",
-        cookie=(
-            "session=1; locale=en-AU; XSRF-TOKEN=stale-xsrf; "
-            f"enlighten_manager_token_production={token}"
-        ),
-    )
-    client._timeout = 1  # noqa: SLF001
-    client._json = AsyncMock(return_value={"message": "success"})  # noqa: SLF001
-
-    async def _to_thread(func, *args, **kwargs):
-        return func(*args, **kwargs)
-
-    monkeypatch.setattr(api.asyncio, "to_thread", _to_thread)
-
-    class _FakeOpener:
-        def __init__(self, cookie_jar):
-            self.cookie_jar = cookie_jar
-            self.calls: list[tuple[str, str, dict[str, str], str | None]] = []
-            self.put_count = 0
-
-        def open(self, request, timeout=None):
-            del timeout
-            body = request.data.decode() if request.data else None
-            headers = {key.lower(): value for key, value in request.header_items()}
-            self.calls.append((request.get_method(), request.full_url, headers, body))
-            if request.full_url.endswith("/app-api/jwt_token.json"):
-                return _FakeUrlLibResponse(status=200, body='{"token":"legacy-token"}')
-            if request.full_url.endswith("/schedules/isValid?userId=100&source=enho"):
-                self.cookie_jar.set_cookie(
-                    api.http.cookiejar.Cookie(
-                        version=0,
-                        name="BP-XSRF-Token",
-                        value="fresh-xsrf",
-                        port=None,
-                        port_specified=False,
-                        domain=".enphaseenergy.com",
-                        domain_specified=True,
-                        domain_initial_dot=True,
-                        path="/",
-                        path_specified=True,
-                        secure=False,
-                        expires=None,
-                        discard=False,
-                        comment=None,
-                        comment_url=None,
-                        rest={},
-                    )
-                )
-                return _FakeUrlLibResponse(status=200, body='{"isValid":true}')
-            self.put_count += 1
-            if self.put_count == 1:
-                raise api.urllib.error.HTTPError(
-                    request.full_url,
-                    403,
-                    "Forbidden",
-                    hdrs={},
-                    fp=io.BytesIO(b'{"status":403}'),
-                )
-            return _FakeUrlLibResponse(status=200, body='{"message":"success"}')
-
-    openers: list[_FakeOpener] = []
-
-    def _build_opener(processor):
-        opener = _FakeOpener(processor.cookiejar)
-        openers.append(opener)
-        return opener
-
-    monkeypatch.setattr(api.urllib.request, "build_opener", _build_opener)
-
-    out = await client.set_battery_profile(
-        profile="cost_savings",
-        battery_backup_percentage=25,
-        operation_mode_sub_type="prioritize-energy",
-        devices=[{"uuid": "abc", "deviceType": "iqEvse", "enable": False}],
-    )
-
-    assert out == {"message": "success"}
-    put_calls = [
-        call for opener in openers for call in opener.calls if call[0] == "PUT"
-    ]
-    assert len(put_calls) == 2
-    assert json.loads(put_calls[0][3]) == {
-        "profile": "cost_savings",
-        "batteryBackupPercentage": 25,
-        "operationModeSubType": "prioritize-energy",
-        "devices": [{"uuid": "abc", "deviceType": "iqEvse", "enable": False}],
-    }
-    assert json.loads(put_calls[1][3]) == {
-        "profile": "cost_savings",
-        "batteryBackupPercentage": 25,
-        "operationModeSubType": "prioritize-energy",
-    }
-    client._json.assert_awaited_once()
-    assert client._json.await_args.args == (
-        "PUT",
-        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
-    )
-    assert client._json.await_args.kwargs["json"] == {
-        "profile": "cost_savings",
-        "batteryBackupPercentage": 25,
-        "operationModeSubType": "prioritize-energy",
-    }
-
-
-@pytest.mark.asyncio
-async def test_set_battery_profile_reraises_non_403_profile_write_errors() -> None:
-    client = _make_client()
-    client._battery_config_profile_write_request = AsyncMock(  # noqa: SLF001
-        side_effect=_make_cre(500, "boom")
-    )
+    client._json = AsyncMock(side_effect=_make_cre(500, "boom"))
 
     with pytest.raises(aiohttp.ClientResponseError) as err:
         await client.set_battery_profile(
@@ -4662,9 +4429,9 @@ async def test_cancel_battery_profile_update_uses_empty_body() -> None:
     assert kwargs["json"] == {}
     assert kwargs["params"]["userId"] == "44"
     assert kwargs["headers"]["X-XSRF-Token"] == "t"
-    assert kwargs["headers"]["X-CSRF-Token"] == "t"
+    assert kwargs["headers"]["X-CSRF-Token"] is None
     assert kwargs["headers"]["e-auth-token"] == token
-    assert kwargs["headers"]["Authorization"] == f"Bearer {token}"
+    assert kwargs["headers"]["Authorization"] is None
     assert "requestid" in kwargs["headers"]
 
 
@@ -4690,9 +4457,9 @@ async def test_set_storm_guard_passes_payload_and_xsrf() -> None:
     }
     assert kwargs["params"]["userId"] == "99"
     assert kwargs["headers"]["X-XSRF-Token"] == "xsrf-token"
-    assert kwargs["headers"]["X-CSRF-Token"] == "xsrf-token"
+    assert kwargs["headers"]["X-CSRF-Token"] is None
     assert kwargs["headers"]["e-auth-token"] == token
-    assert kwargs["headers"]["Authorization"] == f"Bearer {token}"
+    assert kwargs["headers"]["Authorization"] is None
     assert "requestid" in kwargs["headers"]
 
 
@@ -4756,7 +4523,7 @@ async def test_battery_config_prefers_cookie_bearer_when_it_has_user_id() -> Non
     await client.set_storm_guard(enabled=True, evse_enabled=True)
 
     _args, kwargs = client._json.await_args
-    assert kwargs["headers"]["Authorization"] == f"Bearer {cookie_token}"
+    assert kwargs["headers"]["Authorization"] is None
     assert kwargs["headers"]["e-auth-token"] == eauth_token
     assert kwargs["headers"]["Username"] == "123"
     assert "requestid" in kwargs["headers"]


### PR DESCRIPTION
## Summary

Fixes part of #460 by hardening BatteryConfig XSRF bootstrap handling. When the `schedules/isValid` preflight returns a non-success response, the client now keeps the existing `BP-XSRF-Token` instead of promoting a bad token from the session jar and poisoning the follow-up battery write. This preserves the working official-web write shape for affected battery settings/profile flows.

## Related Issues

- #460

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py tests/components/enphase_ev/test_api_client_methods.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_api_client_methods.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py --fail-under=100"
python3 -m pre_commit run --all-files
```

Manual validation:
- Ran reversible live `batterySettings` writes against a real Enphase account in the Docker dev environment using `EnphaseEVClient`:
  - `veryLowSoc: 10 -> 11`
  - `veryLowSoc: 11 -> 10`
- Verified both calls returned success through the real client path after the bootstrap fix.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The fix is intentionally narrow: failed BatteryConfig `isValid` bootstrap calls no longer overwrite the working `BP-XSRF-Token` used by the follow-up write.
- This keeps the compatibility logic centralized in `api.py` and avoids adding further ad hoc request variants.
