### PR TITLE
Prepare release 2.8.3 and trim README release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,34 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- Redacted EV charger session auth identifiers and tokens from downloadable diagnostics and removed raw session/auth identifiers from the last-session sensor attributes so Home Assistant history no longer stores those values.
+- None
 
 ### 🔧 Improvements
-- Enforced minimum EV charger polling intervals in the options/runtime paths and added cooldown tracking for `summary_v2` and EVSE timeseries failures so transient cloud issues do not trigger overly aggressive retry loops.
+- None
 
 ### 🔄 Other changes
 - None
+
+## v2.8.3 - 2026-04-18
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Redacted EV charger session auth identifiers and tokens from downloadable diagnostics and removed raw session/auth identifiers from the last-session sensor attributes so Home Assistant history no longer stores those values.
+- Finalized IQ Battery schedule add/update/delete handling so rejected Enphase schedule writes now raise validation errors cleanly instead of failing as generic service errors.
+
+### 🔧 Improvements
+- Enforced minimum EV charger polling intervals in the options/runtime paths and added cooldown tracking for `summary_v2` and EVSE timeseries failures so transient cloud issues do not trigger overly aggressive retry loops.
+- Aligned the IQ EV Charger scheduler editor with the IQ Battery scheduler pattern: the editor now keeps a stable schedule selection, supports explicit create mode, exposes dedicated refresh/save/delete buttons, and uses translated weekday/time labels across the helper entities.
+- Finalized the IQ Battery scheduler editor flow with clearer schedule labels, improved default selection and create/edit state handling, and success notifications after save/delete actions.
+
+### 🔄 Other changes
+- Refactored redundant Enphase helper and runtime utility implementations to reduce duplicated logic across entity setup, cleanup, labels, firmware helpers, and related initialization paths.
+- Updated internal API documentation and test coverage for the EV charger and battery scheduler/editor flows.
 
 ## v2.8.2 - 2026-04-17
 

--- a/README.md
+++ b/README.md
@@ -109,57 +109,6 @@ Manual install steps: see the wiki Installation page.
 
 Sign in with your Enlighten credentials; MFA is supported. See the wiki for details.
 
-## Local Docker workflows
-
-The repository now ships two separate Docker workflows:
-
-- `ha-dev` is the pinned Python toolchain used for linting, formatting, tests, coverage, and other contributor checks.
-- `ha-runtime` is a manual verification Home Assistant instance based on the official `ghcr.io/home-assistant/home-assistant:stable` image.
-
-Build the contributor container:
-
-```bash
-docker compose -f devtools/docker/docker-compose.yml build ha-dev
-```
-
-Run the standard checks inside `ha-dev`:
-
-```bash
-docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
-docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev tests/components/enphase_ev"
-docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
-```
-
-Start a real Home Assistant instance for UI verification:
-
-```bash
-mkdir -p .ha-config
-docker compose -f devtools/docker/docker-compose.yml up -d ha-runtime
-```
-
-Then open [http://localhost:8123](http://localhost:8123). The runtime container mounts:
-
-- `.ha-config/` to `/config` for local Home Assistant state
-- `custom_components/enphase_ev` to `/config/custom_components/enphase_ev` so the running instance uses this checkout
-
-Notes:
-
-- `.ha-config/` is gitignored and intended only for local verification data.
-- `ha-runtime` inherits the `TZ` environment variable from your shell and defaults to `UTC` if it is unset.
-- `ha-runtime` now pins container DNS to public resolvers by default to avoid intermittent Docker Desktop resolver timeouts. Override with `HA_RUNTIME_DNS_1` and `HA_RUNTIME_DNS_2` if your network requires different upstream DNS servers.
-- The runtime service uses port mapping instead of `network_mode: host` so it works reliably on Docker Desktop for macOS and Windows.
-- If you need Linux-only host networking or hardware access for local discovery testing, adjust the runtime service locally with the options from the official Home Assistant Container docs.
-
 ## Documentation
 
 Refer to the [Wiki](https://github.com/barneyonline/ha-enphase-energy/wiki), including [Envoy History Migration](https://github.com/barneyonline/ha-enphase-energy/wiki/Envoy-History-Migration) for preserving Energy dashboard history when migrating from Enphase Envoy.
-
-## Battery Scheduling Notes
-
-- Battery schedule toggles and limits are exposed as `switch` and `number` entities.
-- Battery schedule start and end values are exposed as separate `time` entities.
-- Battery schedule inventory is also exposed through diagnostic `sensor` entities, including a combined summary plus per-mode CFG, DTG, and RBD schedule lists with schedule IDs in the attributes.
-- Battery schedule CRUD is available through dedicated `select`, `time`, `number`, `switch`, and `button` editor entities on the battery device, plus `force_refresh`, `add_schedule`, `update_schedule`, `delete_schedule`, and `validate_schedule` services for automations.
-- Use the integration Options page to enable `EV Charger Scheduler` and `Battery Scheduler` independently. The battery scheduler editor now uses a single shared form with a `New schedule` option instead of exposing separate edit and create entity sets.
-- In Home Assistant, those `time` entities may need to be added to dashboards manually if you want the schedule window visible on a card.
-- Related battery schedule entities also expose the current schedule window and write-pending status as state attributes to make delayed Enphase cloud updates easier to diagnose.

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.8.2"
+  "version": "2.8.3"
 }


### PR DESCRIPTION
## Summary

Prepare the `2.8.3` release metadata by bumping the integration manifest version and refreshing the changelog to cover the PRs merged since `v2.8.2`.

Trim README sections that should not ship as top-level release documentation by removing the battery scheduling notes and local Docker workflow guidance.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Other: release metadata update.

## Testing

List the exact commands you ran. Prefer the pinned Docker environment from `devtools/docker/`.

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
```

Add any extra commands, targeted tests, or manual validation below.

- Did not run `pytest`; this change only updates release metadata and README content.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- No diagnostics or screenshots for this docs and release-prep change.
