### PR TITLE
[codex] Improve performance refresh paths

### DIFF
--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from datetime import timedelta
 from datetime import timezone as _tz
-from typing import TYPE_CHECKING, Iterable
+from typing import TYPE_CHECKING, Awaitable, Iterable
 
 import aiohttp
 
@@ -43,6 +43,7 @@ AUTH_SETTINGS_CACHE_TTL = 300.0
 CHARGE_MODE_CACHE_TTL = 300.0
 CHARGER_CONFIG_CACHE_TTL = 3600.0
 CHARGER_CONFIG_FAILURE_BACKOFF_S = 900.0
+EVSE_LOOKUP_CONCURRENCY = 5
 CHARGE_MODE_PREFERENCE_MAP: dict[str, str] = {
     "MANUAL": "MANUAL_CHARGING",
     "MANUAL_CHARGING": "MANUAL_CHARGING",
@@ -118,9 +119,30 @@ def evse_power_is_actively_charging(
 class EvseRuntime:
     def __init__(self, coordinator: EnphaseCoordinator) -> None:
         self.coordinator = coordinator
+        self._lookup_semaphore = asyncio.Semaphore(EVSE_LOOKUP_CONCURRENCY)
 
     def _instance_override(self, name: str) -> object | None:
         return self.coordinator.__dict__.get(name)
+
+    async def _run_lookup_tasks(
+        self,
+        pending: dict[str, Awaitable[object]],
+    ) -> dict[str, object]:
+        """Execute per-serial lookups with a shared concurrency limit."""
+
+        if not pending:
+            return {}
+
+        async def _run(awaitable: Awaitable[object]) -> object:
+            async with self._lookup_semaphore:
+                return await awaitable
+
+        wrapped = {
+            sn: asyncio.create_task(_run(awaitable))
+            for sn, awaitable in pending.items()
+        }
+        responses = await asyncio.gather(*wrapped.values(), return_exceptions=True)
+        return dict(zip(wrapped.keys(), responses, strict=False))
 
     def schedule_session_enrichment(
         self,
@@ -545,10 +567,9 @@ class EvseRuntime:
             if cached is not None:
                 results[sn] = ChargeModeResolution(cached, "cache")
                 continue
-            pending[sn] = asyncio.create_task(self.async_get_charge_mode(sn))
+            pending[sn] = self.async_get_charge_mode(sn)
         if pending:
-            responses = await asyncio.gather(*pending.values(), return_exceptions=True)
-            for sn, response in zip(pending.keys(), responses, strict=False):
+            for sn, response in (await self._run_lookup_tasks(pending)).items():
                 if isinstance(response, Exception):
                     _LOGGER.debug(
                         "Charge mode lookup failed for %s: %s",
@@ -1360,10 +1381,9 @@ class EvseRuntime:
             if cached and (now - cached[2] < GREEN_BATTERY_CACHE_TTL):
                 results[sn] = (cached[0], cached[1])
                 continue
-            pending[sn] = asyncio.create_task(self.async_get_green_battery_setting(sn))
+            pending[sn] = self.async_get_green_battery_setting(sn)
         if pending:
-            responses = await asyncio.gather(*pending.values(), return_exceptions=True)
-            for sn, response in zip(pending.keys(), responses, strict=False):
+            for sn, response in (await self._run_lookup_tasks(pending)).items():
                 if isinstance(response, Exception):
                     _LOGGER.debug(
                         "Green battery setting lookup failed for %s: %s",
@@ -1411,10 +1431,9 @@ class EvseRuntime:
             if cached and (now - cached[4] < AUTH_SETTINGS_CACHE_TTL):
                 results[sn] = cached[0], cached[1], cached[2], cached[3]
                 continue
-            pending[sn] = asyncio.create_task(self.async_get_auth_settings(sn))
+            pending[sn] = self.async_get_auth_settings(sn)
         if pending:
-            responses = await asyncio.gather(*pending.values(), return_exceptions=True)
-            for sn, response in zip(pending.keys(), responses, strict=False):
+            for sn, response in (await self._run_lookup_tasks(pending)).items():
                 if isinstance(response, Exception):
                     _LOGGER.debug(
                         "Auth settings lookup failed for %s: %s",
@@ -1474,12 +1493,9 @@ class EvseRuntime:
                         if key in cached_values
                     }
                     continue
-            pending[sn] = asyncio.create_task(
-                self.async_get_charger_config(sn, keys=requested)
-            )
+            pending[sn] = self.async_get_charger_config(sn, keys=requested)
         if pending:
-            responses = await asyncio.gather(*pending.values(), return_exceptions=True)
-            for sn, response in zip(pending.keys(), responses, strict=False):
+            for sn, response in (await self._run_lookup_tasks(pending)).items():
                 if isinstance(response, Exception):
                     _LOGGER.debug(
                         "Charger config lookup failed for %s: %s",

--- a/custom_components/enphase_ev/session_history.py
+++ b/custom_components/enphase_ev/session_history.py
@@ -62,7 +62,8 @@ class SessionHistoryManager:
         self._cache: dict[tuple[str, str], tuple[float, list[dict]]] = {}
         self._block_until: dict[str, float] = {}
         self._refresh_in_progress: set[str] = set()
-        self._criteria_cache: dict[str, float] = {}
+        self._criteria_checked_mono: float | None = None
+        self._criteria_lock = asyncio.Lock()
         self._enrichment_tasks: set[asyncio.Task[None]] = set()
         self._data_supplier = data_supplier
         self._publish_callback = publish_callback
@@ -313,14 +314,37 @@ class SessionHistoryManager:
         current = self._data_supplier()
         if not isinstance(current, dict):
             return
-        merged: dict[str, dict] = {}
-        for sn, payload in current.items():
-            merged[sn] = dict(payload)
+        merged = dict(current)
         for sn, sessions in updates.items():
-            entry = merged.setdefault(sn, {})
+            existing = current.get(sn)
+            entry = dict(existing) if isinstance(existing, dict) else {}
             entry["energy_today_sessions"] = sessions
             entry["energy_today_sessions_kwh"] = self._sum_session_energy(sessions)
+            merged[sn] = entry
         self._publish_callback(merged)
+
+    async def _async_refresh_filter_criteria(
+        self,
+        criteria_fetcher: Callable[..., Awaitable[dict]],
+    ) -> None:
+        """Fetch site-scoped filter criteria once per cache window."""
+
+        checked_mono = self._criteria_checked_mono
+        if (
+            checked_mono is not None
+            and (time.monotonic() - checked_mono) < self._cache_ttl
+        ):
+            return
+
+        async with self._criteria_lock:
+            checked_mono = self._criteria_checked_mono
+            if (
+                checked_mono is not None
+                and (time.monotonic() - checked_mono) < self._cache_ttl
+            ):
+                return
+            await criteria_fetcher(request_id=str(uuid.uuid4()))
+            self._criteria_checked_mono = time.monotonic()
 
     async def _async_fetch_sessions_today(
         self,
@@ -367,47 +391,44 @@ class SessionHistoryManager:
 
         criteria_fetcher = getattr(client, "session_history_filter_criteria", None)
         if callable(criteria_fetcher):
-            last_checked = self._criteria_cache.get(sn)
-            if last_checked is None or (now_mono - last_checked) >= self._cache_ttl:
-                try:
-                    await criteria_fetcher(request_id=str(uuid.uuid4()))
-                    self._criteria_cache[sn] = now_mono
-                except SessionHistoryUnavailable as err:
-                    self._logger.debug(
-                        "Session history criteria unavailable for %s: %s", sn, err
-                    )
-                    if cached:
-                        self._note_service_unavailable(err, using_stale=True)
-                        return cached[1]
-                    self._note_service_unavailable(err)
-                    self._set_cache_entry(sn, day_key, now_mono, [])
-                    return []
-                except Unauthorized as err:
-                    self._logger.debug(
-                        "Session history criteria unauthorized for %s: %s", sn, err
-                    )
-                    self._set_cache_entry(sn, day_key, now_mono, [])
-                    return []
-                except aiohttp.ClientResponseError as err:
-                    self._logger.debug(
-                        "Session history criteria error for %s: %s (%s)",
-                        sn,
-                        err.status,
-                        err.message,
-                    )
-                    if err.status in (500, 502, 503, 504, 550):
-                        self._block_until[sn] = now_mono + self._failure_backoff
-                    self._set_cache_entry(sn, day_key, now_mono, [])
-                    return []
-                except Exception as err:  # noqa: BLE001
-                    self._logger.debug(
-                        "Session history criteria failed for %s: %s", sn, err
-                    )
-                    if cached:
-                        self._note_service_unavailable(err, using_stale=True)
-                        return cached[1]
-                    self._set_cache_entry(sn, day_key, now_mono, [])
-                    return []
+            try:
+                await self._async_refresh_filter_criteria(criteria_fetcher)
+            except SessionHistoryUnavailable as err:
+                self._logger.debug(
+                    "Session history criteria unavailable for %s: %s", sn, err
+                )
+                if cached:
+                    self._note_service_unavailable(err, using_stale=True)
+                    return cached[1]
+                self._note_service_unavailable(err)
+                self._set_cache_entry(sn, day_key, now_mono, [])
+                return []
+            except Unauthorized as err:
+                self._logger.debug(
+                    "Session history criteria unauthorized for %s: %s", sn, err
+                )
+                self._set_cache_entry(sn, day_key, now_mono, [])
+                return []
+            except aiohttp.ClientResponseError as err:
+                self._logger.debug(
+                    "Session history criteria error for %s: %s (%s)",
+                    sn,
+                    err.status,
+                    err.message,
+                )
+                if err.status in (500, 502, 503, 504, 550):
+                    self._block_until[sn] = now_mono + self._failure_backoff
+                self._set_cache_entry(sn, day_key, now_mono, [])
+                return []
+            except Exception as err:  # noqa: BLE001
+                self._logger.debug(
+                    "Session history criteria failed for %s: %s", sn, err
+                )
+                if cached:
+                    self._note_service_unavailable(err, using_stale=True)
+                    return cached[1]
+                self._set_cache_entry(sn, day_key, now_mono, [])
+                return []
 
         async def _fetch_page(offset: int, limit: int) -> tuple[list[dict], bool]:
             payload = await client.session_history(
@@ -564,9 +585,6 @@ class SessionHistoryManager:
                 self._block_until.pop(sn, None)
 
         if active_set is not None:
-            for sn in list(self._criteria_cache):
-                if sn not in active_set:
-                    self._criteria_cache.pop(sn, None)
             self._refresh_in_progress.intersection_update(active_set)
 
     def clear(self) -> None:
@@ -576,7 +594,7 @@ class SessionHistoryManager:
         self._enrichment_tasks.clear()
         self._cache.clear()
         self._block_until.clear()
-        self._criteria_cache.clear()
+        self._criteria_checked_mono = None
         self._refresh_in_progress.clear()
 
     def set_fetch_override(

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -12,6 +12,7 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import dt as dt_util
 
 from custom_components.enphase_ev.evse_runtime import (
+    EVSE_LOOKUP_CONCURRENCY,
     FAST_TOGGLE_POLL_HOLD_S,
     ChargeModeResolution,
     ChargeModeStartPreferences,
@@ -207,6 +208,83 @@ async def test_evse_runtime_resolvers_use_runtime_methods(
     runtime.async_get_charge_mode.assert_awaited_once_with("EV1")
     runtime.async_get_green_battery_setting.assert_awaited_once_with("EV1")
     runtime.async_get_auth_settings.assert_awaited_once_with("EV1")
+
+
+@pytest.mark.asyncio
+async def test_evse_runtime_run_lookup_tasks_handles_empty_input(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory().evse_runtime
+
+    assert await runtime._run_lookup_tasks({}) == {}  # noqa: SLF001
+
+
+@pytest.mark.parametrize(
+    ("resolver_name", "getter_name", "kwargs", "expected"),
+    [
+        (
+            "async_resolve_charge_modes",
+            "async_get_charge_mode",
+            {},
+            lambda _sn: "GREEN_CHARGING",
+        ),
+        (
+            "async_resolve_green_battery_settings",
+            "async_get_green_battery_setting",
+            {},
+            lambda _sn: (True, True),
+        ),
+        (
+            "async_resolve_auth_settings",
+            "async_get_auth_settings",
+            {},
+            lambda _sn: (True, False, True, True),
+        ),
+        (
+            "async_resolve_charger_config",
+            "async_get_charger_config",
+            {"keys": ["DefaultChargeLevel"]},
+            lambda _sn: {"DefaultChargeLevel": 80},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_evse_runtime_resolvers_limit_lookup_concurrency(
+    coordinator_factory,
+    resolver_name,
+    getter_name,
+    kwargs,
+    expected,
+) -> None:
+    coord = coordinator_factory(serials=[f"EV{i:02d}" for i in range(12)])
+    runtime = coord.evse_runtime
+    current = 0
+    peak = 0
+
+    async def _fake_get(sn: str, **_kwargs):
+        nonlocal current, peak
+        current += 1
+        peak = max(peak, current)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        current -= 1
+        return expected(sn)
+
+    setattr(runtime, getter_name, _fake_get)
+
+    resolver = getattr(runtime, resolver_name)
+    serials = [f"EV{i:02d}" for i in range(12)]
+    result = await resolver(serials, **kwargs)
+
+    assert peak == EVSE_LOOKUP_CONCURRENCY
+    expected_value = expected(serials[0])
+    if resolver_name == "async_resolve_charge_modes":
+        assert result[serials[0]] == ChargeModeResolution(
+            expected_value,
+            "scheduler_endpoint",
+        )
+    else:
+        assert result[serials[0]] == expected_value
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_helper_modules.py
+++ b/tests/components/enphase_ev/test_helper_modules.py
@@ -769,6 +769,67 @@ async def test_session_history_fetch_calls_filter_criteria(hass) -> None:
     assert client.history_calls == 1
 
 
+@pytest.mark.asyncio
+async def test_session_history_fetch_shares_filter_criteria_across_serials(
+    hass,
+) -> None:
+    class _CriteriaClient:
+        def __init__(self) -> None:
+            self.criteria_calls = 0
+            self.history_calls = 0
+
+        async def session_history_filter_criteria(self, **_kwargs):
+            self.criteria_calls += 1
+            await asyncio.sleep(0)
+            return {"data": [{"id": "EV-01"}]}
+
+        async def session_history(self, *_args, **_kwargs) -> dict:
+            self.history_calls += 1
+            await asyncio.sleep(0)
+            return {"data": {"result": [], "hasMore": False}}
+
+    await hass.config.async_set_time_zone("UTC")
+    client = _CriteriaClient()
+    manager = SessionHistoryManager(
+        hass,
+        lambda: client,
+        cache_ttl=600,
+        data_supplier=lambda: {},
+        publish_callback=lambda _: None,
+    )
+    day = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+    await manager.async_enrich(["EV-01", "EV-02", "EV-03"], day, in_background=False)
+
+    assert client.criteria_calls == 1
+    assert client.history_calls == 3
+
+
+@pytest.mark.asyncio
+async def test_session_history_filter_criteria_short_circuits_when_recent(
+    hass,
+) -> None:
+    called = False
+
+    async def _criteria_fetcher(**_kwargs):
+        nonlocal called
+        called = True
+        return {"data": []}
+
+    manager = SessionHistoryManager(
+        hass,
+        lambda: None,
+        cache_ttl=600,
+        data_supplier=lambda: {},
+        publish_callback=lambda _: None,
+    )
+    manager._criteria_checked_mono = time.monotonic()
+
+    await manager._async_refresh_filter_criteria(_criteria_fetcher)  # noqa: SLF001
+
+    assert called is False
+
+
 def test_session_history_apply_updates_merges_data(hass) -> None:
     """Applying updates should merge sessions and compute totals."""
     published: list[dict] = []
@@ -785,6 +846,26 @@ def test_session_history_apply_updates_merges_data(hass) -> None:
     assert published
     merged = published[-1]
     assert merged["EV-01"]["energy_today_sessions_kwh"] == 1.5
+
+
+def test_session_history_apply_updates_reuses_untouched_payloads(hass) -> None:
+    """Applying updates should only clone payloads that actually change."""
+    published: list[dict] = []
+    untouched = {"sn": "EV-02"}
+    base = {"EV-01": {"sn": "EV-01"}, "EV-02": untouched}
+    manager = SessionHistoryManager(
+        hass,
+        lambda: None,
+        cache_ttl=60,
+        data_supplier=lambda: base,
+        publish_callback=lambda data: published.append(data),
+    )
+
+    manager._apply_updates({"EV-01": [{"energy_kwh": 1.5}]})
+
+    merged = published[-1]
+    assert merged["EV-01"] is not base["EV-01"]
+    assert merged["EV-02"] is untouched
 
 
 def test_session_history_cache_view_states(hass) -> None:
@@ -1036,7 +1117,7 @@ def test_session_history_prune_bounds_cache_and_serial_state(hass) -> None:
         "EV-01": time.monotonic() - 1,
         "EV-OLD": time.monotonic() + 60,
     }
-    manager._criteria_cache = {"EV-01": 1.0, "EV-OLD": 2.0}
+    manager._criteria_checked_mono = 1.0
     manager._refresh_in_progress = {"EV-01", "EV-OLD"}
 
     manager.prune(active_serials={"EV-01"}, keep_day_keys={"2020-01-02"})
@@ -1044,7 +1125,7 @@ def test_session_history_prune_bounds_cache_and_serial_state(hass) -> None:
     assert manager._cache == {("EV-01", "2020-01-02"): (2.0, [{"session_id": "keep"}])}
     assert "EV-OLD" not in manager._block_until
     assert "EV-01" not in manager._block_until
-    assert manager._criteria_cache == {"EV-01": 1.0}
+    assert manager._criteria_checked_mono == 1.0
     assert manager._refresh_in_progress == {"EV-01"}
 
 
@@ -1059,7 +1140,7 @@ async def test_session_history_clear_cancels_tasks_and_clears_state(hass) -> Non
     )
     manager._cache[("EV-01", "2020-01-02")] = (time.monotonic(), [])
     manager._block_until["EV-01"] = time.monotonic() + 60
-    manager._criteria_cache["EV-01"] = time.monotonic()
+    manager._criteria_checked_mono = time.monotonic()
     manager._refresh_in_progress.add("EV-01")
     task = hass.loop.create_task(asyncio.sleep(30))
     manager._enrichment_tasks.add(task)
@@ -1070,7 +1151,7 @@ async def test_session_history_clear_cancels_tasks_and_clears_state(hass) -> Non
     assert task.cancelled()
     assert manager._cache == {}
     assert manager._block_until == {}
-    assert manager._criteria_cache == {}
+    assert manager._criteria_checked_mono is None
     assert manager._refresh_in_progress == set()
     assert manager._enrichment_tasks == set()
 


### PR DESCRIPTION
## Summary
- treat session-history filter criteria as a shared site-scoped cache instead of repeating the extra request per serial
- bound warmup EVSE lookup concurrency across charge mode, green battery, auth settings, and charger config refreshes
- avoid cloning untouched coordinator payloads during background session-history publishes and add regression coverage for the new fast paths

## Why
The refresh path was doing unnecessary network fan-out and extra state copying. Session history repeated a site-level criteria call for each charger, warmup EVSE lookups could burst unbounded per-serial requests, and background enrichment rebuilt the full payload even when only one charger changed.

## Impact
This reduces avoidable API load during refresh and warmup, keeps lookup fan-out bounded on larger sites, and preserves 100% coverage for the touched performance-sensitive modules.

## Testing
- `pre-commit run --all-files`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/session_history.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_helper_modules.py --check"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/evse_runtime.py,custom_components/enphase_ev/session_history.py --fail-under=100"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
