### PR TITLE
Rationalize battery schedule controls and harden battery writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,28 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v2.8.2 - 2026-04-17
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Hardened IQ Battery BatteryConfig writes for issue `#460` by using endpoint-specific request planning and a stateless raw-cookie browser compatibility path on affected sites: profile writes now retry without `devices` and then without `source`, battery-settings writes can retry without `source` on `supportsMqtt=true` sites and fall back to `acceptedItcDisclaimer: true`, and schedule create/update/delete writes now use the same cookie-backed compatibility flow instead of failing with `403`.
+- Fixed IQ Battery schedule parity for DTG/RBD in Home Assistant: RBD on/off toggles no longer invent a schedule when Enphase reports `rbdControl.enabled` without any saved RBD schedule.
+- Restored correct gating for the `Manage IQ Battery Schedules` option so the generic battery schedule editor is shown when that option is enabled, the duplicate dedicated CFG/DTG/RBD schedule time and limit editors are hidden in that mode, and the plain CFG/DTG/RBD control switches still remain available.
+- Fixed Home Assistant battery schedule services so Enphase `schedules/isValid` preflight `403` responses are treated as optional compatibility failures instead of crashing `add_schedule` with an internal server error on affected sites.
+
+### 🔧 Improvements
+- Keep the IQ Battery shutdown-level control available when Enphase still returns explicit `veryLowSoc` values, even if `batteryLimitSupport=false` is present in site settings, so working production sites are not hidden by an over-strict capability flag.
+- Rationalised the battery schedule editor by defaulting it to a valid schedule selection after refresh, auto-falling back to create mode only when no schedules exist, and replacing raw schedule IDs with translated, readable schedule labels in the selector.
+- Updated the BatteryConfig API reference to document the verified profile, battery-settings, and schedule request/response shapes and the validated compatibility fallbacks.
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `2.8.2`.
+
 ## v2.8.0 - 2026-04-17
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import copy
 import hashlib
 import json
 import logging
@@ -42,10 +43,30 @@ _ENLIGHTEN_BROWSER_USER_AGENT = (
     "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
     "AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.3.1 Safari/605.1.15"
 )
+_BATTERY_CONFIG_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36"
+)
 _BATTERY_CONFIG_VARIANT_PRIMARY = "official_web_primary"
 _BATTERY_CONFIG_VARIANT_LEAN = "official_web_lean"
+_BATTERY_CONFIG_VARIANT_COOKIE_EAUTH = "cookie_eauth_compatible"
+_BATTERY_CONFIG_VARIANT_MIXED = "mixed_auth_compatible"
 _ENLIGHTEN_READ_CONCURRENCY_LIMIT = 2
 _enlighten_read_semaphore: asyncio.Semaphore | None = None
+
+
+@dataclass(frozen=True)
+class _BatteryConfigWriteAttempt:
+    """Describe one BatteryConfig write attempt shape."""
+
+    attempt_id: str
+    auth_mode: str
+    omit_source: bool = False
+    strip_devices: bool = False
+    disclaimer_bool_true: bool = False
+    merged_payload: bool = False
+    preserve_base_devices: bool = False
+    prefer_existing_xsrf: bool = False
 
 
 class Unauthorized(Exception):
@@ -1874,6 +1895,11 @@ class EnphaseEVClient:
         self._stop_variant_idx: int | None = None
         self._bp_xsrf_token: str | None = None
         self._battery_config_variant_cache: dict[tuple[str, str, str], str] = {}
+        self._battery_config_write_attempt_cache: dict[
+            tuple[str, str, str, str], str
+        ] = {}
+        self._battery_config_supports_mqtt: bool | None = None
+        self._battery_config_write_bases: dict[str, dict[str, Any]] = {}
         self._cookie = cookie or ""
         self._eauth = eauth or None
         self._hems_site_supported: bool | None = None
@@ -2379,25 +2405,25 @@ class EnphaseEVClient:
     ) -> dict[str, str | None]:
         """Return headers for BatteryConfig read/write calls."""
 
-        headers: dict[str, str | None] = dict(self._h)
-        headers["Accept"] = "application/json, text/plain, */*"
-        headers["Origin"] = "https://battery-profile-ui.enphaseenergy.com"
-        headers["Referer"] = "https://battery-profile-ui.enphaseenergy.com/"
-        headers["Authorization"] = None
-        headers["X-Requested-With"] = None
-        headers["Cookie"] = None
-        headers["X-CSRF-Token"] = None
-        headers["requestid"] = (
-            str(uuid.uuid4()) if variant == _BATTERY_CONFIG_VARIANT_PRIMARY else None
-        )
+        headers: dict[str, str | None] = {
+            "Accept": "application/json, text/plain, */*",
+            "Origin": "https://battery-profile-ui.enphaseenergy.com",
+            "Referer": "https://battery-profile-ui.enphaseenergy.com/",
+            "User-Agent": _BATTERY_CONFIG_BROWSER_USER_AGENT,
+            "Authorization": None,
+            "X-Requested-With": None,
+            "Cookie": None,
+            "e-auth-token": None,
+            "X-CSRF-Token": None,
+            "requestid": (
+                str(uuid.uuid4())
+                if variant == _BATTERY_CONFIG_VARIANT_PRIMARY
+                else None
+            ),
+        }
         token, user_id = self._battery_config_auth_context()
         if variant == _BATTERY_CONFIG_VARIANT_PRIMARY:
-            if self._eauth:
-                headers["e-auth-token"] = self._eauth
-            elif token:
-                headers["e-auth-token"] = token
-            else:
-                headers["e-auth-token"] = None
+            headers["e-auth-token"] = token
         else:
             headers["e-auth-token"] = None
         if user_id:
@@ -2408,6 +2434,140 @@ class EnphaseEVClient:
             xsrf = self._xsrf_token()
             if xsrf:
                 headers["X-XSRF-Token"] = xsrf
+        return headers
+
+    def _battery_config_cookie_eauth_headers(
+        self,
+        *,
+        include_xsrf: bool = False,
+    ) -> dict[str, str | None]:
+        """Return the cookie-backed external-compatible BatteryConfig headers."""
+
+        token = self._battery_config_single_auth_token()
+        user_id = self._battery_config_user_id_for_token(token)
+        headers: dict[str, str | None] = {
+            "Accept": "application/json, text/plain, */*",
+            "Origin": "https://battery-profile-ui.enphaseenergy.com",
+            "Referer": "https://battery-profile-ui.enphaseenergy.com/",
+            "User-Agent": _BATTERY_CONFIG_BROWSER_USER_AGENT,
+            "Authorization": None,
+            "X-Requested-With": "XMLHttpRequest",
+            "Cookie": self._cookie or None,
+            "e-auth-token": token,
+            "X-CSRF-Token": None,
+            "requestid": None,
+        }
+        if user_id:
+            headers["Username"] = user_id
+        else:
+            headers.pop("Username", None)
+        if include_xsrf:
+            xsrf = self._battery_config_cookie_header_xsrf_token()
+            if xsrf:
+                headers["X-XSRF-Token"] = xsrf
+            else:
+                headers["X-XSRF-Token"] = None
+        return headers
+
+    def _battery_config_cookie(self, *, include_xsrf: bool = False) -> str | None:
+        """Return a normalized BatteryConfig cookie header value."""
+
+        cookies: dict[str, str] = {}
+
+        try:
+            cookie_str = str(self._cookie) if self._cookie else ""
+        except Exception:  # noqa: BLE001 - defensive parsing
+            cookie_str = ""
+
+        cookies.update(_cookie_map_from_header(cookie_str))
+
+        jar = getattr(self._s, "cookie_jar", None)
+        if jar is not None:
+            _cookie_header, jar_cookies = _serialize_cookie_jar(
+                jar,
+                (
+                    BASE_URL,
+                    ENTREZ_URL,
+                    "https://battery-profile-ui.enphaseenergy.com",
+                ),
+            )
+            cookies.update(jar_cookies)
+
+        cookies = {
+            name: value
+            for name, value in cookies.items()
+            if name.strip().lower() not in _XSRF_COOKIE_NAMES
+        }
+
+        if include_xsrf:
+            xsrf = self._xsrf_token()
+            if xsrf:
+                cookies["BP-XSRF-Token"] = xsrf
+        if not cookies:
+            return None
+        return _cookie_header_from_map(cookies)
+
+    def _battery_config_cookie_header_xsrf_token(self) -> str | None:
+        """Return the BP-XSRF token from the stored cookie header."""
+
+        try:
+            parts = [p.strip() for p in (self._cookie or "").split(";")]
+        except Exception:  # noqa: BLE001 - defensive parsing
+            return None
+        for part in parts:
+            key, sep, value = part.partition("=")
+            if not sep or key.strip().lower() not in _XSRF_COOKIE_NAMES:
+                continue
+            token = value.strip()
+            if token.startswith('"') and token.endswith('"') and len(token) >= 2:
+                token = token[1:-1]
+            if not token:
+                continue
+            try:
+                return unquote(token)
+            except Exception:  # noqa: BLE001 - defensive decoding
+                return token
+        return None
+
+    def _battery_config_mixed_auth_headers(
+        self,
+        *,
+        include_xsrf: bool = False,
+    ) -> dict[str, str | None]:
+        """Return the mixed-auth compatibility BatteryConfig headers."""
+
+        headers: dict[str, str | None] = {
+            "Accept": "application/json, text/plain, */*",
+            "Origin": "https://battery-profile-ui.enphaseenergy.com",
+            "Referer": "https://battery-profile-ui.enphaseenergy.com/",
+            "User-Agent": _BATTERY_CONFIG_BROWSER_USER_AGENT,
+            "Authorization": None,
+            "X-Requested-With": "XMLHttpRequest",
+            "Cookie": None,
+            "e-auth-token": None,
+            "X-CSRF-Token": None,
+            "requestid": None,
+        }
+        token, user_id = self._battery_config_auth_context()
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+        else:
+            headers["Authorization"] = None
+        headers["e-auth-token"] = token
+        if user_id:
+            headers["Username"] = user_id
+        else:
+            headers.pop("Username", None)
+        cookie = self._battery_config_cookie(include_xsrf=include_xsrf)
+        headers["Cookie"] = cookie
+        if include_xsrf:
+            xsrf = self._xsrf_token()
+            if xsrf:
+                headers["X-XSRF-Token"] = xsrf
+                headers["X-CSRF-Token"] = xsrf
+        else:
+            headers["X-XSRF-Token"] = None
+            headers["X-CSRF-Token"] = None
         return headers
 
     def _battery_schedule_validation_payload(
@@ -2485,6 +2645,637 @@ class EnphaseEVClient:
             if variant
             in {_BATTERY_CONFIG_VARIANT_PRIMARY, _BATTERY_CONFIG_VARIANT_LEAN}
         ]
+
+    def _battery_config_write_attempt_cache_key(
+        self,
+        endpoint_family: str,
+        *,
+        supports_mqtt: bool | None,
+    ) -> tuple[str, str, str, str]:
+        """Return the cache key for BatteryConfig write attempts."""
+
+        user_id = self._battery_config_user_id() or "<unknown>"
+        mqtt_key = (
+            "mqtt"
+            if supports_mqtt is True
+            else "nomqtt" if supports_mqtt is False else "<unknown>"
+        )
+        return (str(self._site), user_id, str(endpoint_family), mqtt_key)
+
+    def _battery_config_cached_write_attempt(
+        self,
+        endpoint_family: str,
+        *,
+        supports_mqtt: bool | None,
+    ) -> str | None:
+        """Return the cached BatteryConfig write attempt id for an endpoint family."""
+
+        key = self._battery_config_write_attempt_cache_key(
+            endpoint_family,
+            supports_mqtt=supports_mqtt,
+        )
+        return self._battery_config_write_attempt_cache.get(key)
+
+    def _cache_battery_config_write_attempt(
+        self,
+        endpoint_family: str,
+        attempt_id: str,
+        *,
+        supports_mqtt: bool | None,
+    ) -> None:
+        """Remember the working BatteryConfig write attempt id for an endpoint family."""
+
+        key = self._battery_config_write_attempt_cache_key(
+            endpoint_family,
+            supports_mqtt=supports_mqtt,
+        )
+        self._battery_config_write_attempt_cache[key] = attempt_id
+
+    def _battery_config_write_attempts(
+        self,
+        endpoint_family: str,
+        *,
+        write_intent: str,
+        supports_mqtt: bool | None,
+        params: dict[str, str] | None,
+        json_body: dict[str, Any] | list[Any] | None,
+    ) -> list[_BatteryConfigWriteAttempt]:
+        """Return ordered write attempts for a BatteryConfig endpoint family."""
+
+        attempts: list[_BatteryConfigWriteAttempt]
+        body = json_body if isinstance(json_body, dict) else None
+        has_source = isinstance(params, dict) and "source" in params
+        has_devices = isinstance(body, dict) and "devices" in body
+        has_disclaimer = (
+            isinstance(body, dict)
+            and "acceptedItcDisclaimer" in body
+            and body.get("acceptedItcDisclaimer") is not True
+        )
+        has_compat_auth_material = bool(self._battery_config_single_auth_token())
+        prefer_cookie_compat = self._battery_config_prefers_cookie_compat()
+        has_stateful_base = endpoint_family in self._battery_config_write_bases
+
+        if write_intent == "profile_update":
+            attempts = [
+                _BatteryConfigWriteAttempt(
+                    attempt_id="profile_primary",
+                    auth_mode=_BATTERY_CONFIG_VARIANT_PRIMARY,
+                ),
+            ]
+            if has_devices:
+                attempts.append(
+                    _BatteryConfigWriteAttempt(
+                        attempt_id="profile_primary_no_devices",
+                        auth_mode=_BATTERY_CONFIG_VARIANT_PRIMARY,
+                        strip_devices=True,
+                    )
+                )
+            if has_source:
+                attempts.append(
+                    _BatteryConfigWriteAttempt(
+                        attempt_id="profile_primary_no_source",
+                        auth_mode=_BATTERY_CONFIG_VARIANT_PRIMARY,
+                        omit_source=True,
+                        strip_devices=has_devices,
+                    )
+                )
+            if has_stateful_base:
+                attempts.extend(
+                    [
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="profile_stateful_primary",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_PRIMARY,
+                            merged_payload=True,
+                            preserve_base_devices=has_devices,
+                        ),
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="profile_stateful_primary_no_source",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_PRIMARY,
+                            omit_source=has_source,
+                            merged_payload=True,
+                            preserve_base_devices=has_devices,
+                        ),
+                    ]
+                )
+            if has_compat_auth_material:
+                attempts.append(
+                    _BatteryConfigWriteAttempt(
+                        attempt_id="profile_cookie_eauth_compat",
+                        auth_mode=_BATTERY_CONFIG_VARIANT_COOKIE_EAUTH,
+                        omit_source=has_source,
+                        strip_devices=has_devices,
+                        prefer_existing_xsrf=True,
+                    )
+                )
+                if has_stateful_base:
+                    attempts.append(
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="profile_stateful_cookie_eauth_compat",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_COOKIE_EAUTH,
+                            omit_source=has_source,
+                            merged_payload=True,
+                            preserve_base_devices=has_devices,
+                            prefer_existing_xsrf=True,
+                        )
+                    )
+            if has_compat_auth_material:
+                attempts.append(
+                    _BatteryConfigWriteAttempt(
+                        attempt_id="profile_mixed_compat",
+                        auth_mode=_BATTERY_CONFIG_VARIANT_MIXED,
+                        omit_source=has_source,
+                        strip_devices=has_devices,
+                    )
+                )
+                if has_stateful_base:
+                    attempts.append(
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="profile_stateful_mixed_compat",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_MIXED,
+                            omit_source=has_source,
+                            merged_payload=True,
+                            preserve_base_devices=has_devices,
+                        )
+                    )
+        elif write_intent == "battery_settings_update":
+            attempts = [
+                _BatteryConfigWriteAttempt(
+                    attempt_id="battery_settings_primary_source",
+                    auth_mode=_BATTERY_CONFIG_VARIANT_PRIMARY,
+                ),
+                _BatteryConfigWriteAttempt(
+                    attempt_id="battery_settings_lean_source",
+                    auth_mode=_BATTERY_CONFIG_VARIANT_LEAN,
+                ),
+            ]
+            if supports_mqtt is True and has_source:
+                attempts.extend(
+                    [
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="battery_settings_primary_no_source",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_PRIMARY,
+                            omit_source=True,
+                        ),
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="battery_settings_lean_no_source",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_LEAN,
+                            omit_source=True,
+                        ),
+                    ]
+                )
+            if has_stateful_base:
+                attempts.extend(
+                    [
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="battery_settings_stateful_primary_source",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_PRIMARY,
+                            merged_payload=True,
+                        ),
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="battery_settings_stateful_lean_source",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_LEAN,
+                            merged_payload=True,
+                        ),
+                    ]
+                )
+                if supports_mqtt is True and has_source:
+                    attempts.extend(
+                        [
+                            _BatteryConfigWriteAttempt(
+                                attempt_id=(
+                                    "battery_settings_stateful_primary_no_source"
+                                ),
+                                auth_mode=_BATTERY_CONFIG_VARIANT_PRIMARY,
+                                omit_source=True,
+                                merged_payload=True,
+                            ),
+                            _BatteryConfigWriteAttempt(
+                                attempt_id="battery_settings_stateful_lean_no_source",
+                                auth_mode=_BATTERY_CONFIG_VARIANT_LEAN,
+                                omit_source=True,
+                                merged_payload=True,
+                            ),
+                        ]
+                    )
+            if has_compat_auth_material:
+                attempts.append(
+                    _BatteryConfigWriteAttempt(
+                        attempt_id="battery_settings_cookie_eauth_source",
+                        auth_mode=_BATTERY_CONFIG_VARIANT_COOKIE_EAUTH,
+                        prefer_existing_xsrf=True,
+                    )
+                )
+                if supports_mqtt is True and has_source:
+                    attempts.append(
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="battery_settings_cookie_eauth_no_source",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_COOKIE_EAUTH,
+                            omit_source=True,
+                            prefer_existing_xsrf=True,
+                        )
+                    )
+                if has_stateful_base:
+                    attempts.append(
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="battery_settings_stateful_cookie_eauth_source",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_COOKIE_EAUTH,
+                            merged_payload=True,
+                            prefer_existing_xsrf=True,
+                        )
+                    )
+                    if supports_mqtt is True and has_source:
+                        attempts.append(
+                            _BatteryConfigWriteAttempt(
+                                attempt_id=(
+                                    "battery_settings_stateful_cookie_eauth_no_source"
+                                ),
+                                auth_mode=_BATTERY_CONFIG_VARIANT_COOKIE_EAUTH,
+                                omit_source=True,
+                                merged_payload=True,
+                                prefer_existing_xsrf=True,
+                            )
+                        )
+            if has_compat_auth_material:
+                attempts.append(
+                    _BatteryConfigWriteAttempt(
+                        attempt_id="battery_settings_mixed_source",
+                        auth_mode=_BATTERY_CONFIG_VARIANT_MIXED,
+                    )
+                )
+                if supports_mqtt is True and has_source:
+                    attempts.append(
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="battery_settings_mixed_no_source",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_MIXED,
+                            omit_source=True,
+                        )
+                    )
+                if has_stateful_base:
+                    attempts.append(
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="battery_settings_stateful_mixed_source",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_MIXED,
+                            merged_payload=True,
+                        )
+                    )
+                    if supports_mqtt is True and has_source:
+                        attempts.append(
+                            _BatteryConfigWriteAttempt(
+                                attempt_id="battery_settings_stateful_mixed_no_source",
+                                auth_mode=_BATTERY_CONFIG_VARIANT_MIXED,
+                                omit_source=True,
+                                merged_payload=True,
+                            )
+                        )
+                if has_disclaimer:
+                    attempts.append(
+                        _BatteryConfigWriteAttempt(
+                            attempt_id="battery_settings_disclaimer_true",
+                            auth_mode=_BATTERY_CONFIG_VARIANT_MIXED,
+                            omit_source=supports_mqtt is True and has_source,
+                            disclaimer_bool_true=True,
+                        )
+                    )
+                    if has_stateful_base:
+                        attempts.append(
+                            _BatteryConfigWriteAttempt(
+                                attempt_id=(
+                                    "battery_settings_stateful_disclaimer_true"
+                                ),
+                                auth_mode=_BATTERY_CONFIG_VARIANT_MIXED,
+                                omit_source=supports_mqtt is True and has_source,
+                                disclaimer_bool_true=True,
+                                merged_payload=True,
+                            )
+                        )
+        elif write_intent == "battery_settings_disclaimer_accept":
+            attempts = [
+                _BatteryConfigWriteAttempt(
+                    attempt_id="battery_settings_disclaimer_primary",
+                    auth_mode=_BATTERY_CONFIG_VARIANT_PRIMARY,
+                ),
+                _BatteryConfigWriteAttempt(
+                    attempt_id="battery_settings_disclaimer_lean",
+                    auth_mode=_BATTERY_CONFIG_VARIANT_LEAN,
+                ),
+            ]
+            if has_compat_auth_material:
+                attempts.append(
+                    _BatteryConfigWriteAttempt(
+                        attempt_id="battery_settings_disclaimer_cookie_eauth",
+                        auth_mode=_BATTERY_CONFIG_VARIANT_COOKIE_EAUTH,
+                        prefer_existing_xsrf=True,
+                    )
+                )
+            if has_compat_auth_material:
+                attempts.append(
+                    _BatteryConfigWriteAttempt(
+                        attempt_id="battery_settings_disclaimer_mixed",
+                        auth_mode=_BATTERY_CONFIG_VARIANT_MIXED,
+                    )
+                )
+        else:
+            attempts = [
+                _BatteryConfigWriteAttempt(
+                    attempt_id=f"{endpoint_family}_primary",
+                    auth_mode=_BATTERY_CONFIG_VARIANT_PRIMARY,
+                ),
+                _BatteryConfigWriteAttempt(
+                    attempt_id=f"{endpoint_family}_lean",
+                    auth_mode=_BATTERY_CONFIG_VARIANT_LEAN,
+                ),
+            ]
+            if has_compat_auth_material:
+                attempts.append(
+                    _BatteryConfigWriteAttempt(
+                        attempt_id=f"{endpoint_family}_cookie_eauth",
+                        auth_mode=_BATTERY_CONFIG_VARIANT_COOKIE_EAUTH,
+                        prefer_existing_xsrf=True,
+                    )
+                )
+                attempts.append(
+                    _BatteryConfigWriteAttempt(
+                        attempt_id=f"{endpoint_family}_mixed",
+                        auth_mode=_BATTERY_CONFIG_VARIANT_MIXED,
+                    )
+                )
+
+        cached_attempt = self._battery_config_cached_write_attempt(
+            endpoint_family,
+            supports_mqtt=supports_mqtt,
+        )
+        if cached_attempt:
+            attempts = sorted(
+                attempts,
+                key=lambda attempt: 0 if attempt.attempt_id == cached_attempt else 1,
+            )
+        elif prefer_cookie_compat:
+            attempts = sorted(
+                attempts,
+                key=lambda attempt: (
+                    0
+                    if attempt.auth_mode == _BATTERY_CONFIG_VARIANT_COOKIE_EAUTH
+                    else 1
+                ),
+            )
+        return attempts
+
+    def _battery_config_prefers_cookie_compat(self) -> bool:
+        """Return True when cookie-backed BatteryConfig writes should be preferred.
+
+        Some Enphase battery sites only accept the browser-like request that reuses
+        the stored session cookie and its original BP-XSRF token. When that raw
+        cookie/XSRF pair is present locally, start with the cookie-backed attempt
+        instead of probing the known-bad official-web variants first.
+        """
+
+        return bool(
+            self._cookie
+            and self._battery_config_single_auth_token()
+            and self._battery_config_cookie_header_xsrf_token()
+        )
+
+    def _battery_config_attempt_headers(
+        self,
+        attempt: _BatteryConfigWriteAttempt,
+        *,
+        include_xsrf: bool,
+    ) -> dict[str, str | None]:
+        """Return headers for a BatteryConfig write attempt."""
+
+        if attempt.auth_mode == _BATTERY_CONFIG_VARIANT_MIXED:
+            return self._battery_config_mixed_auth_headers(include_xsrf=include_xsrf)
+        if attempt.auth_mode == _BATTERY_CONFIG_VARIANT_COOKIE_EAUTH:
+            return self._battery_config_cookie_eauth_headers(include_xsrf=include_xsrf)
+        return self._battery_config_headers(
+            include_xsrf=include_xsrf,
+            variant=attempt.auth_mode,
+        )
+
+    def _battery_config_attempt_params(
+        self,
+        params: dict[str, str] | None,
+        attempt: _BatteryConfigWriteAttempt,
+    ) -> dict[str, str] | None:
+        """Return query params for a BatteryConfig write attempt."""
+
+        if not isinstance(params, dict):
+            return params
+        adjusted = dict(params)
+        if attempt.omit_source:
+            adjusted.pop("source", None)
+        return adjusted
+
+    def _battery_config_attempt_json_body(
+        self,
+        json_body: dict[str, Any] | list[Any] | None,
+        endpoint_family: str,
+        attempt: _BatteryConfigWriteAttempt,
+    ) -> dict[str, Any] | list[Any] | None:
+        """Return the request payload for a BatteryConfig write attempt."""
+
+        body_for_attempt = json_body
+        if (
+            attempt.merged_payload
+            and attempt.preserve_base_devices
+            and isinstance(json_body, dict)
+            and "devices" in json_body
+        ):
+            body_for_attempt = copy.deepcopy(json_body)
+            body_for_attempt.pop("devices", None)
+
+        if attempt.merged_payload:
+            adjusted = self._battery_config_merged_write_payload(
+                endpoint_family,
+                body_for_attempt,
+            )
+        else:
+            adjusted = copy.deepcopy(body_for_attempt)
+        if not isinstance(adjusted, dict):
+            return adjusted
+        if attempt.strip_devices:
+            adjusted.pop("devices", None)
+        if attempt.disclaimer_bool_true and "acceptedItcDisclaimer" in adjusted:
+            adjusted["acceptedItcDisclaimer"] = True
+        return adjusted
+
+    def _battery_config_attempt_change_summary(
+        self,
+        attempt: _BatteryConfigWriteAttempt,
+        *,
+        params: dict[str, str] | None,
+        json_body: dict[str, Any] | list[Any] | None,
+    ) -> dict[str, object]:
+        """Return safe debug details describing how an attempt differs from canonical."""
+
+        return {
+            "auth_mode": attempt.auth_mode,
+            "source": (
+                "omitted"
+                if attempt.omit_source
+                and isinstance(params, dict)
+                and "source" in params
+                else "kept"
+            ),
+            "source_value": params.get("source") if isinstance(params, dict) else None,
+            "devices": (
+                "stripped"
+                if attempt.strip_devices
+                and isinstance(json_body, dict)
+                and "devices" in json_body
+                else "kept"
+            ),
+            "payload": "merged" if attempt.merged_payload else "partial",
+            "devices_shape": (
+                "preserved_from_base"
+                if attempt.preserve_base_devices
+                and isinstance(json_body, dict)
+                and "devices" in json_body
+                else "from_request"
+            ),
+            "disclaimer": (
+                "boolean_true"
+                if attempt.disclaimer_bool_true
+                and isinstance(json_body, dict)
+                and "acceptedItcDisclaimer" in json_body
+                else "preserved"
+            ),
+        }
+
+    @staticmethod
+    def _battery_config_attempt_signature(
+        *,
+        attempt: _BatteryConfigWriteAttempt,
+        params: dict[str, str] | None,
+        json_body: dict[str, Any] | list[Any] | None,
+    ) -> str:
+        """Return a stable signature for deduplicating write attempts."""
+
+        return json.dumps(
+            {
+                "attempt_id": attempt.attempt_id,
+                "auth_mode": attempt.auth_mode,
+                "omit_source": attempt.omit_source,
+                "strip_devices": attempt.strip_devices,
+                "disclaimer_bool_true": attempt.disclaimer_bool_true,
+                "merged_payload": attempt.merged_payload,
+                "preserve_base_devices": attempt.preserve_base_devices,
+                "params": params,
+                "json_body": json_body,
+            },
+            sort_keys=True,
+            default=str,
+        )
+
+    def _remember_battery_config_capabilities(self, payload: object) -> None:
+        """Persist BatteryConfig capability hints discovered from payloads."""
+
+        if not isinstance(payload, dict):
+            return
+        data = payload.get("data")
+        if not isinstance(data, dict):
+            data = payload
+        supports_mqtt = data.get("supportsMqtt")
+        if isinstance(supports_mqtt, bool):
+            self._battery_config_supports_mqtt = supports_mqtt
+
+    @staticmethod
+    def _battery_config_payload_data(payload: object) -> dict[str, Any] | None:
+        """Return the nested BatteryConfig data payload when available."""
+
+        if not isinstance(payload, dict):
+            return None
+        data = payload.get("data")
+        if isinstance(data, dict):
+            return data
+        return payload
+
+    def _remember_battery_config_write_base(
+        self, endpoint_family: str, payload: object
+    ) -> None:
+        """Persist a writable base payload for later state-preserving retries."""
+
+        data = self._battery_config_payload_data(payload)
+        if not isinstance(data, dict):
+            return
+
+        if endpoint_family == "battery_settings":
+            allowed_keys = {
+                "profile",
+                "operationModeSubType",
+                "batteryBackupPercentage",
+                "requestedConfig",
+                "requestedConfigMqtt",
+                "stormGuardState",
+                "showStormGuardAlert",
+                "acceptedItcDisclaimer",
+                "hideChargeFromGrid",
+                "envoySupportsVls",
+                "chargeBeginTime",
+                "chargeEndTime",
+                "batteryGridMode",
+                "veryLowSoc",
+                "chargeFromGrid",
+                "chargeFromGridScheduleEnabled",
+                "systemTask",
+                "dtgControl",
+                "cfgControl",
+                "rbdControl",
+                "evseStormEnabled",
+                "devices",
+            }
+        elif endpoint_family == "profile":
+            allowed_keys = {
+                "profile",
+                "operationModeSubType",
+                "batteryBackupPercentage",
+                "requestedConfig",
+                "requestedConfigMqtt",
+                "stormGuardState",
+                "acceptedStormGuardDisclaimer",
+                "showStormGuardAlert",
+                "systemTask",
+                "veryLowSoc",
+                "dtgControl",
+                "cfgControl",
+                "rbdControl",
+                "evseStormEnabled",
+                "devices",
+            }
+        else:
+            return
+
+        write_base = {
+            key: copy.deepcopy(value)
+            for key, value in data.items()
+            if key in allowed_keys
+        }
+        if write_base:
+            self._battery_config_write_bases[endpoint_family] = write_base
+
+    def _battery_config_merged_write_payload(
+        self,
+        endpoint_family: str,
+        json_body: dict[str, Any] | list[Any] | None,
+    ) -> dict[str, Any] | list[Any] | None:
+        """Merge a partial write payload onto the last successful read payload."""
+
+        if not isinstance(json_body, dict):
+            return json_body
+
+        base_payload = self._battery_config_write_bases.get(endpoint_family)
+        if not isinstance(base_payload, dict):
+            return copy.deepcopy(json_body)
+
+        merged = copy.deepcopy(base_payload)
+        for key, value in json_body.items():
+            if isinstance(value, dict) and isinstance(merged.get(key), dict):
+                nested = dict(merged[key])
+                nested.update(copy.deepcopy(value))
+                merged[key] = nested
+                continue
+            merged[key] = copy.deepcopy(value)
+        return merged
 
     def _xsrf_token(self) -> str | None:
         """Return the XSRF token value.
@@ -2583,19 +3374,118 @@ class EnphaseEVClient:
         params: dict[str, str] | None = None,
         schedule_type: str = "cfg",
         endpoint_family: str | None = None,
+        write_intent: str = "generic",
+        supports_mqtt: bool | None = None,
     ) -> dict:
-        """Issue a BatteryConfig write with centralized variant selection."""
+        """Issue a BatteryConfig write using endpoint-specific compatibility attempts."""
 
-        return await self._battery_config_request(
-            method,
-            url,
-            json_body=json_body,
+        family = endpoint_family or self._battery_config_endpoint_family(url)
+        attempts = self._battery_config_write_attempts(
+            family,
+            write_intent=write_intent,
+            supports_mqtt=supports_mqtt,
             params=params,
-            schedule_type=schedule_type,
-            endpoint_family=endpoint_family,
-            bootstrap_xsrf=True,
-            cache_on_success=True,
+            json_body=json_body,
         )
+        last_error: aiohttp.ClientResponseError | None = None
+        seen_signatures: set[str] = set()
+
+        try:
+            for index, attempt in enumerate(attempts):
+                attempt_params = self._battery_config_attempt_params(params, attempt)
+                attempt_json_body = self._battery_config_attempt_json_body(
+                    json_body,
+                    family,
+                    attempt,
+                )
+                signature = self._battery_config_attempt_signature(
+                    attempt=attempt,
+                    params=attempt_params,
+                    json_body=attempt_json_body,
+                )
+                if signature in seen_signatures:
+                    continue
+                seen_signatures.add(signature)
+
+                try:
+                    if not (
+                        attempt.prefer_existing_xsrf
+                        and self._battery_config_cookie_header_xsrf_token() is not None
+                    ):
+                        await self._acquire_xsrf_token(
+                            schedule_type,
+                            variant=(
+                                _BATTERY_CONFIG_VARIANT_PRIMARY
+                                if attempt.auth_mode
+                                in {
+                                    _BATTERY_CONFIG_VARIANT_MIXED,
+                                    _BATTERY_CONFIG_VARIANT_COOKIE_EAUTH,
+                                }
+                                else attempt.auth_mode
+                            ),
+                        )
+                    headers = self._battery_config_attempt_headers(
+                        attempt,
+                        include_xsrf=True,
+                    )
+                    if attempt_json_body is not None:
+                        headers.setdefault("Content-Type", "application/json")
+                    result = await self._json(
+                        method,
+                        url,
+                        json=attempt_json_body,
+                        headers=headers,
+                        params=attempt_params,
+                        use_cookie_header_only=(
+                            attempt.auth_mode == _BATTERY_CONFIG_VARIANT_COOKIE_EAUTH
+                        ),
+                        debug_auth_source=attempt.auth_mode,
+                        debug_battery_attempt_id=attempt.attempt_id,
+                        debug_battery_attempt_changes=(
+                            self._battery_config_attempt_change_summary(
+                                attempt,
+                                params=params,
+                                json_body=json_body,
+                            )
+                        ),
+                    )
+                except aiohttp.ClientResponseError as err:
+                    if err.status == HTTPStatus.UNAUTHORIZED:
+                        raise
+                    last_error = err
+                    if err.status != HTTPStatus.FORBIDDEN:
+                        raise
+                    if index == len(attempts) - 1:
+                        raise
+                    _LOGGER.debug(
+                        "Retrying BatteryConfig write for %s with attempt %s "
+                        "(cached_attempt=%s, changes=%s)",
+                        _request_label(method, url),
+                        attempts[index + 1].attempt_id,
+                        self._battery_config_cached_write_attempt(
+                            family,
+                            supports_mqtt=supports_mqtt,
+                        ),
+                        self._battery_config_attempt_change_summary(
+                            attempts[index + 1],
+                            params=params,
+                            json_body=json_body,
+                        ),
+                    )
+                    continue
+
+                self._cache_battery_config_write_attempt(
+                    family,
+                    attempt.attempt_id,
+                    supports_mqtt=supports_mqtt,
+                )
+                return result
+        finally:
+            self._bp_xsrf_token = None
+
+        if last_error is not None:
+            raise last_error
+        raise aiohttp.ClientError("BatteryConfig request exhausted variants")
 
     async def _acquire_xsrf_token(
         self,
@@ -2996,7 +3886,13 @@ class EnphaseEVClient:
         auth-sensitive headers after a successful reauthentication callback.
         """
         extra_headers = kwargs.pop("headers", None)
