### PR TITLE
Prepare release v2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v2.8.0 - 2026-04-17
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
 - Added battery schedule parity tooling on supported battery sites: public `force_refresh`, `add_schedule`, `update_schedule`, `delete_schedule`, and `validate_schedule` services; schedule inventory summary sensors; and an on-device battery schedule editor with selection, weekday controls, and CRUD buttons.
 
 ### 🐛 Bug fixes
@@ -21,7 +38,7 @@ All notable changes to this project will be documented in this file.
 - Simplified the battery schedule editor UI by collapsing the duplicate edit/create entity sets into one shared form, hiding weekday toggles by default, and separating the integration options into `Enable EV Charger Scheduler` and `Enable Battery Scheduler`.
 
 ### 🔄 Other changes
-- None
+- Bumped the integration manifest version to `2.8.0`.
 
 ## v2.7.14 - 2026-04-16
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.7.14"
+  "version": "2.8.0"
 }


### PR DESCRIPTION
## Summary

Prepare the `v2.8.0` release metadata by promoting the current unreleased changelog entries into a dated release section and bumping the integration manifest version to `2.8.0`.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release preparation for changelog and manifest metadata.

## Testing

No automated checks run. This change only updates release metadata in `CHANGELOG.md` and `custom_components/enphase_ev/manifest.json`.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This PR only adjusts release metadata on top of the current `origin/main` tip.