+        use_cookie_header_only = kwargs.pop("use_cookie_header_only", False)
         debug_auth_source = kwargs.pop("debug_auth_source", None)
+        debug_battery_attempt_id = kwargs.pop("debug_battery_attempt_id", None)
+        debug_battery_attempt_changes = kwargs.pop(
+            "debug_battery_attempt_changes",
+            None,
+        )
         attempt = 0
         request_label = _request_label(method, url)
         endpoint = ""
@@ -3017,172 +3913,201 @@ class EnphaseEVClient:
 
             async with _enlighten_read_request_guard(method, url):
                 async with asyncio.timeout(self._timeout):
-                    async with self._s.request(
-                        method, url, headers=base_headers, **kwargs
-                    ) as r:
-                        if r.status == 401:
-                            self._last_unauthorized_request = request_label
-                            if self._reauth_cb and attempt == 0:
-                                _LOGGER.debug(
-                                    "Received 401 for %s; attempting stored-credential refresh",
-                                    request_label,
-                                )
-                                attempt += 1
-                                reauth_ok = await self._reauth_cb()
-                                if reauth_ok:
+                    async with self._request_session(
+                        cookie_header_only=use_cookie_header_only
+                    ) as request_session:
+                        async with request_session.request(
+                            method, url, headers=base_headers, **kwargs
+                        ) as r:
+                            if r.status == 401:
+                                self._last_unauthorized_request = request_label
+                                if self._reauth_cb and attempt == 0:
                                     _LOGGER.debug(
-                                        "Stored-credential refresh succeeded for %s; retrying request",
+                                        "Received 401 for %s; attempting stored-credential refresh",
                                         request_label,
                                     )
-                                    continue
-                                _LOGGER.debug(
-                                    "Stored-credential refresh failed for %s",
-                                    request_label,
-                                )
-                            else:
-                                _LOGGER.debug(
-                                    "Received 401 for %s with no stored-credential refresh available",
-                                    request_label,
-                                )
-                            raise Unauthorized()
-                        if r.status in (204, 205):
-                            if mark_payload_success:
-                                self._mark_payload_healthy(endpoint or None)
-                            return {}
-                        if r.status >= 400:
-                            try:
-                                body_text = await r.text()
-                            except (
-                                Exception
-                            ):  # noqa: BLE001 - fall back to generic message
-                                body_text = ""
-                            message = (body_text or r.reason or "").strip()
-                            if len(message) > 512:
-                                message = f"{message[:512]}…"
-                            family = _request_failure_debug_family(
-                                method,
-                                endpoint or url,
-                            )
-                            if family is not None:
-                                params = kwargs.get("params")
-                                if isinstance(params, dict):
-                                    params_summary: object = _redact_debug_json_body(
-                                        params,
-                                        site_ids=(self._site,),
-                                    )
-                                elif params is None:
-                                    params_summary = None
-                                else:
-                                    params_summary = redact_text(
-                                        params,
-                                        site_ids=(self._site,),
-                                        max_length=256,
-                                    )
-                                payload_summary: object = None
-                                json_payload = kwargs.get("json")
-                                data_payload = kwargs.get("data")
-                                if isinstance(json_payload, dict):
-                                    payload_summary = {
-                                        "scheduleType": json_payload.get(
-                                            "scheduleType"
-                                        ),
-                                        "json_keys": sorted(
-                                            str(key) for key in json_payload.keys()
-                                        ),
-                                    }
-                                elif isinstance(json_payload, list):
-                                    key_union: set[str] = set()
-                                    for item in json_payload:
-                                        if isinstance(item, dict):
-                                            key_union.update(
-                                                str(key) for key in item.keys()
-                                            )
-                                    payload_summary = {
-                                        "json_item_count": len(json_payload),
-                                        "json_keys": sorted(key_union),
-                                    }
-                                elif isinstance(data_payload, dict):
-                                    payload_summary = {
-                                        "data_keys": sorted(
-                                            str(key) for key in data_payload.keys()
+                                    attempt += 1
+                                    reauth_ok = await self._reauth_cb()
+                                    if reauth_ok:
+                                        _LOGGER.debug(
+                                            "Stored-credential refresh succeeded for %s; retrying request",
+                                            request_label,
                                         )
-                                    }
-                                header_flags = self._battery_config_header_debug_flags(
-                                    base_headers,
-                                    auth_source_override=debug_auth_source,
+                                        continue
+                                    _LOGGER.debug(
+                                        "Stored-credential refresh failed for %s",
+                                        request_label,
+                                    )
+                                else:
+                                    _LOGGER.debug(
+                                        "Received 401 for %s with no stored-credential refresh available",
+                                        request_label,
+                                    )
+                                raise Unauthorized()
+                            if r.status in (204, 205):
+                                if mark_payload_success:
+                                    self._mark_payload_healthy(endpoint or None)
+                                return {}
+                            if r.status >= 400:
+                                try:
+                                    body_text = await r.text()
+                                except (
+                                    Exception
+                                ):  # noqa: BLE001 - fall back to generic message
+                                    body_text = ""
+                                message = (body_text or r.reason or "").strip()
+                                if len(message) > 512:
+                                    message = f"{message[:512]}…"
+                                family = _request_failure_debug_family(
+                                    method,
+                                    endpoint or url,
                                 )
-                                _LOGGER.debug(
-                                    "%s failed for %s: status=%s params=%s payload=%s "
-                                    "header_flags=%s cookie_names=%s headers=%s response=%s",
-                                    family,
-                                    request_label,
-                                    r.status,
-                                    params_summary,
-                                    payload_summary,
-                                    header_flags,
-                                    _cookie_names_from_header(
-                                        base_headers.get("Cookie")
-                                    ),
-                                    self._redact_headers(base_headers),
-                                    redact_text(
-                                        message,
-                                        site_ids=(self._site,),
-                                        max_length=256,
-                                    ),
+                                if family is not None:
+                                    params = kwargs.get("params")
+                                    if isinstance(params, dict):
+                                        params_summary: object = (
+                                            _redact_debug_json_body(
+                                                params,
+                                                site_ids=(self._site,),
+                                            )
+                                        )
+                                    elif params is None:
+                                        params_summary = None
+                                    else:
+                                        params_summary = redact_text(
+                                            params,
+                                            site_ids=(self._site,),
+                                            max_length=256,
+                                        )
+                                    payload_summary: object = None
+                                    json_payload = kwargs.get("json")
+                                    data_payload = kwargs.get("data")
+                                    if isinstance(json_payload, dict):
+                                        payload_summary = {
+                                            "scheduleType": json_payload.get(
+                                                "scheduleType"
+                                            ),
+                                            "json_keys": sorted(
+                                                str(key) for key in json_payload.keys()
+                                            ),
+                                        }
+                                    elif isinstance(json_payload, list):
+                                        key_union: set[str] = set()
+                                        for item in json_payload:
+                                            if isinstance(item, dict):
+                                                key_union.update(
+                                                    str(key) for key in item.keys()
+                                                )
+                                        payload_summary = {
+                                            "json_item_count": len(json_payload),
+                                            "json_keys": sorted(key_union),
+                                        }
+                                    elif isinstance(data_payload, dict):
+                                        payload_summary = {
+                                            "data_keys": sorted(
+                                                str(key) for key in data_payload.keys()
+                                            )
+                                        }
+                                    header_flags = (
+                                        self._battery_config_header_debug_flags(
+                                            base_headers,
+                                            auth_source_override=debug_auth_source,
+                                        )
+                                    )
+                                    _LOGGER.debug(
+                                        "%s failed for %s: status=%s params=%s payload=%s "
+                                        "attempt_id=%s attempt_changes=%s header_flags=%s "
+                                        "cookie_names=%s headers=%s response=%s",
+                                        family,
+                                        request_label,
+                                        r.status,
+                                        params_summary,
+                                        payload_summary,
+                                        debug_battery_attempt_id,
+                                        debug_battery_attempt_changes,
+                                        header_flags,
+                                        _cookie_names_from_header(
+                                            base_headers.get("Cookie")
+                                        ),
+                                        self._redact_headers(base_headers),
+                                        redact_text(
+                                            message,
+                                            site_ids=(self._site,),
+                                            max_length=256,
+                                        ),
+                                    )
+                                raise aiohttp.ClientResponseError(
+                                    r.request_info,
+                                    r.history,
+                                    status=r.status,
+                                    message=message or r.reason,
+                                    headers=r.headers,
                                 )
-                            raise aiohttp.ClientResponseError(
-                                r.request_info,
-                                r.history,
-                                status=r.status,
-                                message=message or r.reason,
-                                headers=r.headers,
-                            )
-                        try:
-                            payload = await r.json()
-                        except (aiohttp.ContentTypeError, ValueError) as err:
-                            status = int(getattr(r, "status", 0) or 0)
-                            content_type = ""
                             try:
-                                content_type = str(
-                                    r.headers.get("Content-Type", "")
-                                ).strip()
-                            except Exception:  # noqa: BLE001 - defensive header parsing
+                                payload = await r.json()
+                            except (aiohttp.ContentTypeError, ValueError) as err:
+                                status = int(getattr(r, "status", 0) or 0)
                                 content_type = ""
-                            try:
-                                body_text = await r.text()
-                            except Exception as text_err:  # noqa: BLE001
-                                body_text = (
-                                    f"<unavailable:{text_err.__class__.__name__}>"
-                                )
-                            if _is_enphase_login_wall(
-                                endpoint=endpoint or None,
-                                payload=body_text,
-                            ):
-                                self._last_unauthorized_request = request_label
-                                raise self._login_wall_unauthorized(
+                                try:
+                                    content_type = str(
+                                        r.headers.get("Content-Type", "")
+                                    ).strip()
+                                except (
+                                    Exception
+                                ):  # noqa: BLE001 - defensive header parsing
+                                    content_type = ""
+                                try:
+                                    body_text = await r.text()
+                                except Exception as text_err:  # noqa: BLE001
+                                    body_text = (
+                                        f"<unavailable:{text_err.__class__.__name__}>"
+                                    )
+                                if _is_enphase_login_wall(
                                     endpoint=endpoint or None,
-                                    request_label=request_label,
+                                    payload=body_text,
+                                ):
+                                    self._last_unauthorized_request = request_label
+                                    raise self._login_wall_unauthorized(
+                                        endpoint=endpoint or None,
+                                        request_label=request_label,
+                                        status=status or None,
+                                        content_type=content_type or None,
+                                        payload=body_text,
+                                    ) from err
+                                failure_kind = (
+                                    "content_type"
+                                    if isinstance(err, aiohttp.ContentTypeError)
+                                    else "json_decode"
+                                )
+                                raise self._invalid_payload_error(
+                                    endpoint=endpoint or None,
                                     status=status or None,
                                     content_type=content_type or None,
+                                    failure_kind=failure_kind,
+                                    decode_error=err.__class__.__name__,
                                     payload=body_text,
+                                    log_warning=log_invalid_payload,
                                 ) from err
-                            failure_kind = (
-                                "content_type"
-                                if isinstance(err, aiohttp.ContentTypeError)
-                                else "json_decode"
-                            )
-                            raise self._invalid_payload_error(
-                                endpoint=endpoint or None,
-                                status=status or None,
-                                content_type=content_type or None,
-                                failure_kind=failure_kind,
-                                decode_error=err.__class__.__name__,
-                                payload=body_text,
-                                log_warning=log_invalid_payload,
-                            ) from err
-                        if mark_payload_success:
-                            self._mark_payload_healthy(endpoint or None)
-                        return payload
+                            if mark_payload_success:
+                                self._mark_payload_healthy(endpoint or None)
+                            return payload
+
+    @asynccontextmanager
+    async def _request_session(self, *, cookie_header_only: bool = False):
+        """Yield the HTTP session to use for a request.
+
+        Cookie-backed BatteryConfig writes need the explicit raw Cookie header to be
+        sent without any session-jar merging. A short-lived stateless session avoids
+        hidden cookie mutations from the shared client while preserving the normal
+        shared session for all other requests.
+        """
+
+        if not cookie_header_only:
+            yield self._s
+            return
+
+        async with aiohttp.ClientSession(cookie_jar=aiohttp.DummyCookieJar()) as s:
+            yield s
 
     async def _text_response(
         self,
@@ -3928,23 +4853,48 @@ class EnphaseEVClient:
 
         url = f"{BASE_URL}/service/batteryConfig/api/v1/profile/{self._site}"
         params = self._battery_config_params(include_source=True, locale=locale)
-        return await self._battery_config_request(
+        result = await self._battery_config_request(
             "GET",
             url,
             params=params,
             endpoint_family="profile",
         )
+        self._remember_battery_config_capabilities(result)
+        self._remember_battery_config_write_base("profile", result)
+        return result
 
     async def battery_settings_details(self) -> dict:
         """Return BatteryConfig battery details for charge-grid and shutdown controls."""
 
         url = f"{BASE_URL}/service/batteryConfig/api/v1/batterySettings/{self._site}"
         params = self._battery_config_params(include_source="enlm")
-        return await self._battery_config_request(
+        result = await self._battery_config_request(
             "GET",
             url,
             params=params,
             endpoint_family="battery_settings",
+        )
+        self._remember_battery_config_capabilities(result)
+        self._remember_battery_config_write_base("battery_settings", result)
+        return result
+
+    async def accept_battery_settings_disclaimer(
+        self, disclaimer_type: str = "itc"
+    ) -> dict:
+        """Acknowledge the BatteryConfig charge-from-grid disclaimer."""
+
+        url = (
+            f"{BASE_URL}/service/batteryConfig/api/v1/batterySettings/"
+            f"acceptDisclaimer/{self._site}"
+        )
+        body = {"disclaimer-type": str(disclaimer_type)}
+        return await self._battery_config_write_request(
+            "POST",
+            url,
+            json_body=body,
+            params=None,
+            endpoint_family="battery_settings_disclaimer",
+            write_intent="battery_settings_disclaimer_accept",
         )
 
     async def set_battery_settings(
@@ -3956,13 +4906,16 @@ class EnphaseEVClient:
         """Update BatteryConfig battery detail settings using a partial payload."""
         url = f"{BASE_URL}/service/batteryConfig/api/v1/batterySettings/{self._site}"
         params = self._battery_config_params(include_source=True)
-        body = payload if isinstance(payload, dict) else {}
+        body = copy.deepcopy(payload) if isinstance(payload, dict) else {}
         return await self._battery_config_write_request(
             "PUT",
             url,
             json_body=body,
             params=params,
             schedule_type=schedule_type,
+            endpoint_family="battery_settings",
+            write_intent="battery_settings_update",
+            supports_mqtt=self._battery_config_supports_mqtt,
         )
 
     async def set_battery_profile(
@@ -3984,26 +4937,14 @@ class EnphaseEVClient:
             payload["operationModeSubType"] = str(operation_mode_sub_type)
         if devices:
             payload["devices"] = [item for item in devices if isinstance(item, dict)]
-        try:
-            return await self._battery_config_write_request(
-                "PUT",
-                url,
-                json_body=payload,
-                params=params,
-                endpoint_family="profile",
-            )
-        except aiohttp.ClientResponseError as err:
-            if err.status != HTTPStatus.FORBIDDEN or "devices" not in payload:
-                raise
-
-        fallback_payload = dict(payload)
-        fallback_payload.pop("devices", None)
         return await self._battery_config_write_request(
             "PUT",
             url,
-            json_body=fallback_payload,
+            json_body=payload,
             params=params,
             endpoint_family="profile",
+            write_intent="profile_update",
+            supports_mqtt=self._battery_config_supports_mqtt,
         )
 
     async def cancel_battery_profile_update(self) -> dict:

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -3469,11 +3469,6 @@ class BatteryRuntime:
             coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
             await coord.async_request_refresh()
         else:
-            if current_start is None or current_end is None:
-                default_window = self._schedule_default_window_for_create(schedule_type)
-                if default_window is None:
-                    raise ServiceValidationError(f"{label} schedule time is invalid.")
-                current_start, current_end = default_window
             if current_start == current_end:
                 raise ServiceValidationError(
                     f"{label} schedule start and end times must be different."

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -697,6 +697,24 @@ class BatteryRuntime:
             return float(default_ttl)
         return min(float(default_ttl), current_interval)
 
+    def _battery_control_state_settling(self) -> bool:
+        coord = self.coordinator
+        state = self.battery_state
+        if coord.battery_settings_write_pending:
+            return True
+        if coord.battery_cfg_schedule_pending:
+            return True
+        if coord.battery_dtg_schedule_pending:
+            return True
+        if coord.battery_rbd_schedule_pending:
+            return True
+        return getattr(state, "_battery_cfg_pending_expires_mono", None) is not None
+
+    def _battery_control_refresh_success_ttl_seconds(self, default_ttl: float) -> float:
+        if self._battery_control_state_settling():
+            return 0.0
+        return self._battery_profile_refresh_cache_ttl_seconds(default_ttl)
+
     def sync_backend_battery_profile_pending(self, value: object) -> None:
         state = self.battery_state
         backend_pending = self._coerce_optional_bool(value)
@@ -1780,6 +1798,9 @@ class BatteryRuntime:
         )
         state._battery_has_acb = self._coerce_optional_bool(data.get("hasAcb"))
         state._battery_has_enpower = self._coerce_optional_bool(data.get("hasEnpower"))
+        state._battery_limit_support = self._coerce_optional_bool(
+            data.get("batteryLimitSupport")
+        )
         state._battery_country_code = _as_text(data.get("countryCode"))
         state._battery_region = _as_text(data.get("region"))
         state._battery_locale = _as_text(data.get("locale"))
@@ -2613,10 +2634,11 @@ class BatteryRuntime:
             clear_missing_schedule_times=True,
         )
         self.sync_cfg_settings_pending()
-        state._battery_settings_cache_until = now + (
-            self._battery_profile_refresh_cache_ttl_seconds(BATTERY_SETTINGS_CACHE_TTL)
+        success_ttl = self._battery_control_refresh_success_ttl_seconds(
+            BATTERY_SETTINGS_CACHE_TTL
         )
-        coord._note_endpoint_family_success(family)
+        state._battery_settings_cache_until = now + success_ttl
+        coord._note_endpoint_family_success(family, success_ttl_s=success_ttl)
 
     async def async_refresh_battery_schedules(self) -> None:
         coord = self.coordinator
@@ -2643,7 +2665,12 @@ class BatteryRuntime:
         else:
             state._battery_schedules_payload = {"value": redacted}
         self.parse_battery_schedules_payload(payload)
-        coord._note_endpoint_family_success(family)
+        coord._note_endpoint_family_success(
+            family,
+            success_ttl_s=self._battery_control_refresh_success_ttl_seconds(
+                BATTERY_SETTINGS_CACHE_TTL
+            ),
+        )
 
     async def async_refresh_battery_site_settings(self, *, force: bool = False) -> None:
         coord = self.coordinator
@@ -3076,10 +3103,9 @@ class BatteryRuntime:
         )
         if not coord.charge_from_grid_control_available:
             raise ServiceValidationError("Charge from grid setting is unavailable.")
-        payload: dict[str, object] = {
-            "chargeFromGrid": bool(enabled),
-            "acceptedItcDisclaimer": self.battery_itc_disclaimer_value(),
-        }
+        payload: dict[str, object] = {"chargeFromGrid": bool(enabled)}
+        if enabled:
+            payload["acceptedItcDisclaimer"] = self.battery_itc_disclaimer_value()
         await self.async_apply_battery_settings(payload)
 
     async def async_set_charge_from_grid_schedule_enabled(self, enabled: bool) -> None:
@@ -3309,6 +3335,14 @@ class BatteryRuntime:
             return max(5, int(shutdown_floor)) if shutdown_floor is not None else 5
         return None
 
+    def _schedule_default_window_for_create(
+        self, schedule_type: str
+    ) -> tuple[int, int] | None:
+        normalized = str(schedule_type).lower()
+        if normalized == "rbd":
+            return (60, 960)
+        return None
+
     def _schedule_family_days(self, schedule_type: str) -> list[int]:
         state = self.battery_state
         days = getattr(state, self._battery_schedule_days_attr(schedule_type), None)
@@ -3379,43 +3413,39 @@ class BatteryRuntime:
         coord = self.coordinator
         state = self.battery_state
         label = self._battery_schedule_label(schedule_type)
+        normalized_schedule_type = str(schedule_type).lower()
         self._assert_battery_settings_feature_writable(
             f"{label} schedule is unavailable."
         )
         if not getattr(coord, self._schedule_supported_property_name(schedule_type)):
             raise ServiceValidationError(f"{label} schedule is unavailable.")
-        if getattr(coord, self._schedule_pending_property_name(schedule_type)):
+        await self.async_assert_battery_settings_write_allowed()
+        schedule_id = getattr(
+            state, self._battery_schedule_id_attr(schedule_type), None
+        )
+        use_battery_settings_toggle = normalized_schedule_type in {
+            "dtg",
+            "rbd",
+        }
+        if not use_battery_settings_toggle and getattr(
+            coord, self._schedule_pending_property_name(schedule_type)
+        ):
             raise ServiceValidationError(
                 "A schedule change is pending Envoy sync. Please wait."
             )
         current_start, current_end = self._current_battery_schedule_window_for_type(
             schedule_type
         )
-        if current_start is None or current_end is None:
-            raise ServiceValidationError(f"{label} schedule time is invalid.")
-        if current_start == current_end:
-            raise ServiceValidationError(
-                f"{label} schedule start and end times must be different."
-            )
-        current_limit = getattr(
-            state, self._battery_schedule_limit_attr(schedule_type), None
-        )
-        next_limit = (
-            int(current_limit)
-            if current_limit is not None
-            else self._schedule_default_limit_for_create(schedule_type)
-        )
-        await self.async_assert_battery_settings_write_allowed()
-        normalized_schedule_type = str(schedule_type).lower()
-        schedule_id = getattr(
-            state, self._battery_schedule_id_attr(schedule_type), None
-        )
-        if normalized_schedule_type in {"dtg", "rbd"} and (
-            schedule_id is not None or not enabled
-        ):
+        if use_battery_settings_toggle:
             control_key = f"{normalized_schedule_type}Control"
             control_payload: dict[str, object] = {"enabled": bool(enabled)}
             if normalized_schedule_type == "dtg" and enabled:
+                if current_start is None or current_end is None:
+                    raise ServiceValidationError(f"{label} schedule time is invalid.")
+                if current_start == current_end:
+                    raise ServiceValidationError(
+                        f"{label} schedule start and end times must be different."
+                    )
                 control_payload["scheduleSupported"] = True
                 control_payload["startTime"] = current_start
                 control_payload["endTime"] = current_end
@@ -3439,6 +3469,23 @@ class BatteryRuntime:
             coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
             await coord.async_request_refresh()
         else:
+            if current_start is None or current_end is None:
+                default_window = self._schedule_default_window_for_create(schedule_type)
+                if default_window is None:
+                    raise ServiceValidationError(f"{label} schedule time is invalid.")
+                current_start, current_end = default_window
+            if current_start == current_end:
+                raise ServiceValidationError(
+                    f"{label} schedule start and end times must be different."
+                )
+            current_limit = getattr(
+                state, self._battery_schedule_limit_attr(schedule_type), None
+            )
+            next_limit = (
+                int(current_limit)
+                if current_limit is not None
+                else self._schedule_default_limit_for_create(schedule_type)
+            )
             async with state._battery_settings_write_lock:
                 state._battery_settings_last_write_mono = time.monotonic()
                 await self._async_create_or_update_schedule_family(
@@ -3452,8 +3499,11 @@ class BatteryRuntime:
             coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
             await coord.async_request_refresh()
         setattr(state, self._battery_schedule_enabled_attr(schedule_type), enabled)
-        setattr(state, self._battery_schedule_start_attr(schedule_type), current_start)
-        setattr(state, self._battery_schedule_end_attr(schedule_type), current_end)
+        if schedule_id is not None or not use_battery_settings_toggle:
+            setattr(
+                state, self._battery_schedule_start_attr(schedule_type), current_start
+            )
+            setattr(state, self._battery_schedule_end_attr(schedule_type), current_end)
 
     async def _async_set_schedule_family_time(
         self,
@@ -3483,7 +3533,14 @@ class BatteryRuntime:
         )
         next_end = coord.time_to_minutes_of_day(end) if end is not None else current_end
         if next_start is None or next_end is None:
-            raise ServiceValidationError(f"{label} schedule time is invalid.")
+            default_window = self._schedule_default_window_for_create(schedule_type)
+            if default_window is None:
+                raise ServiceValidationError(f"{label} schedule time is invalid.")
+            default_start, default_end = default_window
+            if next_start is None:
+                next_start = default_start
+            if next_end is None:
+                next_end = default_end
         if next_start == next_end:
             raise ServiceValidationError(
                 f"{label} schedule start and end times must be different."

--- a/custom_components/enphase_ev/battery_schedule_editor.py
+++ b/custom_components/enphase_ev/battery_schedule_editor.py
@@ -9,6 +9,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import OPT_BATTERY_SCHEDULES_ENABLED
 from .coordinator import EnphaseCoordinator
+from .labels import battery_schedule_type_label
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
 
 DAY_ORDER: list[tuple[str, int]] = [
@@ -22,7 +23,8 @@ DAY_ORDER: list[tuple[str, int]] = [
 ]
 DAY_KEY_BY_INDEX = {index: key for key, index in DAY_ORDER}
 NEW_SCHEDULE_OPTION = "new_schedule"
-NEW_SCHEDULE_OPTION_LABEL = "New schedule"
+NEW_SCHEDULE_OPTION_LABEL = "Create new schedule"
+SCHEDULE_TYPE_KEYS: tuple[str, ...] = ("cfg", "dtg", "rbd")
 
 
 def default_day_flags() -> dict[str, bool]:
@@ -74,6 +76,25 @@ def battery_scheduler_enabled(entry: EnphaseConfigEntry | None) -> bool:
     if entry is None:
         return False
     return bool(getattr(entry, "options", {}).get(OPT_BATTERY_SCHEDULES_ENABLED, False))
+
+
+def battery_schedule_type_options(
+    *, hass: object | None = None
+) -> list[tuple[str, str]]:
+    return [
+        (key, battery_schedule_type_label(key, hass=hass) or key.upper())
+        for key in SCHEDULE_TYPE_KEYS
+    ]
+
+
+def battery_schedule_option_label(
+    schedule: BatteryScheduleRecord, *, hass: object | None = None
+) -> str:
+    window = f"{schedule.start_time}-{schedule.end_time}"
+    schedule_type = battery_schedule_type_label(schedule.schedule_type, hass=hass)
+    if schedule_type is None:
+        schedule_type = str(schedule.schedule_type).strip() or "Schedule"
+    return f"{schedule_type} {window}"
 
 
 @dataclass(slots=True)
@@ -257,6 +278,35 @@ class BatteryScheduleEditorManager:
         self.edit = BatteryScheduleFormState()
         self.schedules: list[BatteryScheduleRecord] = []
         self._listeners: list[Callable[[], None]] = []
+        self._auto_create_mode = False
+
+    def option_label_by_schedule_id(
+        self, *, hass: object | None = None
+    ) -> dict[str, str]:
+        raw_labels = {
+            schedule.schedule_id: battery_schedule_option_label(schedule, hass=hass)
+            for schedule in self.schedules
+        }
+        counts: dict[str, int] = {}
+        for label in raw_labels.values():
+            counts[label] = counts.get(label, 0) + 1
+        labels: dict[str, str] = {}
+        for schedule in self.schedules:
+            label = raw_labels[schedule.schedule_id]
+            if counts[label] > 1:
+                labels[schedule.schedule_id] = f"{label} [{schedule.schedule_id[:8]}]"
+            else:
+                labels[schedule.schedule_id] = label
+        return labels
+
+    def schedule_id_for_option_label(
+        self, option: str, *, hass: object | None = None
+    ) -> str | None:
+        option_text = str(option).strip()
+        for schedule_id, label in self.option_label_by_schedule_id(hass=hass).items():
+            if label == option_text:
+                return schedule_id
+        return None
 
     @callback
     def async_add_listener(self, listener: Callable[[], None]) -> CALLBACK_TYPE:
@@ -291,17 +341,53 @@ class BatteryScheduleEditorManager:
         self.schedules = next_schedules
 
         if self.edit.create_mode:
+            if self._auto_create_mode and self.schedules:
+                self._apply_schedule_to_form(self.schedules[0])
+                self._notify_listeners()
+                return
+            promoted = self._promote_created_schedule_from_form()
+            if promoted is not None:
+                self._apply_schedule_to_form(promoted)
+                self._notify_listeners()
+                return
             if schedules_changed:
                 self._notify_listeners()
             return
 
         selected = self.get_schedule(self.edit.selected_schedule_id)
         if selected is None:
-            if self.edit.selected_schedule_id is not None:
-                self.edit.reset()
-                self._notify_listeners()
+            fallback = self._default_schedule_selection()
+            if fallback is None:
+                if self.edit.selected_schedule_id is not None:
+                    self._set_create_mode_defaults(auto=False)
+                    self._notify_listeners()
+                    return
+                if schedules_changed:
+                    self._notify_listeners()
                 return
-            if schedules_changed:
+            before = (
+                self.edit.selected_schedule_id,
+                self.edit.create_mode,
+                self.edit.schedule_type,
+                self.edit.start_time,
+                self.edit.end_time,
+                self.edit.limit,
+                self.edit.days,
+            )
+            if fallback == NEW_SCHEDULE_OPTION:
+                self._set_create_mode_defaults(auto=True)
+            else:
+                self._apply_schedule_to_form(fallback)
+            after = (
+                self.edit.selected_schedule_id,
+                self.edit.create_mode,
+                self.edit.schedule_type,
+                self.edit.start_time,
+                self.edit.end_time,
+                self.edit.limit,
+                self.edit.days,
+            )
+            if schedules_changed or before != after:
                 self._notify_listeners()
             return
 
@@ -329,16 +415,38 @@ class BatteryScheduleEditorManager:
     def _apply_schedule_to_form(self, schedule: BatteryScheduleRecord) -> None:
         self.edit.selected_schedule_id = schedule.schedule_id
         self.edit.create_mode = False
+        self._auto_create_mode = False
         self.edit.schedule_type = schedule.schedule_type
         self.edit.start_time = schedule.start_time
         self.edit.end_time = schedule.end_time
         self.edit.limit = int(schedule.limit) if schedule.limit is not None else 100
         self.edit.days = editor_days_from_list(schedule.days)
 
+    def _default_schedule_selection(self) -> BatteryScheduleRecord | str | None:
+        if self.schedules:
+            return self.schedules[0]
+        return NEW_SCHEDULE_OPTION
+
+    def _promote_created_schedule_from_form(self) -> BatteryScheduleRecord | None:
+        matches = [
+            schedule
+            for schedule in self.schedules
+            if schedule.schedule_type == self.edit.schedule_type
+            and schedule.start_time == self.edit.start_time
+            and schedule.end_time == self.edit.end_time
+            and (schedule.limit if schedule.limit is not None else 100)
+            == self.edit.limit
+            and schedule.days == days_list_from_editor(self.edit.days)
+        ]
+        if len(matches) == 1:
+            return matches[0]
+        return None
+
     @callback
-    def _set_create_mode_defaults(self) -> None:
+    def _set_create_mode_defaults(self, *, auto: bool = False) -> None:
         self.edit.reset()
         self.edit.create_mode = True
+        self._auto_create_mode = auto
 
     @property
     def current_selection(self) -> str | None:
@@ -353,12 +461,13 @@ class BatteryScheduleEditorManager:
     @callback
     def select_schedule(self, schedule_id: str) -> None:
         if schedule_id == NEW_SCHEDULE_OPTION:
-            self._set_create_mode_defaults()
+            self._set_create_mode_defaults(auto=False)
             self._notify_listeners()
             return
         schedule = self.get_schedule(schedule_id)
         if schedule is None:
             self.edit.reset()
+            self._auto_create_mode = False
         else:
             self._apply_schedule_to_form(schedule)
         self._notify_listeners()

--- a/custom_components/enphase_ev/battery_schedule_editor.py
+++ b/custom_components/enphase_ev/battery_schedule_editor.py
@@ -357,14 +357,6 @@ class BatteryScheduleEditorManager:
         selected = self.get_schedule(self.edit.selected_schedule_id)
         if selected is None:
             fallback = self._default_schedule_selection()
-            if fallback is None:
-                if self.edit.selected_schedule_id is not None:
-                    self._set_create_mode_defaults(auto=False)
-                    self._notify_listeners()
-                    return
-                if schedules_changed:
-                    self._notify_listeners()
-                return
             before = (
                 self.edit.selected_schedule_id,
                 self.edit.create_mode,

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -5245,11 +5245,29 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
     @property
     def battery_shutdown_level_available(self) -> bool:
-        if getattr(self, "_battery_envoy_supports_vls", None) is False:
+        state = self.battery_state
+        envoy_supports_vls = getattr(
+            state,
+            "_battery_envoy_supports_vls",
+            getattr(self, "_battery_envoy_supports_vls", None),
+        )
+        if envoy_supports_vls is False:
             return False
-        if getattr(self, "_battery_very_low_soc", None) is None:
+        very_low_soc = getattr(
+            state,
+            "_battery_very_low_soc",
+            getattr(self, "_battery_very_low_soc", None),
+        )
+        if very_low_soc is not None:
+            return True
+        battery_limit_support = getattr(
+            state,
+            "_battery_limit_support",
+            getattr(self, "_battery_limit_support", None),
+        )
+        if battery_limit_support is False:
             return False
-        return True
+        return False
 
     def _battery_min_soc_floor(self) -> int:
         value = self._coerce_optional_int(

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -357,7 +357,9 @@ class CoordinatorDiagnostics:
                 coord.battery_profile_selection_available
             ),
             "battery_reserve_editable": coord.battery_reserve_editable,
-            "battery_shutdown_level_available": coord.battery_shutdown_level_available,
+            "battery_shutdown_level_available": getattr(
+                coord, "battery_shutdown_level_available", None
+            ),
             "charge_from_grid_control_available": (
                 coord.charge_from_grid_control_available
             ),

--- a/custom_components/enphase_ev/labels.py
+++ b/custom_components/enphase_ev/labels.py
@@ -48,6 +48,7 @@ STATUS_LABELS: dict[str, str] = {
 }
 
 _SHARED_LABEL_KEY_PREFIX = f"component.{DOMAIN}.entity.sensor.shared_labels.state."
+_ENTITY_LABEL_KEY_PREFIX = f"component.{DOMAIN}.entity."
 
 
 async def async_prime_label_translations(hass: HomeAssistant) -> None:
@@ -72,6 +73,22 @@ def _translation_value(hass: Any | None, key: str) -> str | None:
         return None
     language = getattr(getattr(hass, "config", None), "language", "en")
     path = f"{_SHARED_LABEL_KEY_PREFIX}{key}"
+    value = async_get_cached_translations(hass, language, "entity", DOMAIN).get(path)
+    if isinstance(value, str) and value.strip():
+        return value
+    value = async_get_cached_translations(hass, "en", "entity", DOMAIN).get(path)
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _entity_translation_value(
+    hass: Any | None, platform: str, key: str, field: str = "name"
+) -> str | None:
+    if hass is None:
+        return None
+    language = getattr(getattr(hass, "config", None), "language", "en")
+    path = f"{_ENTITY_LABEL_KEY_PREFIX}{platform}.{key}.{field}"
     value = async_get_cached_translations(hass, language, "entity", DOMAIN).get(path)
     if isinstance(value, str) and value.strip():
         return value
@@ -190,3 +207,38 @@ def friendly_status_text(value: object) -> str | None:
     if text.islower():
         return text.capitalize()
     return text
+
+
+def battery_schedule_create_label(*, hass: Any | None = None) -> str:
+    value = _entity_translation_value(hass, "button", "battery_schedule_add")
+    if value is not None:
+        return value
+    return "Battery Schedule Add"
+
+
+def battery_schedule_type_label(
+    value: object, *, hass: Any | None = None
+) -> str | None:
+    key = _normalize_state_key(value)
+    if key is None:
+        return None
+    path_map = {
+        "cfg": ("switch", "charge_from_grid_schedule", "Charge From Grid Schedule"),
+        "dtg": (
+            "switch",
+            "discharge_to_grid_schedule",
+            "Discharge To Grid Schedule",
+        ),
+        "rbd": (
+            "switch",
+            "restrict_battery_discharge_schedule",
+            "Restrict Battery Discharge Schedule",
+        ),
+    }
+    path = path_map.get(key)
+    if path is not None:
+        translated = _entity_translation_value(hass, path[0], path[1])
+        if translated is not None:
+            return translated
+        return path[2]
+    return _friendly_label_text(value)

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.8.1"
+  "version": "2.8.2"
 }

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Callable
+
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.const import PERCENTAGE, UnitOfElectricCurrent
 from homeassistant.core import HomeAssistant, callback
@@ -100,31 +102,42 @@ def _rbd_schedule_edit_available(coord: EnphaseCoordinator) -> bool:
     return begin is not None and end is not None
 
 
-def _retained_site_number_unique_ids(
-    coord: EnphaseCoordinator, entry: EnphaseConfigEntry | None = None
-) -> set[str]:
-    unique_ids: set[str] = set()
+def _battery_schedule_editor_active(
+    coord: EnphaseCoordinator, entry: EnphaseConfigEntry | None
+) -> bool:
     client = getattr(coord, "client", None)
-    if not _type_available(coord, "encharge"):
-        return unique_ids
-    if _battery_write_access_confirmed(coord):
-        if getattr(coord, "battery_reserve_editable", False):
-            unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_reserve")
-        if getattr(coord, "battery_shutdown_level_available", False):
-            unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_shutdown_level")
-        if _cfg_schedule_edit_available(coord):
-            unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_cfg_schedule_limit")
-        if _dtg_schedule_edit_available(coord):
-            unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_dtg_schedule_limit")
-        if _rbd_schedule_edit_available(coord):
-            unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_rbd_schedule_limit")
-    if (
+    return bool(
         battery_scheduler_enabled(entry)
         and callable(getattr(client, "battery_schedules", None))
         and callable(getattr(client, "create_battery_schedule", None))
         and callable(getattr(client, "update_battery_schedule", None))
         and callable(getattr(client, "delete_battery_schedule", None))
-    ):
+    )
+
+
+def _retained_site_number_unique_ids(
+    coord: EnphaseCoordinator, entry: EnphaseConfigEntry | None = None
+) -> set[str]:
+    unique_ids: set[str] = set()
+    editor_active = _battery_schedule_editor_active(coord, entry)
+    if not _type_available(coord, "encharge"):
+        return unique_ids
+    if _battery_write_access_confirmed(coord):
+        if getattr(coord, "battery_reserve_editable", False):
+            unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_reserve")
+        unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_shutdown_level")
+        if not editor_active and _cfg_schedule_edit_available(coord):
+            unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_cfg_schedule_limit")
+        if not editor_active:
+            if _dtg_schedule_edit_available(coord):
+                unique_ids.add(
+                    f"{DOMAIN}_site_{coord.site_id}_battery_dtg_schedule_limit"
+                )
+            if _rbd_schedule_edit_available(coord):
+                unique_ids.add(
+                    f"{DOMAIN}_site_{coord.site_id}_battery_rbd_schedule_limit"
+                )
+    if editor_active:
         unique_ids.add(f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_limit")
     return unique_ids
 
@@ -137,7 +150,7 @@ async def async_setup_entry(
     coord: EnphaseCoordinator = get_runtime_data(entry).coordinator
     ent_reg = er.async_get(hass)
     known_serials: set[str] = set()
-    site_entities_added = False
+    added_site_number_unique_ids: set[str] = set()
 
     def _managed_site_number_unique_ids() -> set[str]:
         return {
@@ -150,42 +163,101 @@ async def async_setup_entry(
             f"{DOMAIN}_site_{coord.site_id}_battery_new_schedule_limit",
         }
 
+    def _core_site_number_unique_ids() -> set[str]:
+        return {
+            f"{DOMAIN}_site_{coord.site_id}_battery_reserve",
+            f"{DOMAIN}_site_{coord.site_id}_battery_shutdown_level",
+        }
+
     def _charger_number_unique_id(sn: str) -> str:
         return f"{DOMAIN}_{sn}_amps_number"
 
+    def _site_number_entities_by_unique_id(
+        retained_site_number_unique_ids: set[str],
+    ) -> dict[str, NumberEntity]:
+        site_entities: dict[str, NumberEntity] = {}
+        write_access_confirmed = _battery_write_access_confirmed(coord)
+
+        entity_factories: dict[str, Callable[[], NumberEntity]] = {
+            f"{DOMAIN}_site_{coord.site_id}_battery_reserve": lambda: BatteryReserveNumber(
+                coord
+            ),
+            f"{DOMAIN}_site_{coord.site_id}_battery_shutdown_level": lambda: BatteryShutdownLevelNumber(
+                coord
+            ),
+            f"{DOMAIN}_site_{coord.site_id}_battery_cfg_schedule_limit": lambda: BatteryCfgScheduleLimitNumber(
+                coord
+            ),
+            f"{DOMAIN}_site_{coord.site_id}_battery_dtg_schedule_limit": lambda: BatteryDischargeToGridScheduleLimitNumber(
+                coord
+            ),
+            f"{DOMAIN}_site_{coord.site_id}_battery_rbd_schedule_limit": lambda: BatteryRestrictBatteryDischargeScheduleLimitNumber(
+                coord
+            ),
+        }
+
+        if battery_scheduler_enabled(entry):
+            entity_factories[
+                f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_limit"
+            ] = lambda: BatteryScheduleEditLimitNumber(coord, entry)
+
+        active_site_number_unique_ids: set[str] = set()
+        if write_access_confirmed:
+            active_site_number_unique_ids |= _core_site_number_unique_ids() | (
+                retained_site_number_unique_ids
+                & {
+                    f"{DOMAIN}_site_{coord.site_id}_battery_cfg_schedule_limit",
+                    f"{DOMAIN}_site_{coord.site_id}_battery_dtg_schedule_limit",
+                    f"{DOMAIN}_site_{coord.site_id}_battery_rbd_schedule_limit",
+                }
+            )
+        if battery_scheduler_enabled(entry):
+            active_site_number_unique_ids |= retained_site_number_unique_ids & {
+                f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_limit"
+            }
+
+        for unique_id, factory in entity_factories.items():
+            if unique_id in active_site_number_unique_ids:
+                site_entities[unique_id] = factory()
+
+        return site_entities
+
     @callback
     def _async_sync_chargers() -> None:
-        nonlocal site_entities_added
         inventory_ready = bool(getattr(coord, "_devices_inventory_ready", False))
         current_serials = {sn for sn in coord.iter_serials() if sn}
         retained_site_number_unique_ids = _retained_site_number_unique_ids(coord, entry)
-        if (
-            not site_entities_added
-            and _site_has_battery(coord)
-            and _type_available(coord, "encharge")
-        ):
-            site_entities: list[NumberEntity] = []
+        active_site_number_unique_ids: set[str] = set()
+        site_entities: list[NumberEntity] = []
+        if _site_has_battery(coord) and _type_available(coord, "encharge"):
             if _battery_write_access_confirmed(coord):
-                site_entities.extend(
-                    [
-                        BatteryReserveNumber(coord),
-                        BatteryShutdownLevelNumber(coord),
-                        BatteryCfgScheduleLimitNumber(coord),
-                        BatteryDischargeToGridScheduleLimitNumber(coord),
-                        BatteryRestrictBatteryDischargeScheduleLimitNumber(coord),
-                    ]
+                active_site_number_unique_ids = _core_site_number_unique_ids() | (
+                    retained_site_number_unique_ids
+                    & {
+                        f"{DOMAIN}_site_{coord.site_id}_battery_cfg_schedule_limit",
+                        f"{DOMAIN}_site_{coord.site_id}_battery_dtg_schedule_limit",
+                        f"{DOMAIN}_site_{coord.site_id}_battery_rbd_schedule_limit",
+                    }
                 )
-            if (
-                f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_limit"
-                in retained_site_number_unique_ids
-            ):
-                site_entities.append(BatteryScheduleEditLimitNumber(coord, entry))
+            if battery_scheduler_enabled(entry):
+                active_site_number_unique_ids |= retained_site_number_unique_ids & {
+                    f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_limit"
+                }
+            current_site_entities = _site_number_entities_by_unique_id(
+                retained_site_number_unique_ids
+            )
+            site_entities = [
+                entity
+                for unique_id, entity in current_site_entities.items()
+                if unique_id not in added_site_number_unique_ids
+            ]
             if site_entities:
-                async_add_entities(
-                    site_entities,
-                    update_before_add=False,
+                async_add_entities(site_entities, update_before_add=False)
+                added_site_number_unique_ids.update(
+                    entity.unique_id
+                    for entity in site_entities
+                    if isinstance(entity.unique_id, str)
                 )
-                site_entities_added = True
         serials = [sn for sn in current_serials if sn not in known_serials]
         if not serials:
             entities: list[NumberEntity] = []
@@ -193,10 +265,9 @@ async def async_setup_entry(
             entities = [ChargingAmpsNumber(coord, sn) for sn in serials]
         if entities:
             async_add_entities(entities, update_before_add=False)
-        if not retained_site_number_unique_ids:
-            site_entities_added = False
         known_serials.intersection_update(current_serials)
         known_serials.update(serials)
+        added_site_number_unique_ids.intersection_update(active_site_number_unique_ids)
 
         if not inventory_ready:
             return
@@ -206,7 +277,7 @@ async def async_setup_entry(
             entry.entry_id,
             domain="number",
             active_unique_ids={
-                *retained_site_number_unique_ids,
+                *active_site_number_unique_ids,
                 *(_charger_number_unique_id(sn) for sn in current_serials),
             },
             is_managed=lambda unique_id: (

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -16,7 +16,8 @@ from .api import SchedulerUnavailable
 from .battery_schedule_editor import (
     BatteryScheduleEditorEntity,
     NEW_SCHEDULE_OPTION,
-    NEW_SCHEDULE_OPTION_LABEL,
+    battery_schedule_type_label,
+    battery_schedule_type_options,
     battery_scheduler_enabled,
 )
 from .ac_battery_support import (
@@ -29,7 +30,12 @@ from .const import DOMAIN
 from .coordinator import EnphaseCoordinator
 from .entity import EnphaseBaseEntity
 from .entity_cleanup import prune_managed_entities
-from .labels import CHARGE_MODE_LABELS, battery_profile_label, charge_mode_label
+from .labels import (
+    CHARGE_MODE_LABELS,
+    battery_profile_label,
+    battery_schedule_create_label,
+    charge_mode_label,
+)
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
 
 PARALLEL_UPDATES = 0
@@ -428,24 +434,36 @@ class BatteryScheduleSelect(_BatteryScheduleEditorSelect):
     def options(self) -> list[str]:
         if self._editor is None:
             return []
+        hass = getattr(self, "hass", None) or self._coord.hass
         return [
-            *(schedule.schedule_id for schedule in self._editor.schedules),
-            NEW_SCHEDULE_OPTION_LABEL,
+            *self._editor.option_label_by_schedule_id(hass=hass).values(),
+            battery_schedule_create_label(hass=hass),
         ]
 
     @property
     def current_option(self) -> str | None:
         if self._editor is None:
             return None
+        hass = getattr(self, "hass", None) or self._coord.hass
         if self._editor.current_selection == NEW_SCHEDULE_OPTION:
-            return NEW_SCHEDULE_OPTION_LABEL
-        return self._editor.current_selection
+            return battery_schedule_create_label(hass=hass)
+        selected_schedule = self._editor.get_schedule(self._editor.current_selection)
+        if selected_schedule is None:
+            return None
+        return self._editor.option_label_by_schedule_id(hass=hass).get(
+            selected_schedule.schedule_id
+        )
 
     async def async_select_option(self, option: str) -> None:
         if self._editor is not None:
-            self._editor.select_schedule(
-                NEW_SCHEDULE_OPTION if option == NEW_SCHEDULE_OPTION_LABEL else option
+            hass = getattr(self, "hass", None) or self._coord.hass
+            selected = (
+                NEW_SCHEDULE_OPTION
+                if option == battery_schedule_create_label(hass=hass)
+                else self._editor.schedule_id_for_option_label(option, hass=hass)
+                or option
             )
+            self._editor.select_schedule(selected)
 
 
 class BatteryNewScheduleTypeSelect(_BatteryScheduleEditorSelect):
@@ -457,11 +475,11 @@ class BatteryNewScheduleTypeSelect(_BatteryScheduleEditorSelect):
         self._attr_unique_id = (
             f"{DOMAIN}_site_{coord.site_id}_battery_new_schedule_type"
         )
-        self._options = ["cfg", "dtg", "rbd"]
 
     @property
     def options(self) -> list[str]:
-        return list(self._options)
+        hass = getattr(self, "hass", None) or self._coord.hass
+        return [label for _key, label in battery_schedule_type_options(hass=hass)]
 
     @property
     def available(self) -> bool:  # type: ignore[override]
@@ -473,11 +491,17 @@ class BatteryNewScheduleTypeSelect(_BatteryScheduleEditorSelect):
     def current_option(self) -> str | None:
         if self._editor is None:
             return None
-        return self._editor.edit.schedule_type
+        hass = getattr(self, "hass", None) or self._coord.hass
+        return battery_schedule_type_label(self._editor.edit.schedule_type, hass=hass)
 
     async def async_select_option(self, option: str) -> None:
-        if option in self._options and self._editor is not None:
-            self._editor.set_new_schedule_type(option)
+        if self._editor is None:
+            return
+        hass = getattr(self, "hass", None) or self._coord.hass
+        for schedule_type, label in battery_schedule_type_options(hass=hass):
+            if label == option:
+                self._editor.set_new_schedule_type(schedule_type)
+                return
 
 
 class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import logging
 import re
 from typing import TYPE_CHECKING
 
+import aiohttp
 import voluptuous as vol
 
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
@@ -36,6 +38,8 @@ REGISTERED_SERVICES = (
     "validate_schedule",
     "update_cfg_schedule",
 )
+
+_LOGGER = logging.getLogger(__name__)
 
 
 def async_setup_services(
@@ -241,7 +245,18 @@ def async_setup_services(
         validator = getattr(coord.client, "validate_battery_schedule", None)
         if not callable(validator):
             return {}
-        result = await validator(schedule_type)
+        try:
+            result = await validator(schedule_type)
+        except aiohttp.ClientResponseError as err:
+            if err.status in {403, 404}:
+                _LOGGER.debug(
+                    "Ignoring battery schedule preflight failure for site %s (%s %s)",
+                    getattr(coord, "site_id", "unknown"),
+                    err.status,
+                    str(schedule_type).upper(),
+                )
+                return {}
+            raise
         if isinstance(result, dict) and result.get("valid") is False:
             raise ServiceValidationError(
                 str(

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -326,6 +326,7 @@ class BatteryState:
     _battery_has_encharge: bool | None = None
     _battery_has_acb: bool | None = None
     _battery_has_enpower: bool | None = None
+    _battery_limit_support: bool | None = None
     _battery_country_code: str | None = None
     _battery_region: str | None = None
     _battery_locale: str | None = None

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -137,7 +137,7 @@ def _retained_site_switch_keys(
         if getattr(coord, "discharge_to_grid_schedule_available", None) is not False:
             retained.add("discharge_to_grid_schedule")
         if (
-            getattr(coord, "restrict_battery_discharge_schedule_available", None)
+            getattr(coord, "restrict_battery_discharge_schedule_supported", None)
             is not False
         ):
             retained.add("restrict_battery_discharge_schedule")
@@ -757,7 +757,7 @@ class RestrictBatteryDischargeScheduleSwitch(_BaseBatteryScheduleSwitch):
         super().__init__(
             coord,
             unique_suffix="restrict_battery_discharge_schedule",
-            availability_attr="restrict_battery_discharge_schedule_available",
+            availability_attr="restrict_battery_discharge_schedule_supported",
             enabled_attr="battery_restrict_battery_discharge_schedule_enabled",
             setter_name="async_set_restrict_battery_discharge_schedule_enabled",
             suggested_object_id="restrict_battery_discharge_schedule",

--- a/custom_components/enphase_ev/time.py
+++ b/custom_components/enphase_ev/time.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from datetime import time as dt_time
 import logging
 import re
@@ -131,43 +132,23 @@ def _rbd_schedule_edit_available(coord: EnphaseCoordinator) -> bool:
         begin = getattr(coord, "_battery_rbd_control_begin_time", None)
     if end is None:
         end = getattr(coord, "_battery_rbd_control_end_time", None)
-    return begin is not None and end is not None
+    return True
 
 
-def _retained_site_time_unique_ids(
-    coord: EnphaseCoordinator, entry: EnphaseConfigEntry | None = None
-) -> set[str]:
-    unique_ids: set[str] = set()
+def _default_schedule_time_for_create(
+    schedule_type: str, *, end: bool = False
+) -> dt_time | None:
+    normalized = str(schedule_type).lower()
+    if normalized == "rbd":
+        return dt_time(16, 0) if end else dt_time(1, 0)
+    return None
+
+
+def _battery_schedule_editor_active(
+    coord: EnphaseCoordinator, entry: EnphaseConfigEntry | None
+) -> bool:
     client = getattr(coord, "client", None)
-    if not _type_available(coord, "encharge"):
-        return unique_ids
-    cfg_supported = getattr(coord, "charge_from_grid_schedule_supported", None)
-    dtg_supported = getattr(coord, "discharge_to_grid_schedule_supported", None)
-    rbd_supported = getattr(
-        coord, "restrict_battery_discharge_schedule_supported", None
-    )
-    if _cfg_schedule_edit_available(coord) or cfg_supported is not False:
-        unique_ids.update(
-            {
-                f"{DOMAIN}_site_{coord.site_id}_charge_from_grid_start_time",
-                f"{DOMAIN}_site_{coord.site_id}_charge_from_grid_end_time",
-            }
-        )
-    if _dtg_schedule_edit_available(coord) or dtg_supported is not False:
-        unique_ids.update(
-            {
-                f"{DOMAIN}_site_{coord.site_id}_discharge_to_grid_start_time",
-                f"{DOMAIN}_site_{coord.site_id}_discharge_to_grid_end_time",
-            }
-        )
-    if _rbd_schedule_edit_available(coord) or rbd_supported is not False:
-        unique_ids.update(
-            {
-                f"{DOMAIN}_site_{coord.site_id}_restrict_battery_discharge_start_time",
-                f"{DOMAIN}_site_{coord.site_id}_restrict_battery_discharge_end_time",
-            }
-        )
-    if (
+    return bool(
         battery_scheduler_enabled(entry)
         and callable(getattr(client, "battery_schedules", None))
         and all(
@@ -178,7 +159,46 @@ def _retained_site_time_unique_ids(
                 "delete_battery_schedule",
             )
         )
+    )
+
+
+def _retained_site_time_unique_ids(
+    coord: EnphaseCoordinator, entry: EnphaseConfigEntry | None = None
+) -> set[str]:
+    unique_ids: set[str] = set()
+    if not _type_available(coord, "encharge"):
+        return unique_ids
+    editor_active = _battery_schedule_editor_active(coord, entry)
+    cfg_supported = getattr(coord, "charge_from_grid_schedule_supported", None)
+    dtg_supported = getattr(coord, "discharge_to_grid_schedule_supported", None)
+    rbd_supported = getattr(
+        coord, "restrict_battery_discharge_schedule_supported", None
+    )
+    if not editor_active and (
+        _cfg_schedule_edit_available(coord) or cfg_supported is not False
     ):
+        unique_ids.update(
+            {
+                f"{DOMAIN}_site_{coord.site_id}_charge_from_grid_start_time",
+                f"{DOMAIN}_site_{coord.site_id}_charge_from_grid_end_time",
+            }
+        )
+    if not editor_active:
+        if _dtg_schedule_edit_available(coord) or dtg_supported is not False:
+            unique_ids.update(
+                {
+                    f"{DOMAIN}_site_{coord.site_id}_discharge_to_grid_start_time",
+                    f"{DOMAIN}_site_{coord.site_id}_discharge_to_grid_end_time",
+                }
+            )
+        if _rbd_schedule_edit_available(coord) or rbd_supported is not False:
+            unique_ids.update(
+                {
+                    f"{DOMAIN}_site_{coord.site_id}_restrict_battery_discharge_start_time",
+                    f"{DOMAIN}_site_{coord.site_id}_restrict_battery_discharge_end_time",
+                }
+            )
+    if editor_active:
         unique_ids.update(
             {
                 f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_start_time",
@@ -194,7 +214,7 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coord: EnphaseCoordinator = get_runtime_data(entry).coordinator
-    site_entities_added = False
+    added_site_time_unique_ids: set[str] = set()
 
     ent_reg = er.async_get(hass)
     rename_by_unique = _time_entity_id_migrations(coord)
@@ -234,52 +254,85 @@ async def async_setup_entry(
             f"{DOMAIN}_site_{coord.site_id}_battery_new_schedule_end_time",
         }
 
+    def _core_site_time_unique_ids() -> set[str]:
+        return set()
+
+    def _site_time_entities_by_unique_id(
+        retained_site_time_unique_ids: set[str],
+    ) -> dict[str, TimeEntity]:
+        entity_factories: dict[str, Callable[[], TimeEntity]] = {
+            f"{DOMAIN}_site_{coord.site_id}_charge_from_grid_start_time": lambda: ChargeFromGridStartTimeEntity(
+                coord
+            ),
+            f"{DOMAIN}_site_{coord.site_id}_charge_from_grid_end_time": lambda: ChargeFromGridEndTimeEntity(
+                coord
+            ),
+            f"{DOMAIN}_site_{coord.site_id}_discharge_to_grid_start_time": lambda: DischargeToGridStartTimeEntity(
+                coord
+            ),
+            f"{DOMAIN}_site_{coord.site_id}_discharge_to_grid_end_time": lambda: DischargeToGridEndTimeEntity(
+                coord
+            ),
+            f"{DOMAIN}_site_{coord.site_id}_restrict_battery_discharge_start_time": lambda: RestrictBatteryDischargeStartTimeEntity(
+                coord
+            ),
+            f"{DOMAIN}_site_{coord.site_id}_restrict_battery_discharge_end_time": lambda: RestrictBatteryDischargeEndTimeEntity(
+                coord
+            ),
+        }
+        if battery_scheduler_enabled(entry):
+            entity_factories[
+                f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_start_time"
+            ] = lambda: BatteryScheduleEditStartTimeEntity(coord, entry)
+            entity_factories[
+                f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_end_time"
+            ] = lambda: BatteryScheduleEditEndTimeEntity(coord, entry)
+
+        active_site_time_unique_ids = retained_site_time_unique_ids
+
+        return {
+            unique_id: factory()
+            for unique_id, factory in entity_factories.items()
+            if unique_id in active_site_time_unique_ids
+        }
+
     @callback
     def _async_sync_site_entities() -> None:
-        nonlocal site_entities_added
         inventory_ready = bool(getattr(coord, "_devices_inventory_ready", False))
         retained_site_time_unique_ids = _retained_site_time_unique_ids(coord, entry)
-        if site_entities_added:
-            pass
-        elif _site_has_battery(coord) and _type_available(coord, "encharge"):
-            site_entities: list[TimeEntity] = [
-                ChargeFromGridStartTimeEntity(coord),
-                ChargeFromGridEndTimeEntity(coord),
-                DischargeToGridStartTimeEntity(coord),
-                DischargeToGridEndTimeEntity(coord),
-                RestrictBatteryDischargeStartTimeEntity(coord),
-                RestrictBatteryDischargeEndTimeEntity(coord),
-            ]
-            if (
-                f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_start_time"
-                in retained_site_time_unique_ids
-            ):
-                site_entities.extend(
-                    [
-                        BatteryScheduleEditStartTimeEntity(coord, entry),
-                        BatteryScheduleEditEndTimeEntity(coord, entry),
-                    ]
-                )
-            async_add_entities(
-                site_entities,
-                update_before_add=False,
+        active_site_time_unique_ids: set[str] = set()
+        if _site_has_battery(coord) and _type_available(coord, "encharge"):
+            active_site_time_unique_ids = retained_site_time_unique_ids
+            current_site_entities = _site_time_entities_by_unique_id(
+                retained_site_time_unique_ids
             )
-            site_entities_added = True
-        if not _site_has_battery(coord) or not _type_available(coord, "encharge"):
-            site_entities_added = False
+            site_entities = [
+                entity
+                for unique_id, entity in current_site_entities.items()
+                if unique_id not in added_site_time_unique_ids
+            ]
+            if site_entities:
+                async_add_entities(site_entities, update_before_add=False)
+                added_site_time_unique_ids.update(
+                    entity.unique_id
+                    for entity in site_entities
+                    if isinstance(entity.unique_id, str)
+                )
+        added_site_time_unique_ids.intersection_update(active_site_time_unique_ids)
         if not inventory_ready:
             return
         prune_managed_entities(
             ent_reg,
             entry.entry_id,
             domain="time",
-            active_unique_ids=retained_site_time_unique_ids,
+            active_unique_ids=active_site_time_unique_ids,
             is_managed=lambda unique_id: unique_id in _managed_site_time_unique_ids(),
         )
 
-    add_listener = getattr(coord, "async_add_topology_listener", None)
-    if not callable(add_listener):
-        add_listener = getattr(coord, "async_add_listener", None)
+    add_topology_listener = getattr(coord, "async_add_topology_listener", None)
+    if callable(add_topology_listener):
+        entry.async_on_unload(add_topology_listener(_async_sync_site_entities))
+    add_listener = getattr(coord, "async_add_listener", None)
     if callable(add_listener):
         entry.async_on_unload(add_listener(_async_sync_site_entities))
     _async_sync_site_entities()
@@ -383,6 +436,7 @@ class _BaseNamedBatteryScheduleTimeEntity(CoordinatorEntity, TimeEntity):
         coord: EnphaseCoordinator,
         *,
         suffix: str,
+        schedule_type: str,
         availability_check,
         value_attr: str,
         setter_name: str,
@@ -390,6 +444,7 @@ class _BaseNamedBatteryScheduleTimeEntity(CoordinatorEntity, TimeEntity):
     ) -> None:
         super().__init__(coord)
         self._coord = coord
+        self._schedule_type = schedule_type
         self._availability_check = availability_check
         self._value_attr = value_attr
         self._setter_name = setter_name
@@ -410,7 +465,16 @@ class _BaseNamedBatteryScheduleTimeEntity(CoordinatorEntity, TimeEntity):
 
     @property
     def native_value(self) -> dt_time | None:
-        return getattr(self._coord, self._value_attr)
+        value = getattr(self._coord, self._value_attr)
+        if value is not None:
+            return value
+        default_value = _default_schedule_time_for_create(
+            self._schedule_type,
+            end=self._schedule_endpoint_key() == "end",
+        )
+        if default_value is not None and self._availability_check(self._coord):
+            return default_value
+        return None
 
     def _extra_schedule_state_attributes(self) -> dict[str, object]:
         return {}
@@ -457,6 +521,7 @@ class DischargeToGridStartTimeEntity(_BaseNamedBatteryScheduleStartTimeEntity):
         super().__init__(
             coord,
             suffix="discharge_to_grid_start_time",
+            schedule_type="dtg",
             availability_check=_dtg_schedule_edit_available,
             value_attr="battery_discharge_to_grid_start_time",
             setter_name="async_set_discharge_to_grid_schedule_time",
@@ -480,6 +545,7 @@ class DischargeToGridEndTimeEntity(_BaseNamedBatteryScheduleEndTimeEntity):
         super().__init__(
             coord,
             suffix="discharge_to_grid_end_time",
+            schedule_type="dtg",
             availability_check=_dtg_schedule_edit_available,
             value_attr="battery_discharge_to_grid_end_time",
             setter_name="async_set_discharge_to_grid_schedule_time",
@@ -503,6 +569,7 @@ class RestrictBatteryDischargeStartTimeEntity(_BaseNamedBatteryScheduleStartTime
         super().__init__(
             coord,
             suffix="restrict_battery_discharge_start_time",
+            schedule_type="rbd",
             availability_check=_rbd_schedule_edit_available,
             value_attr="battery_restrict_battery_discharge_start_time",
             setter_name="async_set_restrict_battery_discharge_schedule_time",
@@ -526,6 +593,7 @@ class RestrictBatteryDischargeEndTimeEntity(_BaseNamedBatteryScheduleEndTimeEnti
         super().__init__(
             coord,
             suffix="restrict_battery_discharge_end_time",
+            schedule_type="rbd",
             availability_check=_rbd_schedule_edit_available,
             value_attr="battery_restrict_battery_discharge_end_time",
             setter_name="async_set_restrict_battery_discharge_schedule_time",

--- a/custom_components/enphase_ev/time.py
+++ b/custom_components/enphase_ev/time.py
@@ -254,9 +254,6 @@ async def async_setup_entry(
             f"{DOMAIN}_site_{coord.site_id}_battery_new_schedule_end_time",
         }
 
-    def _core_site_time_unique_ids() -> set[str]:
-        return set()
-
     def _site_time_entities_by_unique_id(
         retained_site_time_unique_ids: set[str],
     ) -> dict[str, TimeEntity]:

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -134,12 +134,12 @@ Example response:
 | BatteryConfig site settings | `GET` | `/service/batteryConfig/api/v1/siteSettings/<site_id>?userId=<user_id>` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Safari-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | Yes |
 | BatteryConfig MQTT authorizer bootstrap | `GET` | `/service/batteryConfig/api/v1/mqttSignedUrl/<site_id>` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Safari-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No |
 | BatteryConfig third-party settings | `GET` | `/service/batteryConfig/api/v1/<site_id>/thirdPartyControlSettings` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Safari-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI) |
-| BatteryConfig schedules | `GET` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Safari-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI) |
-| BatteryConfig schedule create | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | official-web BatteryConfig write shape plus `X-XSRF-Token`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No |
+| BatteryConfig schedules | `GET` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | official-web BatteryConfig read shape: `Accept`, `Origin`, `Referer`, Safari-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI) |
+| BatteryConfig schedule create | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | BatteryConfig write shape plus `X-XSRF-Token`; on affected sites the verified working shape is the raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`) sent from a stateless client session so aiohttp does not merge cookie-jar state; current client falls back across cookie-backed, primary, lean, and mixed-auth variants | No |
 | BatteryConfig schedule validation | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid` | official-web BatteryConfig write shape plus `X-XSRF-Token`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI) |
-| BatteryConfig schedule update | `PUT` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>` | official-web BatteryConfig write shape plus `X-XSRF-Token`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI) |
-| BatteryConfig schedule legacy delete alias | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>/delete` | official-web BatteryConfig write shape plus `X-XSRF-Token`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No |
-| BatteryConfig disclaimer accept | `POST` | `/service/batteryConfig/api/v1/batterySettings/acceptDisclaimer/<site_id>` | documented write pattern only: official-web BatteryConfig write shape plus `X-XSRF-Token`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client would use primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (not currently implemented) |
+| BatteryConfig schedule update | `PUT` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>` | BatteryConfig write shape plus `X-XSRF-Token`; verified working update uses the raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`) from a stateless client session; current client falls back across cookie-backed, primary, lean, and mixed-auth variants | No (documented from live verification) |
+| BatteryConfig schedule legacy delete alias | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>/delete` | same BatteryConfig write planner as schedule create/update; cookie-backed browser request is the verified working compatibility shape on affected sites | No |
+| BatteryConfig disclaimer accept | `POST` | `/service/batteryConfig/api/v1/batterySettings/acceptDisclaimer/<site_id>` | documented write pattern only; when used, current client will try the same cookie-backed, primary, lean, and mixed-auth BatteryConfig write variants | No (not currently used by runtime) |
 | PES in-app banner/status | `GET` | `/service/pes_management/systems/<site_id>/inapp?type=<type>` | authenticated session cookies | No (documented from mobile/web HAR) |
 | Login | `POST` | `/login/login.json` | credentials; session/XSRF cookies are established by the response rather than pre-required | Yes |
 
@@ -4217,13 +4217,14 @@ Updates the system profile and reserve percentage. Observed profile keys include
 
 Implementation auth notes:
 - The current client first acquires a fresh `BP-XSRF-Token` by POSTing to `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid`.
-- It then sends the official-web BatteryConfig shape plus `X-XSRF-Token`: `Accept`, `Username`, battery-profile `Origin`/`Referer`, and the Safari-style browser `User-Agent` used by the current integration.
-- The current implementation explicitly suppresses inherited `Authorization`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` on this write path.
-- The current implementation tries two observed first-party variants in a centralized API-layer flow:
-  - primary: add `e-auth-token` and `requestid`
-  - lean fallback: omit `e-auth-token` and `requestid`
-- If the initial `/profile` write returns `403` and the payload includes `devices`, the current client retries once without `devices`.
-- The current implementation also appends `source=enho` to profile writes, even though the first-party write capture documented for this spec only confirmed `userId=<user_id>`.
+- On affected issue `#460` sites, the verified working write uses the raw stored BatteryConfig cookie (`Cookie`), `e-auth-token` from `enlighten_manager_token_production`, `Username`, `X-XSRF-Token` from the raw cookie header, and `X-Requested-With: XMLHttpRequest`.
+- That cookie-backed write must be sent from a stateless request session so aiohttp does not merge cookie-jar state into the raw `Cookie` header.
+- Verified write planner order:
+  - preferred compatibility request on affected sites: `PUT /profile/<site_id>?userId=<user_id>&source=enho` with the raw-cookie browser shape
+  - first compatibility retry: same request without `devices` when the payload included an EVSE `devices` list
+  - second compatibility retry: same stripped payload without `source`
+  - later retries: official-web primary, official-web lean, then mixed-auth browser shape when auth material is available
+- Direct live verification also succeeded without `source`.
 
 Example payloads observed:
 ```json
@@ -4299,6 +4300,8 @@ Response:
 ```
 
 Notes:
+- Verified working profile response body remains the compact success envelope:
+  - `{"message":"success"}`
 - The reserve slider enforces a 10% minimum (Self-Consumption) and 100% for Full Backup. The Savings profile uses a reserve slider plus a "Use battery after peak hours" toggle; `operationModeSubType` appears to track this state (only `prioritize-energy` observed so far).
 - The AI Optimization flow uses the profile key `ai_optimisation` and also sends `operationModeSubType: "prioritize-energy"` with the EVSE device payload.
 - Switching away from AI Optimization may still include an EVSE `devices` payload. In the observed AI -> Self-Consumption transition, the EVSE payload included `profileConfig: "full"` and `chargeMode: "SMART"`.
@@ -4408,11 +4411,13 @@ Updates battery settings. Captured requests used partial payloads to change indi
 
 Implementation auth notes:
 - The current client first acquires a fresh `BP-XSRF-Token` via `/battery/sites/<site_id>/schedules/isValid`.
-- It then sends the official-web BatteryConfig shape: `Username`, `X-XSRF-Token`, browser `Origin`/`Referer`, and the Safari-style browser `User-Agent` used by the current integration.
-- The current implementation explicitly suppresses inherited `Authorization`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` for BatteryConfig reads and writes.
-- The current implementation tries two observed first-party variants in a centralized API-layer flow:
-  - primary: add `e-auth-token` and `requestid`
-  - lean fallback: omit `e-auth-token` and `requestid`
+- On affected issue `#460` sites, the verified working write uses the raw stored BatteryConfig cookie (`Cookie`), `e-auth-token` from `enlighten_manager_token_production`, `Username`, `X-XSRF-Token` from the raw cookie header, and `X-Requested-With: XMLHttpRequest`.
+- That cookie-backed write must be sent from a stateless request session so aiohttp does not merge cookie-jar state into the raw `Cookie` header.
+- Verified write planner order:
+  - preferred compatibility request on affected sites: `PUT /batterySettings/<site_id>?userId=<user_id>&source=enho` with the raw-cookie browser shape
+  - on `supportsMqtt=true` sites, next retries drop `source`
+  - later retries: official-web primary, official-web lean, then mixed-auth browser shape when auth material is available
+  - if the payload includes `acceptedItcDisclaimer` and prior attempts still fail, the final compatibility retry sends `acceptedItcDisclaimer: true` instead of the timestamp string; on `supportsMqtt=true` sites this final retry follows the no-`source` path
 
 Example payloads observed:
 ```json
@@ -4439,6 +4444,13 @@ Response:
 ```
 
 Notes:
+- Verified working battery-settings response body remains the compact success envelope:
+  - `{"message":"success"}`
+- Direct live verification on the affected site also accepted each of these write bodies with the raw-cookie request shape:
+  - `{"chargeFromGrid":false}`
+  - `{"chargeFromGrid":true}`
+  - `{"chargeFromGrid":true,"acceptedItcDisclaimer":"<timestamp>"}`
+  - `{"chargeFromGrid":true,"acceptedItcDisclaimer":true}`
 - The raw capture contained live cookies, JWTs, XSRF tokens, site IDs, and user IDs. Only the endpoint shape and sanitized field values are recorded here.
 - `supportsMqtt` and `pollingInterval` indicate whether the page can use the MQTT-backed battery settings flow and how often the UI expects state refreshes. Observed values so far: `supportsMqtt=true`, `pollingInterval=60`.
 - `requestedConfig` and `requestedConfigMqtt` were empty objects in the capture; they appear to be placeholders for pending configuration writes or async acknowledgements. Observed values so far: `{}` for both fields.
@@ -4464,17 +4476,19 @@ Notes:
 - Two equivalent write variants were observed:
   - REST-only flows use `PUT /batterySettings/<site_id>?source=enho&userId=<user_id>`.
   - MQTT-backed RBD flows on `supportsMqtt=true` systems use `PUT /batterySettings/<site_id>?userId=<user_id>` after opening the MQTT response stream.
-- In the official homeowner web capture used to guide the current implementation, the successful `PUT /batterySettings/<site_id>?userId=<user_id>&source=enho` request did not include `Authorization`, `e-auth-token`, `Cookie`, `X-CSRF-Token`, or `X-Requested-With`.
+- First-party homeowner captures used a lean official-web request with no `Authorization`, `Cookie`, `X-CSRF-Token`, or `X-Requested-With`.
+- Direct live verification for issue `#460` showed those first-party shapes still returning `403` on the affected site, while the raw-cookie browser request succeeded.
 - In the current implementation, BatteryConfig variant selection is cached per `(site_id, battery_config_user_id, endpoint_family)` after a successful write so later calls reuse the proven request shape instead of retrying both variants each time.
 - Additional partial payloads were observed on the same endpoint for DTG/RBD enablement toggles:
   - `{"dtgControl":{"enabled":true}}`
   - `{"dtgControl":{"enabled":false}}`
   - `{"rbdControl":{"enabled":true}}`
   - `{"rbdControl":{"enabled":false}}`
-- External client source sends a richer DTG enable payload:
+- Live local verification on 2026-04-17 confirmed that `rbdControl.enabled=true` can coexist with `rbd.count=0`, so RBD on/off writes must not assume an RBD schedule record already exists.
+- External client source and the current integration use a richer DTG enable payload when no DTG schedule record exists yet:
   - `{"dtgControl":{"enabled":true,"scheduleSupported":true,"startTime":<minutes>,"endTime":<minutes>}}`
   - `startTime` / `endTime` are minute-of-day integers derived from the current DTG control window
-- This is another concrete comparison point for issue `#460`: the current integration only sends the minimal `enabled` toggle for DTG/RBD BatterySettings writes.
+- When a DTG schedule already exists, the integration still uses the same battery-settings toggle family for on/off writes and leaves schedule create/update/delete to the `/battery/sites/<site_id>/schedules` endpoints.
 
 ### 5.6 Storm Guard Alert Status, Opt-Out, and Toggle
 ```
@@ -4667,8 +4681,9 @@ Creates a new battery schedule entry. The same endpoint is used for CFG, DTG, an
 
 Implementation auth notes:
 - The current client acquires fresh XSRF first, then sends the official-web BatteryConfig shape plus `X-XSRF-Token`.
-- Inherited `Authorization`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` are explicitly suppressed on this path.
-- The current client tries the primary first-party variant with `e-auth-token` + `requestid` first, then retries once with the lean first-party variant without those headers after a `403`.
+- On affected issue `#460` sites, the verified working write instead reuses the raw stored BatteryConfig cookie (`Cookie`), `e-auth-token`, `Username`, `X-XSRF-Token`, and `X-Requested-With: XMLHttpRequest`.
+- That cookie-backed create/update/delete flow is sent from a stateless request session so aiohttp does not merge cookie-jar state into the raw `Cookie` header.
+- The current client now tries the cookie-backed compatibility write first when the raw cookie/XSRF pair is available, then falls back through official-web primary, official-web lean, and mixed-auth variants.
 
 Observed behavior:
 - `scheduleType` is sent uppercase (`CFG`, `DTG`, `RBD`).
@@ -4702,7 +4717,7 @@ Body: {}
 Observed behavior:
 - Soft-delete is supported through the canonical `PUT /schedules/<schedule_id>` resource, sometimes with the full schedule echoed back and sometimes with only `{ "isDeleted": true }`.
 - A `/delete` alias also exists. This path is useful as a compatibility note, but it was not present in the newer browser traces captured for this repository.
-- The current client implements the legacy `/delete` alias and sends it with the same BatteryConfig write flow: acquire XSRF first, then send the official-web BatteryConfig shape plus `X-XSRF-Token`, using the primary `e-auth-token` + `requestid` variant first and the lean fallback after `403`.
+- The current client implements the legacy `/delete` alias and sends it through the same compatibility write planner used by schedule create/update, including the raw-cookie browser request on affected sites.
 
 ### 5.9 Battery Schedule Validation
 ```
@@ -4762,8 +4777,14 @@ the Enlighten battery profile UI when the user modifies a CFG schedule.
 
 Implementation auth notes:
 - The current client acquires fresh XSRF via `/schedules/isValid` immediately before issuing this `PUT`.
-- The current client explicitly suppresses `Authorization`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` on this BatteryConfig schedule write path.
-- The current client tries the primary first-party variant with `e-auth-token` + `requestid` first, then retries once with the lean first-party variant without those headers after a `403`.
+- On affected issue `#460` sites, the verified working request is the raw-cookie browser shape:
+  - `Cookie: <serialized stored cookie>`
+  - `e-auth-token: <enlighten_manager_token_production>`
+  - `Username: <user_id>`
+  - `X-XSRF-Token: <BP-XSRF-Token from raw cookie header>`
+  - `X-Requested-With: XMLHttpRequest`
+- That cookie-backed write must be sent from a stateless request session so aiohttp does not merge cookie-jar state into the raw `Cookie` header.
+- The current client now tries the cookie-backed compatibility write first when that raw cookie/XSRF pair is available, then falls back through official-web primary, official-web lean, and mixed-auth variants.
 
 Example response (anonymized):
 ```json
@@ -4785,14 +4806,37 @@ Example response (anonymized):
 }
 ```
 
+Verified live DTG update response on the affected site:
+```json
+{
+  "createdBy": "<user_id>",
+  "updatedBy": "<user_id>",
+  "createdAt": "<epoch_ms>",
+  "updatedAt": "<epoch_ms>",
+  "scheduleId": "<uuid>",
+  "timezone": "Australia/Melbourne",
+  "startTime": "00:00",
+  "endTime": "23:59",
+  "limit": 22,
+  "scheduleType": "DTG",
+  "scheduleStatus": "pending",
+  "days": [1, 2, 3, 4, 5, 6, 7],
+  "isDeleted": false,
+  "isEnabled": false
+}
+```
+
 Observed behavior:
 - The response includes a `scheduleStatus` field that transitions from `"pending"` to `"active"` once the Envoy acknowledges the change.
-- While a schedule is pending, subsequent PUT requests are accepted by the cloud but may block at the integration level to prevent conflicting updates.
+- While a schedule is pending, schedule time/limit edits should still be treated as conflicting, but DTG/RBD on/off toggles can succeed because those writes use `PUT /batterySettings/<site_id>` rather than the schedule CRUD route.
 - `startTime` and `endTime` use `HH:MM` format (24-hour, no seconds).
 - `limit` is the maximum SoC percentage (5-100).
 - `days` is a 1-indexed day-of-week array (1=Monday through 7=Sunday).
 - This replaces the delete+create pattern previously used for schedule modifications.
 - Captured DTG/RBD enablement toggles were also observed as partial `PUT /batterySettings/<site_id>` payloads (`dtgControl.enabled` / `rbdControl.enabled`), so clients should not assume all schedule-family toggles go through `PUT /battery/sites/<site_id>/schedules/<schedule_id>`.
+- The current DTG runtime now follows that split explicitly:
+  - toggle enable/disable uses `PUT /batterySettings/<site_id>`
+  - schedule time/limit creation and edits use `/battery/sites/<site_id>/schedules`
 
 ### 5.11 ITC Disclaimer Acknowledgement
 ```
@@ -4811,7 +4855,8 @@ Example response (anonymized):
 Observed behavior:
 - This call preceded `PUT /batterySettings/<site_id>` in the captured sequence.
 - A subsequent battery-settings update used `acceptedItcDisclaimer: true`; later `GET /batterySettings/<site_id>` returned `acceptedItcDisclaimer` as a timestamp string, so the backend normalizes the acknowledgement internally.
-- The current integration does not implement this route today, but if added it should follow the same BatteryConfig write pattern as the other mutation endpoints: acquire fresh XSRF first, then send the official-web BatteryConfig shape plus `X-XSRF-Token`, using the primary `e-auth-token` + `requestid` variant first and the lean fallback after `403`.
+- The runtime no longer preflights this route before `PUT /batterySettings/<site_id>`, because the affected site accepted direct battery-settings writes without the extra disclaimer POST.
+- If used again in the future, it should follow the same compatibility planner as the other BatteryConfig mutation endpoints, including the raw-cookie browser request on affected sites.
 
 ---
 
@@ -5011,7 +5056,7 @@ There is no single universal header set; the implementation varies headers by en
 | System dashboard reads | authenticated cookies; may also include bearer auth opportunistically |
 | HEMS | bearer-preferred auth plus cookies/base headers; `username` and `requestId` when available |
 | BatteryConfig reads | official-web BatteryConfig shape: `Accept`, `Username`, battery-profile `Origin`/`Referer`, Safari-style `User-Agent`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With`; current client prefers the `e-auth-token` + `requestid` variant and falls back to the lean variant if needed |
-| BatteryConfig writes | acquire fresh XSRF via `/battery/sites/<site_id>/schedules/isValid`, keep the existing `BP-XSRF-Token` if bootstrap returns `4xx`, then send official-web BatteryConfig headers plus `X-XSRF-Token`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With`; current client prefers the `e-auth-token` + `requestid` variant and retries once with the lean variant after `403` |
+| BatteryConfig writes | acquire fresh XSRF via `/battery/sites/<site_id>/schedules/isValid`, keep the existing `BP-XSRF-Token` if bootstrap returns `4xx`, then use an endpoint-specific compatibility planner; on affected sites the verified working shape is a stateless raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`), with official-web primary, official-web lean, and mixed-auth fallbacks retained |
 
 - Base Enlighten reads:
   - `Cookie: <serialized cookie jar>`
@@ -5035,9 +5080,11 @@ There is no single universal header set; the implementation varies headers by en
   - `Origin` / `Referer` for the battery-profile UI
   - Safari-style `User-Agent`
   - `X-XSRF-Token` for `isValid` preflight and writes after token acquisition
-  - primary variant adds `e-auth-token` and `requestid`
-  - lean fallback omits `e-auth-token` and `requestid`
-  - inherited `Authorization`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With` are explicitly suppressed
+  - affected-site compatibility write adds raw `Cookie`, `e-auth-token`, and `X-Requested-With`
+  - official-web primary fallback adds `e-auth-token` and `requestid`
+  - official-web lean fallback omits `e-auth-token` and `requestid`
+  - mixed-auth compatibility fallback restores `Authorization`, `Cookie`, and `X-CSRF-Token`
+  - cookie-backed compatibility writes must use a stateless request session so aiohttp does not merge cookie-jar state into the raw `Cookie` header
 
 ---
 

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import base64
+from contextlib import asynccontextmanager
 import datetime
 import hashlib
+from http.cookies import SimpleCookie
 import json
 import logging
 from types import SimpleNamespace
@@ -158,6 +160,74 @@ def test_update_credentials_manages_headers() -> None:
     client._cookie = _BadCookie()
     client.update_credentials()
     assert "X-CSRF-Token" not in client._h
+
+
+def test_battery_config_cookie_handles_bad_string_and_empty_cookie() -> None:
+    client = _make_client()
+
+    class _BadStringCookie:
+        def __bool__(self) -> bool:
+            return True
+
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    client._cookie = _BadStringCookie()  # noqa: SLF001
+
+    assert client._battery_config_cookie() is None  # noqa: SLF001
+
+    client.update_credentials(cookie="")
+    assert client._battery_config_cookie() is None  # noqa: SLF001
+
+
+def test_battery_config_mixed_auth_headers_without_tokens_or_xsrf() -> None:
+    client = api.EnphaseEVClient(_DefaultSession(), "SITE", None, None)
+
+    headers = client._battery_config_mixed_auth_headers()  # noqa: SLF001
+
+    assert headers["Authorization"] is None
+    assert headers["e-auth-token"] is None
+    assert headers["requestid"] is None
+    assert headers["X-XSRF-Token"] is None
+    assert headers["X-CSRF-Token"] is None
+    assert headers["Cookie"] is None
+
+
+def test_battery_config_mixed_auth_headers_uses_token_when_eauth_missing() -> None:
+    token = _make_token({"user_id": "88"})
+    client = api.EnphaseEVClient(
+        _DefaultSession(),
+        "SITE",
+        None,
+        f"session=1; enlighten_manager_token_production={token}",
+    )
+
+    headers = client._battery_config_mixed_auth_headers()  # noqa: SLF001
+
+    assert headers["Authorization"] == f"Bearer {token}"
+    assert headers["e-auth-token"] == token
+    assert headers["Username"] == "88"
+
+
+def test_battery_config_cookie_merges_session_jar_cookies() -> None:
+    session = _DefaultSession()
+    session.cookie_jar = SimpleNamespace(
+        filter_cookies=lambda _url: SimpleCookie("battery_profile_session=live-cookie")
+    )
+    client = api.EnphaseEVClient(
+        session,
+        "SITE",
+        None,
+        "session=1; locale=en-AU; BP-XSRF-Token=stale-token",
+    )
+
+    cookie_header = client._battery_config_cookie(include_xsrf=True)  # noqa: SLF001
+
+    assert cookie_header is not None
+    assert "session=1" in cookie_header
+    assert "locale=en-AU" in cookie_header
+    assert "battery_profile_session=live-cookie" in cookie_header
+    assert "BP-XSRF-Token=stale-token" in cookie_header
 
 
 def test_update_credentials_handles_xsrf_extractor_exception(monkeypatch) -> None:
@@ -641,7 +711,7 @@ def test_battery_config_headers_preserve_original_eauth_and_replace_stale_xsrf()
 
     headers = client._battery_config_headers(include_xsrf=True)  # noqa: SLF001
 
-    assert headers["e-auth-token"] == "session-token"
+    assert headers["e-auth-token"] == bearer
     assert headers["X-XSRF-Token"] == "fresh-token"
     assert headers["Authorization"] is None
     assert headers["X-CSRF-Token"] is None
@@ -760,12 +830,12 @@ def test_battery_config_headers_match_official_web_shape() -> None:
     assert headers["Accept"] == "application/json, text/plain, */*"
     assert headers["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
     assert headers["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
-    assert headers["User-Agent"] == api._ENLIGHTEN_BROWSER_USER_AGENT
+    assert headers["User-Agent"] == api._BATTERY_CONFIG_BROWSER_USER_AGENT
     assert headers["X-Requested-With"] is None
     assert headers["X-XSRF-Token"] == "raw-token"
     assert headers["X-CSRF-Token"] is None
     assert headers["Authorization"] is None
-    assert headers["e-auth-token"] == "access-token"
+    assert headers["e-auth-token"] == bearer
     assert headers["Cookie"] is None
     assert headers["Username"] == "77"
     assert "requestid" in headers
@@ -3598,12 +3668,10 @@ async def test_battery_settings_details_wire_headers_match_official_web_shape() 
     response = _FakeResponse(status=200, json_body={"data": {"chargeFromGrid": True}})
     session = _FakeSession([response])
     client = _make_client(session)
+    token = _make_token({"user_id": "99"})
     client.update_credentials(
-        eauth="access-token",
-        cookie=(
-            "session=1; XSRF-TOKEN=base-xsrf; "
-            f"enlighten_manager_token_production={_make_token({'user_id': '99'})}"
-        ),
+        eauth=token,
+        cookie="session=1; XSRF-TOKEN=base-xsrf",
     )
 
     out = await client.battery_settings_details()
@@ -3615,7 +3683,7 @@ async def test_battery_settings_details_wire_headers_match_official_web_shape() 
     assert headers["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
     assert headers["Username"] == "99"
     assert "Authorization" not in headers
-    assert headers["e-auth-token"] == "access-token"
+    assert headers["e-auth-token"] == token
     assert "Cookie" not in headers
     assert "X-CSRF-Token" not in headers
     assert "X-Requested-With" not in headers
@@ -3626,7 +3694,7 @@ async def test_battery_settings_details_wire_headers_match_official_web_shape() 
 async def test_set_battery_settings_payload_and_xsrf() -> None:
     token = _make_token({"user_id": "88"})
     client = _make_client()
-    client.update_credentials(eauth=token, cookie="XSRF-TOKEN=xsrf%3Dtoken; other=1")
+    client.update_credentials(eauth=token, cookie="other=1")
     client._acquire_xsrf_token = AsyncMock(return_value="xsrf=token")  # noqa: SLF001
     client._bp_xsrf_token = "xsrf=token"  # noqa: SLF001
     client._json = AsyncMock(return_value={"message": "success"})
@@ -3701,31 +3769,67 @@ async def test_set_battery_settings_retries_403_with_lean_official_web_variant(
         json_body={},
         text_body='{"timestamp":"2026-04-11T06:16:00.098+00:00","status":403}',
     )
+    validate_cookie = _FakeResponse(status=200, json_body={"isValid": True})
+    validate_cookie.headers = CIMultiDict(
+        [("Set-Cookie", "BP-XSRF-Token=cfg-token-cookie; Path=/; Secure")]
+    )
+    cookie_write = _FakeResponse(
+        status=403,
+        json_body={},
+        text_body='{"timestamp":"2026-04-11T06:16:00.412+00:00","status":403}',
+    )
+    validate_mixed = _FakeResponse(status=200, json_body={"isValid": True})
+    validate_mixed.headers = CIMultiDict(
+        [("Set-Cookie", "BP-XSRF-Token=cfg-token-mixed; Path=/; Secure")]
+    )
+    mixed_write = _FakeResponse(
+        status=403,
+        json_body={},
+        text_body='{"timestamp":"2026-04-11T06:16:00.687+00:00","status":403}',
+    )
     session = _FakeSession(
-        [validate_primary, initial_write, validate_fallback, fallback_write]
+        [
+            validate_primary,
+            initial_write,
+            validate_fallback,
+            fallback_write,
+            validate_cookie,
+            cookie_write,
+            validate_mixed,
+            mixed_write,
+        ]
     )
     primary_token = _make_token({"user_id": "88"})
     client = _make_client(session)
     client.update_credentials(
         eauth=primary_token,
-        cookie=(
-            "session=1; XSRF-TOKEN=base-xsrf; "
-            f"enlighten_manager_token_production={primary_token}"
-        ),
+        cookie="session=1",
     )
+
+    @asynccontextmanager
+    async def _request_session(*, cookie_header_only: bool = False):
+        yield session
+
+    client._request_session = _request_session  # noqa: SLF001
 
     with caplog.at_level(logging.DEBUG):
         with pytest.raises(aiohttp.ClientResponseError) as err:
             await client.set_battery_settings({"veryLowSoc": 15})
 
     assert err.value.status == 403
-    assert len(session.calls) == 4
+    assert len(session.calls) == 8
     assert session.calls[0][0] == "POST"
     assert session.calls[1][0] == "PUT"
     assert session.calls[2][0] == "POST"
     assert session.calls[3][0] == "PUT"
+    assert session.calls[4][0] == "POST"
+    assert session.calls[5][0] == "PUT"
+    assert session.calls[6][0] == "POST"
+    assert session.calls[7][0] == "PUT"
     primary_headers = session.calls[1][2]["headers"]
     fallback_headers = session.calls[3][2]["headers"]
+    cookie_headers = session.calls[5][2]["headers"]
+    mixed_headers = session.calls[7][2]["headers"]
     assert "Authorization" not in primary_headers
     assert primary_headers["e-auth-token"] == primary_token
     assert "requestid" in primary_headers
@@ -3739,8 +3843,29 @@ async def test_set_battery_settings_retries_403_with_lean_official_web_variant(
     assert fallback_headers["Username"] == "88"
     assert fallback_headers["X-XSRF-Token"] == "cfg-token-lean"
     assert "X-CSRF-Token" not in fallback_headers
+    assert "Authorization" not in cookie_headers
+    assert cookie_headers["e-auth-token"] == primary_token
+    assert cookie_headers["Cookie"] == "session=1"
+    assert "X-CSRF-Token" not in cookie_headers
+    assert "X-XSRF-Token" not in cookie_headers
+    assert cookie_headers["X-Requested-With"] == "XMLHttpRequest"
+    assert "requestid" not in cookie_headers
+    assert mixed_headers["Authorization"] == f"Bearer {primary_token}"
+    assert mixed_headers["e-auth-token"] == primary_token
+    assert mixed_headers["Cookie"].startswith("session=1;")
+    assert "BP-XSRF-Token=cfg-token-mixed" in mixed_headers["Cookie"]
+    assert mixed_headers["X-CSRF-Token"] == "cfg-token-mixed"
+    assert mixed_headers["X-XSRF-Token"] == "cfg-token-mixed"
+    assert mixed_headers["X-Requested-With"] == "XMLHttpRequest"
+    assert "requestid" not in mixed_headers
     assert "Retrying BatteryConfig write" in caplog.text
     assert "official_web_lean" in caplog.text
+    assert "cookie_eauth_compatible" in caplog.text
+    assert "mixed_auth_compatible" in caplog.text
+    assert "attempt_id=battery_settings_primary_source" in caplog.text
+    assert "attempt_id=battery_settings_lean_source" in caplog.text
+    assert "attempt_id=battery_settings_cookie_eauth_source" in caplog.text
+    assert "attempt_id=battery_settings_mixed_source" in caplog.text
     assert client._bp_xsrf_token is None  # noqa: SLF001
 
 
@@ -3748,10 +3873,7 @@ async def test_set_battery_settings_retries_403_with_lean_official_web_variant(
 async def test_set_battery_profile_uses_canonical_batteryconfig_write_path() -> None:
     token = _make_token({"user_id": "100"})
     client = _make_client()
-    client.update_credentials(
-        eauth=token,
-        cookie=f"XSRF-TOKEN=fresh-xsrf; enlighten_manager_token_production={token}",
-    )
+    client.update_credentials(eauth=token, cookie="session=1")
     client._acquire_xsrf_token = AsyncMock(return_value="fresh-xsrf")  # noqa: SLF001
     client._bp_xsrf_token = "fresh-xsrf"  # noqa: SLF001
     client._json = AsyncMock(return_value={"message": "success"})
@@ -3801,6 +3923,30 @@ def test_battery_config_endpoint_family_identifies_schedule_routes() -> None:
     )
 
 
+def test_battery_config_attempt_json_body_returns_list_unchanged() -> None:
+    client = _make_client()
+    payload = [{"enabled": True}]
+    attempt = api._BatteryConfigWriteAttempt(  # noqa: SLF001
+        attempt_id="list-payload",
+        auth_mode=api._BATTERY_CONFIG_VARIANT_PRIMARY,
+    )
+
+    assert (
+        client._battery_config_attempt_json_body(payload, "battery_settings", attempt)
+        == payload
+    )  # noqa: SLF001
+
+
+def test_remember_battery_config_capabilities_handles_payload_shapes() -> None:
+    client = _make_client()
+
+    client._remember_battery_config_capabilities(["bad"])  # noqa: SLF001
+    assert client._battery_config_supports_mqtt is None  # noqa: SLF001
+
+    client._remember_battery_config_capabilities({"supportsMqtt": True})  # noqa: SLF001
+    assert client._battery_config_supports_mqtt is True  # noqa: SLF001
+
+
 @pytest.mark.asyncio
 async def test_battery_config_request_raises_when_no_variants_are_available() -> None:
     client = _make_client()
@@ -3811,6 +3957,65 @@ async def test_battery_config_request_raises_when_no_variants_are_available() ->
             "GET",
             "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
         )
+
+
+@pytest.mark.asyncio
+async def test_battery_config_request_retries_403_and_caches_variant_when_bootstrapping() -> (
+    None
+):
+    client = _make_client()
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
+    client._json = AsyncMock(
+        side_effect=[_make_cre(403, "Forbidden"), {"message": "success"}]
+    )
+
+    out = await client._battery_config_request(  # noqa: SLF001
+        "PUT",
+        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
+        json_body={"profile": "self-consumption"},
+        params={"userId": "88", "source": "enho"},
+        endpoint_family="profile",
+        bootstrap_xsrf=True,
+        cache_on_success=True,
+    )
+
+    assert out == {"message": "success"}
+    assert client._acquire_xsrf_token.await_count == 2  # noqa: SLF001
+    assert (
+        client._battery_config_cached_variant("profile")  # noqa: SLF001
+        == api._BATTERY_CONFIG_VARIANT_LEAN
+    )
+    assert client._bp_xsrf_token is None  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_battery_config_request_reraises_401() -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=_make_cre(401, "Unauthorized"))
+
+    with pytest.raises(aiohttp.ClientResponseError) as err:
+        await client._battery_config_request(  # noqa: SLF001
+            "GET",
+            "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
+            endpoint_family="profile",
+        )
+
+    assert err.value.status == 401
+
+
+@pytest.mark.asyncio
+async def test_battery_config_request_reraises_non_403_errors() -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=_make_cre(500, "boom"))
+
+    with pytest.raises(aiohttp.ClientResponseError) as err:
+        await client._battery_config_request(  # noqa: SLF001
+            "GET",
+            "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/profile/SITE",
+            endpoint_family="profile",
+        )
+
+    assert err.value.status == 500
 
 
 @pytest.mark.asyncio
@@ -3836,6 +4041,13 @@ async def test_battery_config_write_request_reraises_403_after_fallback() -> Non
     client = _make_client()
     client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
     client._json = AsyncMock(side_effect=_make_cre(403, "Forbidden"))
+    attempts = client._battery_config_write_attempts(  # noqa: SLF001
+        "profile",
+        write_intent="generic",
+        supports_mqtt=None,
+        params={"userId": "88"},
+        json_body={"profile": "self-consumption"},
+    )
 
     with pytest.raises(aiohttp.ClientResponseError):
         await client._battery_config_write_request(  # noqa: SLF001
@@ -3845,16 +4057,13 @@ async def test_battery_config_write_request_reraises_403_after_fallback() -> Non
             params={"userId": "88"},
         )
 
-    assert client._json.await_count == 2
-    assert client._acquire_xsrf_token.await_count == 2
+    assert client._json.await_count == len(attempts)
+    assert client._acquire_xsrf_token.await_count == len(attempts)
     assert client._acquire_xsrf_token.await_args_list[0].args == ("cfg",)
     assert client._acquire_xsrf_token.await_args_list[0].kwargs == {
         "variant": api._BATTERY_CONFIG_VARIANT_PRIMARY
     }
-    assert client._acquire_xsrf_token.await_args_list[1].args == ("cfg",)
-    assert client._acquire_xsrf_token.await_args_list[1].kwargs == {
-        "variant": api._BATTERY_CONFIG_VARIANT_LEAN
-    }
+    assert client._acquire_xsrf_token.await_args_list[-1].args == ("cfg",)
 
 
 @pytest.mark.asyncio
@@ -3895,13 +4104,22 @@ async def test_battery_config_write_request_caches_successful_fallback_variant()
     assert fallback_call.kwargs["headers"]["e-auth-token"] is None
     assert cached_call.kwargs["headers"]["requestid"] is None
     assert cached_call.kwargs["headers"]["e-auth-token"] is None
+    assert (
+        client._battery_config_cached_write_attempt(  # noqa: SLF001
+            "battery_settings",
+            supports_mqtt=None,
+        )
+        == "battery_settings_lean"
+    )
 
 
 @pytest.mark.asyncio
-async def test_battery_config_write_request_updates_cached_variant_after_403() -> None:
+async def test_battery_config_write_request_updates_cached_attempt_after_403() -> None:
     client = _make_client()
-    client._cache_battery_config_variant(  # noqa: SLF001
-        "battery_settings", api._BATTERY_CONFIG_VARIANT_PRIMARY
+    client._cache_battery_config_write_attempt(  # noqa: SLF001
+        "battery_settings",
+        "battery_settings_primary_source",
+        supports_mqtt=None,
     )
     client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
     client._json = AsyncMock(
@@ -3917,16 +4135,23 @@ async def test_battery_config_write_request_updates_cached_variant_after_403() -
 
     assert out == {"message": "success"}
     assert (
-        client._battery_config_cached_variant("battery_settings")  # noqa: SLF001
-        == api._BATTERY_CONFIG_VARIANT_LEAN
+        client._battery_config_cached_write_attempt(  # noqa: SLF001
+            "battery_settings",
+            supports_mqtt=None,
+        )
+        == "battery_settings_lean"
     )
 
 
 @pytest.mark.asyncio
-async def test_battery_config_write_request_does_not_cache_on_401() -> None:
+async def test_battery_config_write_request_does_not_update_cached_attempt_on_401() -> (
+    None
+):
     client = _make_client()
-    client._cache_battery_config_variant(  # noqa: SLF001
-        "battery_settings", api._BATTERY_CONFIG_VARIANT_PRIMARY
+    client._cache_battery_config_write_attempt(  # noqa: SLF001
+        "battery_settings",
+        "battery_settings_primary_source",
+        supports_mqtt=None,
     )
     client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
     client._json = AsyncMock(side_effect=_make_cre(401, "Unauthorized"))
@@ -3940,9 +4165,236 @@ async def test_battery_config_write_request_does_not_cache_on_401() -> None:
         )
 
     assert (
-        client._battery_config_cached_variant("battery_settings")  # noqa: SLF001
-        == api._BATTERY_CONFIG_VARIANT_PRIMARY
+        client._battery_config_cached_write_attempt(  # noqa: SLF001
+            "battery_settings",
+            supports_mqtt=None,
+        )
+        == "battery_settings_primary_source"
     )
+
+
+@pytest.mark.asyncio
+async def test_battery_config_write_request_raises_last_error_when_duplicate_attempts_are_skipped() -> (
+    None
+):
+    client = _make_client()
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
+    duplicate = api._BatteryConfigWriteAttempt(  # noqa: SLF001
+        attempt_id="duplicate",
+        auth_mode=api._BATTERY_CONFIG_VARIANT_PRIMARY,
+    )
+    client._battery_config_write_attempts = MagicMock(  # noqa: SLF001
+        return_value=[duplicate, duplicate]
+    )
+    client._json = AsyncMock(side_effect=[_make_cre(403, "Forbidden")])
+
+    with pytest.raises(aiohttp.ClientResponseError) as err:
+        await client._battery_config_write_request(  # noqa: SLF001
+            "PUT",
+            "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/batterySettings/SITE",
+            json_body={"veryLowSoc": 15},
+            params={"userId": "88", "source": "enho"},
+            endpoint_family="battery_settings",
+            write_intent="battery_settings_update",
+        )
+
+    assert err.value.status == 403
+    assert client._json.await_count == 1  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_battery_config_write_request_raises_when_no_attempts_are_available() -> (
+    None
+):
+    client = _make_client()
+    client._battery_config_write_attempts = MagicMock(return_value=[])  # noqa: SLF001
+
+    with pytest.raises(aiohttp.ClientError, match="exhausted variants"):
+        await client._battery_config_write_request(  # noqa: SLF001
+            "PUT",
+            "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/batterySettings/SITE",
+            json_body={"veryLowSoc": 15},
+            params={"userId": "88", "source": "enho"},
+            endpoint_family="battery_settings",
+            write_intent="battery_settings_update",
+        )
+
+
+@pytest.mark.asyncio
+async def test_battery_config_write_request_retries_without_source_when_mqtt_supported() -> (
+    None
+):
+    client = _make_client()
+    client._battery_config_supports_mqtt = True  # noqa: SLF001
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
+    client._json = AsyncMock(
+        side_effect=[
+            _make_cre(403, "Forbidden"),
+            _make_cre(403, "Forbidden"),
+            {"message": "success"},
+        ]
+    )
+
+    out = await client.set_battery_settings(
+        {
+            "acceptedItcDisclaimer": "2026-04-17T09:30:00+00:00",
+            "chargeFromGrid": True,
+        }
+    )
+
+    assert out == {"message": "success"}
+    first_call, second_call, third_call = client._json.await_args_list
+    assert first_call.kwargs["params"] == {"source": "enho"}
+    assert second_call.kwargs["params"] == {"source": "enho"}
+    assert third_call.kwargs["params"] == {}
+    assert third_call.kwargs["headers"]["requestid"]
+    assert third_call.kwargs["headers"]["e-auth-token"] == "EAUTH"
+    assert (
+        client._battery_config_cached_write_attempt(  # noqa: SLF001
+            "battery_settings",
+            supports_mqtt=True,
+        )
+        == "battery_settings_primary_no_source"
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_config_write_request_cache_isolated_by_endpoint_family_and_mqtt() -> (
+    None
+):
+    client = _make_client()
+    client._cache_battery_config_write_attempt(  # noqa: SLF001
+        "battery_settings",
+        "battery_settings_primary_no_source",
+        supports_mqtt=True,
+    )
+    client._cache_battery_config_write_attempt(  # noqa: SLF001
+        "profile",
+        "profile_mixed_compat",
+        supports_mqtt=True,
+    )
+
+    assert (
+        client._battery_config_cached_write_attempt(  # noqa: SLF001
+            "battery_settings",
+            supports_mqtt=True,
+        )
+        == "battery_settings_primary_no_source"
+    )
+    assert (
+        client._battery_config_cached_write_attempt(  # noqa: SLF001
+            "battery_settings",
+            supports_mqtt=False,
+        )
+        is None
+    )
+    assert (
+        client._battery_config_cached_write_attempt(  # noqa: SLF001
+            "profile",
+            supports_mqtt=True,
+        )
+        == "profile_mixed_compat"
+    )
+
+
+def test_battery_config_write_attempts_prefer_cookie_compat_when_raw_xsrf_available() -> (
+    None
+):
+    token = _make_token({"user_id": "88"})
+    client = _make_client()
+    client.update_credentials(
+        cookie=(
+            "session=1; BP-XSRF-Token=raw-xsrf; "
+            f"enlighten_manager_token_production={token}"
+        )
+    )
+
+    attempts = client._battery_config_write_attempts(  # noqa: SLF001
+        "battery_settings",
+        write_intent="battery_settings_update",
+        supports_mqtt=True,
+        params={"userId": "88", "source": "enho"},
+        json_body={
+            "chargeFromGrid": True,
+            "acceptedItcDisclaimer": "2026-04-17T09:30:00+00:00",
+        },
+    )
+
+    assert attempts[0].attempt_id == "battery_settings_cookie_eauth_source"
+    assert attempts[1].attempt_id == "battery_settings_cookie_eauth_no_source"
+
+
+def test_battery_config_schedule_write_attempts_include_cookie_compat() -> None:
+    token = _make_token({"user_id": "88"})
+    client = _make_client()
+    client.update_credentials(
+        cookie=(
+            "session=1; BP-XSRF-Token=raw-xsrf; "
+            f"enlighten_manager_token_production={token}"
+        )
+    )
+
+    attempts = client._battery_config_write_attempts(  # noqa: SLF001
+        "schedules",
+        write_intent="generic",
+        supports_mqtt=None,
+        params=None,
+        json_body={
+            "timezone": "Australia/Melbourne",
+            "startTime": "00:00",
+            "endTime": "23:59",
+            "scheduleType": "DTG",
+            "days": [1, 2, 3, 4, 5, 6, 7],
+            "limit": 21,
+            "isEnabled": False,
+        },
+    )
+
+    assert attempts[0].attempt_id == "schedules_cookie_eauth"
+    assert [attempt.attempt_id for attempt in attempts] == [
+        "schedules_cookie_eauth",
+        "schedules_primary",
+        "schedules_lean",
+        "schedules_mixed",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_battery_config_write_request_uses_cookie_header_only_for_cookie_attempt() -> (
+    None
+):
+    token = _make_token({"user_id": "88"})
+    client = _make_client()
+    client.update_credentials(
+        cookie=(
+            "session=1; BP-XSRF-Token=raw-xsrf; "
+            f"enlighten_manager_token_production={token}"
+        )
+    )
+    client._battery_config_write_attempts = MagicMock(  # noqa: SLF001
+        return_value=[
+            api._BatteryConfigWriteAttempt(  # noqa: SLF001
+                attempt_id="cookie-only",
+                auth_mode=api._BATTERY_CONFIG_VARIANT_COOKIE_EAUTH,
+                prefer_existing_xsrf=True,
+            )
+        ]
+    )
+    client._acquire_xsrf_token = AsyncMock(return_value="fresh-xsrf")  # noqa: SLF001
+    client._json = AsyncMock(return_value={"message": "success"})
+
+    out = await client._battery_config_write_request(  # noqa: SLF001
+        "PUT",
+        "https://enlighten.enphaseenergy.com/service/batteryConfig/api/v1/batterySettings/SITE",
+        json_body={"chargeFromGrid": True},
+        params={"userId": "88", "source": "enho"},
+        endpoint_family="battery_settings",
+        write_intent="battery_settings_update",
+    )
+
+    assert out == {"message": "success"}
+    client._acquire_xsrf_token.assert_not_awaited()  # noqa: SLF001
+    assert client._json.await_args.kwargs["use_cookie_header_only"] is True
 
 
 @pytest.mark.asyncio
@@ -3994,23 +4446,20 @@ async def test_validate_battery_schedule_cfg_payload_keeps_force_schedule_opted(
 
 @pytest.mark.asyncio
 async def test_acquire_xsrf_token_uses_official_web_headers() -> None:
-    bearer = _make_token({"user_id": "88"})
+    token = _make_token({"user_id": "88"})
     response = _FakeResponse(status=200, json_body={"isValid": True})
     response.headers = CIMultiDict(
         [("Set-Cookie", "BP-XSRF-Token=fresh-token; Path=/; Secure")]
     )
     session = _FakeSession([response])
     client = _make_client(session)
-    client.update_credentials(
-        eauth="session-token",
-        cookie=f"session=1; enlighten_manager_token_production={bearer}",
-    )
+    client.update_credentials(eauth=token, cookie="session=1")
 
     await client._acquire_xsrf_token()  # noqa: SLF001
 
     headers = session.calls[0][2]["headers"]
     assert "Authorization" not in headers
-    assert headers["e-auth-token"] == "session-token"
+    assert headers["e-auth-token"] == token
     assert headers["Username"] == "88"
     assert headers["Origin"] == "https://battery-profile-ui.enphaseenergy.com"
     assert headers["Referer"] == "https://battery-profile-ui.enphaseenergy.com/"
@@ -4412,10 +4861,14 @@ async def test_set_battery_profile_reraises_non_403_errors() -> None:
 
 
 @pytest.mark.asyncio
-async def test_set_battery_profile_retries_without_devices_on_403() -> None:
+async def test_set_battery_profile_retries_without_devices_then_without_source() -> (
+    None
+):
     client = _make_client()
-    client._battery_config_write_request = AsyncMock(  # noqa: SLF001
+    client._acquire_xsrf_token = AsyncMock(return_value="xsrf-token")  # noqa: SLF001
+    client._json = AsyncMock(
         side_effect=[
+            _make_cre(403, "Forbidden"),
             _make_cre(403, "Forbidden"),
             {"message": "success"},
         ]
@@ -4428,19 +4881,104 @@ async def test_set_battery_profile_retries_without_devices_on_403() -> None:
     )
 
     assert out == {"message": "success"}
-    first_call = client._battery_config_write_request.await_args_list[0]  # noqa: SLF001
-    fallback_call = client._battery_config_write_request.await_args_list[
-        1
-    ]  # noqa: SLF001
-    assert first_call.kwargs["json_body"] == {
+    first_call, second_call, third_call = client._json.await_args_list
+    assert first_call.kwargs["json"] == {
         "profile": "self-consumption",
         "batteryBackupPercentage": 20,
         "devices": [{"uuid": "abc", "deviceType": "iqEvse", "enable": False}],
     }
-    assert fallback_call.kwargs["json_body"] == {
+    assert second_call.kwargs["json"] == {
         "profile": "self-consumption",
         "batteryBackupPercentage": 20,
     }
+    assert second_call.kwargs["params"] == {"source": "enho"}
+    assert third_call.kwargs["json"] == {
+        "profile": "self-consumption",
+        "batteryBackupPercentage": 20,
+    }
+    assert third_call.kwargs["params"] == {}
+
+
+@pytest.mark.asyncio
+async def test_set_battery_settings_retries_disclaimer_as_boolean_true_after_403() -> (
+    None
+):
+    client = _make_client()
+
+    async def _acquire(*_args: object, **_kwargs: object) -> str:
+        client._bp_xsrf_token = "xsrf-token"  # noqa: SLF001
+        return "xsrf-token"
+
+    client._acquire_xsrf_token = AsyncMock(side_effect=_acquire)  # noqa: SLF001
+    client._json = AsyncMock(
+        side_effect=[
+            _make_cre(403, "Forbidden"),
+            _make_cre(403, "Forbidden"),
+            _make_cre(403, "Forbidden"),
+            _make_cre(403, "Forbidden"),
+            {"message": "success"},
+        ]
+    )
+
+    out = await client.set_battery_settings(
+        {
+            "chargeFromGrid": True,
+            "acceptedItcDisclaimer": "2026-04-17T09:30:00+00:00",
+        }
+    )
+
+    assert out == {"message": "success"}
+    (
+        primary_call,
+        lean_call,
+        cookie_call,
+        mixed_call,
+        disclaimer_call,
+    ) = client._json.await_args_list
+    assert primary_call.kwargs["json"]["acceptedItcDisclaimer"] == (
+        "2026-04-17T09:30:00+00:00"
+    )
+    assert lean_call.kwargs["json"]["acceptedItcDisclaimer"] == (
+        "2026-04-17T09:30:00+00:00"
+    )
+    assert cookie_call.kwargs["json"]["acceptedItcDisclaimer"] == (
+        "2026-04-17T09:30:00+00:00"
+    )
+    assert mixed_call.kwargs["json"]["acceptedItcDisclaimer"] == (
+        "2026-04-17T09:30:00+00:00"
+    )
+    assert disclaimer_call.kwargs["json"]["acceptedItcDisclaimer"] is True
+    assert disclaimer_call.kwargs["params"] == {"source": "enho"}
+    assert disclaimer_call.kwargs["headers"]["Authorization"] == "Bearer EAUTH"
+    assert disclaimer_call.kwargs["headers"]["e-auth-token"] == "EAUTH"
+    assert disclaimer_call.kwargs["headers"]["X-CSRF-Token"] == "xsrf-token"
+
+
+@pytest.mark.asyncio
+async def test_set_battery_settings_does_not_preflight_disclaimer_accept() -> None:
+    client = _make_client()
+    client.accept_battery_settings_disclaimer = AsyncMock(  # noqa: SLF001
+        return_value={"message": "success"}
+    )
+    client._battery_config_write_request = AsyncMock(
+        return_value={"message": "ok"}
+    )  # noqa: SLF001
+
+    out = await client.set_battery_settings(
+        {
+            "chargeFromGrid": True,
+            "acceptedItcDisclaimer": "2026-04-17T09:30:00+00:00",
+        }
+    )
+
+    assert out == {"message": "ok"}
+    client.accept_battery_settings_disclaimer.assert_not_awaited()  # noqa: SLF001
+    assert (
+        client._battery_config_write_request.await_args.kwargs["json_body"][
+            "acceptedItcDisclaimer"
+        ]
+        == "2026-04-17T09:30:00+00:00"
+    )
 
 
 @pytest.mark.asyncio
@@ -4573,7 +5111,7 @@ async def test_battery_config_prefers_cookie_bearer_when_it_has_user_id() -> Non
 
     _args, kwargs = client._json.await_args
     assert kwargs["headers"]["Authorization"] is None
-    assert kwargs["headers"]["e-auth-token"] == eauth_token
+    assert kwargs["headers"]["e-auth-token"] == cookie_token
     assert kwargs["headers"]["Username"] == "123"
     assert "requestid" in kwargs["headers"]
     assert kwargs["params"]["userId"] == "123"

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -180,6 +180,26 @@ def test_battery_config_cookie_handles_bad_string_and_empty_cookie() -> None:
     assert client._battery_config_cookie() is None  # noqa: SLF001
 
 
+def test_battery_config_cookie_header_xsrf_token_handles_quotes_and_decode_fallback(
+    monkeypatch,
+) -> None:
+    client = _make_client()
+    client.update_credentials(cookie='session=1; BP-XSRF-Token="quoted%20token"; a=1')
+
+    assert (
+        client._battery_config_cookie_header_xsrf_token() == "quoted token"
+    )  # noqa: SLF001
+
+    client.update_credentials(cookie='session=1; BP-XSRF-Token=""')
+    assert client._battery_config_cookie_header_xsrf_token() is None  # noqa: SLF001
+
+    client.update_credentials(cookie='session=1; BP-XSRF-Token="opaque"')
+    monkeypatch.setattr(
+        api, "unquote", lambda value: (_ for _ in ()).throw(ValueError(value))
+    )
+    assert client._battery_config_cookie_header_xsrf_token() == "opaque"  # noqa: SLF001
+
+
 def test_battery_config_mixed_auth_headers_without_tokens_or_xsrf() -> None:
     client = api.EnphaseEVClient(_DefaultSession(), "SITE", None, None)
 
@@ -4359,6 +4379,150 @@ def test_battery_config_schedule_write_attempts_include_cookie_compat() -> None:
     ]
 
 
+def test_battery_config_write_attempts_cover_stateful_profile_and_settings_variants() -> (
+    None
+):
+    token = _make_token({"user_id": "88"})
+    client = _make_client()
+    client.update_credentials(eauth=token, cookie="session=1")
+    client._battery_config_write_bases["profile"] = {  # noqa: SLF001
+        "profile": "self-consumption",
+        "devices": {"iqEvse": {"enabled": True}},
+    }
+    client._battery_config_write_bases["battery_settings"] = {  # noqa: SLF001
+        "chargeFromGrid": False,
+        "dtgControl": {"enabled": False},
+        "acceptedItcDisclaimer": "2026-04-17T09:30:00+00:00",
+    }
+
+    profile_attempts = client._battery_config_write_attempts(  # noqa: SLF001
+        "profile",
+        write_intent="profile_update",
+        supports_mqtt=True,
+        params={"userId": "88", "source": "enho"},
+        json_body={"profile": "full_backup", "devices": {"iqEvse": {"enabled": False}}},
+    )
+    assert [attempt.attempt_id for attempt in profile_attempts] == [
+        "profile_primary",
+        "profile_primary_no_devices",
+        "profile_primary_no_source",
+        "profile_stateful_primary",
+        "profile_stateful_primary_no_source",
+        "profile_cookie_eauth_compat",
+        "profile_stateful_cookie_eauth_compat",
+        "profile_mixed_compat",
+        "profile_stateful_mixed_compat",
+    ]
+
+    settings_attempts = client._battery_config_write_attempts(  # noqa: SLF001
+        "battery_settings",
+        write_intent="battery_settings_update",
+        supports_mqtt=True,
+        params={"userId": "88", "source": "enho"},
+        json_body={
+            "chargeFromGrid": True,
+            "acceptedItcDisclaimer": "2026-04-17T09:30:00+00:00",
+        },
+    )
+    assert [attempt.attempt_id for attempt in settings_attempts] == [
+        "battery_settings_primary_source",
+        "battery_settings_lean_source",
+        "battery_settings_primary_no_source",
+        "battery_settings_lean_no_source",
+        "battery_settings_stateful_primary_source",
+        "battery_settings_stateful_lean_source",
+        "battery_settings_stateful_primary_no_source",
+        "battery_settings_stateful_lean_no_source",
+        "battery_settings_cookie_eauth_source",
+        "battery_settings_cookie_eauth_no_source",
+        "battery_settings_stateful_cookie_eauth_source",
+        "battery_settings_stateful_cookie_eauth_no_source",
+        "battery_settings_mixed_source",
+        "battery_settings_mixed_no_source",
+        "battery_settings_stateful_mixed_source",
+        "battery_settings_stateful_mixed_no_source",
+        "battery_settings_disclaimer_true",
+        "battery_settings_stateful_disclaimer_true",
+    ]
+
+    disclaimer_attempts = client._battery_config_write_attempts(  # noqa: SLF001
+        "battery_settings",
+        write_intent="battery_settings_disclaimer_accept",
+        supports_mqtt=None,
+        params=None,
+        json_body={"disclaimer-type": "itc"},
+    )
+    assert [attempt.attempt_id for attempt in disclaimer_attempts] == [
+        "battery_settings_disclaimer_primary",
+        "battery_settings_disclaimer_lean",
+        "battery_settings_disclaimer_cookie_eauth",
+        "battery_settings_disclaimer_mixed",
+    ]
+
+
+def test_battery_config_write_payload_helpers_cover_merge_and_base_fallbacks() -> None:
+    client = _make_client()
+
+    assert client._battery_config_payload_data(None) is None  # noqa: SLF001
+    assert client._battery_config_payload_data({"a": 1}) == {"a": 1}  # noqa: SLF001
+
+    client._remember_battery_config_write_base(
+        "other", {"data": {"a": 1}}
+    )  # noqa: SLF001
+    client._remember_battery_config_write_base("profile", "bad")  # noqa: SLF001
+    assert client._battery_config_write_bases == {}  # noqa: SLF001
+
+    client._remember_battery_config_write_base(  # noqa: SLF001
+        "battery_settings",
+        {
+            "data": {
+                "dtgControl": {"enabled": False, "startTime": "00:00"},
+                "devices": {"iqEvse": {"enabled": True}},
+                "ignored": 1,
+            }
+        },
+    )
+    assert client._battery_config_write_bases["battery_settings"] == {  # noqa: SLF001
+        "dtgControl": {"enabled": False, "startTime": "00:00"},
+        "devices": {"iqEvse": {"enabled": True}},
+    }
+
+    assert (
+        client._battery_config_merged_write_payload("battery_settings", None) is None
+    )  # noqa: SLF001
+    assert client._battery_config_merged_write_payload(
+        "missing", {"chargeFromGrid": True}
+    ) == {  # noqa: SLF001
+        "chargeFromGrid": True
+    }
+    assert client._battery_config_merged_write_payload(  # noqa: SLF001
+        "battery_settings",
+        {"dtgControl": {"enabled": True}, "chargeFromGrid": True},
+    ) == {
+        "dtgControl": {"enabled": True, "startTime": "00:00"},
+        "devices": {"iqEvse": {"enabled": True}},
+        "chargeFromGrid": True,
+    }
+
+    attempt = api._BatteryConfigWriteAttempt(  # noqa: SLF001
+        attempt_id="stateful",
+        auth_mode=api._BATTERY_CONFIG_VARIANT_PRIMARY,
+        merged_payload=True,
+        preserve_base_devices=True,
+    )
+    assert client._battery_config_attempt_json_body(  # noqa: SLF001
+        {
+            "dtgControl": {"enabled": True},
+            "devices": {"iqEvse": {"enabled": False}},
+        },
+        "battery_settings",
+        attempt,
+    ) == {
+        "dtgControl": {"enabled": True, "startTime": "00:00"},
+        "devices": {"iqEvse": {"enabled": True}},
+    }
+
+
 @pytest.mark.asyncio
 async def test_battery_config_write_request_uses_cookie_header_only_for_cookie_attempt() -> (
     None
@@ -4398,6 +4562,24 @@ async def test_battery_config_write_request_uses_cookie_header_only_for_cookie_a
 
 
 @pytest.mark.asyncio
+async def test_request_session_cookie_header_only_uses_ephemeral_client_session() -> (
+    None
+):
+    client = _make_client()
+
+    async with client._request_session(
+        cookie_header_only=False
+    ) as shared:  # noqa: SLF001
+        assert shared is client._s  # noqa: SLF001
+
+    async with client._request_session(
+        cookie_header_only=True
+    ) as isolated:  # noqa: SLF001
+        assert isinstance(isolated, aiohttp.ClientSession)
+        assert isolated is not client._s  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_acquire_xsrf_token_uses_requested_validation_payload() -> None:
     token = _make_token({"user_id": "88"})
     response = _FakeResponse(status=200, json_body={"isValid": True})
@@ -4426,6 +4608,28 @@ async def test_acquire_xsrf_token_uses_requested_validation_payload() -> None:
     assert "Authorization" not in kwargs["headers"]
     assert "requestid" in kwargs["headers"]
     assert "Cookie" not in kwargs["headers"]
+
+
+@pytest.mark.asyncio
+async def test_accept_battery_settings_disclaimer_uses_battery_config_write_request() -> (
+    None
+):
+    client = _make_client()
+    client._battery_config_write_request = AsyncMock(
+        return_value={"status": "ok"}
+    )  # noqa: SLF001
+
+    out = await client.accept_battery_settings_disclaimer("custom")
+
+    assert out == {"status": "ok"}
+    client._battery_config_write_request.assert_awaited_once_with(  # noqa: SLF001
+        "POST",
+        f"{api.BASE_URL}/service/batteryConfig/api/v1/batterySettings/acceptDisclaimer/SITE",
+        json_body={"disclaimer-type": "custom"},
+        params=None,
+        endpoint_family="battery_settings_disclaimer",
+        write_intent="battery_settings_disclaimer_accept",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -268,19 +268,6 @@ async def test_dtg_schedule_enabled_rejects_guard_branches(coordinator_factory) 
         show_day_schedule=True,
         schedule_supported=True,
     )
-    coord._battery_dtg_schedule_status = "pending"  # noqa: SLF001
-    with pytest.raises(ServiceValidationError, match="pending Envoy sync"):
-        await coord.async_set_discharge_to_grid_schedule_enabled(True)
-
-    coord = coordinator_factory()
-    coord._battery_has_encharge = True  # noqa: SLF001
-    coord._battery_user_is_owner = True  # noqa: SLF001
-    coord._battery_dtg_control = BatteryControlCapability(
-        show=True,
-        locked=False,
-        show_day_schedule=True,
-        schedule_supported=True,
-    )
     with pytest.raises(ServiceValidationError, match="time is invalid"):
         await coord.async_set_discharge_to_grid_schedule_enabled(True)
 
@@ -288,6 +275,23 @@ async def test_dtg_schedule_enabled_rejects_guard_branches(coordinator_factory) 
     coord._battery_dtg_control_end_time = 60  # noqa: SLF001
     with pytest.raises(ServiceValidationError, match="must be different"):
         await coord.async_set_discharge_to_grid_schedule_enabled(True)
+
+
+@pytest.mark.asyncio
+async def test_dtg_schedule_enabled_allows_toggle_while_schedule_pending(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_schedule_family(coord, "dtg")
+    coord._battery_dtg_schedule_status = "pending"  # noqa: SLF001
+    coord.client.set_battery_settings = AsyncMock(return_value={})
+
+    await coord.async_set_discharge_to_grid_schedule_enabled(False)
+
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {"dtgControl": {"enabled": False}},
+        schedule_type="dtg",
+    )
 
 
 @pytest.mark.asyncio
@@ -629,7 +633,7 @@ async def test_refresh_battery_settings_cache_ttl_tracks_polling_cadence(
     coord._configured_slow_poll_interval = 120  # noqa: SLF001
     coord._battery_polling_interval_s = 60  # noqa: SLF001
     coord._endpoint_family_should_run = lambda *args, **kwargs: True  # noqa: SLF001
-    coord._note_endpoint_family_success = lambda *args, **kwargs: None  # noqa: SLF001
+    coord._note_endpoint_family_success = MagicMock()  # noqa: SLF001
     coord._note_endpoint_family_failure = lambda *args, **kwargs: None  # noqa: SLF001
     coord.client.battery_settings_details = AsyncMock(
         side_effect=[
@@ -656,6 +660,10 @@ async def test_refresh_battery_settings_cache_ttl_tracks_polling_cadence(
 
     assert coord.client.battery_settings_details.await_count == 1
     assert coord._battery_settings_cache_until == 1060.0  # noqa: SLF001
+    coord._note_endpoint_family_success.assert_called_once_with(  # noqa: SLF001
+        "battery_settings",
+        success_ttl_s=60.0,
+    )
 
     await coord.battery_runtime.async_refresh_battery_settings()
 
@@ -665,6 +673,37 @@ async def test_refresh_battery_settings_cache_ttl_tracks_polling_cadence(
 
     assert coord.client.battery_settings_details.await_count == 2
     assert coord.battery_profile == "backup_only"
+
+
+@pytest.mark.asyncio
+async def test_refresh_battery_settings_uses_zero_success_ttl_while_settling(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    coord._endpoint_family_should_run = lambda *args, **kwargs: True  # noqa: SLF001
+    coord._note_endpoint_family_success = MagicMock()  # noqa: SLF001
+    coord._note_endpoint_family_failure = lambda *args, **kwargs: None  # noqa: SLF001
+    coord.client.battery_settings_details = AsyncMock(
+        return_value={
+            "data": {
+                "profile": "self-consumption",
+                "batteryBackupPercentage": 20,
+            }
+        }
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.battery_runtime.time.monotonic",
+        lambda: 1000.0,
+    )
+    coord._battery_settings_last_write_mono = 995.0  # noqa: SLF001
+
+    await coord.battery_runtime.async_refresh_battery_settings(force=True)
+
+    assert coord._battery_settings_cache_until == 1000.0  # noqa: SLF001
+    coord._note_endpoint_family_success.assert_called_once_with(  # noqa: SLF001
+        "battery_settings",
+        success_ttl_s=0.0,
+    )
 
 
 @pytest.mark.asyncio
@@ -734,6 +773,58 @@ async def test_set_charge_from_grid_enable_autostamps_and_defaults(
     assert "chargeFromGridScheduleEnabled" not in payload
     assert coord.battery_charge_from_grid_enabled is True
     coord.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_set_charge_from_grid_disable_omits_disclaimer(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_hide_charge_from_grid = False  # noqa: SLF001
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord.client.set_battery_settings = AsyncMock(return_value={"message": "success"})
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+
+    await coord.battery_runtime.async_set_charge_from_grid(False)
+
+    payload = coord.client.set_battery_settings.await_args.args[0]
+    assert payload == {"chargeFromGrid": False}
+    coord.async_request_refresh.assert_awaited_once()
+
+
+def test_parse_battery_settings_payload_keeps_shutdown_level_when_values_present(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.battery_runtime
+
+    runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "batteryGridMode": "ImportExport",
+                "hideChargeFromGrid": False,
+                "envoySupportsVls": True,
+                "chargeFromGrid": True,
+                "veryLowSoc": 15,
+                "veryLowSocMin": 10,
+                "veryLowSocMax": 25,
+                "cfgControl": {"show": True, "enabled": True, "locked": False},
+                "systemTask": False,
+            }
+        }
+    )
+    runtime.parse_battery_site_settings_payload(
+        {
+            "data": {
+                "batteryLimitSupport": False,
+            }
+        }
+    )
+
+    assert coord.battery_shutdown_level == 15
+    assert coord.battery_shutdown_level_available is True
 
 
 def test_cfg_settings_pending_helpers_overlay_and_clear(
@@ -1785,6 +1876,42 @@ async def test_refresh_battery_schedules_stores_dict_redacted_payload(
     assert coord.battery_cfg_schedule_limit == 85
 
 
+@pytest.mark.asyncio
+async def test_refresh_battery_schedules_uses_zero_success_ttl_while_pending(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._endpoint_family_should_run = lambda *args, **kwargs: True  # noqa: SLF001
+    coord._note_endpoint_family_success = MagicMock()  # noqa: SLF001
+    coord._note_endpoint_family_failure = lambda *args, **kwargs: None  # noqa: SLF001
+    coord._battery_dtg_schedule_status = "pending"  # noqa: SLF001
+    coord.client.battery_schedules = AsyncMock(
+        return_value={
+            "dtg": {
+                "details": [
+                    {
+                        "scheduleId": "sched-dtg",
+                        "startTime": "00:00",
+                        "endTime": "23:59",
+                        "limit": 22,
+                        "days": [1, 2, 3, 4, 5, 6, 7],
+                        "timezone": "Australia/Melbourne",
+                        "isEnabled": False,
+                        "scheduleStatus": "pending",
+                    }
+                ]
+            }
+        }
+    )
+
+    await coord.battery_runtime.async_refresh_battery_schedules()
+
+    coord._note_endpoint_family_success.assert_called_once_with(  # noqa: SLF001
+        "battery_schedules",
+        success_ttl_s=0.0,
+    )
+
+
 def test_parse_battery_schedules_payload_handles_invalid_shapes(
     coordinator_factory,
 ) -> None:
@@ -2541,7 +2668,24 @@ async def test_rbd_schedule_enabled_uses_battery_settings(
 
 
 @pytest.mark.asyncio
-async def test_dtg_schedule_enabled_creates_missing_schedule_when_enabling(
+async def test_rbd_schedule_enabled_allows_toggle_while_schedule_pending(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_schedule_family(coord, "rbd")
+    coord._battery_rbd_schedule_status = "pending"  # noqa: SLF001
+    coord.client.set_battery_settings = AsyncMock(return_value={})
+
+    await coord.async_set_restrict_battery_discharge_schedule_enabled(False)
+
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {"rbdControl": {"enabled": False}},
+        schedule_type="rbd",
+    )
+
+
+@pytest.mark.asyncio
+async def test_dtg_schedule_enabled_without_schedule_uses_battery_settings_toggle(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -2550,34 +2694,101 @@ async def test_dtg_schedule_enabled_creates_missing_schedule_when_enabling(
 
     await coord.async_set_discharge_to_grid_schedule_enabled(True)
 
-    coord.client.set_battery_settings.assert_not_awaited()
-    call = coord.client.create_battery_schedule.await_args
-    assert call.kwargs["schedule_type"] == "DTG"
-    assert call.kwargs["start_time"] == "19:00"
-    assert call.kwargs["end_time"] == "22:00"
-    assert call.kwargs["limit"] == 5
-    assert call.kwargs["is_enabled"] is True
+    coord.client.create_battery_schedule.assert_not_awaited()
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "dtgControl": {
+                "enabled": True,
+                "scheduleSupported": True,
+                "startTime": 1140,
+                "endTime": 1320,
+            }
+        },
+        schedule_type="dtg",
+    )
     assert coord._battery_dtg_schedule_enabled is True  # noqa: SLF001
+    assert coord._battery_dtg_schedule_id is None  # noqa: SLF001
+    assert coord._battery_dtg_begin_time is None  # noqa: SLF001
+    assert coord._battery_dtg_end_time is None  # noqa: SLF001
+    assert coord.battery_discharge_to_grid_start_time == dt_time(19, 0)
+    assert coord.battery_discharge_to_grid_end_time == dt_time(22, 0)
 
 
 @pytest.mark.asyncio
-async def test_rbd_schedule_enabled_creates_missing_schedule_when_enabling(
+async def test_rbd_schedule_disabled_without_schedule_uses_battery_settings_toggle(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
     _seed_no_schedule_family(coord, "rbd")
     coord.client.set_battery_settings = AsyncMock(return_value={})
 
+    await coord.async_set_restrict_battery_discharge_schedule_enabled(False)
+
+    coord.client.create_battery_schedule.assert_not_awaited()
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {"rbdControl": {"enabled": False}},
+        schedule_type="rbd",
+    )
+    assert coord._battery_rbd_schedule_enabled is False  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_rbd_schedule_enabled_without_schedule_uses_battery_settings_toggle(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_no_schedule_family(coord, "rbd")
+    coord.client.set_battery_settings = AsyncMock(return_value={})
+    coord.client.create_battery_schedule = AsyncMock(return_value={})
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+
     await coord.async_set_restrict_battery_discharge_schedule_enabled(True)
 
-    coord.client.set_battery_settings.assert_not_awaited()
-    call = coord.client.create_battery_schedule.await_args
-    assert call.kwargs["schedule_type"] == "RBD"
-    assert call.kwargs["start_time"] == "01:00"
-    assert call.kwargs["end_time"] == "16:00"
-    assert call.kwargs["limit"] is None
-    assert call.kwargs["is_enabled"] is True
+    coord.client.create_battery_schedule.assert_not_awaited()
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {"rbdControl": {"enabled": True}},
+        schedule_type="rbd",
+    )
     assert coord._battery_rbd_schedule_enabled is True  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_rbd_schedule_enabled_without_schedule_or_window_uses_battery_settings_toggle(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord.battery_runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "batteryGridMode": "ImportExport",
+                "rbdControl": {
+                    "show": True,
+                    "showDaySchedule": True,
+                    "scheduleSupported": True,
+                    "enabled": False,
+                    "locked": False,
+                },
+            }
+        }
+    )
+    coord._battery_schedules_payload = {
+        "rbd": {"count": 0, "scheduleStatus": "active"}
+    }  # noqa: SLF001
+    coord.client.set_battery_settings = AsyncMock(return_value={})
+    coord.client.create_battery_schedule = AsyncMock(return_value={})
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+
+    await coord.async_set_restrict_battery_discharge_schedule_enabled(True)
+
+    coord.client.create_battery_schedule.assert_not_awaited()
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {"rbdControl": {"enabled": True}},
+        schedule_type="rbd",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -222,6 +222,27 @@ def test_schedule_family_helper_defaults_and_cfg_window(coordinator_factory) -> 
     assert (
         runtime._schedule_family_timezone("dtg") == "Australia/Sydney"
     )  # noqa: SLF001
+    assert runtime._schedule_default_window_for_create("rbd") == (
+        60,
+        960,
+    )  # noqa: SLF001
+
+
+def test_battery_control_refresh_helpers_cover_pending_paths(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.battery_runtime
+
+    coord._battery_cfg_schedule_status = "pending"  # noqa: SLF001
+    assert runtime._battery_control_state_settling() is True  # noqa: SLF001
+    assert (
+        runtime._battery_control_refresh_success_ttl_seconds(300.0) == 0.0
+    )  # noqa: SLF001
+
+    coord._battery_cfg_schedule_status = "active"  # noqa: SLF001
+    coord._battery_rbd_schedule_status = "pending"  # noqa: SLF001
+    assert runtime._battery_control_state_settling() is True  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -275,6 +296,96 @@ async def test_dtg_schedule_enabled_rejects_guard_branches(coordinator_factory) 
     coord._battery_dtg_control_end_time = 60  # noqa: SLF001
     with pytest.raises(ServiceValidationError, match="must be different"):
         await coord.async_set_discharge_to_grid_schedule_enabled(True)
+
+
+@pytest.mark.asyncio
+async def test_cfg_schedule_enabled_rejects_pending_and_equal_window(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_cfg_control = BatteryControlCapability(
+        show=True,
+        locked=False,
+        show_day_schedule=True,
+        schedule_supported=True,
+    )
+    coord._battery_cfg_control_force_schedule_supported = True  # noqa: SLF001
+    coord._battery_charge_from_grid = False  # noqa: SLF001
+    coord._battery_cfg_schedule_status = "pending"  # noqa: SLF001
+
+    with pytest.raises(ServiceValidationError, match="pending Envoy sync"):
+        await coord.battery_runtime._async_set_schedule_family_enabled(  # noqa: SLF001
+            "cfg", True
+        )
+
+    coord._battery_cfg_schedule_status = "active"  # noqa: SLF001
+    coord._battery_charge_begin_time = 60  # noqa: SLF001
+    coord._battery_charge_end_time = 60  # noqa: SLF001
+    with pytest.raises(ServiceValidationError, match="must be different"):
+        await coord.battery_runtime._async_set_schedule_family_enabled(  # noqa: SLF001
+            "cfg", True
+        )
+
+
+@pytest.mark.asyncio
+async def test_rbd_schedule_time_uses_default_window_when_missing(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_rbd_control = BatteryControlCapability(
+        show=True,
+        locked=False,
+        show_day_schedule=True,
+        schedule_supported=True,
+    )
+    coord.client.create_battery_schedule = AsyncMock(return_value={})
+    coord.client.battery_schedules = AsyncMock(return_value={})
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord._battery_schedules_payload = {}  # noqa: SLF001
+
+    await coord.async_set_restrict_battery_discharge_schedule_time(start=dt_time(2, 0))
+
+    coord.client.create_battery_schedule.assert_awaited_once_with(
+        schedule_type="RBD",
+        start_time="02:00",
+        end_time="16:00",
+        limit=None,
+        days=[1, 2, 3, 4, 5, 6, 7],
+        timezone="UTC",
+        is_enabled=None,
+    )
+    coord.client.create_battery_schedule.reset_mock()
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_rbd_control = BatteryControlCapability(
+        show=True,
+        locked=False,
+        show_day_schedule=True,
+        schedule_supported=True,
+    )
+    coord.client.create_battery_schedule = AsyncMock(return_value={})
+    coord.client.battery_schedules = AsyncMock(return_value={})
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord._battery_schedules_payload = {}  # noqa: SLF001
+
+    await coord.async_set_restrict_battery_discharge_schedule_time(end=dt_time(15, 0))
+
+    coord.client.create_battery_schedule.assert_awaited_once_with(
+        schedule_type="RBD",
+        start_time="01:00",
+        end_time="15:00",
+        limit=None,
+        days=[1, 2, 3, 4, 5, 6, 7],
+        timezone="UTC",
+        is_enabled=None,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
+++ b/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
@@ -5,6 +5,7 @@ from types import MappingProxyType
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
+import aiohttp
 import pytest
 from homeassistant.helpers.entity import EntityCategory
 
@@ -12,12 +13,14 @@ from custom_components.enphase_ev.battery_schedule_editor import (
     BatteryScheduleEditorEntity,
     BatteryScheduleEditorManager,
     NEW_SCHEDULE_OPTION,
-    NEW_SCHEDULE_OPTION_LABEL,
     _normalize_days,
     _time_to_text,
+    battery_schedule_option_label,
+    battery_schedule_type_options,
     battery_schedule_inventory,
 )
 from custom_components.enphase_ev.const import DOMAIN, OPT_BATTERY_SCHEDULES_ENABLED
+from custom_components.enphase_ev.labels import battery_schedule_create_label
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
 
 
@@ -171,6 +174,8 @@ def test_battery_schedule_editor_manager_syncs_and_resets_selection() -> None:
     assert len(notifications) == 1
     assert [item["schedule_id"] for item in manager.as_dicts()] == ["abc123", "def456"]
     assert manager.get_schedule("abc123") is not None
+    assert manager.edit.selected_schedule_id == "abc123"
+    assert manager.current_selection == "abc123"
 
     manager.select_schedule("abc123")
     assert manager.edit.selected_schedule_id == "abc123"
@@ -217,8 +222,8 @@ def test_battery_schedule_editor_manager_syncs_and_resets_selection() -> None:
     manager.edit.selected_schedule_id = "ghost"
     manager.edit.limit = 12
     manager.sync_from_coordinator()
-    assert manager.edit.selected_schedule_id is None
-    assert manager.edit.limit == 100
+    assert manager.edit.selected_schedule_id == "abc123"
+    assert manager.edit.limit == 90
 
     coord._battery_schedules_payload = {
         "cfg": {"scheduleStatus": "active", "details": []}
@@ -228,6 +233,12 @@ def test_battery_schedule_editor_manager_syncs_and_resets_selection() -> None:
     assert manager.edit.selected_schedule_id is None
     assert manager.edit.limit == 100
     assert manager.edit.days["tue"] is False
+    assert manager.is_creating is True
+
+    coord._battery_schedules_payload = _schedule_payload()
+    manager.sync_from_coordinator()
+    assert manager.edit.selected_schedule_id == "abc123"
+    assert manager.is_creating is False
 
     unsub()
     manager.set_edit_limit(55)
@@ -603,30 +614,41 @@ async def test_battery_schedule_editor_entities_update_state_and_call_services(
     custom_info = {"name": "Battery Device"}
     coord.inventory_view.type_device_info = lambda *_args: custom_info
 
+    create_label = battery_schedule_create_label()
+    cfg_label = battery_schedule_option_label(editor.schedules[0])
+    dtg_label = battery_schedule_option_label(editor.schedules[1])
+
     schedule_select = BatteryScheduleSelect(coord, config_entry)
-    assert schedule_select.options == ["abc123", "def456", NEW_SCHEDULE_OPTION_LABEL]
-    assert schedule_select.current_option is None
+    assert schedule_select.options == [
+        cfg_label,
+        dtg_label,
+        create_label,
+    ]
+    assert schedule_select.current_option == cfg_label
 
     save_button = BatteryScheduleSaveButton(coord, config_entry)
     delete_button = BatteryScheduleDeleteButton(coord, config_entry)
-    assert save_button.available is False
-    assert delete_button.available is False
+    assert save_button.available is True
+    assert delete_button.available is True
 
-    await schedule_select.async_select_option("abc123")
+    await schedule_select.async_select_option(cfg_label)
     assert editor.edit.selected_schedule_id == "abc123"
     assert save_button.available is True
     assert delete_button.available is True
 
     new_type_select = BatteryNewScheduleTypeSelect(coord, config_entry)
     assert new_type_select.available is False
-    await schedule_select.async_select_option(NEW_SCHEDULE_OPTION_LABEL)
+    await schedule_select.async_select_option(create_label)
     assert editor.is_creating is True
-    assert schedule_select.current_option == NEW_SCHEDULE_OPTION_LABEL
+    assert schedule_select.current_option == create_label
     assert save_button.available is True
     assert delete_button.available is False
     assert new_type_select.available is True
-    await new_type_select.async_select_option("rbd")
-    assert new_type_select.current_option == "rbd"
+    rbd_label = [
+        label for key, label in battery_schedule_type_options() if key == "rbd"
+    ][0]
+    await new_type_select.async_select_option(rbd_label)
+    assert new_type_select.current_option == rbd_label
     assert editor.edit.schedule_type == "rbd"
 
     edit_start = BatteryScheduleEditStartTimeEntity(coord, config_entry)
@@ -668,7 +690,7 @@ async def test_battery_schedule_editor_entities_update_state_and_call_services(
 
     await refresh_button.async_press()
     await save_button.async_press()
-    await schedule_select.async_select_option("abc123")
+    await schedule_select.async_select_option(cfg_label)
     await delete_button.async_press()
     await save_button.async_press()
 
@@ -687,7 +709,7 @@ async def test_battery_schedule_editor_entities_update_state_and_call_services(
 
 
 @pytest.mark.asyncio
-async def test_battery_schedule_save_button_noops_without_selected_schedule(
+async def test_battery_schedule_save_button_updates_selected_schedule_by_default(
     hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:
     from custom_components.enphase_ev.button import BatteryScheduleSaveButton
@@ -710,7 +732,7 @@ async def test_battery_schedule_save_button_noops_without_selected_schedule(
 
     await save_button.async_press()
 
-    assert service_calls == []
+    assert service_calls == [(DOMAIN, "update_schedule")]
 
 
 @pytest.mark.asyncio
@@ -751,7 +773,9 @@ async def test_battery_schedule_editor_guard_paths_cover_missing_editor_and_fall
     assert schedule_select.available is False
     assert schedule_select.options == []
     assert schedule_select.current_option is None
-    assert new_type_select.options == ["cfg", "dtg", "rbd"]
+    assert new_type_select.options == [
+        label for _key, label in battery_schedule_type_options()
+    ]
     assert new_type_select.current_option is None
     assert edit_limit.available is False
     assert edit_limit.native_value is None
@@ -1292,6 +1316,26 @@ async def test_battery_schedule_services_cover_failure_paths(
                 }
             )
         )
+
+    coord.client.validate_battery_schedule = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=Mock(real_url="https://example.invalid"),
+            history=(),
+            status=403,
+            message="Forbidden",
+        )
+    )
+    assert (
+        await validate_schedule(
+            SimpleNamespace(
+                data={
+                    "config_entry_id": config_entry.entry_id,
+                    "schedule_type": "cfg",
+                }
+            )
+        )
+        == {}
+    )
 
     coord._battery_write_access_confirmed = False  # noqa: SLF001
     coord._battery_user_is_owner = False  # noqa: SLF001

--- a/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
+++ b/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.entity import EntityCategory
 from custom_components.enphase_ev.battery_schedule_editor import (
     BatteryScheduleEditorEntity,
     BatteryScheduleEditorManager,
+    BatteryScheduleRecord,
     NEW_SCHEDULE_OPTION,
     _normalize_days,
     _time_to_text,
@@ -243,6 +244,125 @@ def test_battery_schedule_editor_manager_syncs_and_resets_selection() -> None:
     unsub()
     manager.set_edit_limit(55)
     assert notifications
+
+
+def test_battery_schedule_editor_manager_promotes_created_match_and_duplicate_labels() -> (
+    None
+):
+    coord = SimpleNamespace(_battery_schedules_payload=_schedule_payload())
+    manager = BatteryScheduleEditorManager(coord)
+    manager.sync_from_coordinator()
+    manager.select_schedule(NEW_SCHEDULE_OPTION)
+    manager.set_new_schedule_type("cfg")
+    manager.set_edit_time("start_time", dt_time(1, 0))
+    manager.set_edit_time("end_time", dt_time(3, 30))
+    manager.set_edit_limit(90)
+    manager.set_edit_day("sun", False)
+    manager.set_edit_day("mon", True)
+    manager.set_edit_day("wed", True)
+    manager.set_edit_day("fri", True)
+
+    manager.sync_from_coordinator()
+
+    assert manager.edit.selected_schedule_id == "abc123"
+    assert manager.is_creating is False
+
+    coord._battery_schedules_payload = {
+        "cfg": {
+            "scheduleStatus": "active",
+            "details": [
+                {
+                    "scheduleId": "abc123",
+                    "startTime": "01:00:00",
+                    "endTime": "03:30:00",
+                    "limit": 90,
+                    "days": [1, 3, 5],
+                    "timezone": "Australia/Melbourne",
+                    "isEnabled": True,
+                },
+                {
+                    "scheduleId": "dup99999",
+                    "startTime": "01:00:00",
+                    "endTime": "03:30:00",
+                    "limit": 90,
+                    "days": [1, 3, 5],
+                    "timezone": "Australia/Melbourne",
+                    "isEnabled": True,
+                },
+            ],
+        }
+    }
+    manager.sync_from_coordinator()
+
+    labels = manager.option_label_by_schedule_id()
+    assert labels["abc123"].endswith("[abc123]")
+    assert labels["dup99999"].endswith("[dup99999]")
+    assert manager.schedule_id_for_option_label("missing") is None
+
+
+def test_battery_schedule_editor_manager_handles_missing_selection_without_fallback() -> (
+    None
+):
+    coord = SimpleNamespace(_battery_schedules_payload=_schedule_payload())
+    manager = BatteryScheduleEditorManager(coord)
+    notifications: list[str] = []
+    manager.async_add_listener(lambda: notifications.append("updated"))
+    manager.sync_from_coordinator()
+
+    manager.edit.create_mode = False
+    manager.edit.selected_schedule_id = "ghost"
+    coord._battery_schedules_payload = {
+        "cfg": {"scheduleStatus": "active", "details": []}
+    }
+    manager.sync_from_coordinator()
+
+    assert manager.is_creating is True
+    assert manager.edit.selected_schedule_id is None
+    assert notifications
+
+    notifications.clear()
+    coord._battery_schedules_payload = {
+        "cfg": {
+            "scheduleStatus": "active",
+            "details": [
+                {
+                    "scheduleId": "abc123",
+                    "startTime": "01:00:00",
+                    "endTime": "03:30:00",
+                    "limit": 90,
+                    "days": [1, 3, 5],
+                    "timezone": "Australia/Melbourne",
+                    "isEnabled": True,
+                }
+            ],
+        }
+    }
+    manager.edit.create_mode = False
+    manager.edit.selected_schedule_id = None
+    coord._battery_schedules_payload = {
+        "cfg": {"scheduleStatus": "active", "details": []}
+    }
+    manager.sync_from_coordinator()
+
+    assert notifications == ["updated"]
+
+
+def test_battery_schedule_option_label_falls_back_for_unknown_type() -> None:
+    label = battery_schedule_option_label(
+        BatteryScheduleRecord(
+            schedule_id="mystery",
+            schedule_type=" ",
+            start_time="09:00",
+            end_time="10:00",
+            limit=None,
+            days=[],
+            timezone=None,
+            enabled=None,
+            schedule_status=None,
+        )
+    )
+
+    assert label == "Schedule 09:00-10:00"
 
 
 @pytest.mark.asyncio
@@ -733,6 +853,46 @@ async def test_battery_schedule_save_button_updates_selected_schedule_by_default
     await save_button.async_press()
 
     assert service_calls == [(DOMAIN, "update_schedule")]
+
+
+@pytest.mark.asyncio
+async def test_battery_schedule_select_and_buttons_cover_missing_selection_paths(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.button import BatteryScheduleSaveButton
+    from custom_components.enphase_ev.select import (
+        BatteryNewScheduleTypeSelect,
+        BatteryScheduleSelect,
+    )
+
+    coord = coordinator_factory()
+    _prepare_battery_schedule_coord(coord)
+    editor = _attach_editor_runtime(config_entry, coord)
+
+    service_calls: list[tuple[str, str]] = []
+
+    async def fake_async_call(
+        self, domain, service, service_data=None, blocking=False, **kwargs
+    ):
+        service_calls.append((domain, service))
+
+    monkeypatch.setattr(hass.services.__class__, "async_call", fake_async_call)
+
+    schedule_select = BatteryScheduleSelect(coord, config_entry)
+    schedule_select.hass = hass
+    editor.edit.selected_schedule_id = "ghost"
+    assert schedule_select.current_option is None
+
+    save_button = BatteryScheduleSaveButton(coord, config_entry)
+    save_button.hass = hass
+    editor.edit.create_mode = False
+    editor.edit.selected_schedule_id = None
+    await save_button.async_press()
+    assert service_calls == []
+
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    no_editor_type_select = BatteryNewScheduleTypeSelect(coord, config_entry)
+    await no_editor_type_select.async_select_option("Charge From Grid Schedule")
 
 
 @pytest.mark.asyncio
@@ -1336,6 +1496,24 @@ async def test_battery_schedule_services_cover_failure_paths(
         )
         == {}
     )
+
+    coord.client.validate_battery_schedule = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=Mock(real_url="https://example.invalid"),
+            history=(),
+            status=500,
+            message="Boom",
+        )
+    )
+    with pytest.raises(aiohttp.ClientResponseError, match="Boom"):
+        await validate_schedule(
+            SimpleNamespace(
+                data={
+                    "config_entry_id": config_entry.entry_id,
+                    "schedule_type": "cfg",
+                }
+            )
+        )
 
     coord._battery_write_access_confirmed = False  # noqa: SLF001
     coord._battery_user_is_owner = False  # noqa: SLF001

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -1114,6 +1114,33 @@ def test_heatpump_sg_ready_active_binary_sensor_handles_runtime_uid_errors(
     assert sensor.available is False
 
 
+def test_heatpump_sg_ready_active_binary_sensor_requires_runtime_uid(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[], data={})
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "type_label": "Heat Pump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    coord._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-1",
+        "sg_ready_mode_raw": "MODE_2",
+        "sg_ready_mode_label": "Normal",
+        "sg_ready_active": True,
+    }
+    monkeypatch.setattr(coord, "_heatpump_runtime_device_uid", lambda: "")
+
+    sensor = HeatPumpSgReadyActiveBinarySensor(coord)
+    assert sensor.available is False
+
+
 def test_site_cloud_reachable_binary_sensor_fallback_paths(
     coordinator_factory, monkeypatch
 ) -> None:

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1410,6 +1410,8 @@ def test_battery_property_false_paths(hass, monkeypatch) -> None:
     coord._battery_envoy_supports_vls = True  # noqa: SLF001
     coord._battery_very_low_soc = None  # noqa: SLF001
     assert coord.battery_shutdown_level_available is False
+    coord._battery_limit_support = False  # noqa: SLF001
+    assert coord.battery_shutdown_level_available is False
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_labels.py
+++ b/tests/components/enphase_ev/test_labels.py
@@ -83,3 +83,34 @@ def test_unknown_label_paths_return_none_when_display_text_collapses() -> None:
     assert labels.charge_mode_label("_") is None
     assert labels.status_label(None) is None
     assert labels.status_label("mystery_status") is None
+
+
+def test_entity_translation_value_and_schedule_type_label_fallbacks(
+    monkeypatch,
+) -> None:
+    def _fake_get_cached_translations(_hass, language, _category, _integration):
+        if language == "en":
+            return {
+                "component.enphase_ev.entity.switch.charge_from_grid_schedule.name": "Charge Battery From Grid",
+            }
+        return {}
+
+    monkeypatch.setattr(
+        labels, "async_get_cached_translations", _fake_get_cached_translations
+    )
+    hass = SimpleNamespace(config=SimpleNamespace(language="fr"))
+
+    assert (
+        labels._entity_translation_value(None, "switch", "charge_from_grid") is None
+    )  # noqa: SLF001
+    assert (
+        labels._entity_translation_value(hass, "switch", "charge_from_grid_schedule")
+        == "Charge Battery From Grid"
+    )
+    assert labels._entity_translation_value(hass, "switch", "missing_key") is None
+    assert labels.battery_schedule_type_label(None, hass=hass) is None
+    assert (
+        labels.battery_schedule_type_label("cfg", hass=hass)
+        == "Charge Battery From Grid"
+    )
+    assert labels.battery_schedule_type_label("custom_mode", hass=hass) == "Custom Mode"

--- a/tests/components/enphase_ev/test_number_module.py
+++ b/tests/components/enphase_ev/test_number_module.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from custom_components.enphase_ev.const import OPT_BATTERY_SCHEDULES_ENABLED
 from custom_components.enphase_ev.number import (
     BatteryCfgScheduleLimitNumber,
     BatteryDischargeToGridScheduleLimitNumber,
@@ -16,6 +17,34 @@ from custom_components.enphase_ev.number import (
 )
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
+
+
+def _enable_battery_schedule_limits(coord) -> None:
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord.client.battery_schedules = AsyncMock()
+    coord.client.create_battery_schedule = AsyncMock()
+    coord.client.update_battery_schedule = AsyncMock()
+    coord.client.delete_battery_schedule = AsyncMock()
+    capability = coord.battery_runtime._parse_battery_control_capability  # noqa: SLF001
+    coord._battery_cfg_control = capability(  # noqa: SLF001
+        {"show": True, "showDaySchedule": True, "scheduleSupported": True}
+    )
+    coord._battery_cfg_schedule_id = "sched-cfg"  # noqa: SLF001
+    coord._battery_charge_begin_time = 120  # noqa: SLF001
+    coord._battery_charge_end_time = 300  # noqa: SLF001
+    coord._battery_dtg_control = capability(  # noqa: SLF001
+        {"show": True, "showDaySchedule": True, "scheduleSupported": True}
+    )
+    coord._battery_dtg_schedule_id = "sched-dtg"  # noqa: SLF001
+    coord._battery_dtg_begin_time = 60  # noqa: SLF001
+    coord._battery_dtg_end_time = 120  # noqa: SLF001
+    coord._battery_rbd_control = capability(  # noqa: SLF001
+        {"show": True, "showDaySchedule": True, "scheduleSupported": True}
+    )
+    coord._battery_rbd_schedule_id = "sched-rbd"  # noqa: SLF001
+    coord._battery_rbd_begin_time = 180  # noqa: SLF001
+    coord._battery_rbd_end_time = 240  # noqa: SLF001
 
 
 def test_evse_resolved_charge_mode_handles_data_access_failure() -> None:
@@ -134,6 +163,7 @@ def test_dtg_and_rbd_schedule_edit_available_cover_control_window_fallbacks() ->
 def test_number_helper_fallbacks_and_retained_site_unique_ids() -> None:
     from custom_components.enphase_ev import number as number_mod
 
+    entry = SimpleNamespace(options={OPT_BATTERY_SCHEDULES_ENABLED: True})
     coord = SimpleNamespace(
         site_id="site",
         inventory_view=SimpleNamespace(
@@ -172,7 +202,7 @@ def test_number_helper_fallbacks_and_retained_site_unique_ids() -> None:
 
     assert number_mod._type_available(coord, "encharge") is True
     assert number_mod._battery_write_access_confirmed(coord) is True
-    assert number_mod._retained_site_number_unique_ids(coord) == {
+    assert number_mod._retained_site_number_unique_ids(coord, entry) == {
         "enphase_ev_site_site_battery_reserve",
         "enphase_ev_site_site_battery_shutdown_level",
         "enphase_ev_site_site_battery_cfg_schedule_limit",
@@ -182,7 +212,7 @@ def test_number_helper_fallbacks_and_retained_site_unique_ids() -> None:
 
     coord.battery_write_access_confirmed = False
     assert number_mod._battery_write_access_confirmed(coord) is True
-    assert number_mod._retained_site_number_unique_ids(coord) == {
+    assert number_mod._retained_site_number_unique_ids(coord, entry) == {
         "enphase_ev_site_site_battery_reserve",
         "enphase_ev_site_site_battery_shutdown_level",
         "enphase_ev_site_site_battery_cfg_schedule_limit",
@@ -193,12 +223,138 @@ def test_number_helper_fallbacks_and_retained_site_unique_ids() -> None:
     coord.battery_user_is_owner = False
     coord.battery_user_is_installer = False
     assert number_mod._battery_write_access_confirmed(coord) is False
-    assert number_mod._retained_site_number_unique_ids(coord) == set()
+    assert number_mod._retained_site_number_unique_ids(coord, entry) == set()
+
+
+def test_retained_site_number_unique_ids_hide_dedicated_schedule_limits_when_editor_active() -> (
+    None
+):
+    from custom_components.enphase_ev import number as number_mod
+
+    entry = SimpleNamespace(options={OPT_BATTERY_SCHEDULES_ENABLED: True})
+    coord = SimpleNamespace(
+        site_id="site",
+        inventory_view=SimpleNamespace(
+            has_type_for_entities=lambda type_key: type_key == "encharge"
+        ),
+        client=SimpleNamespace(
+            battery_schedules=lambda: None,
+            create_battery_schedule=lambda: None,
+            update_battery_schedule=lambda: None,
+            delete_battery_schedule=lambda: None,
+        ),
+        battery_write_access_confirmed=None,
+        battery_user_is_owner=True,
+        battery_user_is_installer=False,
+        battery_reserve_editable=True,
+        battery_shutdown_level_available=True,
+        charge_from_grid_schedule_available=False,
+        charge_from_grid_control_available=True,
+        charge_from_grid_schedule_supported=True,
+        _battery_cfg_schedule_id="sched-cfg",
+        battery_charge_from_grid_start_time=1,
+        battery_charge_from_grid_end_time=2,
+        _battery_charge_begin_time=None,
+        _battery_charge_end_time=None,
+        discharge_to_grid_schedule_available=False,
+        discharge_to_grid_schedule_supported=True,
+        battery_discharge_to_grid_start_time=3,
+        battery_discharge_to_grid_end_time=4,
+        _battery_dtg_begin_time=None,
+        _battery_dtg_end_time=None,
+        _battery_dtg_control_begin_time=None,
+        _battery_dtg_control_end_time=None,
+        restrict_battery_discharge_schedule_available=False,
+        restrict_battery_discharge_schedule_supported=True,
+        battery_restrict_battery_discharge_start_time=5,
+        battery_restrict_battery_discharge_end_time=6,
+        _battery_rbd_begin_time=None,
+        _battery_rbd_end_time=None,
+        _battery_rbd_control_begin_time=None,
+        _battery_rbd_control_end_time=None,
+    )
+
+    assert number_mod._retained_site_number_unique_ids(coord, entry) == {
+        "enphase_ev_site_site_battery_reserve",
+        "enphase_ev_site_site_battery_shutdown_level",
+        "enphase_ev_site_site_battery_schedule_edit_limit",
+    }
+
+
+def test_retained_site_number_unique_ids_keeps_shutdown_number_when_unavailable() -> (
+    None
+):
+    from custom_components.enphase_ev import number as number_mod
+
+    coord = SimpleNamespace(
+        site_id="site",
+        client=SimpleNamespace(),
+        battery_write_access_confirmed=True,
+        battery_reserve_editable=False,
+        battery_shutdown_level_available=False,
+        charge_from_grid_control_available=False,
+        battery_charge_from_grid_start_time=None,
+        battery_charge_from_grid_end_time=None,
+        _battery_charge_begin_time=None,
+        _battery_charge_end_time=None,
+        _battery_cfg_control_begin_time=None,
+        _battery_cfg_control_end_time=None,
+        discharge_to_grid_schedule_available=False,
+        discharge_to_grid_schedule_supported=False,
+        battery_discharge_to_grid_start_time=None,
+        battery_discharge_to_grid_end_time=None,
+        _battery_dtg_begin_time=None,
+        _battery_dtg_end_time=None,
+        _battery_dtg_control_begin_time=None,
+        _battery_dtg_control_end_time=None,
+        restrict_battery_discharge_schedule_available=False,
+        restrict_battery_discharge_schedule_supported=False,
+        battery_restrict_battery_discharge_start_time=None,
+        battery_restrict_battery_discharge_end_time=None,
+        _battery_rbd_begin_time=None,
+        _battery_rbd_end_time=None,
+        _battery_rbd_control_begin_time=None,
+        _battery_rbd_control_end_time=None,
+    )
+    setattr(coord, "_site_has_battery", True)
+    coord._type_entries = {"encharge": [object()]}
+
+    assert number_mod._retained_site_number_unique_ids(coord) == {
+        "enphase_ev_site_site_battery_shutdown_level"
+    }
+
+
+def test_retained_site_number_unique_ids_hide_schedule_limits_when_scheduler_disabled() -> (
+    None
+):
+    from custom_components.enphase_ev import number as number_mod
+
+    coord = SimpleNamespace(
+        site_id="site",
+        inventory_view=SimpleNamespace(
+            has_type_for_entities=lambda type_key: type_key == "encharge"
+        ),
+        battery_write_access_confirmed=True,
+        battery_reserve_editable=False,
+        charge_from_grid_schedule_available=True,
+        discharge_to_grid_schedule_available=True,
+        restrict_battery_discharge_schedule_available=True,
+    )
+
+    assert number_mod._retained_site_number_unique_ids(
+        coord, SimpleNamespace(options={OPT_BATTERY_SCHEDULES_ENABLED: False})
+    ) == {
+        "enphase_ev_site_site_battery_shutdown_level",
+        "enphase_ev_site_site_battery_cfg_schedule_limit",
+        "enphase_ev_site_site_battery_dtg_schedule_limit",
+        "enphase_ev_site_site_battery_rbd_schedule_limit",
+    }
 
 
 @pytest.mark.asyncio
 async def test_async_setup_entry_syncs_new_serials(hass, config_entry) -> None:
     coord = SimpleNamespace()
+    object.__setattr__(config_entry, "options", {OPT_BATTERY_SCHEDULES_ENABLED: True})
     coord.site_id = "123456"
     coord.battery_write_access_confirmed = True
     coord.serials = {RANDOM_SERIAL}
@@ -227,10 +383,11 @@ async def test_async_setup_entry_syncs_new_serials(hass, config_entry) -> None:
     }
     assert any(isinstance(ent, BatteryReserveNumber) for ent in added)
     assert any(isinstance(ent, BatteryShutdownLevelNumber) for ent in added)
-    assert any(
+    assert not any(isinstance(ent, BatteryCfgScheduleLimitNumber) for ent in added)
+    assert not any(
         isinstance(ent, BatteryDischargeToGridScheduleLimitNumber) for ent in added
     )
-    assert any(
+    assert not any(
         isinstance(ent, BatteryRestrictBatteryDischargeScheduleLimitNumber)
         for ent in added
     )
@@ -238,9 +395,63 @@ async def test_async_setup_entry_syncs_new_serials(hass, config_entry) -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_setup_entry_does_not_duplicate_rbd_limit_when_schedule_becomes_editable(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    object.__setattr__(config_entry, "options", {OPT_BATTERY_SCHEDULES_ENABLED: True})
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_rbd_control = (
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {"show": True, "showDaySchedule": True, "scheduleSupported": True}
+        )
+    )
+    coord._battery_rbd_schedule_id = None  # noqa: SLF001
+    coord._battery_rbd_begin_time = None  # noqa: SLF001
+    coord._battery_rbd_end_time = None  # noqa: SLF001
+    callbacks: list = []
+    added: list = []
+
+    monkeypatch.setattr(
+        coord,
+        "async_add_listener",
+        lambda callback: callbacks.append(callback) or (lambda: None),
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda entities, update_before_add=False: added.extend(entities),
+    )
+
+    initial_rbd_entities = [
+        ent
+        for ent in added
+        if isinstance(ent, BatteryRestrictBatteryDischargeScheduleLimitNumber)
+    ]
+    assert len(initial_rbd_entities) == 0
+
+    coord._battery_rbd_schedule_id = "sched-rbd"  # noqa: SLF001
+    coord._battery_rbd_begin_time = 60  # noqa: SLF001
+    coord._battery_rbd_end_time = 960  # noqa: SLF001
+
+    callbacks[0]()
+
+    later_rbd_entities = [
+        ent
+        for ent in added
+        if isinstance(ent, BatteryRestrictBatteryDischargeScheduleLimitNumber)
+    ]
+    assert len(later_rbd_entities) == 0
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_handles_no_serials(hass, config_entry) -> None:
     """No new serials should short-circuit without adding entities."""
     coord = SimpleNamespace()
+    object.__setattr__(config_entry, "options", {OPT_BATTERY_SCHEDULES_ENABLED: True})
     coord.site_id = "123456"
     coord.battery_write_access_confirmed = True
     coord.serials = set()
@@ -258,14 +469,68 @@ async def test_async_setup_entry_handles_no_serials(hass, config_entry) -> None:
 
     await async_setup_entry(hass, config_entry, _capture)
 
-    assert len(added) == 5
+    assert len(added) == 2
     assert any(isinstance(ent, BatteryReserveNumber) for ent in added)
     assert any(isinstance(ent, BatteryShutdownLevelNumber) for ent in added)
+    assert not any(isinstance(ent, BatteryCfgScheduleLimitNumber) for ent in added)
+    assert not any(
+        isinstance(ent, BatteryDischargeToGridScheduleLimitNumber) for ent in added
+    )
+    assert not any(
+        isinstance(ent, BatteryRestrictBatteryDischargeScheduleLimitNumber)
+        for ent in added
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_adds_dedicated_dtg_rbd_limits_when_scheduler_disabled(
+    hass, config_entry, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    _enable_battery_schedule_limits(coord)
+    object.__setattr__(config_entry, "options", {OPT_BATTERY_SCHEDULES_ENABLED: False})
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    added = []
+
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda entities, update_before_add=False: added.extend(entities),
+    )
+
     assert any(isinstance(ent, BatteryCfgScheduleLimitNumber) for ent in added)
     assert any(
         isinstance(ent, BatteryDischargeToGridScheduleLimitNumber) for ent in added
     )
     assert any(
+        isinstance(ent, BatteryRestrictBatteryDischargeScheduleLimitNumber)
+        for ent in added
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_hides_cfg_limit_when_scheduler_editor_enabled(
+    hass, config_entry, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    _enable_battery_schedule_limits(coord)
+    object.__setattr__(config_entry, "options", {OPT_BATTERY_SCHEDULES_ENABLED: True})
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    added = []
+
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda entities, update_before_add=False: added.extend(entities),
+    )
+
+    assert not any(isinstance(ent, BatteryCfgScheduleLimitNumber) for ent in added)
+    assert not any(
+        isinstance(ent, BatteryDischargeToGridScheduleLimitNumber) for ent in added
+    )
+    assert not any(
         isinstance(ent, BatteryRestrictBatteryDischargeScheduleLimitNumber)
         for ent in added
     )

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -96,7 +96,7 @@ def test_switch_helper_fallbacks_and_retained_site_keys() -> None:
         charge_from_grid_control_available=True,
         charge_from_grid_force_schedule_available=True,
         discharge_to_grid_schedule_available=True,
-        restrict_battery_discharge_schedule_available=True,
+        restrict_battery_discharge_schedule_supported=True,
     )
 
     assert switch_mod._type_available(coord, "envoy") is True
@@ -2022,6 +2022,35 @@ def test_restrict_battery_discharge_schedule_switch_availability(
 
     sw = RestrictBatteryDischargeScheduleSwitch(coord)
 
+    assert sw.available is True
+    assert sw.is_on is True
+
+
+def test_restrict_battery_discharge_schedule_switch_available_without_schedule(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_rbd_control = (
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {
+                "show": True,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "enabled": True,
+                "locked": False,
+            }
+        )
+    )
+    coord._battery_rbd_schedule_id = None  # noqa: SLF001
+    coord._battery_rbd_begin_time = None  # noqa: SLF001
+    coord._battery_rbd_end_time = None  # noqa: SLF001
+    coord._battery_rbd_schedule_enabled = True  # noqa: SLF001
+
+    sw = RestrictBatteryDischargeScheduleSwitch(coord)
+
+    assert coord.restrict_battery_discharge_schedule_available is False
+    assert coord.restrict_battery_discharge_schedule_supported is True
     assert sw.available is True
     assert sw.is_on is True
 

--- a/tests/components/enphase_ev/test_time_module.py
+++ b/tests/components/enphase_ev/test_time_module.py
@@ -157,6 +157,43 @@ def test_dtg_and_rbd_schedule_edit_available_cover_control_window_fallbacks() ->
     assert time_mod._rbd_schedule_edit_available(rbd) is True
 
 
+def test_default_schedule_time_for_create_and_named_entities_cover_fallbacks(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev import time as time_mod
+
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_rbd_control = (
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {"show": True, "showDaySchedule": True, "scheduleSupported": True}
+        )
+    )
+    coord._battery_rbd_control_begin_time = 60  # noqa: SLF001
+    coord._battery_rbd_control_end_time = 960  # noqa: SLF001
+    coord._battery_rbd_begin_time = None  # noqa: SLF001
+    coord._battery_rbd_end_time = None  # noqa: SLF001
+    coord._battery_dtg_control = (
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {"show": True, "showDaySchedule": True, "scheduleSupported": True}
+        )
+    )
+    coord._battery_dtg_control_begin_time = None  # noqa: SLF001
+    coord._battery_dtg_control_end_time = None  # noqa: SLF001
+    coord._battery_dtg_begin_time = None  # noqa: SLF001
+    coord._battery_dtg_end_time = None  # noqa: SLF001
+
+    assert time_mod._default_schedule_time_for_create("dtg") is None
+
+    rbd_start = RestrictBatteryDischargeStartTimeEntity(coord)
+    rbd_end = RestrictBatteryDischargeEndTimeEntity(coord)
+    dtg_start = DischargeToGridStartTimeEntity(coord)
+    assert rbd_start.native_value == dt_time(1, 0)
+    assert rbd_end.native_value == dt_time(16, 0)
+    assert dtg_start.native_value is None
+
+
 def test_retained_site_time_unique_ids_cover_each_schedule_family() -> None:
     from custom_components.enphase_ev import time as time_mod
 

--- a/tests/components/enphase_ev/test_time_module.py
+++ b/tests/components/enphase_ev/test_time_module.py
@@ -6,9 +6,12 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from custom_components.enphase_ev.const import OPT_BATTERY_SCHEDULES_ENABLED
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
 from custom_components.enphase_ev.time import (
     _migrated_time_entity_id,
+    BatteryScheduleEditEndTimeEntity,
+    BatteryScheduleEditStartTimeEntity,
     ChargeFromGridEndTimeEntity,
     ChargeFromGridStartTimeEntity,
     DischargeToGridEndTimeEntity,
@@ -17,6 +20,31 @@ from custom_components.enphase_ev.time import (
     RestrictBatteryDischargeStartTimeEntity,
     async_setup_entry,
 )
+
+
+def _enable_battery_schedule_controls(coord) -> None:
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord.client.battery_schedules = AsyncMock()
+    coord.client.create_battery_schedule = AsyncMock()
+    coord.client.update_battery_schedule = AsyncMock()
+    coord.client.delete_battery_schedule = AsyncMock()
+    capability = coord.battery_runtime._parse_battery_control_capability  # noqa: SLF001
+    coord._battery_cfg_control = capability(  # noqa: SLF001
+        {"show": True, "showDaySchedule": True, "scheduleSupported": True}
+    )
+    coord._battery_charge_begin_time = 60  # noqa: SLF001
+    coord._battery_charge_end_time = 120  # noqa: SLF001
+    coord._battery_dtg_control = capability(  # noqa: SLF001
+        {"show": True, "showDaySchedule": True, "scheduleSupported": True}
+    )
+    coord._battery_dtg_control_begin_time = 180  # noqa: SLF001
+    coord._battery_dtg_control_end_time = 240  # noqa: SLF001
+    coord._battery_rbd_control = capability(  # noqa: SLF001
+        {"show": True, "showDaySchedule": True, "scheduleSupported": True}
+    )
+    coord._battery_rbd_control_begin_time = 300  # noqa: SLF001
+    coord._battery_rbd_control_end_time = 360  # noqa: SLF001
 
 
 def test_time_type_available_uses_inventory_view() -> None:
@@ -118,7 +146,7 @@ def test_dtg_and_rbd_schedule_edit_available_cover_control_window_fallbacks() ->
     )
     assert time_mod._rbd_schedule_edit_available(rbd) is True
     rbd._battery_rbd_control_end_time = None
-    assert time_mod._rbd_schedule_edit_available(rbd) is False
+    assert time_mod._rbd_schedule_edit_available(rbd) is True
 
     rbd.restrict_battery_discharge_schedule_supported = False
     assert time_mod._rbd_schedule_edit_available(rbd) is False
@@ -132,6 +160,7 @@ def test_dtg_and_rbd_schedule_edit_available_cover_control_window_fallbacks() ->
 def test_retained_site_time_unique_ids_cover_each_schedule_family() -> None:
     from custom_components.enphase_ev import time as time_mod
 
+    entry = SimpleNamespace(options={OPT_BATTERY_SCHEDULES_ENABLED: False})
     coord = SimpleNamespace(
         site_id="site",
         has_type=lambda type_key: type_key == "encharge",
@@ -161,7 +190,7 @@ def test_retained_site_time_unique_ids_cover_each_schedule_family() -> None:
         _battery_rbd_control_end_time=None,
     )
 
-    assert time_mod._retained_site_time_unique_ids(coord) == {
+    assert time_mod._retained_site_time_unique_ids(coord, entry) == {
         "enphase_ev_site_site_charge_from_grid_start_time",
         "enphase_ev_site_site_charge_from_grid_end_time",
         "enphase_ev_site_site_discharge_to_grid_start_time",
@@ -171,7 +200,34 @@ def test_retained_site_time_unique_ids_cover_each_schedule_family() -> None:
     }
 
     coord.inventory_view.has_type_for_entities = lambda _type_key: False
-    assert time_mod._retained_site_time_unique_ids(coord) == set()
+    assert time_mod._retained_site_time_unique_ids(coord, entry) == set()
+
+
+def test_retained_site_time_unique_ids_empty_when_scheduler_disabled() -> None:
+    from custom_components.enphase_ev import time as time_mod
+
+    coord = SimpleNamespace(
+        site_id="site",
+        inventory_view=SimpleNamespace(
+            has_type_for_entities=lambda type_key: type_key == "encharge"
+        ),
+        charge_from_grid_schedule_available=True,
+        discharge_to_grid_schedule_available=True,
+        restrict_battery_discharge_schedule_supported=True,
+        client=SimpleNamespace(
+            battery_schedules=lambda: None,
+            create_battery_schedule=lambda: None,
+            update_battery_schedule=lambda: None,
+            delete_battery_schedule=lambda: None,
+        ),
+    )
+
+    assert time_mod._retained_site_time_unique_ids(
+        coord, SimpleNamespace(options={OPT_BATTERY_SCHEDULES_ENABLED: True})
+    ) == {
+        "enphase_ev_site_site_battery_schedule_edit_start_time",
+        "enphase_ev_site_site_battery_schedule_edit_end_time",
+    }
 
 
 def test_migrated_time_entity_id_handles_strong_migration_and_auto_suffix() -> None:
@@ -238,6 +294,8 @@ async def test_async_setup_entry_adds_site_time_entities(
     hass, config_entry, coordinator_factory
 ) -> None:
     coord = coordinator_factory()
+    _enable_battery_schedule_controls(coord)
+    object.__setattr__(config_entry, "options", {OPT_BATTERY_SCHEDULES_ENABLED: True})
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     added = []
@@ -247,14 +305,134 @@ async def test_async_setup_entry_adds_site_time_entities(
 
     await async_setup_entry(hass, config_entry, _capture)
 
-    assert any(isinstance(ent, ChargeFromGridStartTimeEntity) for ent in added)
-    assert any(isinstance(ent, ChargeFromGridEndTimeEntity) for ent in added)
+    assert not any(isinstance(ent, ChargeFromGridStartTimeEntity) for ent in added)
+    assert not any(isinstance(ent, ChargeFromGridEndTimeEntity) for ent in added)
+    assert not any(isinstance(ent, DischargeToGridStartTimeEntity) for ent in added)
+    assert not any(isinstance(ent, DischargeToGridEndTimeEntity) for ent in added)
+    assert not any(
+        isinstance(ent, RestrictBatteryDischargeStartTimeEntity) for ent in added
+    )
+    assert not any(
+        isinstance(ent, RestrictBatteryDischargeEndTimeEntity) for ent in added
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_adds_time_entities_after_inventory_arrives(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    _enable_battery_schedule_controls(coord)
+    object.__setattr__(config_entry, "options", {OPT_BATTERY_SCHEDULES_ENABLED: True})
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    added: list = []
+    callbacks: list = []
+    inventory_ready = False
+
+    coord.inventory_view.has_type_for_entities = lambda _type_key: inventory_ready
+    monkeypatch.setattr(
+        coord,
+        "async_add_topology_listener",
+        lambda callback: callbacks.append(callback) or (lambda: None),
+    )
+    monkeypatch.setattr(
+        coord,
+        "async_add_listener",
+        lambda callback: callbacks.append(callback) or (lambda: None),
+    )
+
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda entities, update_before_add=False: added.extend(entities),
+    )
+
+    assert not added
+
+    inventory_ready = True
+    for callback in callbacks:
+        callback()
+
+    assert not any(isinstance(ent, ChargeFromGridStartTimeEntity) for ent in added)
+    assert not any(isinstance(ent, DischargeToGridStartTimeEntity) for ent in added)
+    assert not any(
+        isinstance(ent, RestrictBatteryDischargeStartTimeEntity) for ent in added
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_adds_dedicated_dtg_rbd_times_when_scheduler_disabled(
+    hass, config_entry, coordinator_factory
+) -> None:
+    coord = coordinator_factory()
+    _enable_battery_schedule_controls(coord)
+    object.__setattr__(config_entry, "options", {OPT_BATTERY_SCHEDULES_ENABLED: False})
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    added = []
+
+    await async_setup_entry(
+        hass,
+        config_entry,
+        lambda entities, update_before_add=False: added.extend(entities),
+    )
+
     assert any(isinstance(ent, DischargeToGridStartTimeEntity) for ent in added)
     assert any(isinstance(ent, DischargeToGridEndTimeEntity) for ent in added)
     assert any(
         isinstance(ent, RestrictBatteryDischargeStartTimeEntity) for ent in added
     )
-    assert any(isinstance(ent, RestrictBatteryDischargeEndTimeEntity) for ent in added)
+    assert any(isinstance(ent, ChargeFromGridStartTimeEntity) for ent in added)
+    assert any(isinstance(ent, ChargeFromGridEndTimeEntity) for ent in added)
+
+
+def test_retained_site_time_unique_ids_hide_all_dedicated_schedule_times_when_editor_active() -> (
+    None
+):
+    from custom_components.enphase_ev import time as time_mod
+
+    entry = SimpleNamespace(options={OPT_BATTERY_SCHEDULES_ENABLED: True})
+    coord = SimpleNamespace(
+        site_id="site",
+        inventory_view=SimpleNamespace(
+            has_type_for_entities=lambda type_key: type_key == "encharge"
+        ),
+        client=SimpleNamespace(
+            battery_schedules=lambda: None,
+            create_battery_schedule=lambda: None,
+            update_battery_schedule=lambda: None,
+            delete_battery_schedule=lambda: None,
+        ),
+        charge_from_grid_schedule_available=False,
+        charge_from_grid_control_available=True,
+        charge_from_grid_schedule_supported=True,
+        _battery_cfg_schedule_id="sched-cfg",
+        battery_charge_from_grid_start_time=dt_time(1, 0),
+        battery_charge_from_grid_end_time=dt_time(2, 0),
+        _battery_charge_begin_time=None,
+        _battery_charge_end_time=None,
+        discharge_to_grid_schedule_available=False,
+        discharge_to_grid_schedule_supported=True,
+        battery_discharge_to_grid_start_time=dt_time(3, 0),
+        battery_discharge_to_grid_end_time=dt_time(4, 0),
+        _battery_dtg_begin_time=None,
+        _battery_dtg_end_time=None,
+        _battery_dtg_control_begin_time=None,
+        _battery_dtg_control_end_time=None,
+        restrict_battery_discharge_schedule_available=False,
+        restrict_battery_discharge_schedule_supported=True,
+        battery_restrict_battery_discharge_start_time=dt_time(5, 0),
+        battery_restrict_battery_discharge_end_time=dt_time(6, 0),
+        _battery_rbd_begin_time=None,
+        _battery_rbd_end_time=None,
+        _battery_rbd_control_begin_time=None,
+        _battery_rbd_control_end_time=None,
+    )
+
+    assert time_mod._retained_site_time_unique_ids(coord, entry) == {
+        "enphase_ev_site_site_battery_schedule_edit_start_time",
+        "enphase_ev_site_site_battery_schedule_edit_end_time",
+    }
 
 
 @pytest.mark.asyncio
@@ -530,6 +708,8 @@ async def test_async_setup_entry_does_not_duplicate_site_time_entities_on_listen
     hass, config_entry, coordinator_factory
 ) -> None:
     coord = coordinator_factory()
+    _enable_battery_schedule_controls(coord)
+    object.__setattr__(config_entry, "options", {OPT_BATTERY_SCHEDULES_ENABLED: True})
     callbacks: list = []
 
     def _capture_listener(callback):
@@ -546,21 +726,35 @@ async def test_async_setup_entry_does_not_duplicate_site_time_entities_on_listen
 
     await async_setup_entry(hass, config_entry, _capture)
     assert (
-        len([ent for ent in added if isinstance(ent, ChargeFromGridStartTimeEntity)])
+        len(
+            [
+                ent
+                for ent in added
+                if isinstance(ent, BatteryScheduleEditStartTimeEntity)
+            ]
+        )
         == 1
     )
     assert (
-        len([ent for ent in added if isinstance(ent, ChargeFromGridEndTimeEntity)]) == 1
+        len([ent for ent in added if isinstance(ent, BatteryScheduleEditEndTimeEntity)])
+        == 1
     )
     assert callbacks
 
     callbacks[0]()
     assert (
-        len([ent for ent in added if isinstance(ent, ChargeFromGridStartTimeEntity)])
+        len(
+            [
+                ent
+                for ent in added
+                if isinstance(ent, BatteryScheduleEditStartTimeEntity)
+            ]
+        )
         == 1
     )
     assert (
-        len([ent for ent in added if isinstance(ent, ChargeFromGridEndTimeEntity)]) == 1
+        len([ent for ent in added if isinstance(ent, BatteryScheduleEditEndTimeEntity)])
+        == 1
     )
 
 
@@ -715,6 +909,7 @@ async def test_base_named_battery_schedule_time_entity_fallbacks(
     entity = time_mod._BaseNamedBatteryScheduleTimeEntity(
         coord,
         suffix="custom_schedule_time",
+        schedule_type="custom",
         availability_check=lambda _: True,
         value_attr="custom_schedule_time",
         setter_name="async_custom_schedule_time",
@@ -749,6 +944,7 @@ def test_base_named_battery_schedule_time_entity_extra_state_attributes_empty(
     entity = time_mod._BaseNamedBatteryScheduleTimeEntity(
         coord,
         suffix="custom_schedule_time",
+        schedule_type="custom",
         availability_check=lambda _: True,
         value_attr="custom_schedule_time",
         setter_name="async_custom_schedule_time",
@@ -979,6 +1175,29 @@ async def test_restrict_battery_discharge_time_entities_availability_and_setters
     coord.async_set_restrict_battery_discharge_schedule_time.assert_awaited_with(
         end=dt_time(15, 30)
     )
+
+
+def test_restrict_battery_discharge_time_entities_default_without_schedule(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_rbd_control = (
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {"show": True, "showDaySchedule": True, "scheduleSupported": True}
+        )
+    )
+    coord._battery_rbd_schedule_id = None  # noqa: SLF001
+    coord._battery_rbd_begin_time = None  # noqa: SLF001
+    coord._battery_rbd_end_time = None  # noqa: SLF001
+
+    start = RestrictBatteryDischargeStartTimeEntity(coord)
+    end = RestrictBatteryDischargeEndTimeEntity(coord)
+
+    assert start.available is True
+    assert end.available is True
+    assert start.native_value == dt_time(1, 0)
+    assert end.native_value == dt_time(16, 0)
 
 
 def test_restrict_battery_discharge_time_entities_expose_schedule_attributes(


### PR DESCRIPTION
## Summary

Rationalize IQ Battery schedule controls and harden BatteryConfig write compatibility.

Fixes #460.

This change set:
- hardens BatteryConfig write attempts for battery profile and battery settings updates, including endpoint-specific fallback shapes and richer diagnostics
- restores the battery shutdown level number and improves battery capability detection
- fixes DTG and RBD toggle behavior while schedules are settling and improves battery settings/schedule refresh cadence
- fixes HA-side battery schedule CRUD flows, including optional preflight handling and first-schedule RBD behavior
- removes duplicated battery schedule editing surfaces when the generic scheduler is enabled and improves translated selector labels
- closes the remaining integration coverage gaps so `custom_components/enphase_ev/*.py` now reports `100%`
- updates manifest/changelog/API docs for the verified request and response shapes

## Related Issues

- #460

## Type of change

- [x] Bugfix
- [x] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/battery_schedule_editor.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/coordinator_diagnostics.py custom_components/enphase_ev/labels.py custom_components/enphase_ev/number.py custom_components/enphase_ev/select.py custom_components/enphase_ev/services.py custom_components/enphase_ev/state_models.py custom_components/enphase_ev/switch.py custom_components/enphase_ev/time.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_battery_schedule_editor_parity.py tests/components/enphase_ev/test_number_module.py tests/components/enphase_ev/test_switch_module.py tests/components/enphase_ev/test_time_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_api_client_methods.py::test_battery_settings_details_wire_headers_match_official_web_shape tests/components/enphase_ev/test_api_client_methods.py::test_set_battery_settings_payload_and_xsrf tests/components/enphase_ev/test_api_client_methods.py::test_set_battery_settings_retries_403_with_lean_official_web_variant tests/components/enphase_ev/test_api_client_methods.py::test_set_battery_profile_uses_canonical_batteryconfig_write_path tests/components/enphase_ev/test_api_client_methods.py::test_acquire_xsrf_token_uses_official_web_headers tests/components/enphase_ev/test_coordinator_edge_cases.py::test_collect_site_metrics_handles_unfriendly_datetime tests/components/enphase_ev/test_coordinator_edge_cases.py::test_handle_client_unauthorized_creates_issue_after_failures tests/components/enphase_ev/test_number_module.py::test_number_helper_fallbacks_and_retained_site_unique_ids tests/components/enphase_ev/test_time_module.py::test_async_setup_entry_does_not_duplicate_site_time_entities_on_listener"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev_full.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev_full.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev_full.coverage python -m coverage report -m --include=custom_components/enphase_ev/*.py --fail-under=100"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The local HA dev runtime was used to verify IQ Battery schedule toggles and entity-surface changes.
- `custom_components/enphase_ev/*.py` now reports `100%` coverage.
