### PR TITLE
Deduplicate entity attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🔧 Improvements
 - Defaulted both `Enable EV Charger Scheduler` and `Enable Battery Scheduler` integration options to on for entries that have not explicitly chosen a scheduler setting yet.
+- Removed duplicated diagnostic and schedule metadata from Enphase entities so Home Assistant exposes a smaller, less repetitive attribute surface across cloud, site energy, battery, AC battery, heat pump, and update entities.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/binary_sensor.py
+++ b/custom_components/enphase_ev/binary_sensor.py
@@ -23,7 +23,6 @@ from .runtime_data import EnphaseConfigEntry, get_runtime_data
 from .sensor import (
     _heatpump_runtime_device_uid,
     _heatpump_runtime_snapshot,
-    _heatpump_sg_ready_semantics,
 )
 
 PARALLEL_UPDATES = 0
@@ -210,29 +209,7 @@ class SiteCloudReachableBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def extra_state_attributes(self):
-        attrs: dict[str, object] = {}
-        if self._coord.last_failure_utc:
-            attrs["last_failure_utc"] = self._coord.last_failure_utc.isoformat()
-        if self._coord.last_failure_status is not None:
-            attrs["last_failure_status"] = self._coord.last_failure_status
-        if self._coord.last_failure_description:
-            attrs["code_description"] = self._coord.last_failure_description
-        if self._coord.last_failure_response:
-            attrs["last_failure_response"] = self._coord.last_failure_response
-        if self._coord.last_failure_source:
-            attrs["last_failure_source"] = self._coord.last_failure_source
-        last_failure_endpoint = getattr(self._coord, "last_failure_endpoint", None)
-        if last_failure_endpoint:
-            attrs["last_failure_endpoint"] = last_failure_endpoint
-        payload_failure_kind = getattr(self._coord, "payload_failure_kind", None)
-        if payload_failure_kind:
-            attrs["payload_failure_kind"] = payload_failure_kind
-        payload_using_stale = bool(getattr(self._coord, "payload_using_stale", False))
-        if payload_using_stale:
-            attrs["payload_using_stale"] = True
-        if self._coord.backoff_ends_utc:
-            attrs["backoff_ends_utc"] = self._coord.backoff_ends_utc.isoformat()
-        return attrs
+        return {}
 
     @property
     def device_info(self):
@@ -280,31 +257,7 @@ class HeatPumpSgReadyActiveBinarySensor(CoordinatorEntity, BinarySensorEntity):
 
     @property
     def extra_state_attributes(self):
-        snapshot = self._snapshot()
-        details = _heatpump_sg_ready_semantics(
-            snapshot.get("sg_ready_mode_label") or snapshot.get("sg_ready_mode_raw")
-        )
-        return {
-            "device_uid": snapshot.get("device_uid"),
-            "member_name": snapshot.get("member_name"),
-            "member_device_type": snapshot.get("member_device_type"),
-            "pairing_status": snapshot.get("pairing_status"),
-            "device_state": snapshot.get("device_state"),
-            "heatpump_status_raw": snapshot.get("heatpump_status"),
-            "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
-            "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
-            "sg_ready_active": snapshot.get("sg_ready_active"),
-            "sg_ready_contact_state": snapshot.get("sg_ready_contact_state"),
-            "vpp_sgready_mode_override": snapshot.get("vpp_sgready_mode_override"),
-            "last_report_at": snapshot.get("last_report_at"),
-            "runtime_endpoint_type": snapshot.get("endpoint_type"),
-            "runtime_endpoint_timestamp": snapshot.get("endpoint_timestamp"),
-            "source": snapshot.get("source"),
-            "last_error": getattr(
-                self._coord, "heatpump_runtime_state_last_error", None
-            ),
-            **details,
-        }
+        return {}
 
     @property
     def device_info(self):

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -718,8 +718,6 @@ class AcBatteryTargetStateOfChargeSelect(CoordinatorEntity, SelectEntity):
     def extra_state_attributes(self) -> dict[str, object]:
         return {
             "selected_sleep_min_soc": self._coord.ac_battery_selected_sleep_min_soc,
-            "sleep_state": self._coord.ac_battery_sleep_state,
-            "control_pending": self._coord.ac_battery_control_pending,
         }
 
     async def async_select_option(self, option: str) -> None:

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -2068,18 +2068,9 @@ class EnphaseConnectorStatusSensor(_BaseEVSensor):
                 return val
             return text.strip() or None
 
-        def _as_bool(val):
-            if val is None:
-                return None
-            try:
-                return bool(val)
-            except Exception:  # noqa: BLE001
-                return None
-
         return {
             "status_reason": _clean(self.data.get("connector_reason")),
             "connector_status_info": _clean(self.data.get("connector_status_info")),
-            "suspended_by_evse": _as_bool(self.data.get("suspended_by_evse")),
         }
 
 
@@ -5648,97 +5639,66 @@ class EnphaseSiteEnergySensor(_SiteBaseEntity, RestoreSensor):
     @property
     def extra_state_attributes(self):
         data = self._flow_data()
+        attrs: dict[str, object] = {}
         last_report_raw = data.get("last_report_date")
-        last_report_iso = None
-        sampled_at_iso = None
-        if isinstance(last_report_raw, datetime):
-            last_report_iso = last_report_raw.isoformat()
-        elif last_report_raw is not None:
-            try:
-                last_report_iso = str(last_report_raw)
-            except Exception:  # noqa: BLE001
-                last_report_iso = None
         parsed_sample_ts = _EnphaseSiteLifetimePowerSensor._parse_sample_timestamp(
             last_report_raw
         )
         if parsed_sample_ts is not None:
-            sampled_at_iso = datetime.fromtimestamp(
+            attrs["sampled_at_utc"] = datetime.fromtimestamp(
                 parsed_sample_ts, tz=timezone.utc
             ).isoformat()
-        attrs = {
-            "start_date": data.get("start_date"),
-            "sampled_at_utc": sampled_at_iso,
-            "last_report_date": last_report_iso,
-            "bucket_count": data.get("bucket_count"),
-            "source_fields": data.get("fields_used"),
-            "source_unit": data.get("source_unit") or "Wh",
-        }
-        if data.get("interval_minutes") is not None:
-            attrs["interval_minutes"] = data.get("interval_minutes")
+
         reset_at = data.get("last_reset_at") or self._restored_reset_at
         if reset_at:
             attrs["last_reset_at"] = reset_at
-        update_pending = data.get("update_pending")
-        if update_pending is not None:
-            attrs["update_pending"] = bool(update_pending)
-        evse_flow = None
-        try:
-            flows = (
-                getattr(getattr(self._coord, "energy", None), "site_energy", None) or {}
-            )
-            evse_flow = flows.get("evse_charging")
-        except Exception:  # noqa: BLE001
-            evse_flow = None
-        evse_value = None
-        if isinstance(evse_flow, SiteEnergyFlow):
-            evse_value = evse_flow.value_kwh
-        elif isinstance(evse_flow, dict):
-            evse_value = evse_flow.get("value_kwh")
-        if evse_value is not None:
+
+        if self._flow_key != "heat_pump":
+            return attrs
+
+        heatpump_power = getattr(self._coord, "heatpump_power_w", None)
+        if heatpump_power is not None:
             try:
-                attrs["evse_charging_kwh"] = round(float(evse_value), 2)
+                attrs["heat_pump_power_w"] = round(float(heatpump_power), 3)
             except Exception:  # noqa: BLE001
-                attrs["evse_charging_kwh"] = None
-        if self._flow_key == "heat_pump":
-            heatpump_power = getattr(self._coord, "heatpump_power_w", None)
-            if heatpump_power is not None:
-                try:
-                    attrs["heat_pump_power_w"] = round(float(heatpump_power), 3)
-                except Exception:  # noqa: BLE001
-                    attrs["heat_pump_power_w"] = None
-            daily = getattr(self._coord, "heatpump_daily_consumption", None)
-            if isinstance(daily, dict):
-                for key in (
-                    "daily_energy_wh",
-                    "daily_solar_wh",
-                    "daily_battery_wh",
-                    "daily_grid_wh",
-                    "device_uid",
-                    "device_name",
-                    "member_name",
-                    "member_device_type",
-                    "pairing_status",
-                    "device_state",
-                    "endpoint_type",
-                    "endpoint_timestamp",
-                    "day_key",
-                    "timezone",
-                    "source",
-                ):
-                    if key not in daily:
-                        continue
-                    attr_key = {
-                        "device_uid": "daily_device_uid",
-                        "device_name": "daily_device_name",
-                        "member_name": "daily_member_name",
-                        "member_device_type": "daily_member_device_type",
-                        "pairing_status": "daily_pairing_status",
-                        "device_state": "daily_device_state",
-                        "endpoint_type": "daily_endpoint_type",
-                        "endpoint_timestamp": "daily_endpoint_timestamp",
-                        "source": "daily_source",
-                    }.get(key, key)
-                    attrs[attr_key] = daily.get(key)
+                attrs["heat_pump_power_w"] = None
+
+        daily = getattr(self._coord, "heatpump_daily_consumption", None)
+        if not isinstance(daily, dict):
+            return attrs
+
+        for key in (
+            "daily_energy_wh",
+            "daily_solar_wh",
+            "daily_battery_wh",
+            "daily_grid_wh",
+            "device_uid",
+            "device_name",
+            "member_name",
+            "member_device_type",
+            "pairing_status",
+            "device_state",
+            "endpoint_type",
+            "endpoint_timestamp",
+            "day_key",
+            "timezone",
+            "source",
+        ):
+            if key not in daily:
+                continue
+            attr_key = {
+                "device_uid": "daily_device_uid",
+                "device_name": "daily_device_name",
+                "member_name": "daily_member_name",
+                "member_device_type": "daily_member_device_type",
+                "pairing_status": "daily_pairing_status",
+                "device_state": "daily_device_state",
+                "endpoint_type": "daily_endpoint_type",
+                "endpoint_timestamp": "daily_endpoint_timestamp",
+                "source": "daily_source",
+            }.get(key, key)
+            attrs[attr_key] = daily.get(key)
+
         return attrs
 
 
@@ -6373,7 +6333,6 @@ class _EnphaseSiteLifetimePowerSensor(_SiteBaseEntity, RestoreEntity):
             "last_sample_ts": self._last_sample_ts,
             "last_power_w": self._last_power_w,
             "last_window_seconds": self._last_window_s,
-            "last_report_date": self._last_report_date_iso,
             "last_reset_at": self._last_reset_at,
             "method": self._last_method,
             "source_flows": list(self._flow_signs),
@@ -6427,6 +6386,10 @@ class EnphaseSiteLastUpdateSensor(_SiteBaseEntity):
         return self._coord.last_success_utc
 
     @property
+    def extra_state_attributes(self):
+        return self._cloud_diag_attrs(include_last_success=False)
+
+    @property
     def device_info(self):
         info = _type_device_info(self._coord, "cloud")
         if info is not None:
@@ -6450,7 +6413,7 @@ class EnphaseCloudLatencySensor(_SiteBaseEntity):
 
     @property
     def extra_state_attributes(self):
-        return self._cloud_diag_attrs(include_last_success=False)
+        return {}
 
     @property
     def device_info(self):
@@ -6622,7 +6585,7 @@ class EnphaseSiteLastErrorCodeSensor(_SiteBaseEntity):
 
     @property
     def extra_state_attributes(self):
-        return self._cloud_diag_attrs(include_last_success=False)
+        return {}
 
     @property
     def device_info(self):
@@ -6669,7 +6632,7 @@ class EnphaseSiteBackoffEndsSensor(_SiteBaseEntity):
 
     @property
     def extra_state_attributes(self):
-        return self._cloud_diag_attrs(include_last_success=False)
+        return {}
 
     @property
     def device_info(self):
@@ -7760,11 +7723,6 @@ class _EnphaseHeatPumpDeviceTypeSensor(_SiteBaseEntity):
     def extra_state_attributes(self):
         snapshot = self._snapshot()
         members = snapshot.get("members")
-        safe_members = (
-            [dict(member) for member in members if isinstance(member, dict)]
-            if isinstance(members, list)
-            else []
-        )
         return {
             "device_type": snapshot.get("device_type"),
             "member_count": snapshot.get("member_count"),
@@ -7775,10 +7733,11 @@ class _EnphaseHeatPumpDeviceTypeSensor(_SiteBaseEntity):
             "hems_data_stale": snapshot.get("hems_data_stale"),
             "hems_last_success_utc": snapshot.get("hems_last_success_utc"),
             "hems_last_success_age_s": snapshot.get("hems_last_success_age_s"),
-            "members": safe_members,
-            "member_attributes": [
-                _gateway_flat_member_attributes(member) for member in safe_members
-            ],
+            "members": (
+                [dict(member) for member in members if isinstance(member, dict)]
+                if isinstance(members, list)
+                else []
+            ),
         }
 
 
@@ -7831,19 +7790,15 @@ class EnphaseHeatPumpSgReadyModeSensor(_SiteBaseEntity):
         details = _heatpump_sg_ready_semantics(
             snapshot.get("sg_ready_mode_label") or snapshot.get("sg_ready_mode_raw")
         )
-        attrs = _heatpump_runtime_common_attrs(self._coord, snapshot)
-        attrs.update(
-            {
-                "heatpump_status_raw": snapshot.get("heatpump_status"),
-                "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
-                "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
-                "sg_ready_active": snapshot.get("sg_ready_active"),
-                "sg_ready_contact_state": snapshot.get("sg_ready_contact_state"),
-                "vpp_sgready_mode_override": snapshot.get("vpp_sgready_mode_override"),
-                **details,
-            }
-        )
-        return attrs
+        return {
+            "heatpump_status_raw": snapshot.get("heatpump_status"),
+            "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
+            "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
+            "sg_ready_active": snapshot.get("sg_ready_active"),
+            "sg_ready_contact_state": snapshot.get("sg_ready_contact_state"),
+            "vpp_sgready_mode_override": snapshot.get("vpp_sgready_mode_override"),
+            **details,
+        }
 
 
 class EnphaseHeatPumpEnergyMeterSensor(_EnphaseHeatPumpDeviceTypeSensor):
@@ -7905,16 +7860,7 @@ class EnphaseHeatPumpLastReportedSensor(_SiteBaseEntity):
 
     @property
     def extra_state_attributes(self):
-        snapshot = _heatpump_runtime_snapshot(self._coord)
-        attrs = _heatpump_runtime_common_attrs(self._coord, snapshot)
-        attrs.update(
-            {
-                "heatpump_status_raw": snapshot.get("heatpump_status"),
-                "sg_ready_mode_raw": snapshot.get("sg_ready_mode_raw"),
-                "sg_ready_mode_label": snapshot.get("sg_ready_mode_label"),
-            }
-        )
-        return attrs
+        return {}
 
 
 class _EnphaseHeatPumpDailyEnergySensor(_SiteBaseEntity):
@@ -8183,28 +8129,7 @@ class EnphaseBatteryOverallChargeSensor(_SiteBaseEntity):
 
     @property
     def extra_state_attributes(self):
-        summary = self._coord.battery_status_summary
-        return {
-            "aggregate_status": summary.get("aggregate_status"),
-            "aggregate_charge_source": summary.get("aggregate_charge_source"),
-            "included_count": summary.get("included_count"),
-            "contributing_count": summary.get("contributing_count"),
-            "missing_energy_capacity_keys": summary.get("missing_energy_capacity_keys"),
-            "excluded_count": summary.get("excluded_count"),
-            "available_energy_kwh": summary.get("available_energy_kwh"),
-            "max_capacity_kwh": summary.get("max_capacity_kwh"),
-            "site_current_charge_pct": summary.get("site_current_charge_pct"),
-            "site_available_energy_kwh": summary.get("site_available_energy_kwh"),
-            "site_max_capacity_kwh": summary.get("site_max_capacity_kwh"),
-            "site_available_power_kw": summary.get("site_available_power_kw"),
-            "site_max_power_kw": summary.get("site_max_power_kw"),
-            "site_total_micros": summary.get("site_total_micros"),
-            "site_active_micros": summary.get("site_active_micros"),
-            "site_inactive_micros": summary.get("site_inactive_micros"),
-            "site_included_count": summary.get("site_included_count"),
-            "site_excluded_count": summary.get("site_excluded_count"),
-            "battery_order": summary.get("battery_order"),
-        }
+        return {}
 
 
 class EnphaseBatteryOverallStatusSensor(_SiteBaseEntity):
@@ -8233,12 +8158,6 @@ class EnphaseBatteryOverallStatusSensor(_SiteBaseEntity):
     def extra_state_attributes(self):
         summary = self._coord.battery_status_summary
         return {
-            "aggregate_charge_pct": summary.get("aggregate_charge_pct"),
-            "aggregate_charge_source": summary.get("aggregate_charge_source"),
-            "included_count": summary.get("included_count"),
-            "contributing_count": summary.get("contributing_count"),
-            "missing_energy_capacity_keys": summary.get("missing_energy_capacity_keys"),
-            "excluded_count": summary.get("excluded_count"),
             "worst_storage_key": summary.get("worst_storage_key"),
             "worst_status": summary.get("worst_status"),
             "per_battery_status": summary.get("per_battery_status"),
@@ -8359,16 +8278,11 @@ class EnphaseBatteryAvailableEnergySensor(_SiteBaseEntity):
 
     @property
     def extra_state_attributes(self):
-        summary = self._coord.battery_status_summary
         sampled_at = getattr(self._coord, "battery_summary_sample_utc", None)
         return {
             "sampled_at_utc": (
                 sampled_at.isoformat() if sampled_at is not None else None
             ),
-            "site_max_capacity_kwh": summary.get("site_max_capacity_kwh"),
-            "site_current_charge_pct": summary.get("site_current_charge_pct"),
-            "included_count": summary.get("site_included_count"),
-            "excluded_count": summary.get("site_excluded_count"),
         }
 
 
@@ -8405,13 +8319,11 @@ class EnphaseBatteryAvailablePowerSensor(_SiteBaseEntity):
 
     @property
     def extra_state_attributes(self):
-        summary = self._coord.battery_status_summary
         sampled_at = getattr(self._coord, "battery_summary_sample_utc", None)
         return {
             "sampled_at_utc": (
                 sampled_at.isoformat() if sampled_at is not None else None
             ),
-            "site_max_power_kw": summary.get("site_max_power_kw"),
         }
 
 
@@ -8450,7 +8362,6 @@ class EnphaseBatteryLastReportedSensor(_SiteBaseEntity):
             "latest_reported_device": snapshot.get("latest_reported_device"),
             "without_last_report_count": snapshot.get("without_last_report_count"),
             "total_batteries": snapshot.get("total_batteries"),
-            "latest_reported_utc": snapshot.get("latest_reported_utc"),
         }
 
 
@@ -8479,22 +8390,15 @@ class EnphaseAcBatteryOverallStatusSensor(_SiteBaseEntity):
     @property
     def extra_state_attributes(self):
         summary = self._coord.ac_battery_status_summary
-        attrs = self._cloud_diag_attrs()
-        attrs.update(
-            {
-                "battery_count": summary.get("battery_count"),
-                "worst_storage_key": summary.get("worst_storage_key"),
-                "worst_status": summary.get("worst_status"),
-                "sleep_state": summary.get("sleep_state"),
-                "selected_sleep_min_soc": summary.get("selected_sleep_min_soc"),
-                "sleep_state_map": summary.get("sleep_state_map"),
-                "sleep_state_raw": summary.get("sleep_state_raw"),
-                "latest_reported_utc": summary.get("latest_reported_utc"),
-                "control_pending": self._coord.ac_battery_control_pending,
-                "last_command": getattr(self._coord, "_ac_battery_last_command", None),
-            }
-        )
-        return attrs
+        return {
+            "battery_count": summary.get("battery_count"),
+            "worst_storage_key": summary.get("worst_storage_key"),
+            "worst_status": summary.get("worst_status"),
+            "sleep_state": summary.get("sleep_state"),
+            "sleep_state_map": summary.get("sleep_state_map"),
+            "sleep_state_raw": summary.get("sleep_state_raw"),
+            "last_command": getattr(self._coord, "_ac_battery_last_command", None),
+        }
 
 
 class EnphaseAcBatteryPowerSensor(_SiteBaseEntity):
@@ -8530,20 +8434,13 @@ class EnphaseAcBatteryPowerSensor(_SiteBaseEntity):
 
     @property
     def extra_state_attributes(self):
-        summary = self._coord.ac_battery_status_summary
         sampled_at = getattr(self._coord, "ac_battery_summary_sample_utc", None)
-        attrs = self._cloud_diag_attrs()
-        attrs.update(
-            {
-                "sampled_at_utc": (
-                    sampled_at.isoformat() if sampled_at is not None else None
-                ),
-                "battery_count": summary.get("battery_count"),
-                "power_map_w": summary.get("power_map_w"),
-                "latest_reported_utc": summary.get("latest_reported_utc"),
-            }
-        )
-        return attrs
+        return {
+            "sampled_at_utc": (
+                sampled_at.isoformat() if sampled_at is not None else None
+            ),
+            "power_map_w": self._coord.ac_battery_status_summary.get("power_map_w"),
+        }
 
 
 class EnphaseAcBatteryLastReportedSensor(_SiteBaseEntity):
@@ -8577,16 +8474,11 @@ class EnphaseAcBatteryLastReportedSensor(_SiteBaseEntity):
     @property
     def extra_state_attributes(self):
         snapshot = ac_battery_last_reported_snapshot(self._coord)
-        attrs = self._cloud_diag_attrs()
-        attrs.update(
-            {
-                "latest_reported_device": snapshot.get("latest_reported_device"),
-                "without_last_report_count": snapshot.get("without_last_report_count"),
-                "total_batteries": snapshot.get("total_batteries"),
-                "latest_reported_utc": snapshot.get("latest_reported_utc"),
-            }
-        )
-        return attrs
+        return {
+            "latest_reported_device": snapshot.get("latest_reported_device"),
+            "without_last_report_count": snapshot.get("without_last_report_count"),
+            "total_batteries": snapshot.get("total_batteries"),
+        }
 
 
 class EnphaseBatteryModeSensor(_SiteBaseEntity):
@@ -8633,24 +8525,10 @@ class EnphaseBatteryModeSensor(_SiteBaseEntity):
 
     @property
     def extra_state_attributes(self):
-        start_time = getattr(self._coord, "battery_charge_from_grid_start_time", None)
-        end_time = getattr(self._coord, "battery_charge_from_grid_end_time", None)
         return {
             "mode_raw": self._mode_raw(),
             "charge_from_grid_allowed": self._coord.battery_charge_from_grid_allowed,
             "discharge_to_grid_allowed": self._coord.battery_discharge_to_grid_allowed,
-            "charge_from_grid_enabled": getattr(
-                self._coord, "battery_charge_from_grid_enabled", None
-            ),
-            "charge_from_grid_schedule_enabled": getattr(
-                self._coord, "battery_charge_from_grid_schedule_enabled", None
-            ),
-            "charge_from_grid_start_time": (
-                start_time.isoformat() if start_time is not None else None
-            ),
-            "charge_from_grid_end_time": (
-                end_time.isoformat() if end_time is not None else None
-            ),
             "shutdown_level": getattr(self._coord, "battery_shutdown_level", None),
             "shutdown_level_min": getattr(
                 self._coord, "battery_shutdown_level_min", None

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -490,9 +490,6 @@
       "last_successful_update": {
         "name": "Last Successful Update",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Last Success (UTC)"
-          },
           "last_failure_utc": {
             "name": "Last Failure (UTC)"
           },
@@ -514,27 +511,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Cloud Latency",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Latency"
       },
       "current_production_power": {
         "name": "Current Production Power",
@@ -555,26 +532,6 @@
       },
       "cloud_error_code": {
         "name": "Cloud Error Code",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None",
           "dns_error": "DNS error",
@@ -583,26 +540,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None"
         }
@@ -760,87 +697,33 @@
       "site_solar_production": {
         "name": "Site Solar Production",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_consumption": {
         "name": "Site Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_grid_import": {
         "name": "Site Grid Import",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -862,8 +745,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -879,87 +762,33 @@
       "site_grid_export": {
         "name": "Site Grid Export",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_charge": {
         "name": "Site Battery Charge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Site Battery Discharge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -981,8 +810,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -1129,87 +958,33 @@
       "site_evse_charging": {
         "name": "Site EVSE Charging",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Site Heat Pump Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Site Water Heater Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -1293,27 +1068,7 @@
         "name": "Heat Pump SG-Ready Active"
       },
       "cloud_reachable": {
-        "name": "Cloud Reachable",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Reachable"
       },
       "connected": {
         "name": "Connectivity",

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -590,15 +590,7 @@ class ChargeFromGridSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, object]:
-        return battery_schedule_extra_state_attributes(
-            self._coord,
-            start_time=self._coord.battery_charge_from_grid_start_time,
-            end_time=self._coord.battery_charge_from_grid_end_time,
-            schedule_status=self._coord.battery_cfg_schedule_status,
-            schedule_pending=self._coord.battery_cfg_schedule_pending,
-            schedule_enabled=self._coord.battery_charge_from_grid_schedule_enabled,
-            schedule_limit=self._coord.battery_cfg_schedule_limit,
-        )
+        return battery_schedule_extra_state_attributes(self._coord)
 
     async def async_turn_on(self, **kwargs) -> None:
         await self._coord.async_set_charge_from_grid(True)
@@ -815,13 +807,9 @@ class AcBatterySleepModeSwitch(CoordinatorEntity, SwitchEntity):
 
     @property
     def extra_state_attributes(self) -> dict[str, object]:
-        summary = self._coord.ac_battery_status_summary
         return {
             "sleep_state": self._coord.ac_battery_sleep_state,
             "pending": self._coord.ac_battery_control_pending,
-            "selected_sleep_min_soc": self._coord.ac_battery_selected_sleep_min_soc,
-            "sleep_state_raw": summary.get("sleep_state_raw"),
-            "sleep_state_map": summary.get("sleep_state_map"),
             "last_command": getattr(self._coord, "_ac_battery_last_command", None),
         }
 

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Последно успешно обновяване",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Последен успех (UTC)"
-          },
           "last_failure_utc": {
             "name": "Последен неуспех (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Латентност на облака",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Последен неуспех (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Последен статус на неуспех"
-          },
-          "code_description": {
-            "name": "Описание на кода"
-          },
-          "last_failure_response": {
-            "name": "Последен отговор при неуспех"
-          },
-          "last_failure_source": {
-            "name": "Последен източник на неуспех"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff приключва (UTC)"
-          }
-        }
+        "name": "Латентност на облака"
       },
       "current_production_power": {
         "name": "Текуща производствена мощност",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Код на грешка в облака",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Последен неуспех (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Последен статус на неуспех"
-          },
-          "code_description": {
-            "name": "Описание на кода"
-          },
-          "last_failure_response": {
-            "name": "Последен отговор при неуспех"
-          },
-          "last_failure_source": {
-            "name": "Последен източник на неуспех"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff приключва (UTC)"
-          }
-        },
         "state": {
           "none": "Няма",
           "dns_error": "DNS грешка",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud backoff приключва",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Последен неуспех (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Последен статус на неуспех"
-          },
-          "code_description": {
-            "name": "Описание на кода"
-          },
-          "last_failure_response": {
-            "name": "Последен отговор при неуспех"
-          },
-          "last_failure_source": {
-            "name": "Последен източник на неуспех"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff приключва (UTC)"
-          }
-        },
         "state": {
           "none": "Няма"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Соларно производство на обекта",
         "state_attributes": {
-          "start_date": {
-            "name": "Начална дата"
-          },
-          "last_report_date": {
-            "name": "Дата на последен отчет"
-          },
-          "bucket_count": {
-            "name": "Брой bucket-и"
-          },
-          "source_fields": {
-            "name": "Полета на източника"
-          },
-          "source_unit": {
-            "name": "Единица на източника"
-          },
-          "interval_minutes": {
-            "name": "Интервал (min)"
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
           },
           "last_reset_at": {
             "name": "Последно нулиране"
-          },
-          "update_pending": {
-            "name": "Очакващо обновяване"
           }
         }
       },
       "site_consumption": {
         "name": "Потребление на обекта",
         "state_attributes": {
-          "start_date": {
-            "name": "Начална дата"
-          },
-          "last_report_date": {
-            "name": "Дата на последен отчет"
-          },
-          "bucket_count": {
-            "name": "Брой bucket-и"
-          },
-          "source_fields": {
-            "name": "Полета на източника"
-          },
-          "source_unit": {
-            "name": "Единица на източника"
-          },
-          "interval_minutes": {
-            "name": "Интервал (min)"
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
           },
           "last_reset_at": {
             "name": "Последно нулиране"
-          },
-          "update_pending": {
-            "name": "Очакващо обновяване"
           }
         }
       },
       "site_grid_import": {
         "name": "Внос от мрежата на обекта",
         "state_attributes": {
-          "start_date": {
-            "name": "Начална дата"
-          },
-          "last_report_date": {
-            "name": "Дата на последен отчет"
-          },
-          "bucket_count": {
-            "name": "Брой bucket-и"
-          },
-          "source_fields": {
-            "name": "Полета на източника"
-          },
-          "source_unit": {
-            "name": "Единица на източника"
-          },
-          "interval_minutes": {
-            "name": "Интервал (min)"
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
           },
           "last_reset_at": {
             "name": "Последно нулиране"
-          },
-          "update_pending": {
-            "name": "Очакващо обновяване"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Последен прозорец (s)"
           },
-          "last_report_date": {
-            "name": "Дата на последен отчет"
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
           },
           "last_reset_at": {
             "name": "Последно нулиране"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Износ към мрежата на обекта",
         "state_attributes": {
-          "start_date": {
-            "name": "Начална дата"
-          },
-          "last_report_date": {
-            "name": "Дата на последен отчет"
-          },
-          "bucket_count": {
-            "name": "Брой bucket-и"
-          },
-          "source_fields": {
-            "name": "Полета на източника"
-          },
-          "source_unit": {
-            "name": "Единица на източника"
-          },
-          "interval_minutes": {
-            "name": "Интервал (min)"
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
           },
           "last_reset_at": {
             "name": "Последно нулиране"
-          },
-          "update_pending": {
-            "name": "Очакващо обновяване"
           }
         }
       },
       "site_battery_charge": {
         "name": "Зареждане на батерията на обекта",
         "state_attributes": {
-          "start_date": {
-            "name": "Начална дата"
-          },
-          "last_report_date": {
-            "name": "Дата на последен отчет"
-          },
-          "bucket_count": {
-            "name": "Брой bucket-и"
-          },
-          "source_fields": {
-            "name": "Полета на източника"
-          },
-          "source_unit": {
-            "name": "Единица на източника"
-          },
-          "interval_minutes": {
-            "name": "Интервал (min)"
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
           },
           "last_reset_at": {
             "name": "Последно нулиране"
-          },
-          "update_pending": {
-            "name": "Очакващо обновяване"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Разреждане на батерията на обекта",
         "state_attributes": {
-          "start_date": {
-            "name": "Начална дата"
-          },
-          "last_report_date": {
-            "name": "Дата на последен отчет"
-          },
-          "bucket_count": {
-            "name": "Брой bucket-и"
-          },
-          "source_fields": {
-            "name": "Полета на източника"
-          },
-          "source_unit": {
-            "name": "Единица на източника"
-          },
-          "interval_minutes": {
-            "name": "Интервал (min)"
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
           },
           "last_reset_at": {
             "name": "Последно нулиране"
-          },
-          "update_pending": {
-            "name": "Очакващо обновяване"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Последен прозорец (s)"
           },
-          "last_report_date": {
-            "name": "Дата на последен отчет"
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
           },
           "last_reset_at": {
             "name": "Последно нулиране"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Зареждане EVSE на обекта",
         "state_attributes": {
-          "start_date": {
-            "name": "Начална дата"
-          },
-          "last_report_date": {
-            "name": "Дата на последен отчет"
-          },
-          "bucket_count": {
-            "name": "Брой bucket-и"
-          },
-          "source_fields": {
-            "name": "Полета на източника"
-          },
-          "source_unit": {
-            "name": "Единица на източника"
-          },
-          "interval_minutes": {
-            "name": "Интервал (min)"
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
           },
           "last_reset_at": {
             "name": "Последно нулиране"
-          },
-          "update_pending": {
-            "name": "Очакващо обновяване"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Потребление на термопомпа на обекта",
         "state_attributes": {
-          "start_date": {
-            "name": "Начална дата"
-          },
-          "last_report_date": {
-            "name": "Дата на последен отчет"
-          },
-          "bucket_count": {
-            "name": "Брой bucket-и"
-          },
-          "source_fields": {
-            "name": "Полета на източника"
-          },
-          "source_unit": {
-            "name": "Единица на източника"
-          },
-          "interval_minutes": {
-            "name": "Интервал (min)"
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
           },
           "last_reset_at": {
             "name": "Последно нулиране"
-          },
-          "update_pending": {
-            "name": "Очакващо обновяване"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Потребление на бойлер на обекта",
         "state_attributes": {
-          "start_date": {
-            "name": "Начална дата"
-          },
-          "last_report_date": {
-            "name": "Дата на последен отчет"
-          },
-          "bucket_count": {
-            "name": "Брой bucket-и"
-          },
-          "source_fields": {
-            "name": "Полета на източника"
-          },
-          "source_unit": {
-            "name": "Единица на източника"
-          },
-          "interval_minutes": {
-            "name": "Интервал (min)"
+          "sampled_at_utc": {
+            "name": "Измерено в (UTC)"
           },
           "last_reset_at": {
             "name": "Последно нулиране"
-          },
-          "update_pending": {
-            "name": "Очакващо обновяване"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "SG-Ready на термопомпата е активен"
       },
       "cloud_reachable": {
-        "name": "Облакът е достъпен",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Последен неуспех (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Последен статус на неуспех"
-          },
-          "code_description": {
-            "name": "Описание на кода"
-          },
-          "last_failure_response": {
-            "name": "Последен отговор при неуспех"
-          },
-          "last_failure_source": {
-            "name": "Последен източник на неуспех"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff приключва (UTC)"
-          }
-        }
+        "name": "Облакът е достъпен"
       },
       "connected": {
         "name": "Свързаност",

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Poslední úspěšná aktualizace",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Poslední úspěch (UTC)"
-          },
           "last_failure_utc": {
             "name": "Poslední selhání (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Latence cloudu",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Poslední selhání (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Poslední stav selhání"
-          },
-          "code_description": {
-            "name": "Popis kódu"
-          },
-          "last_failure_response": {
-            "name": "Poslední odpověď selhání"
-          },
-          "last_failure_source": {
-            "name": "Poslední zdroj selhání"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff končí (UTC)"
-          }
-        }
+        "name": "Latence cloudu"
       },
       "current_production_power": {
         "name": "Aktuální výrobní výkon",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Kód chyby cloudu",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Poslední selhání (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Poslední stav selhání"
-          },
-          "code_description": {
-            "name": "Popis kódu"
-          },
-          "last_failure_response": {
-            "name": "Poslední odpověď selhání"
-          },
-          "last_failure_source": {
-            "name": "Poslední zdroj selhání"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff končí (UTC)"
-          }
-        },
         "state": {
           "none": "Žádné",
           "dns_error": "Chyba DNS",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud backoff končí",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Poslední selhání (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Poslední stav selhání"
-          },
-          "code_description": {
-            "name": "Popis kódu"
-          },
-          "last_failure_response": {
-            "name": "Poslední odpověď selhání"
-          },
-          "last_failure_source": {
-            "name": "Poslední zdroj selhání"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff končí (UTC)"
-          }
-        },
         "state": {
           "none": "Žádné"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Solární výroba lokality",
         "state_attributes": {
-          "start_date": {
-            "name": "Datum začátku"
-          },
-          "last_report_date": {
-            "name": "Datum poslední zprávy"
-          },
-          "bucket_count": {
-            "name": "Počet bucketů"
-          },
-          "source_fields": {
-            "name": "Zdrojová pole"
-          },
-          "source_unit": {
-            "name": "Zdrojová jednotka"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuty)"
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
           },
           "last_reset_at": {
             "name": "Poslední reset"
-          },
-          "update_pending": {
-            "name": "Aktualizace čeká"
           }
         }
       },
       "site_consumption": {
         "name": "Spotřeba lokality",
         "state_attributes": {
-          "start_date": {
-            "name": "Datum začátku"
-          },
-          "last_report_date": {
-            "name": "Datum poslední zprávy"
-          },
-          "bucket_count": {
-            "name": "Počet bucketů"
-          },
-          "source_fields": {
-            "name": "Zdrojová pole"
-          },
-          "source_unit": {
-            "name": "Zdrojová jednotka"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuty)"
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
           },
           "last_reset_at": {
             "name": "Poslední reset"
-          },
-          "update_pending": {
-            "name": "Aktualizace čeká"
           }
         }
       },
       "site_grid_import": {
         "name": "Import ze sítě lokality",
         "state_attributes": {
-          "start_date": {
-            "name": "Datum začátku"
-          },
-          "last_report_date": {
-            "name": "Datum poslední zprávy"
-          },
-          "bucket_count": {
-            "name": "Počet bucketů"
-          },
-          "source_fields": {
-            "name": "Zdrojová pole"
-          },
-          "source_unit": {
-            "name": "Zdrojová jednotka"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuty)"
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
           },
           "last_reset_at": {
             "name": "Poslední reset"
-          },
-          "update_pending": {
-            "name": "Aktualizace čeká"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Poslední okno (s)"
           },
-          "last_report_date": {
-            "name": "Datum poslední zprávy"
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
           },
           "last_reset_at": {
             "name": "Poslední reset"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Export do sítě lokality",
         "state_attributes": {
-          "start_date": {
-            "name": "Datum začátku"
-          },
-          "last_report_date": {
-            "name": "Datum poslední zprávy"
-          },
-          "bucket_count": {
-            "name": "Počet bucketů"
-          },
-          "source_fields": {
-            "name": "Zdrojová pole"
-          },
-          "source_unit": {
-            "name": "Zdrojová jednotka"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuty)"
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
           },
           "last_reset_at": {
             "name": "Poslední reset"
-          },
-          "update_pending": {
-            "name": "Aktualizace čeká"
           }
         }
       },
       "site_battery_charge": {
         "name": "Nabíjení baterie lokality",
         "state_attributes": {
-          "start_date": {
-            "name": "Datum začátku"
-          },
-          "last_report_date": {
-            "name": "Datum poslední zprávy"
-          },
-          "bucket_count": {
-            "name": "Počet bucketů"
-          },
-          "source_fields": {
-            "name": "Zdrojová pole"
-          },
-          "source_unit": {
-            "name": "Zdrojová jednotka"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuty)"
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
           },
           "last_reset_at": {
             "name": "Poslední reset"
-          },
-          "update_pending": {
-            "name": "Aktualizace čeká"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Vybíjení baterie lokality",
         "state_attributes": {
-          "start_date": {
-            "name": "Datum začátku"
-          },
-          "last_report_date": {
-            "name": "Datum poslední zprávy"
-          },
-          "bucket_count": {
-            "name": "Počet bucketů"
-          },
-          "source_fields": {
-            "name": "Zdrojová pole"
-          },
-          "source_unit": {
-            "name": "Zdrojová jednotka"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuty)"
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
           },
           "last_reset_at": {
             "name": "Poslední reset"
-          },
-          "update_pending": {
-            "name": "Aktualizace čeká"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Poslední okno (s)"
           },
-          "last_report_date": {
-            "name": "Datum poslední zprávy"
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
           },
           "last_reset_at": {
             "name": "Poslední reset"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Nabíjení EVSE objektu",
         "state_attributes": {
-          "start_date": {
-            "name": "Datum začátku"
-          },
-          "last_report_date": {
-            "name": "Datum poslední zprávy"
-          },
-          "bucket_count": {
-            "name": "Počet bucketů"
-          },
-          "source_fields": {
-            "name": "Zdrojová pole"
-          },
-          "source_unit": {
-            "name": "Zdrojová jednotka"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuty)"
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
           },
           "last_reset_at": {
             "name": "Poslední reset"
-          },
-          "update_pending": {
-            "name": "Aktualizace čeká"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Spotřeba tepelného čerpadla objektu",
         "state_attributes": {
-          "start_date": {
-            "name": "Datum začátku"
-          },
-          "last_report_date": {
-            "name": "Datum poslední zprávy"
-          },
-          "bucket_count": {
-            "name": "Počet bucketů"
-          },
-          "source_fields": {
-            "name": "Zdrojová pole"
-          },
-          "source_unit": {
-            "name": "Zdrojová jednotka"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuty)"
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
           },
           "last_reset_at": {
             "name": "Poslední reset"
-          },
-          "update_pending": {
-            "name": "Aktualizace čeká"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Spotřeba ohřívače vody objektu",
         "state_attributes": {
-          "start_date": {
-            "name": "Datum začátku"
-          },
-          "last_report_date": {
-            "name": "Datum poslední zprávy"
-          },
-          "bucket_count": {
-            "name": "Počet bucketů"
-          },
-          "source_fields": {
-            "name": "Zdrojová pole"
-          },
-          "source_unit": {
-            "name": "Zdrojová jednotka"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuty)"
+          "sampled_at_utc": {
+            "name": "Čas vzorku (UTC)"
           },
           "last_reset_at": {
             "name": "Poslední reset"
-          },
-          "update_pending": {
-            "name": "Aktualizace čeká"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "SG-Ready tepelného čerpadla aktivní"
       },
       "cloud_reachable": {
-        "name": "Cloud dostupný",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Poslední selhání (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Poslední stav selhání"
-          },
-          "code_description": {
-            "name": "Popis kódu"
-          },
-          "last_failure_response": {
-            "name": "Poslední odpověď selhání"
-          },
-          "last_failure_source": {
-            "name": "Poslední zdroj selhání"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff končí (UTC)"
-          }
-        }
+        "name": "Cloud dostupný"
       },
       "connected": {
         "name": "Konektivita",

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Seneste vellykkede opdatering",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Seneste succes (UTC)"
-          },
           "last_failure_utc": {
             "name": "Seneste fejl (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Cloud-latenstid",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Seneste fejl (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Seneste fejlstatus"
-          },
-          "code_description": {
-            "name": "Kodebeskrivelse"
-          },
-          "last_failure_response": {
-            "name": "Seneste fejlsvar"
-          },
-          "last_failure_source": {
-            "name": "Seneste fejlkilde"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff slutter (UTC)"
-          }
-        }
+        "name": "Cloud-latenstid"
       },
       "current_production_power": {
         "name": "Aktuel produktionskraft",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Cloud-fejlkode",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Seneste fejl (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Seneste fejlstatus"
-          },
-          "code_description": {
-            "name": "Kodebeskrivelse"
-          },
-          "last_failure_response": {
-            "name": "Seneste fejlsvar"
-          },
-          "last_failure_source": {
-            "name": "Seneste fejlkilde"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff slutter (UTC)"
-          }
-        },
         "state": {
           "none": "Ingen",
           "dns_error": "DNS-fejl",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud-backoff slutter",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Seneste fejl (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Seneste fejlstatus"
-          },
-          "code_description": {
-            "name": "Kodebeskrivelse"
-          },
-          "last_failure_response": {
-            "name": "Seneste fejlsvar"
-          },
-          "last_failure_source": {
-            "name": "Seneste fejlkilde"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff slutter (UTC)"
-          }
-        },
         "state": {
           "none": "Ingen"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Site-solproduktion",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Seneste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antal buckets"
-          },
-          "source_fields": {
-            "name": "Kilde felter"
-          },
-          "source_unit": {
-            "name": "Kildeenhed"
-          },
-          "interval_minutes": {
-            "name": "Interval (minutter)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Seneste nulstilling"
-          },
-          "update_pending": {
-            "name": "Opdatering afventer"
           }
         }
       },
       "site_consumption": {
         "name": "Site-forbrug",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Seneste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antal buckets"
-          },
-          "source_fields": {
-            "name": "Kilde felter"
-          },
-          "source_unit": {
-            "name": "Kildeenhed"
-          },
-          "interval_minutes": {
-            "name": "Interval (minutter)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Seneste nulstilling"
-          },
-          "update_pending": {
-            "name": "Opdatering afventer"
           }
         }
       },
       "site_grid_import": {
         "name": "Site-netimport",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Seneste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antal buckets"
-          },
-          "source_fields": {
-            "name": "Kilde felter"
-          },
-          "source_unit": {
-            "name": "Kildeenhed"
-          },
-          "interval_minutes": {
-            "name": "Interval (minutter)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Seneste nulstilling"
-          },
-          "update_pending": {
-            "name": "Opdatering afventer"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Seneste vindue (s)"
           },
-          "last_report_date": {
-            "name": "Seneste rapportdato"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Seneste nulstilling"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Site-neteksport",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Seneste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antal buckets"
-          },
-          "source_fields": {
-            "name": "Kilde felter"
-          },
-          "source_unit": {
-            "name": "Kildeenhed"
-          },
-          "interval_minutes": {
-            "name": "Interval (minutter)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Seneste nulstilling"
-          },
-          "update_pending": {
-            "name": "Opdatering afventer"
           }
         }
       },
       "site_battery_charge": {
         "name": "Site-batteriopladning",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Seneste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antal buckets"
-          },
-          "source_fields": {
-            "name": "Kilde felter"
-          },
-          "source_unit": {
-            "name": "Kildeenhed"
-          },
-          "interval_minutes": {
-            "name": "Interval (minutter)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Seneste nulstilling"
-          },
-          "update_pending": {
-            "name": "Opdatering afventer"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Site-batteriafladning",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Seneste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antal buckets"
-          },
-          "source_fields": {
-            "name": "Kilde felter"
-          },
-          "source_unit": {
-            "name": "Kildeenhed"
-          },
-          "interval_minutes": {
-            "name": "Interval (minutter)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Seneste nulstilling"
-          },
-          "update_pending": {
-            "name": "Opdatering afventer"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Seneste vindue (s)"
           },
-          "last_report_date": {
-            "name": "Seneste rapportdato"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Seneste nulstilling"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Stedets EVSE-opladning",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Seneste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antal buckets"
-          },
-          "source_fields": {
-            "name": "Kilde felter"
-          },
-          "source_unit": {
-            "name": "Kildeenhed"
-          },
-          "interval_minutes": {
-            "name": "Interval (minutter)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Seneste nulstilling"
-          },
-          "update_pending": {
-            "name": "Opdatering afventer"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Stedets varmepumpeforbrug",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Seneste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antal buckets"
-          },
-          "source_fields": {
-            "name": "Kilde felter"
-          },
-          "source_unit": {
-            "name": "Kildeenhed"
-          },
-          "interval_minutes": {
-            "name": "Interval (minutter)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Seneste nulstilling"
-          },
-          "update_pending": {
-            "name": "Opdatering afventer"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Stedets varmtvandsbeholderforbrug",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Seneste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antal buckets"
-          },
-          "source_fields": {
-            "name": "Kilde felter"
-          },
-          "source_unit": {
-            "name": "Kildeenhed"
-          },
-          "interval_minutes": {
-            "name": "Interval (minutter)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Seneste nulstilling"
-          },
-          "update_pending": {
-            "name": "Opdatering afventer"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "Varmepumpens SG-Ready aktiv"
       },
       "cloud_reachable": {
-        "name": "Cloud kan nås",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Seneste fejl (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Seneste fejlstatus"
-          },
-          "code_description": {
-            "name": "Kodebeskrivelse"
-          },
-          "last_failure_response": {
-            "name": "Seneste fejlsvar"
-          },
-          "last_failure_source": {
-            "name": "Seneste fejlkilde"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff slutter (UTC)"
-          }
-        }
+        "name": "Cloud kan nås"
       },
       "connected": {
         "name": "Forbindelse",

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Letzte erfolgreiche Aktualisierung",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Letzter Erfolg (UTC)"
-          },
           "last_failure_utc": {
             "name": "Letzter Fehler (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Cloud-Latenz",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Letzter Fehler (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Letzter Fehlerstatus"
-          },
-          "code_description": {
-            "name": "Fehlerbeschreibung"
-          },
-          "last_failure_response": {
-            "name": "Letzte Fehlermeldung"
-          },
-          "last_failure_source": {
-            "name": "Letzte Fehlerquelle"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff endet (UTC)"
-          }
-        }
+        "name": "Cloud-Latenz"
       },
       "current_production_power": {
         "name": "Aktuelle Erzeugungsleistung",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Cloud-Fehlercode",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Letzter Fehler (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Letzter Fehlerstatus"
-          },
-          "code_description": {
-            "name": "Fehlerbeschreibung"
-          },
-          "last_failure_response": {
-            "name": "Letzte Fehlermeldung"
-          },
-          "last_failure_source": {
-            "name": "Letzte Fehlerquelle"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff endet (UTC)"
-          }
-        },
         "state": {
           "none": "Keiner",
           "dns_error": "DNS-Fehler",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Ende des Cloud-Backoffs",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Letzter Fehler (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Letzter Fehlerstatus"
-          },
-          "code_description": {
-            "name": "Fehlerbeschreibung"
-          },
-          "last_failure_response": {
-            "name": "Letzte Fehlermeldung"
-          },
-          "last_failure_source": {
-            "name": "Letzte Fehlerquelle"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff endet (UTC)"
-          }
-        },
         "state": {
           "none": "Keiner"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Standort Solarproduktion",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Letzter Bericht"
-          },
-          "bucket_count": {
-            "name": "Bucket-Anzahl"
-          },
-          "source_fields": {
-            "name": "Quellfelder"
-          },
-          "source_unit": {
-            "name": "Quelleinheit"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
           },
           "last_reset_at": {
             "name": "Letzter Reset"
-          },
-          "update_pending": {
-            "name": "Update ausstehend"
           }
         }
       },
       "site_consumption": {
         "name": "Standortverbrauch",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Letzter Bericht"
-          },
-          "bucket_count": {
-            "name": "Bucket-Anzahl"
-          },
-          "source_fields": {
-            "name": "Quellfelder"
-          },
-          "source_unit": {
-            "name": "Quelleinheit"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
           },
           "last_reset_at": {
             "name": "Letzter Reset"
-          },
-          "update_pending": {
-            "name": "Update ausstehend"
           }
         }
       },
       "site_grid_import": {
         "name": "Standort Netzbezug",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Letzter Bericht"
-          },
-          "bucket_count": {
-            "name": "Bucket-Anzahl"
-          },
-          "source_fields": {
-            "name": "Quellfelder"
-          },
-          "source_unit": {
-            "name": "Quelleinheit"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
           },
           "last_reset_at": {
             "name": "Letzter Reset"
-          },
-          "update_pending": {
-            "name": "Update ausstehend"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Letztes Fenster (s)"
           },
-          "last_report_date": {
-            "name": "Letzter Bericht"
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
           },
           "last_reset_at": {
             "name": "Letzter Reset"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Standort Netzeinspeisung",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Letzter Bericht"
-          },
-          "bucket_count": {
-            "name": "Bucket-Anzahl"
-          },
-          "source_fields": {
-            "name": "Quellfelder"
-          },
-          "source_unit": {
-            "name": "Quelleinheit"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
           },
           "last_reset_at": {
             "name": "Letzter Reset"
-          },
-          "update_pending": {
-            "name": "Update ausstehend"
           }
         }
       },
       "site_battery_charge": {
         "name": "Standort Batterieladung",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Letzter Bericht"
-          },
-          "bucket_count": {
-            "name": "Bucket-Anzahl"
-          },
-          "source_fields": {
-            "name": "Quellfelder"
-          },
-          "source_unit": {
-            "name": "Quelleinheit"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
           },
           "last_reset_at": {
             "name": "Letzter Reset"
-          },
-          "update_pending": {
-            "name": "Update ausstehend"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Standort Batterientladung",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Letzter Bericht"
-          },
-          "bucket_count": {
-            "name": "Bucket-Anzahl"
-          },
-          "source_fields": {
-            "name": "Quellfelder"
-          },
-          "source_unit": {
-            "name": "Quelleinheit"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
           },
           "last_reset_at": {
             "name": "Letzter Reset"
-          },
-          "update_pending": {
-            "name": "Update ausstehend"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Letztes Fenster (s)"
           },
-          "last_report_date": {
-            "name": "Letzter Bericht"
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
           },
           "last_reset_at": {
             "name": "Letzter Reset"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "EVSE-Ladung der Anlage",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Letzter Bericht"
-          },
-          "bucket_count": {
-            "name": "Bucket-Anzahl"
-          },
-          "source_fields": {
-            "name": "Quellfelder"
-          },
-          "source_unit": {
-            "name": "Quelleinheit"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
           },
           "last_reset_at": {
             "name": "Letzter Reset"
-          },
-          "update_pending": {
-            "name": "Update ausstehend"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Wärmepumpenverbrauch der Anlage",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Letzter Bericht"
-          },
-          "bucket_count": {
-            "name": "Bucket-Anzahl"
-          },
-          "source_fields": {
-            "name": "Quellfelder"
-          },
-          "source_unit": {
-            "name": "Quelleinheit"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
           },
           "last_reset_at": {
             "name": "Letzter Reset"
-          },
-          "update_pending": {
-            "name": "Update ausstehend"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Warmwasserbereiterverbrauch der Anlage",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Letzter Bericht"
-          },
-          "bucket_count": {
-            "name": "Bucket-Anzahl"
-          },
-          "source_fields": {
-            "name": "Quellfelder"
-          },
-          "source_unit": {
-            "name": "Quelleinheit"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Gemessen um (UTC)"
           },
           "last_reset_at": {
             "name": "Letzter Reset"
-          },
-          "update_pending": {
-            "name": "Update ausstehend"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "SG-Ready der Wärmepumpe aktiv"
       },
       "cloud_reachable": {
-        "name": "Cloud erreichbar",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Letzter Fehler (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Letzter Fehlerstatus"
-          },
-          "code_description": {
-            "name": "Fehlerbeschreibung"
-          },
-          "last_failure_response": {
-            "name": "Letzte Fehlermeldung"
-          },
-          "last_failure_source": {
-            "name": "Letzte Fehlerquelle"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff endet (UTC)"
-          }
-        }
+        "name": "Cloud erreichbar"
       },
       "connected": {
         "name": "Konnektivität",

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Τελευταία επιτυχής ενημέρωση",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Τελευταία επιτυχία (UTC)"
-          },
           "last_failure_utc": {
             "name": "Τελευταία αποτυχία (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Καθυστέρηση cloud",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Τελευταία αποτυχία (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Τελευταία κατάσταση αποτυχίας"
-          },
-          "code_description": {
-            "name": "Περιγραφή κωδικού"
-          },
-          "last_failure_response": {
-            "name": "Τελευταία απόκριση αποτυχίας"
-          },
-          "last_failure_source": {
-            "name": "Τελευταία πηγή αποτυχίας"
-          },
-          "backoff_ends_utc": {
-            "name": "Λήξη backoff (UTC)"
-          }
-        }
+        "name": "Καθυστέρηση cloud"
       },
       "current_production_power": {
         "name": "Τρέχουσα ισχύς παραγωγής",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Κωδικός σφάλματος cloud",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Τελευταία αποτυχία (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Τελευταία κατάσταση αποτυχίας"
-          },
-          "code_description": {
-            "name": "Περιγραφή κωδικού"
-          },
-          "last_failure_response": {
-            "name": "Τελευταία απόκριση αποτυχίας"
-          },
-          "last_failure_source": {
-            "name": "Τελευταία πηγή αποτυχίας"
-          },
-          "backoff_ends_utc": {
-            "name": "Λήξη backoff (UTC)"
-          }
-        },
         "state": {
           "none": "Κανένα",
           "dns_error": "Σφάλμα DNS",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Λήξη backoff cloud",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Τελευταία αποτυχία (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Τελευταία κατάσταση αποτυχίας"
-          },
-          "code_description": {
-            "name": "Περιγραφή κωδικού"
-          },
-          "last_failure_response": {
-            "name": "Τελευταία απόκριση αποτυχίας"
-          },
-          "last_failure_source": {
-            "name": "Τελευταία πηγή αποτυχίας"
-          },
-          "backoff_ends_utc": {
-            "name": "Λήξη backoff (UTC)"
-          }
-        },
         "state": {
           "none": "Κανένα"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Ηλιακή παραγωγή τοποθεσίας",
         "state_attributes": {
-          "start_date": {
-            "name": "Ημερομηνία έναρξης"
-          },
-          "last_report_date": {
-            "name": "Ημερομηνία τελευταίας αναφοράς"
-          },
-          "bucket_count": {
-            "name": "Αριθμός κάδων"
-          },
-          "source_fields": {
-            "name": "Πεδία πηγής"
-          },
-          "source_unit": {
-            "name": "Μονάδα πηγής"
-          },
-          "interval_minutes": {
-            "name": "Διάστημα (min)"
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
           },
           "last_reset_at": {
             "name": "Τελευταία επαναφορά"
-          },
-          "update_pending": {
-            "name": "Εκκρεμεί ενημέρωση"
           }
         }
       },
       "site_consumption": {
         "name": "Κατανάλωση τοποθεσίας",
         "state_attributes": {
-          "start_date": {
-            "name": "Ημερομηνία έναρξης"
-          },
-          "last_report_date": {
-            "name": "Ημερομηνία τελευταίας αναφοράς"
-          },
-          "bucket_count": {
-            "name": "Αριθμός κάδων"
-          },
-          "source_fields": {
-            "name": "Πεδία πηγής"
-          },
-          "source_unit": {
-            "name": "Μονάδα πηγής"
-          },
-          "interval_minutes": {
-            "name": "Διάστημα (min)"
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
           },
           "last_reset_at": {
             "name": "Τελευταία επαναφορά"
-          },
-          "update_pending": {
-            "name": "Εκκρεμεί ενημέρωση"
           }
         }
       },
       "site_grid_import": {
         "name": "Εισαγωγή από το δίκτυο τοποθεσίας",
         "state_attributes": {
-          "start_date": {
-            "name": "Ημερομηνία έναρξης"
-          },
-          "last_report_date": {
-            "name": "Ημερομηνία τελευταίας αναφοράς"
-          },
-          "bucket_count": {
-            "name": "Αριθμός κάδων"
-          },
-          "source_fields": {
-            "name": "Πεδία πηγής"
-          },
-          "source_unit": {
-            "name": "Μονάδα πηγής"
-          },
-          "interval_minutes": {
-            "name": "Διάστημα (min)"
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
           },
           "last_reset_at": {
             "name": "Τελευταία επαναφορά"
-          },
-          "update_pending": {
-            "name": "Εκκρεμεί ενημέρωση"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Τελευταίο παράθυρο (s)"
           },
-          "last_report_date": {
-            "name": "Ημερομηνία τελευταίας αναφοράς"
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
           },
           "last_reset_at": {
             "name": "Τελευταία επαναφορά"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Εξαγωγή στο δίκτυο τοποθεσίας",
         "state_attributes": {
-          "start_date": {
-            "name": "Ημερομηνία έναρξης"
-          },
-          "last_report_date": {
-            "name": "Ημερομηνία τελευταίας αναφοράς"
-          },
-          "bucket_count": {
-            "name": "Αριθμός κάδων"
-          },
-          "source_fields": {
-            "name": "Πεδία πηγής"
-          },
-          "source_unit": {
-            "name": "Μονάδα πηγής"
-          },
-          "interval_minutes": {
-            "name": "Διάστημα (min)"
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
           },
           "last_reset_at": {
             "name": "Τελευταία επαναφορά"
-          },
-          "update_pending": {
-            "name": "Εκκρεμεί ενημέρωση"
           }
         }
       },
       "site_battery_charge": {
         "name": "Φόρτιση μπαταρίας τοποθεσίας",
         "state_attributes": {
-          "start_date": {
-            "name": "Ημερομηνία έναρξης"
-          },
-          "last_report_date": {
-            "name": "Ημερομηνία τελευταίας αναφοράς"
-          },
-          "bucket_count": {
-            "name": "Αριθμός κάδων"
-          },
-          "source_fields": {
-            "name": "Πεδία πηγής"
-          },
-          "source_unit": {
-            "name": "Μονάδα πηγής"
-          },
-          "interval_minutes": {
-            "name": "Διάστημα (min)"
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
           },
           "last_reset_at": {
             "name": "Τελευταία επαναφορά"
-          },
-          "update_pending": {
-            "name": "Εκκρεμεί ενημέρωση"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Εκφόρτιση μπαταρίας τοποθεσίας",
         "state_attributes": {
-          "start_date": {
-            "name": "Ημερομηνία έναρξης"
-          },
-          "last_report_date": {
-            "name": "Ημερομηνία τελευταίας αναφοράς"
-          },
-          "bucket_count": {
-            "name": "Αριθμός κάδων"
-          },
-          "source_fields": {
-            "name": "Πεδία πηγής"
-          },
-          "source_unit": {
-            "name": "Μονάδα πηγής"
-          },
-          "interval_minutes": {
-            "name": "Διάστημα (min)"
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
           },
           "last_reset_at": {
             "name": "Τελευταία επαναφορά"
-          },
-          "update_pending": {
-            "name": "Εκκρεμεί ενημέρωση"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Τελευταίο παράθυρο (s)"
           },
-          "last_report_date": {
-            "name": "Ημερομηνία τελευταίας αναφοράς"
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
           },
           "last_reset_at": {
             "name": "Τελευταία επαναφορά"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Φόρτιση EVSE τοποθεσίας",
         "state_attributes": {
-          "start_date": {
-            "name": "Ημερομηνία έναρξης"
-          },
-          "last_report_date": {
-            "name": "Ημερομηνία τελευταίας αναφοράς"
-          },
-          "bucket_count": {
-            "name": "Αριθμός κάδων"
-          },
-          "source_fields": {
-            "name": "Πεδία πηγής"
-          },
-          "source_unit": {
-            "name": "Μονάδα πηγής"
-          },
-          "interval_minutes": {
-            "name": "Διάστημα (min)"
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
           },
           "last_reset_at": {
             "name": "Τελευταία επαναφορά"
-          },
-          "update_pending": {
-            "name": "Εκκρεμεί ενημέρωση"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Κατανάλωση αντλίας θερμότητας τοποθεσίας",
         "state_attributes": {
-          "start_date": {
-            "name": "Ημερομηνία έναρξης"
-          },
-          "last_report_date": {
-            "name": "Ημερομηνία τελευταίας αναφοράς"
-          },
-          "bucket_count": {
-            "name": "Αριθμός κάδων"
-          },
-          "source_fields": {
-            "name": "Πεδία πηγής"
-          },
-          "source_unit": {
-            "name": "Μονάδα πηγής"
-          },
-          "interval_minutes": {
-            "name": "Διάστημα (min)"
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
           },
           "last_reset_at": {
             "name": "Τελευταία επαναφορά"
-          },
-          "update_pending": {
-            "name": "Εκκρεμεί ενημέρωση"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Κατανάλωση θερμοσίφωνα τοποθεσίας",
         "state_attributes": {
-          "start_date": {
-            "name": "Ημερομηνία έναρξης"
-          },
-          "last_report_date": {
-            "name": "Ημερομηνία τελευταίας αναφοράς"
-          },
-          "bucket_count": {
-            "name": "Αριθμός κάδων"
-          },
-          "source_fields": {
-            "name": "Πεδία πηγής"
-          },
-          "source_unit": {
-            "name": "Μονάδα πηγής"
-          },
-          "interval_minutes": {
-            "name": "Διάστημα (min)"
+          "sampled_at_utc": {
+            "name": "Δειγματοληψία στις (UTC)"
           },
           "last_reset_at": {
             "name": "Τελευταία επαναφορά"
-          },
-          "update_pending": {
-            "name": "Εκκρεμεί ενημέρωση"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "SG-Ready αντλίας θερμότητας ενεργό"
       },
       "cloud_reachable": {
-        "name": "Cloud προσβάσιμο",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Τελευταία αποτυχία (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Τελευταία κατάσταση αποτυχίας"
-          },
-          "code_description": {
-            "name": "Περιγραφή κωδικού"
-          },
-          "last_failure_response": {
-            "name": "Τελευταία απόκριση αποτυχίας"
-          },
-          "last_failure_source": {
-            "name": "Τελευταία πηγή αποτυχίας"
-          },
-          "backoff_ends_utc": {
-            "name": "Λήξη backoff (UTC)"
-          }
-        }
+        "name": "Cloud προσβάσιμο"
       },
       "connected": {
         "name": "Συνδεσιμότητα",

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -490,9 +490,6 @@
       "last_successful_update": {
         "name": "Last Successful Update",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Last Success (UTC)"
-          },
           "last_failure_utc": {
             "name": "Last Failure (UTC)"
           },
@@ -514,27 +511,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Cloud Latency",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Latency"
       },
       "current_production_power": {
         "name": "Current Production Power",
@@ -555,26 +532,6 @@
       },
       "cloud_error_code": {
         "name": "Cloud Error Code",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None",
           "dns_error": "DNS error",
@@ -583,26 +540,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None"
         }
@@ -760,87 +697,33 @@
       "site_solar_production": {
         "name": "Site Solar Production",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_consumption": {
         "name": "Site Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_grid_import": {
         "name": "Site Grid Import",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -862,8 +745,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -879,87 +762,33 @@
       "site_grid_export": {
         "name": "Site Grid Export",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_charge": {
         "name": "Site Battery Charge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Site Battery Discharge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -981,8 +810,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -1090,87 +919,33 @@
       "site_evse_charging": {
         "name": "Site EVSE Charging",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Site Heat Pump Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Site Water Heater Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -1293,27 +1068,7 @@
         "name": "Heat Pump SG-Ready Active"
       },
       "cloud_reachable": {
-        "name": "Cloud Reachable",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Reachable"
       },
       "connected": {
         "name": "Connectivity",

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -490,9 +490,6 @@
       "last_successful_update": {
         "name": "Last Successful Update",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Last Success (UTC)"
-          },
           "last_failure_utc": {
             "name": "Last Failure (UTC)"
           },
@@ -514,27 +511,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Cloud Latency",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Latency"
       },
       "current_production_power": {
         "name": "Current Production Power",
@@ -555,26 +532,6 @@
       },
       "cloud_error_code": {
         "name": "Cloud Error Code",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None",
           "dns_error": "DNS error",
@@ -583,26 +540,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None"
         }
@@ -760,87 +697,33 @@
       "site_solar_production": {
         "name": "Site Solar Production",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_consumption": {
         "name": "Site Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_grid_import": {
         "name": "Site Grid Import",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -862,8 +745,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -879,87 +762,33 @@
       "site_grid_export": {
         "name": "Site Grid Export",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_charge": {
         "name": "Site Battery Charge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Site Battery Discharge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -981,8 +810,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -1090,87 +919,33 @@
       "site_evse_charging": {
         "name": "Site EVSE Charging",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Site Heat Pump Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Site Water Heater Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -1293,27 +1068,7 @@
         "name": "Heat Pump SG-Ready Active"
       },
       "cloud_reachable": {
-        "name": "Cloud Reachable",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Reachable"
       },
       "connected": {
         "name": "Connectivity",

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -490,9 +490,6 @@
       "last_successful_update": {
         "name": "Last Successful Update",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Last Success (UTC)"
-          },
           "last_failure_utc": {
             "name": "Last Failure (UTC)"
           },
@@ -514,27 +511,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Cloud Latency",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Latency"
       },
       "current_production_power": {
         "name": "Current Production Power",
@@ -555,26 +532,6 @@
       },
       "cloud_error_code": {
         "name": "Cloud Error Code",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None",
           "dns_error": "DNS error",
@@ -583,26 +540,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None"
         }
@@ -760,87 +697,33 @@
       "site_solar_production": {
         "name": "Site Solar Production",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_consumption": {
         "name": "Site Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_grid_import": {
         "name": "Site Grid Import",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -862,8 +745,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -879,87 +762,33 @@
       "site_grid_export": {
         "name": "Site Grid Export",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_charge": {
         "name": "Site Battery Charge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Site Battery Discharge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -981,8 +810,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -1090,87 +919,33 @@
       "site_evse_charging": {
         "name": "Site EVSE Charging",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Site Heat Pump Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Site Water Heater Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -1293,27 +1068,7 @@
         "name": "Heat Pump SG-Ready Active"
       },
       "cloud_reachable": {
-        "name": "Cloud Reachable",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Reachable"
       },
       "connected": {
         "name": "Connectivity",

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -490,9 +490,6 @@
       "last_successful_update": {
         "name": "Last Successful Update",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Last Success (UTC)"
-          },
           "last_failure_utc": {
             "name": "Last Failure (UTC)"
           },
@@ -514,27 +511,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Cloud Latency",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Latency"
       },
       "current_production_power": {
         "name": "Current Production Power",
@@ -555,26 +532,6 @@
       },
       "cloud_error_code": {
         "name": "Cloud Error Code",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None",
           "dns_error": "DNS error",
@@ -583,26 +540,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None"
         }
@@ -760,87 +697,33 @@
       "site_solar_production": {
         "name": "Site Solar Production",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_consumption": {
         "name": "Site Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_grid_import": {
         "name": "Site Grid Import",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -862,8 +745,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -879,87 +762,33 @@
       "site_grid_export": {
         "name": "Site Grid Export",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_charge": {
         "name": "Site Battery Charge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Site Battery Discharge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -981,8 +810,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -1090,87 +919,33 @@
       "site_evse_charging": {
         "name": "Site EVSE Charging",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Site Heat Pump Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Site Water Heater Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -1293,27 +1068,7 @@
         "name": "Heat Pump SG-Ready Active"
       },
       "cloud_reachable": {
-        "name": "Cloud Reachable",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Reachable"
       },
       "connected": {
         "name": "Connectivity",

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -490,9 +490,6 @@
       "last_successful_update": {
         "name": "Last Successful Update",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Last Success (UTC)"
-          },
           "last_failure_utc": {
             "name": "Last Failure (UTC)"
           },
@@ -514,27 +511,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Cloud Latency",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Latency"
       },
       "current_production_power": {
         "name": "Current Production Power",
@@ -555,26 +532,6 @@
       },
       "cloud_error_code": {
         "name": "Cloud Error Code",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None",
           "dns_error": "DNS error",
@@ -583,26 +540,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None"
         }
@@ -760,87 +697,33 @@
       "site_solar_production": {
         "name": "Site Solar Production",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_consumption": {
         "name": "Site Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_grid_import": {
         "name": "Site Grid Import",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -862,8 +745,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -879,87 +762,33 @@
       "site_grid_export": {
         "name": "Site Grid Export",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_charge": {
         "name": "Site Battery Charge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Site Battery Discharge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -981,8 +810,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -1090,87 +919,33 @@
       "site_evse_charging": {
         "name": "Site EVSE Charging",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Site Heat Pump Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Site Water Heater Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -1293,27 +1068,7 @@
         "name": "Heat Pump SG-Ready Active"
       },
       "cloud_reachable": {
-        "name": "Cloud Reachable",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Reachable"
       },
       "connected": {
         "name": "Connectivity",

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -490,9 +490,6 @@
       "last_successful_update": {
         "name": "Last Successful Update",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Last Success (UTC)"
-          },
           "last_failure_utc": {
             "name": "Last Failure (UTC)"
           },
@@ -514,27 +511,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Cloud Latency",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Latency"
       },
       "current_production_power": {
         "name": "Current Production Power",
@@ -555,26 +532,6 @@
       },
       "cloud_error_code": {
         "name": "Cloud Error Code",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None",
           "dns_error": "DNS error",
@@ -583,26 +540,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        },
         "state": {
           "none": "None"
         }
@@ -760,87 +697,33 @@
       "site_solar_production": {
         "name": "Site Solar Production",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_consumption": {
         "name": "Site Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_grid_import": {
         "name": "Site Grid Import",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -862,8 +745,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -879,87 +762,33 @@
       "site_grid_export": {
         "name": "Site Grid Export",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_charge": {
         "name": "Site Battery Charge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Site Battery Discharge",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -981,8 +810,8 @@
           "last_window_seconds": {
             "name": "Last Window (s)"
           },
-          "last_report_date": {
-            "name": "Last Report Date"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
@@ -1090,87 +919,33 @@
       "site_evse_charging": {
         "name": "Site EVSE Charging",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Site Heat Pump Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Site Water Heater Consumption",
         "state_attributes": {
-          "start_date": {
-            "name": "Start Date"
-          },
-          "last_report_date": {
-            "name": "Last Report Date"
-          },
-          "bucket_count": {
-            "name": "Bucket Count"
-          },
-          "source_fields": {
-            "name": "Source Fields"
-          },
-          "source_unit": {
-            "name": "Source Unit"
-          },
-          "interval_minutes": {
-            "name": "Interval (min)"
+          "sampled_at_utc": {
+            "name": "Sampled At (UTC)"
           },
           "last_reset_at": {
             "name": "Last Reset At"
-          },
-          "update_pending": {
-            "name": "Update Pending"
           }
         }
       },
@@ -1293,27 +1068,7 @@
         "name": "Heat Pump SG-Ready Active"
       },
       "cloud_reachable": {
-        "name": "Cloud Reachable",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Last Failure (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Last Failure Status"
-          },
-          "code_description": {
-            "name": "Code Description"
-          },
-          "last_failure_response": {
-            "name": "Last Failure Response"
-          },
-          "last_failure_source": {
-            "name": "Last Failure Source"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff Ends (UTC)"
-          }
-        }
+        "name": "Cloud Reachable"
       },
       "connected": {
         "name": "Connectivity",

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Última actualización correcta",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Último éxito (UTC)"
-          },
           "last_failure_utc": {
             "name": "Último fallo (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Latencia en la nube",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Último fallo (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Estado del último fallo"
-          },
-          "code_description": {
-            "name": "Descripción del código"
-          },
-          "last_failure_response": {
-            "name": "Respuesta del último fallo"
-          },
-          "last_failure_source": {
-            "name": "Fuente del último fallo"
-          },
-          "backoff_ends_utc": {
-            "name": "Fin del backoff (UTC)"
-          }
-        }
+        "name": "Latencia en la nube"
       },
       "current_production_power": {
         "name": "Potencia actual de producción",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Código de error en la nube",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Último fallo (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Estado del último fallo"
-          },
-          "code_description": {
-            "name": "Descripción del código"
-          },
-          "last_failure_response": {
-            "name": "Respuesta del último fallo"
-          },
-          "last_failure_source": {
-            "name": "Fuente del último fallo"
-          },
-          "backoff_ends_utc": {
-            "name": "Fin del backoff (UTC)"
-          }
-        },
         "state": {
           "none": "Ninguno",
           "dns_error": "Error de DNS",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Fin del tiempo de espera en la nube",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Último fallo (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Estado del último fallo"
-          },
-          "code_description": {
-            "name": "Descripción del código"
-          },
-          "last_failure_response": {
-            "name": "Respuesta del último fallo"
-          },
-          "last_failure_source": {
-            "name": "Fuente del último fallo"
-          },
-          "backoff_ends_utc": {
-            "name": "Fin del backoff (UTC)"
-          }
-        },
         "state": {
           "none": "Ninguno"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Producción solar del sitio",
         "state_attributes": {
-          "start_date": {
-            "name": "Fecha de inicio"
-          },
-          "last_report_date": {
-            "name": "Última fecha de informe"
-          },
-          "bucket_count": {
-            "name": "Conteo de bloques"
-          },
-          "source_fields": {
-            "name": "Campos de origen"
-          },
-          "source_unit": {
-            "name": "Unidad de origen"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
           },
           "last_reset_at": {
             "name": "Último restablecimiento"
-          },
-          "update_pending": {
-            "name": "Actualización pendiente"
           }
         }
       },
       "site_consumption": {
         "name": "Consumo del sitio",
         "state_attributes": {
-          "start_date": {
-            "name": "Fecha de inicio"
-          },
-          "last_report_date": {
-            "name": "Última fecha de informe"
-          },
-          "bucket_count": {
-            "name": "Conteo de bloques"
-          },
-          "source_fields": {
-            "name": "Campos de origen"
-          },
-          "source_unit": {
-            "name": "Unidad de origen"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
           },
           "last_reset_at": {
             "name": "Último restablecimiento"
-          },
-          "update_pending": {
-            "name": "Actualización pendiente"
           }
         }
       },
       "site_grid_import": {
         "name": "Importación de red del sitio",
         "state_attributes": {
-          "start_date": {
-            "name": "Fecha de inicio"
-          },
-          "last_report_date": {
-            "name": "Última fecha de informe"
-          },
-          "bucket_count": {
-            "name": "Conteo de bloques"
-          },
-          "source_fields": {
-            "name": "Campos de origen"
-          },
-          "source_unit": {
-            "name": "Unidad de origen"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
           },
           "last_reset_at": {
             "name": "Último restablecimiento"
-          },
-          "update_pending": {
-            "name": "Actualización pendiente"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Última ventana (s)"
           },
-          "last_report_date": {
-            "name": "Última fecha de informe"
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
           },
           "last_reset_at": {
             "name": "Último restablecimiento"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Exportación a la red del sitio",
         "state_attributes": {
-          "start_date": {
-            "name": "Fecha de inicio"
-          },
-          "last_report_date": {
-            "name": "Última fecha de informe"
-          },
-          "bucket_count": {
-            "name": "Conteo de bloques"
-          },
-          "source_fields": {
-            "name": "Campos de origen"
-          },
-          "source_unit": {
-            "name": "Unidad de origen"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
           },
           "last_reset_at": {
             "name": "Último restablecimiento"
-          },
-          "update_pending": {
-            "name": "Actualización pendiente"
           }
         }
       },
       "site_battery_charge": {
         "name": "Carga de batería del sitio",
         "state_attributes": {
-          "start_date": {
-            "name": "Fecha de inicio"
-          },
-          "last_report_date": {
-            "name": "Última fecha de informe"
-          },
-          "bucket_count": {
-            "name": "Conteo de bloques"
-          },
-          "source_fields": {
-            "name": "Campos de origen"
-          },
-          "source_unit": {
-            "name": "Unidad de origen"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
           },
           "last_reset_at": {
             "name": "Último restablecimiento"
-          },
-          "update_pending": {
-            "name": "Actualización pendiente"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Descarga de batería del sitio",
         "state_attributes": {
-          "start_date": {
-            "name": "Fecha de inicio"
-          },
-          "last_report_date": {
-            "name": "Última fecha de informe"
-          },
-          "bucket_count": {
-            "name": "Conteo de bloques"
-          },
-          "source_fields": {
-            "name": "Campos de origen"
-          },
-          "source_unit": {
-            "name": "Unidad de origen"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
           },
           "last_reset_at": {
             "name": "Último restablecimiento"
-          },
-          "update_pending": {
-            "name": "Actualización pendiente"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Última ventana (s)"
           },
-          "last_report_date": {
-            "name": "Última fecha de informe"
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
           },
           "last_reset_at": {
             "name": "Último restablecimiento"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Carga EVSE del sitio",
         "state_attributes": {
-          "start_date": {
-            "name": "Fecha de inicio"
-          },
-          "last_report_date": {
-            "name": "Última fecha de informe"
-          },
-          "bucket_count": {
-            "name": "Conteo de bloques"
-          },
-          "source_fields": {
-            "name": "Campos de origen"
-          },
-          "source_unit": {
-            "name": "Unidad de origen"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
           },
           "last_reset_at": {
             "name": "Último restablecimiento"
-          },
-          "update_pending": {
-            "name": "Actualización pendiente"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Consumo de bomba de calor del sitio",
         "state_attributes": {
-          "start_date": {
-            "name": "Fecha de inicio"
-          },
-          "last_report_date": {
-            "name": "Última fecha de informe"
-          },
-          "bucket_count": {
-            "name": "Conteo de bloques"
-          },
-          "source_fields": {
-            "name": "Campos de origen"
-          },
-          "source_unit": {
-            "name": "Unidad de origen"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
           },
           "last_reset_at": {
             "name": "Último restablecimiento"
-          },
-          "update_pending": {
-            "name": "Actualización pendiente"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Consumo de calentador de agua del sitio",
         "state_attributes": {
-          "start_date": {
-            "name": "Fecha de inicio"
-          },
-          "last_report_date": {
-            "name": "Última fecha de informe"
-          },
-          "bucket_count": {
-            "name": "Conteo de bloques"
-          },
-          "source_fields": {
-            "name": "Campos de origen"
-          },
-          "source_unit": {
-            "name": "Unidad de origen"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Muestreado a las (UTC)"
           },
           "last_reset_at": {
             "name": "Último restablecimiento"
-          },
-          "update_pending": {
-            "name": "Actualización pendiente"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "SG-Ready activo de la bomba de calor"
       },
       "cloud_reachable": {
-        "name": "Nube accesible",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Último fallo (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Estado del último fallo"
-          },
-          "code_description": {
-            "name": "Descripción del código"
-          },
-          "last_failure_response": {
-            "name": "Respuesta del último fallo"
-          },
-          "last_failure_source": {
-            "name": "Fuente del último fallo"
-          },
-          "backoff_ends_utc": {
-            "name": "Fin del backoff (UTC)"
-          }
-        }
+        "name": "Nube accesible"
       },
       "connected": {
         "name": "Conectividad",

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Viimane edukas värskendus",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Viimane õnnestumine (UTC)"
-          },
           "last_failure_utc": {
             "name": "Viimane tõrge (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Pilve latentsus",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Viimane tõrge (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Viimane tõrke olek"
-          },
-          "code_description": {
-            "name": "Koodi kirjeldus"
-          },
-          "last_failure_response": {
-            "name": "Viimane tõrke vastus"
-          },
-          "last_failure_source": {
-            "name": "Viimane tõrke allikas"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff lõpeb (UTC)"
-          }
-        }
+        "name": "Pilve latentsus"
       },
       "current_production_power": {
         "name": "Praegune tootmisvõimsus",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Pilve veakood",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Viimane tõrge (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Viimane tõrke olek"
-          },
-          "code_description": {
-            "name": "Koodi kirjeldus"
-          },
-          "last_failure_response": {
-            "name": "Viimane tõrke vastus"
-          },
-          "last_failure_source": {
-            "name": "Viimane tõrke allikas"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff lõpeb (UTC)"
-          }
-        },
         "state": {
           "none": "Puudub",
           "dns_error": "DNS viga",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Pilve backoff lõpeb",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Viimane tõrge (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Viimane tõrke olek"
-          },
-          "code_description": {
-            "name": "Koodi kirjeldus"
-          },
-          "last_failure_response": {
-            "name": "Viimane tõrke vastus"
-          },
-          "last_failure_source": {
-            "name": "Viimane tõrke allikas"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff lõpeb (UTC)"
-          }
-        },
         "state": {
           "none": "Puudub"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Koha päikeseenergia tootmine",
         "state_attributes": {
-          "start_date": {
-            "name": "Alguskuupäev"
-          },
-          "last_report_date": {
-            "name": "Viimane aruande kuupäev"
-          },
-          "bucket_count": {
-            "name": "Bucketite arv"
-          },
-          "source_fields": {
-            "name": "Allikaväljad"
-          },
-          "source_unit": {
-            "name": "Allika ühik"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
           },
           "last_reset_at": {
             "name": "Viimane lähtestus"
-          },
-          "update_pending": {
-            "name": "Värskendus ootel"
           }
         }
       },
       "site_consumption": {
         "name": "Koha tarbimine",
         "state_attributes": {
-          "start_date": {
-            "name": "Alguskuupäev"
-          },
-          "last_report_date": {
-            "name": "Viimane aruande kuupäev"
-          },
-          "bucket_count": {
-            "name": "Bucketite arv"
-          },
-          "source_fields": {
-            "name": "Allikaväljad"
-          },
-          "source_unit": {
-            "name": "Allika ühik"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
           },
           "last_reset_at": {
             "name": "Viimane lähtestus"
-          },
-          "update_pending": {
-            "name": "Värskendus ootel"
           }
         }
       },
       "site_grid_import": {
         "name": "Koha võrgu import",
         "state_attributes": {
-          "start_date": {
-            "name": "Alguskuupäev"
-          },
-          "last_report_date": {
-            "name": "Viimane aruande kuupäev"
-          },
-          "bucket_count": {
-            "name": "Bucketite arv"
-          },
-          "source_fields": {
-            "name": "Allikaväljad"
-          },
-          "source_unit": {
-            "name": "Allika ühik"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
           },
           "last_reset_at": {
             "name": "Viimane lähtestus"
-          },
-          "update_pending": {
-            "name": "Värskendus ootel"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Viimane aken (s)"
           },
-          "last_report_date": {
-            "name": "Viimane aruande kuupäev"
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
           },
           "last_reset_at": {
             "name": "Viimane lähtestus"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Koha võrgu eksport",
         "state_attributes": {
-          "start_date": {
-            "name": "Alguskuupäev"
-          },
-          "last_report_date": {
-            "name": "Viimane aruande kuupäev"
-          },
-          "bucket_count": {
-            "name": "Bucketite arv"
-          },
-          "source_fields": {
-            "name": "Allikaväljad"
-          },
-          "source_unit": {
-            "name": "Allika ühik"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
           },
           "last_reset_at": {
             "name": "Viimane lähtestus"
-          },
-          "update_pending": {
-            "name": "Värskendus ootel"
           }
         }
       },
       "site_battery_charge": {
         "name": "Koha aku laadimine",
         "state_attributes": {
-          "start_date": {
-            "name": "Alguskuupäev"
-          },
-          "last_report_date": {
-            "name": "Viimane aruande kuupäev"
-          },
-          "bucket_count": {
-            "name": "Bucketite arv"
-          },
-          "source_fields": {
-            "name": "Allikaväljad"
-          },
-          "source_unit": {
-            "name": "Allika ühik"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
           },
           "last_reset_at": {
             "name": "Viimane lähtestus"
-          },
-          "update_pending": {
-            "name": "Värskendus ootel"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Koha aku tühjendamine",
         "state_attributes": {
-          "start_date": {
-            "name": "Alguskuupäev"
-          },
-          "last_report_date": {
-            "name": "Viimane aruande kuupäev"
-          },
-          "bucket_count": {
-            "name": "Bucketite arv"
-          },
-          "source_fields": {
-            "name": "Allikaväljad"
-          },
-          "source_unit": {
-            "name": "Allika ühik"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
           },
           "last_reset_at": {
             "name": "Viimane lähtestus"
-          },
-          "update_pending": {
-            "name": "Värskendus ootel"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Viimane aken (s)"
           },
-          "last_report_date": {
-            "name": "Viimane aruande kuupäev"
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
           },
           "last_reset_at": {
             "name": "Viimane lähtestus"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Objekti EVSE laadimine",
         "state_attributes": {
-          "start_date": {
-            "name": "Alguskuupäev"
-          },
-          "last_report_date": {
-            "name": "Viimane aruande kuupäev"
-          },
-          "bucket_count": {
-            "name": "Bucketite arv"
-          },
-          "source_fields": {
-            "name": "Allikaväljad"
-          },
-          "source_unit": {
-            "name": "Allika ühik"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
           },
           "last_reset_at": {
             "name": "Viimane lähtestus"
-          },
-          "update_pending": {
-            "name": "Värskendus ootel"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Objekti soojuspumba tarbimine",
         "state_attributes": {
-          "start_date": {
-            "name": "Alguskuupäev"
-          },
-          "last_report_date": {
-            "name": "Viimane aruande kuupäev"
-          },
-          "bucket_count": {
-            "name": "Bucketite arv"
-          },
-          "source_fields": {
-            "name": "Allikaväljad"
-          },
-          "source_unit": {
-            "name": "Allika ühik"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
           },
           "last_reset_at": {
             "name": "Viimane lähtestus"
-          },
-          "update_pending": {
-            "name": "Värskendus ootel"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Objekti veesoojendi tarbimine",
         "state_attributes": {
-          "start_date": {
-            "name": "Alguskuupäev"
-          },
-          "last_report_date": {
-            "name": "Viimane aruande kuupäev"
-          },
-          "bucket_count": {
-            "name": "Bucketite arv"
-          },
-          "source_fields": {
-            "name": "Allikaväljad"
-          },
-          "source_unit": {
-            "name": "Allika ühik"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Mõõdetud kell (UTC)"
           },
           "last_reset_at": {
             "name": "Viimane lähtestus"
-          },
-          "update_pending": {
-            "name": "Värskendus ootel"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "Soojuspumba SG-Ready aktiivne"
       },
       "cloud_reachable": {
-        "name": "Pilv kättesaadav",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Viimane tõrge (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Viimane tõrke olek"
-          },
-          "code_description": {
-            "name": "Koodi kirjeldus"
-          },
-          "last_failure_response": {
-            "name": "Viimane tõrke vastus"
-          },
-          "last_failure_source": {
-            "name": "Viimane tõrke allikas"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff lõpeb (UTC)"
-          }
-        }
+        "name": "Pilv kättesaadav"
       },
       "connected": {
         "name": "Ühenduvus",

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Viimeinen onnistunut päivitys",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Viimeinen menestys (UTC)"
-          },
           "last_failure_utc": {
             "name": "Viimeinen epäonnistuminen (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Pilviviive",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Viimeinen epäonnistuminen (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Viimeisen epäonnistumisen tila"
-          },
-          "code_description": {
-            "name": "Koodi Kuvaus"
-          },
-          "last_failure_response": {
-            "name": "Viimeinen epäonnistumisvastaus"
-          },
-          "last_failure_source": {
-            "name": "Viimeisen epäonnistumisen lähde"
-          },
-          "backoff_ends_utc": {
-            "name": "Peruutus päättyy (UTC)"
-          }
-        }
+        "name": "Pilviviive"
       },
       "current_production_power": {
         "name": "Nykyinen tuotantoteho",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Pilvivirhekoodi",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Viimeinen epäonnistuminen (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Viimeisen epäonnistumisen tila"
-          },
-          "code_description": {
-            "name": "Koodi Kuvaus"
-          },
-          "last_failure_response": {
-            "name": "Viimeinen epäonnistumisvastaus"
-          },
-          "last_failure_source": {
-            "name": "Viimeisen epäonnistumisen lähde"
-          },
-          "backoff_ends_utc": {
-            "name": "Peruutus päättyy (UTC)"
-          }
-        },
         "state": {
           "none": "Ei mitään",
           "dns_error": "DNS-virhe",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff päättyy",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Viimeinen epäonnistuminen (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Viimeisen epäonnistumisen tila"
-          },
-          "code_description": {
-            "name": "Koodi Kuvaus"
-          },
-          "last_failure_response": {
-            "name": "Viimeinen epäonnistumisvastaus"
-          },
-          "last_failure_source": {
-            "name": "Viimeisen epäonnistumisen lähde"
-          },
-          "backoff_ends_utc": {
-            "name": "Peruutus päättyy (UTC)"
-          }
-        },
         "state": {
           "none": "Ei mitään"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Aurinkoenergian tuotantosivusto",
         "state_attributes": {
-          "start_date": {
-            "name": "Aloituspäivämäärä"
-          },
-          "last_report_date": {
-            "name": "Viimeisen raportin päivämäärä"
-          },
-          "bucket_count": {
-            "name": "Kauhan määrä"
-          },
-          "source_fields": {
-            "name": "Lähdekentät"
-          },
-          "source_unit": {
-            "name": "Lähdeyksikkö"
-          },
-          "interval_minutes": {
-            "name": "Väli (min)"
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
           },
           "last_reset_at": {
             "name": "Viimeinen nollaus klo"
-          },
-          "update_pending": {
-            "name": "Päivitys odottaa"
           }
         }
       },
       "site_consumption": {
         "name": "Sivuston kulutus",
         "state_attributes": {
-          "start_date": {
-            "name": "Aloituspäivämäärä"
-          },
-          "last_report_date": {
-            "name": "Viimeisen raportin päivämäärä"
-          },
-          "bucket_count": {
-            "name": "Kauhan määrä"
-          },
-          "source_fields": {
-            "name": "Lähdekentät"
-          },
-          "source_unit": {
-            "name": "Lähdeyksikkö"
-          },
-          "interval_minutes": {
-            "name": "Väli (min)"
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
           },
           "last_reset_at": {
             "name": "Viimeinen nollaus klo"
-          },
-          "update_pending": {
-            "name": "Päivitys odottaa"
           }
         }
       },
       "site_grid_import": {
         "name": "Sivustoruudukon tuonti",
         "state_attributes": {
-          "start_date": {
-            "name": "Aloituspäivämäärä"
-          },
-          "last_report_date": {
-            "name": "Viimeisen raportin päivämäärä"
-          },
-          "bucket_count": {
-            "name": "Kauhan määrä"
-          },
-          "source_fields": {
-            "name": "Lähdekentät"
-          },
-          "source_unit": {
-            "name": "Lähdeyksikkö"
-          },
-          "interval_minutes": {
-            "name": "Väli (min)"
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
           },
           "last_reset_at": {
             "name": "Viimeinen nollaus klo"
-          },
-          "update_pending": {
-            "name": "Päivitys odottaa"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Viimeiset ikkunat"
           },
-          "last_report_date": {
-            "name": "Viimeisen raportin päivämäärä"
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
           },
           "last_reset_at": {
             "name": "Viimeinen nollaus klo"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Sivustoruudukon vienti",
         "state_attributes": {
-          "start_date": {
-            "name": "Aloituspäivämäärä"
-          },
-          "last_report_date": {
-            "name": "Viimeisen raportin päivämäärä"
-          },
-          "bucket_count": {
-            "name": "Kauhan määrä"
-          },
-          "source_fields": {
-            "name": "Lähdekentät"
-          },
-          "source_unit": {
-            "name": "Lähdeyksikkö"
-          },
-          "interval_minutes": {
-            "name": "Väli (min)"
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
           },
           "last_reset_at": {
             "name": "Viimeinen nollaus klo"
-          },
-          "update_pending": {
-            "name": "Päivitys odottaa"
           }
         }
       },
       "site_battery_charge": {
         "name": "Sivuston akun lataus",
         "state_attributes": {
-          "start_date": {
-            "name": "Aloituspäivämäärä"
-          },
-          "last_report_date": {
-            "name": "Viimeisen raportin päivämäärä"
-          },
-          "bucket_count": {
-            "name": "Kauhan määrä"
-          },
-          "source_fields": {
-            "name": "Lähdekentät"
-          },
-          "source_unit": {
-            "name": "Lähdeyksikkö"
-          },
-          "interval_minutes": {
-            "name": "Väli (min)"
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
           },
           "last_reset_at": {
             "name": "Viimeinen nollaus klo"
-          },
-          "update_pending": {
-            "name": "Päivitys odottaa"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Sivuston akun purkautuminen",
         "state_attributes": {
-          "start_date": {
-            "name": "Aloituspäivämäärä"
-          },
-          "last_report_date": {
-            "name": "Viimeisen raportin päivämäärä"
-          },
-          "bucket_count": {
-            "name": "Kauhan määrä"
-          },
-          "source_fields": {
-            "name": "Lähdekentät"
-          },
-          "source_unit": {
-            "name": "Lähdeyksikkö"
-          },
-          "interval_minutes": {
-            "name": "Väli (min)"
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
           },
           "last_reset_at": {
             "name": "Viimeinen nollaus klo"
-          },
-          "update_pending": {
-            "name": "Päivitys odottaa"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Viimeiset ikkunat"
           },
-          "last_report_date": {
-            "name": "Viimeisen raportin päivämäärä"
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
           },
           "last_reset_at": {
             "name": "Viimeinen nollaus klo"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Kohteen EVSE-lataus",
         "state_attributes": {
-          "start_date": {
-            "name": "Aloituspäivämäärä"
-          },
-          "last_report_date": {
-            "name": "Viimeisen raportin päivämäärä"
-          },
-          "bucket_count": {
-            "name": "Kauhan määrä"
-          },
-          "source_fields": {
-            "name": "Lähdekentät"
-          },
-          "source_unit": {
-            "name": "Lähdeyksikkö"
-          },
-          "interval_minutes": {
-            "name": "Väli (min)"
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
           },
           "last_reset_at": {
             "name": "Viimeinen nollaus klo"
-          },
-          "update_pending": {
-            "name": "Päivitys odottaa"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Kohteen lämpöpumpun kulutus",
         "state_attributes": {
-          "start_date": {
-            "name": "Aloituspäivämäärä"
-          },
-          "last_report_date": {
-            "name": "Viimeisen raportin päivämäärä"
-          },
-          "bucket_count": {
-            "name": "Kauhan määrä"
-          },
-          "source_fields": {
-            "name": "Lähdekentät"
-          },
-          "source_unit": {
-            "name": "Lähdeyksikkö"
-          },
-          "interval_minutes": {
-            "name": "Väli (min)"
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
           },
           "last_reset_at": {
             "name": "Viimeinen nollaus klo"
-          },
-          "update_pending": {
-            "name": "Päivitys odottaa"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Kohteen vedenlämmittimen kulutus",
         "state_attributes": {
-          "start_date": {
-            "name": "Aloituspäivämäärä"
-          },
-          "last_report_date": {
-            "name": "Viimeisen raportin päivämäärä"
-          },
-          "bucket_count": {
-            "name": "Kauhan määrä"
-          },
-          "source_fields": {
-            "name": "Lähdekentät"
-          },
-          "source_unit": {
-            "name": "Lähdeyksikkö"
-          },
-          "interval_minutes": {
-            "name": "Väli (min)"
+          "sampled_at_utc": {
+            "name": "Näyte otettu (UTC)"
           },
           "last_reset_at": {
             "name": "Viimeinen nollaus klo"
-          },
-          "update_pending": {
-            "name": "Päivitys odottaa"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "Lämpöpumpun SG-Ready aktiivinen"
       },
       "cloud_reachable": {
-        "name": "Pilvi tavoitettavissa",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Viimeinen epäonnistuminen (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Viimeisen epäonnistumisen tila"
-          },
-          "code_description": {
-            "name": "Koodi Kuvaus"
-          },
-          "last_failure_response": {
-            "name": "Viimeinen epäonnistumisvastaus"
-          },
-          "last_failure_source": {
-            "name": "Viimeisen epäonnistumisen lähde"
-          },
-          "backoff_ends_utc": {
-            "name": "Peruutus päättyy (UTC)"
-          }
-        }
+        "name": "Pilvi tavoitettavissa"
       },
       "connected": {
         "name": "Yhteydet",

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Dernière mise à jour réussie",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Dernier succès (UTC)"
-          },
           "last_failure_utc": {
             "name": "Dernier échec (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Latence cloud",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Dernier échec (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Statut du dernier échec"
-          },
-          "code_description": {
-            "name": "Description du code"
-          },
-          "last_failure_response": {
-            "name": "Réponse du dernier échec"
-          },
-          "last_failure_source": {
-            "name": "Source du dernier échec"
-          },
-          "backoff_ends_utc": {
-            "name": "Fin du backoff (UTC)"
-          }
-        }
+        "name": "Latence cloud"
       },
       "current_production_power": {
         "name": "Puissance actuelle de production",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Code d'erreur cloud",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Dernier échec (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Statut du dernier échec"
-          },
-          "code_description": {
-            "name": "Description du code"
-          },
-          "last_failure_response": {
-            "name": "Réponse du dernier échec"
-          },
-          "last_failure_source": {
-            "name": "Source du dernier échec"
-          },
-          "backoff_ends_utc": {
-            "name": "Fin du backoff (UTC)"
-          }
-        },
         "state": {
           "none": "Aucune",
           "dns_error": "Erreur DNS",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Fin du backoff cloud",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Dernier échec (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Statut du dernier échec"
-          },
-          "code_description": {
-            "name": "Description du code"
-          },
-          "last_failure_response": {
-            "name": "Réponse du dernier échec"
-          },
-          "last_failure_source": {
-            "name": "Source du dernier échec"
-          },
-          "backoff_ends_utc": {
-            "name": "Fin du backoff (UTC)"
-          }
-        },
         "state": {
           "none": "Aucune"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Production solaire du site",
         "state_attributes": {
-          "start_date": {
-            "name": "Date de début"
-          },
-          "last_report_date": {
-            "name": "Dernière date de rapport"
-          },
-          "bucket_count": {
-            "name": "Nombre de buckets"
-          },
-          "source_fields": {
-            "name": "Champs source"
-          },
-          "source_unit": {
-            "name": "Unité source"
-          },
-          "interval_minutes": {
-            "name": "Intervalle (min)"
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
           },
           "last_reset_at": {
             "name": "Dernière réinitialisation"
-          },
-          "update_pending": {
-            "name": "Mise à jour en attente"
           }
         }
       },
       "site_consumption": {
         "name": "Consommation du site",
         "state_attributes": {
-          "start_date": {
-            "name": "Date de début"
-          },
-          "last_report_date": {
-            "name": "Dernière date de rapport"
-          },
-          "bucket_count": {
-            "name": "Nombre de buckets"
-          },
-          "source_fields": {
-            "name": "Champs source"
-          },
-          "source_unit": {
-            "name": "Unité source"
-          },
-          "interval_minutes": {
-            "name": "Intervalle (min)"
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
           },
           "last_reset_at": {
             "name": "Dernière réinitialisation"
-          },
-          "update_pending": {
-            "name": "Mise à jour en attente"
           }
         }
       },
       "site_grid_import": {
         "name": "Import réseau du site",
         "state_attributes": {
-          "start_date": {
-            "name": "Date de début"
-          },
-          "last_report_date": {
-            "name": "Dernière date de rapport"
-          },
-          "bucket_count": {
-            "name": "Nombre de buckets"
-          },
-          "source_fields": {
-            "name": "Champs source"
-          },
-          "source_unit": {
-            "name": "Unité source"
-          },
-          "interval_minutes": {
-            "name": "Intervalle (min)"
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
           },
           "last_reset_at": {
             "name": "Dernière réinitialisation"
-          },
-          "update_pending": {
-            "name": "Mise à jour en attente"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Dernière fenêtre (s)"
           },
-          "last_report_date": {
-            "name": "Dernière date de rapport"
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
           },
           "last_reset_at": {
             "name": "Dernière réinitialisation"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Export réseau du site",
         "state_attributes": {
-          "start_date": {
-            "name": "Date de début"
-          },
-          "last_report_date": {
-            "name": "Dernière date de rapport"
-          },
-          "bucket_count": {
-            "name": "Nombre de buckets"
-          },
-          "source_fields": {
-            "name": "Champs source"
-          },
-          "source_unit": {
-            "name": "Unité source"
-          },
-          "interval_minutes": {
-            "name": "Intervalle (min)"
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
           },
           "last_reset_at": {
             "name": "Dernière réinitialisation"
-          },
-          "update_pending": {
-            "name": "Mise à jour en attente"
           }
         }
       },
       "site_battery_charge": {
         "name": "Charge batterie du site",
         "state_attributes": {
-          "start_date": {
-            "name": "Date de début"
-          },
-          "last_report_date": {
-            "name": "Dernière date de rapport"
-          },
-          "bucket_count": {
-            "name": "Nombre de buckets"
-          },
-          "source_fields": {
-            "name": "Champs source"
-          },
-          "source_unit": {
-            "name": "Unité source"
-          },
-          "interval_minutes": {
-            "name": "Intervalle (min)"
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
           },
           "last_reset_at": {
             "name": "Dernière réinitialisation"
-          },
-          "update_pending": {
-            "name": "Mise à jour en attente"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Décharge batterie du site",
         "state_attributes": {
-          "start_date": {
-            "name": "Date de début"
-          },
-          "last_report_date": {
-            "name": "Dernière date de rapport"
-          },
-          "bucket_count": {
-            "name": "Nombre de buckets"
-          },
-          "source_fields": {
-            "name": "Champs source"
-          },
-          "source_unit": {
-            "name": "Unité source"
-          },
-          "interval_minutes": {
-            "name": "Intervalle (min)"
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
           },
           "last_reset_at": {
             "name": "Dernière réinitialisation"
-          },
-          "update_pending": {
-            "name": "Mise à jour en attente"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Dernière fenêtre (s)"
           },
-          "last_report_date": {
-            "name": "Dernière date de rapport"
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
           },
           "last_reset_at": {
             "name": "Dernière réinitialisation"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Recharge EVSE du site",
         "state_attributes": {
-          "start_date": {
-            "name": "Date de début"
-          },
-          "last_report_date": {
-            "name": "Dernière date de rapport"
-          },
-          "bucket_count": {
-            "name": "Nombre de buckets"
-          },
-          "source_fields": {
-            "name": "Champs source"
-          },
-          "source_unit": {
-            "name": "Unité source"
-          },
-          "interval_minutes": {
-            "name": "Intervalle (min)"
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
           },
           "last_reset_at": {
             "name": "Dernière réinitialisation"
-          },
-          "update_pending": {
-            "name": "Mise à jour en attente"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Consommation de pompe à chaleur du site",
         "state_attributes": {
-          "start_date": {
-            "name": "Date de début"
-          },
-          "last_report_date": {
-            "name": "Dernière date de rapport"
-          },
-          "bucket_count": {
-            "name": "Nombre de buckets"
-          },
-          "source_fields": {
-            "name": "Champs source"
-          },
-          "source_unit": {
-            "name": "Unité source"
-          },
-          "interval_minutes": {
-            "name": "Intervalle (min)"
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
           },
           "last_reset_at": {
             "name": "Dernière réinitialisation"
-          },
-          "update_pending": {
-            "name": "Mise à jour en attente"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Consommation de chauffe-eau du site",
         "state_attributes": {
-          "start_date": {
-            "name": "Date de début"
-          },
-          "last_report_date": {
-            "name": "Dernière date de rapport"
-          },
-          "bucket_count": {
-            "name": "Nombre de buckets"
-          },
-          "source_fields": {
-            "name": "Champs source"
-          },
-          "source_unit": {
-            "name": "Unité source"
-          },
-          "interval_minutes": {
-            "name": "Intervalle (min)"
+          "sampled_at_utc": {
+            "name": "Mesuré à (UTC)"
           },
           "last_reset_at": {
             "name": "Dernière réinitialisation"
-          },
-          "update_pending": {
-            "name": "Mise à jour en attente"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "SG-Ready actif de la pompe à chaleur"
       },
       "cloud_reachable": {
-        "name": "Cloud accessible",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Dernier échec (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Statut du dernier échec"
-          },
-          "code_description": {
-            "name": "Description du code"
-          },
-          "last_failure_response": {
-            "name": "Réponse du dernier échec"
-          },
-          "last_failure_source": {
-            "name": "Source du dernier échec"
-          },
-          "backoff_ends_utc": {
-            "name": "Fin du backoff (UTC)"
-          }
-        }
+        "name": "Cloud accessible"
       },
       "connected": {
         "name": "Connectivité",

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Utolsó sikeres frissítés",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Utolsó siker (UTC)"
-          },
           "last_failure_utc": {
             "name": "Utolsó hiba (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Cloud késleltetés",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Utolsó hiba (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Utolsó hibastátusz"
-          },
-          "code_description": {
-            "name": "Kódleírás"
-          },
-          "last_failure_response": {
-            "name": "Utolsó hibaválasz"
-          },
-          "last_failure_source": {
-            "name": "Utolsó hibaforrás"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff vége (UTC)"
-          }
-        }
+        "name": "Cloud késleltetés"
       },
       "current_production_power": {
         "name": "Aktuális termelési teljesítmény",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Cloud hibakód",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Utolsó hiba (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Utolsó hibastátusz"
-          },
-          "code_description": {
-            "name": "Kódleírás"
-          },
-          "last_failure_response": {
-            "name": "Utolsó hibaválasz"
-          },
-          "last_failure_source": {
-            "name": "Utolsó hibaforrás"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff vége (UTC)"
-          }
-        },
         "state": {
           "none": "Nincs",
           "dns_error": "DNS-hiba",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud backoff vége",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Utolsó hiba (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Utolsó hibastátusz"
-          },
-          "code_description": {
-            "name": "Kódleírás"
-          },
-          "last_failure_response": {
-            "name": "Utolsó hibaválasz"
-          },
-          "last_failure_source": {
-            "name": "Utolsó hibaforrás"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff vége (UTC)"
-          }
-        },
         "state": {
           "none": "Nincs"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Helyszín napenergia-termelés",
         "state_attributes": {
-          "start_date": {
-            "name": "Kezdési dátum"
-          },
-          "last_report_date": {
-            "name": "Utolsó jelentés dátuma"
-          },
-          "bucket_count": {
-            "name": "Bucketek száma"
-          },
-          "source_fields": {
-            "name": "Forrásmezők"
-          },
-          "source_unit": {
-            "name": "Forrásegység"
-          },
-          "interval_minutes": {
-            "name": "Intervallum (min)"
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
           },
           "last_reset_at": {
             "name": "Utolsó visszaállítás"
-          },
-          "update_pending": {
-            "name": "Frissítés függőben"
           }
         }
       },
       "site_consumption": {
         "name": "Helyszín fogyasztás",
         "state_attributes": {
-          "start_date": {
-            "name": "Kezdési dátum"
-          },
-          "last_report_date": {
-            "name": "Utolsó jelentés dátuma"
-          },
-          "bucket_count": {
-            "name": "Bucketek száma"
-          },
-          "source_fields": {
-            "name": "Forrásmezők"
-          },
-          "source_unit": {
-            "name": "Forrásegység"
-          },
-          "interval_minutes": {
-            "name": "Intervallum (min)"
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
           },
           "last_reset_at": {
             "name": "Utolsó visszaállítás"
-          },
-          "update_pending": {
-            "name": "Frissítés függőben"
           }
         }
       },
       "site_grid_import": {
         "name": "Helyszín hálózati import",
         "state_attributes": {
-          "start_date": {
-            "name": "Kezdési dátum"
-          },
-          "last_report_date": {
-            "name": "Utolsó jelentés dátuma"
-          },
-          "bucket_count": {
-            "name": "Bucketek száma"
-          },
-          "source_fields": {
-            "name": "Forrásmezők"
-          },
-          "source_unit": {
-            "name": "Forrásegység"
-          },
-          "interval_minutes": {
-            "name": "Intervallum (min)"
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
           },
           "last_reset_at": {
             "name": "Utolsó visszaállítás"
-          },
-          "update_pending": {
-            "name": "Frissítés függőben"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Utolsó ablak (s)"
           },
-          "last_report_date": {
-            "name": "Utolsó jelentés dátuma"
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
           },
           "last_reset_at": {
             "name": "Utolsó visszaállítás"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Helyszín hálózati export",
         "state_attributes": {
-          "start_date": {
-            "name": "Kezdési dátum"
-          },
-          "last_report_date": {
-            "name": "Utolsó jelentés dátuma"
-          },
-          "bucket_count": {
-            "name": "Bucketek száma"
-          },
-          "source_fields": {
-            "name": "Forrásmezők"
-          },
-          "source_unit": {
-            "name": "Forrásegység"
-          },
-          "interval_minutes": {
-            "name": "Intervallum (min)"
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
           },
           "last_reset_at": {
             "name": "Utolsó visszaállítás"
-          },
-          "update_pending": {
-            "name": "Frissítés függőben"
           }
         }
       },
       "site_battery_charge": {
         "name": "Helyszín akkumulátor töltés",
         "state_attributes": {
-          "start_date": {
-            "name": "Kezdési dátum"
-          },
-          "last_report_date": {
-            "name": "Utolsó jelentés dátuma"
-          },
-          "bucket_count": {
-            "name": "Bucketek száma"
-          },
-          "source_fields": {
-            "name": "Forrásmezők"
-          },
-          "source_unit": {
-            "name": "Forrásegység"
-          },
-          "interval_minutes": {
-            "name": "Intervallum (min)"
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
           },
           "last_reset_at": {
             "name": "Utolsó visszaállítás"
-          },
-          "update_pending": {
-            "name": "Frissítés függőben"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Helyszín akkumulátor kisütés",
         "state_attributes": {
-          "start_date": {
-            "name": "Kezdési dátum"
-          },
-          "last_report_date": {
-            "name": "Utolsó jelentés dátuma"
-          },
-          "bucket_count": {
-            "name": "Bucketek száma"
-          },
-          "source_fields": {
-            "name": "Forrásmezők"
-          },
-          "source_unit": {
-            "name": "Forrásegység"
-          },
-          "interval_minutes": {
-            "name": "Intervallum (min)"
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
           },
           "last_reset_at": {
             "name": "Utolsó visszaállítás"
-          },
-          "update_pending": {
-            "name": "Frissítés függőben"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Utolsó ablak (s)"
           },
-          "last_report_date": {
-            "name": "Utolsó jelentés dátuma"
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
           },
           "last_reset_at": {
             "name": "Utolsó visszaállítás"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Helyszíni EVSE-töltés",
         "state_attributes": {
-          "start_date": {
-            "name": "Kezdési dátum"
-          },
-          "last_report_date": {
-            "name": "Utolsó jelentés dátuma"
-          },
-          "bucket_count": {
-            "name": "Bucketek száma"
-          },
-          "source_fields": {
-            "name": "Forrásmezők"
-          },
-          "source_unit": {
-            "name": "Forrásegység"
-          },
-          "interval_minutes": {
-            "name": "Intervallum (min)"
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
           },
           "last_reset_at": {
             "name": "Utolsó visszaállítás"
-          },
-          "update_pending": {
-            "name": "Frissítés függőben"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Helyszíni hőszivattyú-fogyasztás",
         "state_attributes": {
-          "start_date": {
-            "name": "Kezdési dátum"
-          },
-          "last_report_date": {
-            "name": "Utolsó jelentés dátuma"
-          },
-          "bucket_count": {
-            "name": "Bucketek száma"
-          },
-          "source_fields": {
-            "name": "Forrásmezők"
-          },
-          "source_unit": {
-            "name": "Forrásegység"
-          },
-          "interval_minutes": {
-            "name": "Intervallum (min)"
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
           },
           "last_reset_at": {
             "name": "Utolsó visszaállítás"
-          },
-          "update_pending": {
-            "name": "Frissítés függőben"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Helyszíni vízmelegítő-fogyasztás",
         "state_attributes": {
-          "start_date": {
-            "name": "Kezdési dátum"
-          },
-          "last_report_date": {
-            "name": "Utolsó jelentés dátuma"
-          },
-          "bucket_count": {
-            "name": "Bucketek száma"
-          },
-          "source_fields": {
-            "name": "Forrásmezők"
-          },
-          "source_unit": {
-            "name": "Forrásegység"
-          },
-          "interval_minutes": {
-            "name": "Intervallum (min)"
+          "sampled_at_utc": {
+            "name": "Mintavételezve ekkor (UTC)"
           },
           "last_reset_at": {
             "name": "Utolsó visszaállítás"
-          },
-          "update_pending": {
-            "name": "Frissítés függőben"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "A hőszivattyú SG-Ready aktív"
       },
       "cloud_reachable": {
-        "name": "Cloud elérhető",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Utolsó hiba (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Utolsó hibastátusz"
-          },
-          "code_description": {
-            "name": "Kódleírás"
-          },
-          "last_failure_response": {
-            "name": "Utolsó hibaválasz"
-          },
-          "last_failure_source": {
-            "name": "Utolsó hibaforrás"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff vége (UTC)"
-          }
-        }
+        "name": "Cloud elérhető"
       },
       "connected": {
         "name": "Kapcsolat",

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Ultimo aggiornamento riuscito",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Ultimo successo (UTC)"
-          },
           "last_failure_utc": {
             "name": "Ultimo fallimento (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Latenza cloud",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Ultimo fallimento (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Ultimo stato errore"
-          },
-          "code_description": {
-            "name": "Descrizione codice"
-          },
-          "last_failure_response": {
-            "name": "Ultima risposta di errore"
-          },
-          "last_failure_source": {
-            "name": "Ultima origine errore"
-          },
-          "backoff_ends_utc": {
-            "name": "Fine backoff (UTC)"
-          }
-        }
+        "name": "Latenza cloud"
       },
       "current_production_power": {
         "name": "Potenza attuale di produzione",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Codice errore cloud",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Ultimo fallimento (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Ultimo stato errore"
-          },
-          "code_description": {
-            "name": "Descrizione codice"
-          },
-          "last_failure_response": {
-            "name": "Ultima risposta di errore"
-          },
-          "last_failure_source": {
-            "name": "Ultima origine errore"
-          },
-          "backoff_ends_utc": {
-            "name": "Fine backoff (UTC)"
-          }
-        },
         "state": {
           "none": "Nessuno",
           "dns_error": "Errore DNS",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Fine backoff cloud",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Ultimo fallimento (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Ultimo stato errore"
-          },
-          "code_description": {
-            "name": "Descrizione codice"
-          },
-          "last_failure_response": {
-            "name": "Ultima risposta di errore"
-          },
-          "last_failure_source": {
-            "name": "Ultima origine errore"
-          },
-          "backoff_ends_utc": {
-            "name": "Fine backoff (UTC)"
-          }
-        },
         "state": {
           "none": "Nessuno"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Produzione solare sito",
         "state_attributes": {
-          "start_date": {
-            "name": "Data inizio"
-          },
-          "last_report_date": {
-            "name": "Data ultimo report"
-          },
-          "bucket_count": {
-            "name": "Numero di bucket"
-          },
-          "source_fields": {
-            "name": "Campi sorgente"
-          },
-          "source_unit": {
-            "name": "Unità sorgente"
-          },
-          "interval_minutes": {
-            "name": "Intervallo (min)"
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
           },
           "last_reset_at": {
             "name": "Ultimo reset"
-          },
-          "update_pending": {
-            "name": "Aggiornamento in sospeso"
           }
         }
       },
       "site_consumption": {
         "name": "Consumo sito",
         "state_attributes": {
-          "start_date": {
-            "name": "Data inizio"
-          },
-          "last_report_date": {
-            "name": "Data ultimo report"
-          },
-          "bucket_count": {
-            "name": "Numero di bucket"
-          },
-          "source_fields": {
-            "name": "Campi sorgente"
-          },
-          "source_unit": {
-            "name": "Unità sorgente"
-          },
-          "interval_minutes": {
-            "name": "Intervallo (min)"
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
           },
           "last_reset_at": {
             "name": "Ultimo reset"
-          },
-          "update_pending": {
-            "name": "Aggiornamento in sospeso"
           }
         }
       },
       "site_grid_import": {
         "name": "Importazione rete sito",
         "state_attributes": {
-          "start_date": {
-            "name": "Data inizio"
-          },
-          "last_report_date": {
-            "name": "Data ultimo report"
-          },
-          "bucket_count": {
-            "name": "Numero di bucket"
-          },
-          "source_fields": {
-            "name": "Campi sorgente"
-          },
-          "source_unit": {
-            "name": "Unità sorgente"
-          },
-          "interval_minutes": {
-            "name": "Intervallo (min)"
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
           },
           "last_reset_at": {
             "name": "Ultimo reset"
-          },
-          "update_pending": {
-            "name": "Aggiornamento in sospeso"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Ultima finestra (s)"
           },
-          "last_report_date": {
-            "name": "Data ultimo report"
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
           },
           "last_reset_at": {
             "name": "Ultimo reset"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Esportazione rete sito",
         "state_attributes": {
-          "start_date": {
-            "name": "Data inizio"
-          },
-          "last_report_date": {
-            "name": "Data ultimo report"
-          },
-          "bucket_count": {
-            "name": "Numero di bucket"
-          },
-          "source_fields": {
-            "name": "Campi sorgente"
-          },
-          "source_unit": {
-            "name": "Unità sorgente"
-          },
-          "interval_minutes": {
-            "name": "Intervallo (min)"
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
           },
           "last_reset_at": {
             "name": "Ultimo reset"
-          },
-          "update_pending": {
-            "name": "Aggiornamento in sospeso"
           }
         }
       },
       "site_battery_charge": {
         "name": "Carica batteria sito",
         "state_attributes": {
-          "start_date": {
-            "name": "Data inizio"
-          },
-          "last_report_date": {
-            "name": "Data ultimo report"
-          },
-          "bucket_count": {
-            "name": "Numero di bucket"
-          },
-          "source_fields": {
-            "name": "Campi sorgente"
-          },
-          "source_unit": {
-            "name": "Unità sorgente"
-          },
-          "interval_minutes": {
-            "name": "Intervallo (min)"
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
           },
           "last_reset_at": {
             "name": "Ultimo reset"
-          },
-          "update_pending": {
-            "name": "Aggiornamento in sospeso"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Scarica batteria sito",
         "state_attributes": {
-          "start_date": {
-            "name": "Data inizio"
-          },
-          "last_report_date": {
-            "name": "Data ultimo report"
-          },
-          "bucket_count": {
-            "name": "Numero di bucket"
-          },
-          "source_fields": {
-            "name": "Campi sorgente"
-          },
-          "source_unit": {
-            "name": "Unità sorgente"
-          },
-          "interval_minutes": {
-            "name": "Intervallo (min)"
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
           },
           "last_reset_at": {
             "name": "Ultimo reset"
-          },
-          "update_pending": {
-            "name": "Aggiornamento in sospeso"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Ultima finestra (s)"
           },
-          "last_report_date": {
-            "name": "Data ultimo report"
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
           },
           "last_reset_at": {
             "name": "Ultimo reset"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Ricarica EVSE del sito",
         "state_attributes": {
-          "start_date": {
-            "name": "Data inizio"
-          },
-          "last_report_date": {
-            "name": "Data ultimo report"
-          },
-          "bucket_count": {
-            "name": "Numero di bucket"
-          },
-          "source_fields": {
-            "name": "Campi sorgente"
-          },
-          "source_unit": {
-            "name": "Unità sorgente"
-          },
-          "interval_minutes": {
-            "name": "Intervallo (min)"
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
           },
           "last_reset_at": {
             "name": "Ultimo reset"
-          },
-          "update_pending": {
-            "name": "Aggiornamento in sospeso"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Consumo pompa di calore del sito",
         "state_attributes": {
-          "start_date": {
-            "name": "Data inizio"
-          },
-          "last_report_date": {
-            "name": "Data ultimo report"
-          },
-          "bucket_count": {
-            "name": "Numero di bucket"
-          },
-          "source_fields": {
-            "name": "Campi sorgente"
-          },
-          "source_unit": {
-            "name": "Unità sorgente"
-          },
-          "interval_minutes": {
-            "name": "Intervallo (min)"
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
           },
           "last_reset_at": {
             "name": "Ultimo reset"
-          },
-          "update_pending": {
-            "name": "Aggiornamento in sospeso"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Consumo scaldacqua del sito",
         "state_attributes": {
-          "start_date": {
-            "name": "Data inizio"
-          },
-          "last_report_date": {
-            "name": "Data ultimo report"
-          },
-          "bucket_count": {
-            "name": "Numero di bucket"
-          },
-          "source_fields": {
-            "name": "Campi sorgente"
-          },
-          "source_unit": {
-            "name": "Unità sorgente"
-          },
-          "interval_minutes": {
-            "name": "Intervallo (min)"
+          "sampled_at_utc": {
+            "name": "Campionato alle (UTC)"
           },
           "last_reset_at": {
             "name": "Ultimo reset"
-          },
-          "update_pending": {
-            "name": "Aggiornamento in sospeso"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "SG-Ready attivo della pompa di calore"
       },
       "cloud_reachable": {
-        "name": "Cloud raggiungibile",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Ultimo fallimento (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Ultimo stato errore"
-          },
-          "code_description": {
-            "name": "Descrizione codice"
-          },
-          "last_failure_response": {
-            "name": "Ultima risposta di errore"
-          },
-          "last_failure_source": {
-            "name": "Ultima origine errore"
-          },
-          "backoff_ends_utc": {
-            "name": "Fine backoff (UTC)"
-          }
-        }
+        "name": "Cloud raggiungibile"
       },
       "connected": {
         "name": "Connettività",

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Paskutinis sėkmingas atnaujinimas",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Paskutinė sėkmė (UTC)"
-          },
           "last_failure_utc": {
             "name": "Paskutinis gedimas (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Debesies delsa",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Paskutinis gedimas (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Paskutinė gedimo būsena"
-          },
-          "code_description": {
-            "name": "Kodo aprašymas"
-          },
-          "last_failure_response": {
-            "name": "Paskutinė gedimo reakcija"
-          },
-          "last_failure_source": {
-            "name": "Paskutinis gedimo šaltinis"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff pabaiga (UTC)"
-          }
-        }
+        "name": "Debesies delsa"
       },
       "current_production_power": {
         "name": "Dabartinė gamybos galia",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Debesies klaidos kodas",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Paskutinis gedimas (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Paskutinė gedimo būsena"
-          },
-          "code_description": {
-            "name": "Kodo aprašymas"
-          },
-          "last_failure_response": {
-            "name": "Paskutinė gedimo reakcija"
-          },
-          "last_failure_source": {
-            "name": "Paskutinis gedimo šaltinis"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff pabaiga (UTC)"
-          }
-        },
         "state": {
           "none": "Nėra",
           "dns_error": "DNS klaida",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Debesies backoff pabaiga",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Paskutinis gedimas (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Paskutinė gedimo būsena"
-          },
-          "code_description": {
-            "name": "Kodo aprašymas"
-          },
-          "last_failure_response": {
-            "name": "Paskutinė gedimo reakcija"
-          },
-          "last_failure_source": {
-            "name": "Paskutinis gedimo šaltinis"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff pabaiga (UTC)"
-          }
-        },
         "state": {
           "none": "Nėra"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Vietos saulės gamyba",
         "state_attributes": {
-          "start_date": {
-            "name": "Pradžios data"
-          },
-          "last_report_date": {
-            "name": "Paskutinė ataskaitos data"
-          },
-          "bucket_count": {
-            "name": "Kibirų skaičius"
-          },
-          "source_fields": {
-            "name": "Šaltinio laukai"
-          },
-          "source_unit": {
-            "name": "Šaltinio vienetas"
-          },
-          "interval_minutes": {
-            "name": "Intervalas (min)"
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
           },
           "last_reset_at": {
             "name": "Paskutinis atstatymas"
-          },
-          "update_pending": {
-            "name": "Laukiamas atnaujinimas"
           }
         }
       },
       "site_consumption": {
         "name": "Vietos suvartojimas",
         "state_attributes": {
-          "start_date": {
-            "name": "Pradžios data"
-          },
-          "last_report_date": {
-            "name": "Paskutinė ataskaitos data"
-          },
-          "bucket_count": {
-            "name": "Kibirų skaičius"
-          },
-          "source_fields": {
-            "name": "Šaltinio laukai"
-          },
-          "source_unit": {
-            "name": "Šaltinio vienetas"
-          },
-          "interval_minutes": {
-            "name": "Intervalas (min)"
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
           },
           "last_reset_at": {
             "name": "Paskutinis atstatymas"
-          },
-          "update_pending": {
-            "name": "Laukiamas atnaujinimas"
           }
         }
       },
       "site_grid_import": {
         "name": "Vietos tinklo importas",
         "state_attributes": {
-          "start_date": {
-            "name": "Pradžios data"
-          },
-          "last_report_date": {
-            "name": "Paskutinė ataskaitos data"
-          },
-          "bucket_count": {
-            "name": "Kibirų skaičius"
-          },
-          "source_fields": {
-            "name": "Šaltinio laukai"
-          },
-          "source_unit": {
-            "name": "Šaltinio vienetas"
-          },
-          "interval_minutes": {
-            "name": "Intervalas (min)"
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
           },
           "last_reset_at": {
             "name": "Paskutinis atstatymas"
-          },
-          "update_pending": {
-            "name": "Laukiamas atnaujinimas"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Paskutinis langas (s)"
           },
-          "last_report_date": {
-            "name": "Paskutinė ataskaitos data"
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
           },
           "last_reset_at": {
             "name": "Paskutinis atstatymas"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Vietos tinklo eksportas",
         "state_attributes": {
-          "start_date": {
-            "name": "Pradžios data"
-          },
-          "last_report_date": {
-            "name": "Paskutinė ataskaitos data"
-          },
-          "bucket_count": {
-            "name": "Kibirų skaičius"
-          },
-          "source_fields": {
-            "name": "Šaltinio laukai"
-          },
-          "source_unit": {
-            "name": "Šaltinio vienetas"
-          },
-          "interval_minutes": {
-            "name": "Intervalas (min)"
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
           },
           "last_reset_at": {
             "name": "Paskutinis atstatymas"
-          },
-          "update_pending": {
-            "name": "Laukiamas atnaujinimas"
           }
         }
       },
       "site_battery_charge": {
         "name": "Vietos baterijos įkrovimas",
         "state_attributes": {
-          "start_date": {
-            "name": "Pradžios data"
-          },
-          "last_report_date": {
-            "name": "Paskutinė ataskaitos data"
-          },
-          "bucket_count": {
-            "name": "Kibirų skaičius"
-          },
-          "source_fields": {
-            "name": "Šaltinio laukai"
-          },
-          "source_unit": {
-            "name": "Šaltinio vienetas"
-          },
-          "interval_minutes": {
-            "name": "Intervalas (min)"
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
           },
           "last_reset_at": {
             "name": "Paskutinis atstatymas"
-          },
-          "update_pending": {
-            "name": "Laukiamas atnaujinimas"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Vietos baterijos iškrovimas",
         "state_attributes": {
-          "start_date": {
-            "name": "Pradžios data"
-          },
-          "last_report_date": {
-            "name": "Paskutinė ataskaitos data"
-          },
-          "bucket_count": {
-            "name": "Kibirų skaičius"
-          },
-          "source_fields": {
-            "name": "Šaltinio laukai"
-          },
-          "source_unit": {
-            "name": "Šaltinio vienetas"
-          },
-          "interval_minutes": {
-            "name": "Intervalas (min)"
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
           },
           "last_reset_at": {
             "name": "Paskutinis atstatymas"
-          },
-          "update_pending": {
-            "name": "Laukiamas atnaujinimas"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Paskutinis langas (s)"
           },
-          "last_report_date": {
-            "name": "Paskutinė ataskaitos data"
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
           },
           "last_reset_at": {
             "name": "Paskutinis atstatymas"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Objekto EVSE įkrovimas",
         "state_attributes": {
-          "start_date": {
-            "name": "Pradžios data"
-          },
-          "last_report_date": {
-            "name": "Paskutinė ataskaitos data"
-          },
-          "bucket_count": {
-            "name": "Kibirų skaičius"
-          },
-          "source_fields": {
-            "name": "Šaltinio laukai"
-          },
-          "source_unit": {
-            "name": "Šaltinio vienetas"
-          },
-          "interval_minutes": {
-            "name": "Intervalas (min)"
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
           },
           "last_reset_at": {
             "name": "Paskutinis atstatymas"
-          },
-          "update_pending": {
-            "name": "Laukiamas atnaujinimas"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Objekto šilumos siurblio sunaudojimas",
         "state_attributes": {
-          "start_date": {
-            "name": "Pradžios data"
-          },
-          "last_report_date": {
-            "name": "Paskutinė ataskaitos data"
-          },
-          "bucket_count": {
-            "name": "Kibirų skaičius"
-          },
-          "source_fields": {
-            "name": "Šaltinio laukai"
-          },
-          "source_unit": {
-            "name": "Šaltinio vienetas"
-          },
-          "interval_minutes": {
-            "name": "Intervalas (min)"
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
           },
           "last_reset_at": {
             "name": "Paskutinis atstatymas"
-          },
-          "update_pending": {
-            "name": "Laukiamas atnaujinimas"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Objekto vandens šildytuvo sunaudojimas",
         "state_attributes": {
-          "start_date": {
-            "name": "Pradžios data"
-          },
-          "last_report_date": {
-            "name": "Paskutinė ataskaitos data"
-          },
-          "bucket_count": {
-            "name": "Kibirų skaičius"
-          },
-          "source_fields": {
-            "name": "Šaltinio laukai"
-          },
-          "source_unit": {
-            "name": "Šaltinio vienetas"
-          },
-          "interval_minutes": {
-            "name": "Intervalas (min)"
+          "sampled_at_utc": {
+            "name": "Matuota (UTC)"
           },
           "last_reset_at": {
             "name": "Paskutinis atstatymas"
-          },
-          "update_pending": {
-            "name": "Laukiamas atnaujinimas"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "Šilumos siurblio SG-Ready aktyvus"
       },
       "cloud_reachable": {
-        "name": "Debesis pasiekiamas",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Paskutinis gedimas (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Paskutinė gedimo būsena"
-          },
-          "code_description": {
-            "name": "Kodo aprašymas"
-          },
-          "last_failure_response": {
-            "name": "Paskutinė gedimo reakcija"
-          },
-          "last_failure_source": {
-            "name": "Paskutinis gedimo šaltinis"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff pabaiga (UTC)"
-          }
-        }
+        "name": "Debesis pasiekiamas"
       },
       "connected": {
         "name": "Ryšys",

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Pēdējā veiksmīgā atjaunināšana",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Pēdējā veiksmīgā (UTC)"
-          },
           "last_failure_utc": {
             "name": "Pēdējā kļūme (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Mākoņa aizture",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Pēdējā kļūme (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Pēdējais kļūmes statuss"
-          },
-          "code_description": {
-            "name": "Koda apraksts"
-          },
-          "last_failure_response": {
-            "name": "Pēdējā kļūmes atbilde"
-          },
-          "last_failure_source": {
-            "name": "Pēdējais kļūmes avots"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff beidzas (UTC)"
-          }
-        }
+        "name": "Mākoņa aizture"
       },
       "current_production_power": {
         "name": "Pašreizējā ražošanas jauda",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Mākoņa kļūdas kods",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Pēdējā kļūme (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Pēdējais kļūmes statuss"
-          },
-          "code_description": {
-            "name": "Koda apraksts"
-          },
-          "last_failure_response": {
-            "name": "Pēdējā kļūmes atbilde"
-          },
-          "last_failure_source": {
-            "name": "Pēdējais kļūmes avots"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff beidzas (UTC)"
-          }
-        },
         "state": {
           "none": "Nav",
           "dns_error": "DNS kļūda",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Mākoņa backoff beidzas",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Pēdējā kļūme (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Pēdējais kļūmes statuss"
-          },
-          "code_description": {
-            "name": "Koda apraksts"
-          },
-          "last_failure_response": {
-            "name": "Pēdējā kļūmes atbilde"
-          },
-          "last_failure_source": {
-            "name": "Pēdējais kļūmes avots"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff beidzas (UTC)"
-          }
-        },
         "state": {
           "none": "Nav"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Vietnes saules ražošana",
         "state_attributes": {
-          "start_date": {
-            "name": "Sākuma datums"
-          },
-          "last_report_date": {
-            "name": "Pēdējā atskaites datums"
-          },
-          "bucket_count": {
-            "name": "Grozu skaits"
-          },
-          "source_fields": {
-            "name": "Avota lauki"
-          },
-          "source_unit": {
-            "name": "Avota vienība"
-          },
-          "interval_minutes": {
-            "name": "Intervāls (min)"
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
           },
           "last_reset_at": {
             "name": "Pēdējā atiestatīšana"
-          },
-          "update_pending": {
-            "name": "Atjauninājums gaida"
           }
         }
       },
       "site_consumption": {
         "name": "Vietnes patēriņš",
         "state_attributes": {
-          "start_date": {
-            "name": "Sākuma datums"
-          },
-          "last_report_date": {
-            "name": "Pēdējā atskaites datums"
-          },
-          "bucket_count": {
-            "name": "Grozu skaits"
-          },
-          "source_fields": {
-            "name": "Avota lauki"
-          },
-          "source_unit": {
-            "name": "Avota vienība"
-          },
-          "interval_minutes": {
-            "name": "Intervāls (min)"
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
           },
           "last_reset_at": {
             "name": "Pēdējā atiestatīšana"
-          },
-          "update_pending": {
-            "name": "Atjauninājums gaida"
           }
         }
       },
       "site_grid_import": {
         "name": "Vietnes tīkla imports",
         "state_attributes": {
-          "start_date": {
-            "name": "Sākuma datums"
-          },
-          "last_report_date": {
-            "name": "Pēdējā atskaites datums"
-          },
-          "bucket_count": {
-            "name": "Grozu skaits"
-          },
-          "source_fields": {
-            "name": "Avota lauki"
-          },
-          "source_unit": {
-            "name": "Avota vienība"
-          },
-          "interval_minutes": {
-            "name": "Intervāls (min)"
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
           },
           "last_reset_at": {
             "name": "Pēdējā atiestatīšana"
-          },
-          "update_pending": {
-            "name": "Atjauninājums gaida"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Pēdējais logs (s)"
           },
-          "last_report_date": {
-            "name": "Pēdējā atskaites datums"
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
           },
           "last_reset_at": {
             "name": "Pēdējā atiestatīšana"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Vietnes tīkla eksports",
         "state_attributes": {
-          "start_date": {
-            "name": "Sākuma datums"
-          },
-          "last_report_date": {
-            "name": "Pēdējā atskaites datums"
-          },
-          "bucket_count": {
-            "name": "Grozu skaits"
-          },
-          "source_fields": {
-            "name": "Avota lauki"
-          },
-          "source_unit": {
-            "name": "Avota vienība"
-          },
-          "interval_minutes": {
-            "name": "Intervāls (min)"
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
           },
           "last_reset_at": {
             "name": "Pēdējā atiestatīšana"
-          },
-          "update_pending": {
-            "name": "Atjauninājums gaida"
           }
         }
       },
       "site_battery_charge": {
         "name": "Vietnes akumulatora uzlāde",
         "state_attributes": {
-          "start_date": {
-            "name": "Sākuma datums"
-          },
-          "last_report_date": {
-            "name": "Pēdējā atskaites datums"
-          },
-          "bucket_count": {
-            "name": "Grozu skaits"
-          },
-          "source_fields": {
-            "name": "Avota lauki"
-          },
-          "source_unit": {
-            "name": "Avota vienība"
-          },
-          "interval_minutes": {
-            "name": "Intervāls (min)"
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
           },
           "last_reset_at": {
             "name": "Pēdējā atiestatīšana"
-          },
-          "update_pending": {
-            "name": "Atjauninājums gaida"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Vietnes akumulatora izlāde",
         "state_attributes": {
-          "start_date": {
-            "name": "Sākuma datums"
-          },
-          "last_report_date": {
-            "name": "Pēdējā atskaites datums"
-          },
-          "bucket_count": {
-            "name": "Grozu skaits"
-          },
-          "source_fields": {
-            "name": "Avota lauki"
-          },
-          "source_unit": {
-            "name": "Avota vienība"
-          },
-          "interval_minutes": {
-            "name": "Intervāls (min)"
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
           },
           "last_reset_at": {
             "name": "Pēdējā atiestatīšana"
-          },
-          "update_pending": {
-            "name": "Atjauninājums gaida"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Pēdējais logs (s)"
           },
-          "last_report_date": {
-            "name": "Pēdējā atskaites datums"
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
           },
           "last_reset_at": {
             "name": "Pēdējā atiestatīšana"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Objekta EVSE uzlāde",
         "state_attributes": {
-          "start_date": {
-            "name": "Sākuma datums"
-          },
-          "last_report_date": {
-            "name": "Pēdējā atskaites datums"
-          },
-          "bucket_count": {
-            "name": "Grozu skaits"
-          },
-          "source_fields": {
-            "name": "Avota lauki"
-          },
-          "source_unit": {
-            "name": "Avota vienība"
-          },
-          "interval_minutes": {
-            "name": "Intervāls (min)"
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
           },
           "last_reset_at": {
             "name": "Pēdējā atiestatīšana"
-          },
-          "update_pending": {
-            "name": "Atjauninājums gaida"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Objekta siltumsūkņa patēriņš",
         "state_attributes": {
-          "start_date": {
-            "name": "Sākuma datums"
-          },
-          "last_report_date": {
-            "name": "Pēdējā atskaites datums"
-          },
-          "bucket_count": {
-            "name": "Grozu skaits"
-          },
-          "source_fields": {
-            "name": "Avota lauki"
-          },
-          "source_unit": {
-            "name": "Avota vienība"
-          },
-          "interval_minutes": {
-            "name": "Intervāls (min)"
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
           },
           "last_reset_at": {
             "name": "Pēdējā atiestatīšana"
-          },
-          "update_pending": {
-            "name": "Atjauninājums gaida"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Objekta ūdens sildītāja patēriņš",
         "state_attributes": {
-          "start_date": {
-            "name": "Sākuma datums"
-          },
-          "last_report_date": {
-            "name": "Pēdējā atskaites datums"
-          },
-          "bucket_count": {
-            "name": "Grozu skaits"
-          },
-          "source_fields": {
-            "name": "Avota lauki"
-          },
-          "source_unit": {
-            "name": "Avota vienība"
-          },
-          "interval_minutes": {
-            "name": "Intervāls (min)"
+          "sampled_at_utc": {
+            "name": "Paraugs iegūts (UTC)"
           },
           "last_reset_at": {
             "name": "Pēdējā atiestatīšana"
-          },
-          "update_pending": {
-            "name": "Atjauninājums gaida"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "Siltumsūkņa SG-Ready aktīvs"
       },
       "cloud_reachable": {
-        "name": "Mākonis sasniedzams",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Pēdējā kļūme (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Pēdējais kļūmes statuss"
-          },
-          "code_description": {
-            "name": "Koda apraksts"
-          },
-          "last_failure_response": {
-            "name": "Pēdējā kļūmes atbilde"
-          },
-          "last_failure_source": {
-            "name": "Pēdējais kļūmes avots"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff beidzas (UTC)"
-          }
-        }
+        "name": "Mākonis sasniedzams"
       },
       "connected": {
         "name": "Savienojamība",

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Siste vellykkede oppdatering",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Siste suksess (UTC)"
-          },
           "last_failure_utc": {
             "name": "Siste feil (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Sky-latens",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Siste feil (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Siste feilstatus"
-          },
-          "code_description": {
-            "name": "Kodebeskrivelse"
-          },
-          "last_failure_response": {
-            "name": "Siste feilrespons"
-          },
-          "last_failure_source": {
-            "name": "Siste feilkilde"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff slutter (UTC)"
-          }
-        }
+        "name": "Sky-latens"
       },
       "current_production_power": {
         "name": "Nåværende produksjonseffekt",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Sky-feilkode",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Siste feil (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Siste feilstatus"
-          },
-          "code_description": {
-            "name": "Kodebeskrivelse"
-          },
-          "last_failure_response": {
-            "name": "Siste feilrespons"
-          },
-          "last_failure_source": {
-            "name": "Siste feilkilde"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff slutter (UTC)"
-          }
-        },
         "state": {
           "none": "Ingen",
           "dns_error": "DNS-feil",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Sky-backoff slutter",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Siste feil (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Siste feilstatus"
-          },
-          "code_description": {
-            "name": "Kodebeskrivelse"
-          },
-          "last_failure_response": {
-            "name": "Siste feilrespons"
-          },
-          "last_failure_source": {
-            "name": "Siste feilkilde"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff slutter (UTC)"
-          }
-        },
         "state": {
           "none": "Ingen"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Anleggssolproduksjon",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Siste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antall bøtter"
-          },
-          "source_fields": {
-            "name": "Kildefelt"
-          },
-          "source_unit": {
-            "name": "Kildeenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Sist tilbakestilt"
-          },
-          "update_pending": {
-            "name": "Oppdatering venter"
           }
         }
       },
       "site_consumption": {
         "name": "Anleggsforbruk",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Siste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antall bøtter"
-          },
-          "source_fields": {
-            "name": "Kildefelt"
-          },
-          "source_unit": {
-            "name": "Kildeenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Sist tilbakestilt"
-          },
-          "update_pending": {
-            "name": "Oppdatering venter"
           }
         }
       },
       "site_grid_import": {
         "name": "Anleggsnettimport",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Siste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antall bøtter"
-          },
-          "source_fields": {
-            "name": "Kildefelt"
-          },
-          "source_unit": {
-            "name": "Kildeenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Sist tilbakestilt"
-          },
-          "update_pending": {
-            "name": "Oppdatering venter"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Siste vindu (s)"
           },
-          "last_report_date": {
-            "name": "Siste rapportdato"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Sist tilbakestilt"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Anleggsnettexport",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Siste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antall bøtter"
-          },
-          "source_fields": {
-            "name": "Kildefelt"
-          },
-          "source_unit": {
-            "name": "Kildeenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Sist tilbakestilt"
-          },
-          "update_pending": {
-            "name": "Oppdatering venter"
           }
         }
       },
       "site_battery_charge": {
         "name": "Anleggsbatterilading",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Siste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antall bøtter"
-          },
-          "source_fields": {
-            "name": "Kildefelt"
-          },
-          "source_unit": {
-            "name": "Kildeenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Sist tilbakestilt"
-          },
-          "update_pending": {
-            "name": "Oppdatering venter"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Anleggsbatteriutlading",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Siste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antall bøtter"
-          },
-          "source_fields": {
-            "name": "Kildefelt"
-          },
-          "source_unit": {
-            "name": "Kildeenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Sist tilbakestilt"
-          },
-          "update_pending": {
-            "name": "Oppdatering venter"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Siste vindu (s)"
           },
-          "last_report_date": {
-            "name": "Siste rapportdato"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Sist tilbakestilt"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "EVSE-lading for anlegg",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Siste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antall bøtter"
-          },
-          "source_fields": {
-            "name": "Kildefelt"
-          },
-          "source_unit": {
-            "name": "Kildeenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Sist tilbakestilt"
-          },
-          "update_pending": {
-            "name": "Oppdatering venter"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Varmepumpeforbruk for anlegg",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Siste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antall bøtter"
-          },
-          "source_fields": {
-            "name": "Kildefelt"
-          },
-          "source_unit": {
-            "name": "Kildeenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Sist tilbakestilt"
-          },
-          "update_pending": {
-            "name": "Oppdatering venter"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Varmtvannsberederforbruk for anlegg",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdato"
-          },
-          "last_report_date": {
-            "name": "Siste rapportdato"
-          },
-          "bucket_count": {
-            "name": "Antall bøtter"
-          },
-          "source_fields": {
-            "name": "Kildefelt"
-          },
-          "source_unit": {
-            "name": "Kildeenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Målt kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Sist tilbakestilt"
-          },
-          "update_pending": {
-            "name": "Oppdatering venter"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "Varmepumpens SG-Ready aktiv"
       },
       "cloud_reachable": {
-        "name": "Sky tilgjengelig",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Siste feil (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Siste feilstatus"
-          },
-          "code_description": {
-            "name": "Kodebeskrivelse"
-          },
-          "last_failure_response": {
-            "name": "Siste feilrespons"
-          },
-          "last_failure_source": {
-            "name": "Siste feilkilde"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff slutter (UTC)"
-          }
-        }
+        "name": "Sky tilgjengelig"
       },
       "connected": {
         "name": "Tilkobling",

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Laatste geslaagde update",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Laatste succes (UTC)"
-          },
           "last_failure_utc": {
             "name": "Laatste fout (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Cloudlatentie",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Laatste fout (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Laatste foutstatus"
-          },
-          "code_description": {
-            "name": "Codebeschrijving"
-          },
-          "last_failure_response": {
-            "name": "Laatste foutrespons"
-          },
-          "last_failure_source": {
-            "name": "Laatste foutbron"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff eindigt (UTC)"
-          }
-        }
+        "name": "Cloudlatentie"
       },
       "current_production_power": {
         "name": "Huidig productievermogen",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Cloud-foutcode",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Laatste fout (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Laatste foutstatus"
-          },
-          "code_description": {
-            "name": "Codebeschrijving"
-          },
-          "last_failure_response": {
-            "name": "Laatste foutrespons"
-          },
-          "last_failure_source": {
-            "name": "Laatste foutbron"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff eindigt (UTC)"
-          }
-        },
         "state": {
           "none": "Geen",
           "dns_error": "DNS-fout",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud-backoff eindigt",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Laatste fout (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Laatste foutstatus"
-          },
-          "code_description": {
-            "name": "Codebeschrijving"
-          },
-          "last_failure_response": {
-            "name": "Laatste foutrespons"
-          },
-          "last_failure_source": {
-            "name": "Laatste foutbron"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff eindigt (UTC)"
-          }
-        },
         "state": {
           "none": "Geen"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Site-zonneproductie",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Laatste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Aantal buckets"
-          },
-          "source_fields": {
-            "name": "Bronvelden"
-          },
-          "source_unit": {
-            "name": "Broneenheid"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuten)"
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
           },
           "last_reset_at": {
             "name": "Laatste reset op"
-          },
-          "update_pending": {
-            "name": "Update in behandeling"
           }
         }
       },
       "site_consumption": {
         "name": "Siteverbruik",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Laatste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Aantal buckets"
-          },
-          "source_fields": {
-            "name": "Bronvelden"
-          },
-          "source_unit": {
-            "name": "Broneenheid"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuten)"
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
           },
           "last_reset_at": {
             "name": "Laatste reset op"
-          },
-          "update_pending": {
-            "name": "Update in behandeling"
           }
         }
       },
       "site_grid_import": {
         "name": "Site-netimport",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Laatste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Aantal buckets"
-          },
-          "source_fields": {
-            "name": "Bronvelden"
-          },
-          "source_unit": {
-            "name": "Broneenheid"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuten)"
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
           },
           "last_reset_at": {
             "name": "Laatste reset op"
-          },
-          "update_pending": {
-            "name": "Update in behandeling"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Laatste venster (s)"
           },
-          "last_report_date": {
-            "name": "Laatste rapportdatum"
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
           },
           "last_reset_at": {
             "name": "Laatste reset op"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Site-netexport",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Laatste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Aantal buckets"
-          },
-          "source_fields": {
-            "name": "Bronvelden"
-          },
-          "source_unit": {
-            "name": "Broneenheid"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuten)"
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
           },
           "last_reset_at": {
             "name": "Laatste reset op"
-          },
-          "update_pending": {
-            "name": "Update in behandeling"
           }
         }
       },
       "site_battery_charge": {
         "name": "Sitebatterij laden",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Laatste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Aantal buckets"
-          },
-          "source_fields": {
-            "name": "Bronvelden"
-          },
-          "source_unit": {
-            "name": "Broneenheid"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuten)"
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
           },
           "last_reset_at": {
             "name": "Laatste reset op"
-          },
-          "update_pending": {
-            "name": "Update in behandeling"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Sitebatterij ontladen",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Laatste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Aantal buckets"
-          },
-          "source_fields": {
-            "name": "Bronvelden"
-          },
-          "source_unit": {
-            "name": "Broneenheid"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuten)"
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
           },
           "last_reset_at": {
             "name": "Laatste reset op"
-          },
-          "update_pending": {
-            "name": "Update in behandeling"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Laatste venster (s)"
           },
-          "last_report_date": {
-            "name": "Laatste rapportdatum"
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
           },
           "last_reset_at": {
             "name": "Laatste reset op"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "EVSE-laden van locatie",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Laatste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Aantal buckets"
-          },
-          "source_fields": {
-            "name": "Bronvelden"
-          },
-          "source_unit": {
-            "name": "Broneenheid"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuten)"
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
           },
           "last_reset_at": {
             "name": "Laatste reset op"
-          },
-          "update_pending": {
-            "name": "Update in behandeling"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Warmtepompverbruik van locatie",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Laatste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Aantal buckets"
-          },
-          "source_fields": {
-            "name": "Bronvelden"
-          },
-          "source_unit": {
-            "name": "Broneenheid"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuten)"
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
           },
           "last_reset_at": {
             "name": "Laatste reset op"
-          },
-          "update_pending": {
-            "name": "Update in behandeling"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Boilerverbruik van locatie",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Laatste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Aantal buckets"
-          },
-          "source_fields": {
-            "name": "Bronvelden"
-          },
-          "source_unit": {
-            "name": "Broneenheid"
-          },
-          "interval_minutes": {
-            "name": "Interval (minuten)"
+          "sampled_at_utc": {
+            "name": "Gemeten om (UTC)"
           },
           "last_reset_at": {
             "name": "Laatste reset op"
-          },
-          "update_pending": {
-            "name": "Update in behandeling"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "SG-Ready van warmtepomp actief"
       },
       "cloud_reachable": {
-        "name": "Cloud bereikbaar",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Laatste fout (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Laatste foutstatus"
-          },
-          "code_description": {
-            "name": "Codebeschrijving"
-          },
-          "last_failure_response": {
-            "name": "Laatste foutrespons"
-          },
-          "last_failure_source": {
-            "name": "Laatste foutbron"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff eindigt (UTC)"
-          }
-        }
+        "name": "Cloud bereikbaar"
       },
       "connected": {
         "name": "Connectiviteit",

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Ostatnia udana aktualizacja",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Ostatni sukces (UTC)"
-          },
           "last_failure_utc": {
             "name": "Ostatnia awaria (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Opóźnienie chmury",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Ostatnia awaria (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Ostatni status błędu"
-          },
-          "code_description": {
-            "name": "Opis kodu"
-          },
-          "last_failure_response": {
-            "name": "Ostatnia odpowiedź błędu"
-          },
-          "last_failure_source": {
-            "name": "Ostatnie źródło błędu"
-          },
-          "backoff_ends_utc": {
-            "name": "Koniec backoff (UTC)"
-          }
-        }
+        "name": "Opóźnienie chmury"
       },
       "current_production_power": {
         "name": "Bieżąca moc produkcji",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Kod błędu chmury",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Ostatnia awaria (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Ostatni status błędu"
-          },
-          "code_description": {
-            "name": "Opis kodu"
-          },
-          "last_failure_response": {
-            "name": "Ostatnia odpowiedź błędu"
-          },
-          "last_failure_source": {
-            "name": "Ostatnie źródło błędu"
-          },
-          "backoff_ends_utc": {
-            "name": "Koniec backoff (UTC)"
-          }
-        },
         "state": {
           "none": "Brak",
           "dns_error": "Błąd DNS",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Koniec backoff chmury",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Ostatnia awaria (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Ostatni status błędu"
-          },
-          "code_description": {
-            "name": "Opis kodu"
-          },
-          "last_failure_response": {
-            "name": "Ostatnia odpowiedź błędu"
-          },
-          "last_failure_source": {
-            "name": "Ostatnie źródło błędu"
-          },
-          "backoff_ends_utc": {
-            "name": "Koniec backoff (UTC)"
-          }
-        },
         "state": {
           "none": "Brak"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Produkcja słoneczna lokalizacji",
         "state_attributes": {
-          "start_date": {
-            "name": "Data rozpoczęcia"
-          },
-          "last_report_date": {
-            "name": "Data ostatniego raportu"
-          },
-          "bucket_count": {
-            "name": "Liczba koszyków"
-          },
-          "source_fields": {
-            "name": "Pola źródłowe"
-          },
-          "source_unit": {
-            "name": "Jednostka źródłowa"
-          },
-          "interval_minutes": {
-            "name": "Interwał (min)"
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
           },
           "last_reset_at": {
             "name": "Ostatni reset"
-          },
-          "update_pending": {
-            "name": "Aktualizacja oczekuje"
           }
         }
       },
       "site_consumption": {
         "name": "Zużycie lokalizacji",
         "state_attributes": {
-          "start_date": {
-            "name": "Data rozpoczęcia"
-          },
-          "last_report_date": {
-            "name": "Data ostatniego raportu"
-          },
-          "bucket_count": {
-            "name": "Liczba koszyków"
-          },
-          "source_fields": {
-            "name": "Pola źródłowe"
-          },
-          "source_unit": {
-            "name": "Jednostka źródłowa"
-          },
-          "interval_minutes": {
-            "name": "Interwał (min)"
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
           },
           "last_reset_at": {
             "name": "Ostatni reset"
-          },
-          "update_pending": {
-            "name": "Aktualizacja oczekuje"
           }
         }
       },
       "site_grid_import": {
         "name": "Import z sieci lokalizacji",
         "state_attributes": {
-          "start_date": {
-            "name": "Data rozpoczęcia"
-          },
-          "last_report_date": {
-            "name": "Data ostatniego raportu"
-          },
-          "bucket_count": {
-            "name": "Liczba koszyków"
-          },
-          "source_fields": {
-            "name": "Pola źródłowe"
-          },
-          "source_unit": {
-            "name": "Jednostka źródłowa"
-          },
-          "interval_minutes": {
-            "name": "Interwał (min)"
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
           },
           "last_reset_at": {
             "name": "Ostatni reset"
-          },
-          "update_pending": {
-            "name": "Aktualizacja oczekuje"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Ostatnie okno (s)"
           },
-          "last_report_date": {
-            "name": "Data ostatniego raportu"
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
           },
           "last_reset_at": {
             "name": "Ostatni reset"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Eksport do sieci lokalizacji",
         "state_attributes": {
-          "start_date": {
-            "name": "Data rozpoczęcia"
-          },
-          "last_report_date": {
-            "name": "Data ostatniego raportu"
-          },
-          "bucket_count": {
-            "name": "Liczba koszyków"
-          },
-          "source_fields": {
-            "name": "Pola źródłowe"
-          },
-          "source_unit": {
-            "name": "Jednostka źródłowa"
-          },
-          "interval_minutes": {
-            "name": "Interwał (min)"
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
           },
           "last_reset_at": {
             "name": "Ostatni reset"
-          },
-          "update_pending": {
-            "name": "Aktualizacja oczekuje"
           }
         }
       },
       "site_battery_charge": {
         "name": "Ładowanie baterii lokalizacji",
         "state_attributes": {
-          "start_date": {
-            "name": "Data rozpoczęcia"
-          },
-          "last_report_date": {
-            "name": "Data ostatniego raportu"
-          },
-          "bucket_count": {
-            "name": "Liczba koszyków"
-          },
-          "source_fields": {
-            "name": "Pola źródłowe"
-          },
-          "source_unit": {
-            "name": "Jednostka źródłowa"
-          },
-          "interval_minutes": {
-            "name": "Interwał (min)"
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
           },
           "last_reset_at": {
             "name": "Ostatni reset"
-          },
-          "update_pending": {
-            "name": "Aktualizacja oczekuje"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Rozładowanie baterii lokalizacji",
         "state_attributes": {
-          "start_date": {
-            "name": "Data rozpoczęcia"
-          },
-          "last_report_date": {
-            "name": "Data ostatniego raportu"
-          },
-          "bucket_count": {
-            "name": "Liczba koszyków"
-          },
-          "source_fields": {
-            "name": "Pola źródłowe"
-          },
-          "source_unit": {
-            "name": "Jednostka źródłowa"
-          },
-          "interval_minutes": {
-            "name": "Interwał (min)"
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
           },
           "last_reset_at": {
             "name": "Ostatni reset"
-          },
-          "update_pending": {
-            "name": "Aktualizacja oczekuje"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Ostatnie okno (s)"
           },
-          "last_report_date": {
-            "name": "Data ostatniego raportu"
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
           },
           "last_reset_at": {
             "name": "Ostatni reset"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Ładowanie EVSE obiektu",
         "state_attributes": {
-          "start_date": {
-            "name": "Data rozpoczęcia"
-          },
-          "last_report_date": {
-            "name": "Data ostatniego raportu"
-          },
-          "bucket_count": {
-            "name": "Liczba koszyków"
-          },
-          "source_fields": {
-            "name": "Pola źródłowe"
-          },
-          "source_unit": {
-            "name": "Jednostka źródłowa"
-          },
-          "interval_minutes": {
-            "name": "Interwał (min)"
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
           },
           "last_reset_at": {
             "name": "Ostatni reset"
-          },
-          "update_pending": {
-            "name": "Aktualizacja oczekuje"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Zużycie pompy ciepła obiektu",
         "state_attributes": {
-          "start_date": {
-            "name": "Data rozpoczęcia"
-          },
-          "last_report_date": {
-            "name": "Data ostatniego raportu"
-          },
-          "bucket_count": {
-            "name": "Liczba koszyków"
-          },
-          "source_fields": {
-            "name": "Pola źródłowe"
-          },
-          "source_unit": {
-            "name": "Jednostka źródłowa"
-          },
-          "interval_minutes": {
-            "name": "Interwał (min)"
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
           },
           "last_reset_at": {
             "name": "Ostatni reset"
-          },
-          "update_pending": {
-            "name": "Aktualizacja oczekuje"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Zużycie podgrzewacza wody obiektu",
         "state_attributes": {
-          "start_date": {
-            "name": "Data rozpoczęcia"
-          },
-          "last_report_date": {
-            "name": "Data ostatniego raportu"
-          },
-          "bucket_count": {
-            "name": "Liczba koszyków"
-          },
-          "source_fields": {
-            "name": "Pola źródłowe"
-          },
-          "source_unit": {
-            "name": "Jednostka źródłowa"
-          },
-          "interval_minutes": {
-            "name": "Interwał (min)"
+          "sampled_at_utc": {
+            "name": "Próbka z godz. (UTC)"
           },
           "last_reset_at": {
             "name": "Ostatni reset"
-          },
-          "update_pending": {
-            "name": "Aktualizacja oczekuje"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "SG-Ready pompy ciepła aktywny"
       },
       "cloud_reachable": {
-        "name": "Chmura osiągalna",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Ostatnia awaria (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Ostatni status błędu"
-          },
-          "code_description": {
-            "name": "Opis kodu"
-          },
-          "last_failure_response": {
-            "name": "Ostatnia odpowiedź błędu"
-          },
-          "last_failure_source": {
-            "name": "Ostatnie źródło błędu"
-          },
-          "backoff_ends_utc": {
-            "name": "Koniec backoff (UTC)"
-          }
-        }
+        "name": "Chmura osiągalna"
       },
       "connected": {
         "name": "Łączność",

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Última atualização bem-sucedida",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Último sucesso (UTC)"
-          },
           "last_failure_utc": {
             "name": "Última falha (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Latência da nuvem",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Última falha (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Status da última falha"
-          },
-          "code_description": {
-            "name": "Descrição do código"
-          },
-          "last_failure_response": {
-            "name": "Resposta da última falha"
-          },
-          "last_failure_source": {
-            "name": "Fonte da última falha"
-          },
-          "backoff_ends_utc": {
-            "name": "Fim do backoff (UTC)"
-          }
-        }
+        "name": "Latência da nuvem"
       },
       "current_production_power": {
         "name": "Potência atual de produção",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Código de erro da nuvem",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Última falha (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Status da última falha"
-          },
-          "code_description": {
-            "name": "Descrição do código"
-          },
-          "last_failure_response": {
-            "name": "Resposta da última falha"
-          },
-          "last_failure_source": {
-            "name": "Fonte da última falha"
-          },
-          "backoff_ends_utc": {
-            "name": "Fim do backoff (UTC)"
-          }
-        },
         "state": {
           "none": "Nenhum",
           "dns_error": "Erro de DNS",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Fim do tempo de espera da nuvem",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Última falha (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Status da última falha"
-          },
-          "code_description": {
-            "name": "Descrição do código"
-          },
-          "last_failure_response": {
-            "name": "Resposta da última falha"
-          },
-          "last_failure_source": {
-            "name": "Fonte da última falha"
-          },
-          "backoff_ends_utc": {
-            "name": "Fim do backoff (UTC)"
-          }
-        },
         "state": {
           "none": "Nenhum"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Produção solar do site",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de início"
-          },
-          "last_report_date": {
-            "name": "Última data de relatório"
-          },
-          "bucket_count": {
-            "name": "Quantidade de buckets"
-          },
-          "source_fields": {
-            "name": "Campos de origem"
-          },
-          "source_unit": {
-            "name": "Unidade de origem"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
           },
           "last_reset_at": {
             "name": "Última redefinição"
-          },
-          "update_pending": {
-            "name": "Atualização pendente"
           }
         }
       },
       "site_consumption": {
         "name": "Consumo do site",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de início"
-          },
-          "last_report_date": {
-            "name": "Última data de relatório"
-          },
-          "bucket_count": {
-            "name": "Quantidade de buckets"
-          },
-          "source_fields": {
-            "name": "Campos de origem"
-          },
-          "source_unit": {
-            "name": "Unidade de origem"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
           },
           "last_reset_at": {
             "name": "Última redefinição"
-          },
-          "update_pending": {
-            "name": "Atualização pendente"
           }
         }
       },
       "site_grid_import": {
         "name": "Importação da rede do site",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de início"
-          },
-          "last_report_date": {
-            "name": "Última data de relatório"
-          },
-          "bucket_count": {
-            "name": "Quantidade de buckets"
-          },
-          "source_fields": {
-            "name": "Campos de origem"
-          },
-          "source_unit": {
-            "name": "Unidade de origem"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
           },
           "last_reset_at": {
             "name": "Última redefinição"
-          },
-          "update_pending": {
-            "name": "Atualização pendente"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Última janela (s)"
           },
-          "last_report_date": {
-            "name": "Última data de relatório"
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
           },
           "last_reset_at": {
             "name": "Última redefinição"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Exportação para a rede do site",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de início"
-          },
-          "last_report_date": {
-            "name": "Última data de relatório"
-          },
-          "bucket_count": {
-            "name": "Quantidade de buckets"
-          },
-          "source_fields": {
-            "name": "Campos de origem"
-          },
-          "source_unit": {
-            "name": "Unidade de origem"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
           },
           "last_reset_at": {
             "name": "Última redefinição"
-          },
-          "update_pending": {
-            "name": "Atualização pendente"
           }
         }
       },
       "site_battery_charge": {
         "name": "Carga da bateria do site",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de início"
-          },
-          "last_report_date": {
-            "name": "Última data de relatório"
-          },
-          "bucket_count": {
-            "name": "Quantidade de buckets"
-          },
-          "source_fields": {
-            "name": "Campos de origem"
-          },
-          "source_unit": {
-            "name": "Unidade de origem"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
           },
           "last_reset_at": {
             "name": "Última redefinição"
-          },
-          "update_pending": {
-            "name": "Atualização pendente"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Descarga da bateria do site",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de início"
-          },
-          "last_report_date": {
-            "name": "Última data de relatório"
-          },
-          "bucket_count": {
-            "name": "Quantidade de buckets"
-          },
-          "source_fields": {
-            "name": "Campos de origem"
-          },
-          "source_unit": {
-            "name": "Unidade de origem"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
           },
           "last_reset_at": {
             "name": "Última redefinição"
-          },
-          "update_pending": {
-            "name": "Atualização pendente"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Última janela (s)"
           },
-          "last_report_date": {
-            "name": "Última data de relatório"
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
           },
           "last_reset_at": {
             "name": "Última redefinição"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Carregamento EVSE do local",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de início"
-          },
-          "last_report_date": {
-            "name": "Última data de relatório"
-          },
-          "bucket_count": {
-            "name": "Quantidade de buckets"
-          },
-          "source_fields": {
-            "name": "Campos de origem"
-          },
-          "source_unit": {
-            "name": "Unidade de origem"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
           },
           "last_reset_at": {
             "name": "Última redefinição"
-          },
-          "update_pending": {
-            "name": "Atualização pendente"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Consumo da bomba de calor do local",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de início"
-          },
-          "last_report_date": {
-            "name": "Última data de relatório"
-          },
-          "bucket_count": {
-            "name": "Quantidade de buckets"
-          },
-          "source_fields": {
-            "name": "Campos de origem"
-          },
-          "source_unit": {
-            "name": "Unidade de origem"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
           },
           "last_reset_at": {
             "name": "Última redefinição"
-          },
-          "update_pending": {
-            "name": "Atualização pendente"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Consumo do aquecedor de água do local",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de início"
-          },
-          "last_report_date": {
-            "name": "Última data de relatório"
-          },
-          "bucket_count": {
-            "name": "Quantidade de buckets"
-          },
-          "source_fields": {
-            "name": "Campos de origem"
-          },
-          "source_unit": {
-            "name": "Unidade de origem"
-          },
-          "interval_minutes": {
-            "name": "Intervalo (min)"
+          "sampled_at_utc": {
+            "name": "Amostrado em (UTC)"
           },
           "last_reset_at": {
             "name": "Última redefinição"
-          },
-          "update_pending": {
-            "name": "Atualização pendente"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "SG-Ready ativo da bomba de calor"
       },
       "cloud_reachable": {
-        "name": "Nuvem acessível",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Última falha (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Status da última falha"
-          },
-          "code_description": {
-            "name": "Descrição do código"
-          },
-          "last_failure_response": {
-            "name": "Resposta da última falha"
-          },
-          "last_failure_source": {
-            "name": "Fonte da última falha"
-          },
-          "backoff_ends_utc": {
-            "name": "Fim do backoff (UTC)"
-          }
-        }
+        "name": "Nuvem acessível"
       },
       "connected": {
         "name": "Conectividade",

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Ultima actualizare reușită",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Ultimul succes (UTC)"
-          },
           "last_failure_utc": {
             "name": "Ultima eroare (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Latență cloud",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Ultima eroare (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Ultimul status al erorii"
-          },
-          "code_description": {
-            "name": "Descriere cod"
-          },
-          "last_failure_response": {
-            "name": "Ultimul răspuns de eroare"
-          },
-          "last_failure_source": {
-            "name": "Ultima sursă a erorii"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff se încheie (UTC)"
-          }
-        }
+        "name": "Latență cloud"
       },
       "current_production_power": {
         "name": "Puterea instantanee de producție",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Cod de eroare cloud",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Ultima eroare (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Ultimul status al erorii"
-          },
-          "code_description": {
-            "name": "Descriere cod"
-          },
-          "last_failure_response": {
-            "name": "Ultimul răspuns de eroare"
-          },
-          "last_failure_source": {
-            "name": "Ultima sursă a erorii"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff se încheie (UTC)"
-          }
-        },
         "state": {
           "none": "Niciunul",
           "dns_error": "Eroare DNS",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Backoff cloud se încheie",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Ultima eroare (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Ultimul status al erorii"
-          },
-          "code_description": {
-            "name": "Descriere cod"
-          },
-          "last_failure_response": {
-            "name": "Ultimul răspuns de eroare"
-          },
-          "last_failure_source": {
-            "name": "Ultima sursă a erorii"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff se încheie (UTC)"
-          }
-        },
         "state": {
           "none": "Niciunul"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Producție solară locație",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de început"
-          },
-          "last_report_date": {
-            "name": "Ultima dată de raportare"
-          },
-          "bucket_count": {
-            "name": "Număr de bucketuri"
-          },
-          "source_fields": {
-            "name": "Câmpuri sursă"
-          },
-          "source_unit": {
-            "name": "Unitate sursă"
-          },
-          "interval_minutes": {
-            "name": "Interval (minute)"
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
           },
           "last_reset_at": {
             "name": "Ultima resetare"
-          },
-          "update_pending": {
-            "name": "Actualizare în așteptare"
           }
         }
       },
       "site_consumption": {
         "name": "Consum locație",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de început"
-          },
-          "last_report_date": {
-            "name": "Ultima dată de raportare"
-          },
-          "bucket_count": {
-            "name": "Număr de bucketuri"
-          },
-          "source_fields": {
-            "name": "Câmpuri sursă"
-          },
-          "source_unit": {
-            "name": "Unitate sursă"
-          },
-          "interval_minutes": {
-            "name": "Interval (minute)"
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
           },
           "last_reset_at": {
             "name": "Ultima resetare"
-          },
-          "update_pending": {
-            "name": "Actualizare în așteptare"
           }
         }
       },
       "site_grid_import": {
         "name": "Import rețea locație",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de început"
-          },
-          "last_report_date": {
-            "name": "Ultima dată de raportare"
-          },
-          "bucket_count": {
-            "name": "Număr de bucketuri"
-          },
-          "source_fields": {
-            "name": "Câmpuri sursă"
-          },
-          "source_unit": {
-            "name": "Unitate sursă"
-          },
-          "interval_minutes": {
-            "name": "Interval (minute)"
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
           },
           "last_reset_at": {
             "name": "Ultima resetare"
-          },
-          "update_pending": {
-            "name": "Actualizare în așteptare"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Ultima fereastră (s)"
           },
-          "last_report_date": {
-            "name": "Ultima dată de raportare"
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
           },
           "last_reset_at": {
             "name": "Ultima resetare"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Export rețea locație",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de început"
-          },
-          "last_report_date": {
-            "name": "Ultima dată de raportare"
-          },
-          "bucket_count": {
-            "name": "Număr de bucketuri"
-          },
-          "source_fields": {
-            "name": "Câmpuri sursă"
-          },
-          "source_unit": {
-            "name": "Unitate sursă"
-          },
-          "interval_minutes": {
-            "name": "Interval (minute)"
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
           },
           "last_reset_at": {
             "name": "Ultima resetare"
-          },
-          "update_pending": {
-            "name": "Actualizare în așteptare"
           }
         }
       },
       "site_battery_charge": {
         "name": "Încărcare baterie locație",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de început"
-          },
-          "last_report_date": {
-            "name": "Ultima dată de raportare"
-          },
-          "bucket_count": {
-            "name": "Număr de bucketuri"
-          },
-          "source_fields": {
-            "name": "Câmpuri sursă"
-          },
-          "source_unit": {
-            "name": "Unitate sursă"
-          },
-          "interval_minutes": {
-            "name": "Interval (minute)"
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
           },
           "last_reset_at": {
             "name": "Ultima resetare"
-          },
-          "update_pending": {
-            "name": "Actualizare în așteptare"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Descărcare baterie locație",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de început"
-          },
-          "last_report_date": {
-            "name": "Ultima dată de raportare"
-          },
-          "bucket_count": {
-            "name": "Număr de bucketuri"
-          },
-          "source_fields": {
-            "name": "Câmpuri sursă"
-          },
-          "source_unit": {
-            "name": "Unitate sursă"
-          },
-          "interval_minutes": {
-            "name": "Interval (minute)"
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
           },
           "last_reset_at": {
             "name": "Ultima resetare"
-          },
-          "update_pending": {
-            "name": "Actualizare în așteptare"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Ultima fereastră (s)"
           },
-          "last_report_date": {
-            "name": "Ultima dată de raportare"
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
           },
           "last_reset_at": {
             "name": "Ultima resetare"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Încărcare EVSE la locație",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de început"
-          },
-          "last_report_date": {
-            "name": "Ultima dată de raportare"
-          },
-          "bucket_count": {
-            "name": "Număr de bucketuri"
-          },
-          "source_fields": {
-            "name": "Câmpuri sursă"
-          },
-          "source_unit": {
-            "name": "Unitate sursă"
-          },
-          "interval_minutes": {
-            "name": "Interval (minute)"
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
           },
           "last_reset_at": {
             "name": "Ultima resetare"
-          },
-          "update_pending": {
-            "name": "Actualizare în așteptare"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Consum pompă de căldură la locație",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de început"
-          },
-          "last_report_date": {
-            "name": "Ultima dată de raportare"
-          },
-          "bucket_count": {
-            "name": "Număr de bucketuri"
-          },
-          "source_fields": {
-            "name": "Câmpuri sursă"
-          },
-          "source_unit": {
-            "name": "Unitate sursă"
-          },
-          "interval_minutes": {
-            "name": "Interval (minute)"
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
           },
           "last_reset_at": {
             "name": "Ultima resetare"
-          },
-          "update_pending": {
-            "name": "Actualizare în așteptare"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Consum încălzitor apă la locație",
         "state_attributes": {
-          "start_date": {
-            "name": "Data de început"
-          },
-          "last_report_date": {
-            "name": "Ultima dată de raportare"
-          },
-          "bucket_count": {
-            "name": "Număr de bucketuri"
-          },
-          "source_fields": {
-            "name": "Câmpuri sursă"
-          },
-          "source_unit": {
-            "name": "Unitate sursă"
-          },
-          "interval_minutes": {
-            "name": "Interval (minute)"
+          "sampled_at_utc": {
+            "name": "Eșantionat la (UTC)"
           },
           "last_reset_at": {
             "name": "Ultima resetare"
-          },
-          "update_pending": {
-            "name": "Actualizare în așteptare"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "SG-Ready activ al pompei de căldură"
       },
       "cloud_reachable": {
-        "name": "Cloud accesibil",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Ultima eroare (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Ultimul status al erorii"
-          },
-          "code_description": {
-            "name": "Descriere cod"
-          },
-          "last_failure_response": {
-            "name": "Ultimul răspuns de eroare"
-          },
-          "last_failure_source": {
-            "name": "Ultima sursă a erorii"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff se încheie (UTC)"
-          }
-        }
+        "name": "Cloud accesibil"
       },
       "connected": {
         "name": "Conectivitate",

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -475,9 +475,6 @@
       "last_successful_update": {
         "name": "Senaste lyckade uppdatering",
         "state_attributes": {
-          "last_success_utc": {
-            "name": "Senaste lyckade (UTC)"
-          },
           "last_failure_utc": {
             "name": "Senaste fel (UTC)"
           },
@@ -499,27 +496,7 @@
         }
       },
       "cloud_latency": {
-        "name": "Molnlatens",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Senaste fel (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Senaste felstatus"
-          },
-          "code_description": {
-            "name": "Kodbeskrivning"
-          },
-          "last_failure_response": {
-            "name": "Senaste felrespons"
-          },
-          "last_failure_source": {
-            "name": "Senaste felkälla"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff slutar (UTC)"
-          }
-        }
+        "name": "Molnlatens"
       },
       "current_production_power": {
         "name": "Aktuell produktionskraft",
@@ -540,26 +517,6 @@
       },
       "cloud_error_code": {
         "name": "Molnfelkod",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Senaste fel (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Senaste felstatus"
-          },
-          "code_description": {
-            "name": "Kodbeskrivning"
-          },
-          "last_failure_response": {
-            "name": "Senaste felrespons"
-          },
-          "last_failure_source": {
-            "name": "Senaste felkälla"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff slutar (UTC)"
-          }
-        },
         "state": {
           "none": "Ingen",
           "dns_error": "DNS-fel",
@@ -568,26 +525,6 @@
       },
       "cloud_backoff_ends": {
         "name": "Cloud-backoff slutar",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Senaste fel (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Senaste felstatus"
-          },
-          "code_description": {
-            "name": "Kodbeskrivning"
-          },
-          "last_failure_response": {
-            "name": "Senaste felrespons"
-          },
-          "last_failure_source": {
-            "name": "Senaste felkälla"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff slutar (UTC)"
-          }
-        },
         "state": {
           "none": "Ingen"
         }
@@ -632,87 +569,33 @@
       "site_solar_production": {
         "name": "Plats solproduktion",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Senaste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Antal bucketar"
-          },
-          "source_fields": {
-            "name": "Källfält"
-          },
-          "source_unit": {
-            "name": "Källenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Senaste återställning"
-          },
-          "update_pending": {
-            "name": "Uppdatering väntar"
           }
         }
       },
       "site_consumption": {
         "name": "Platsförbrukning",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Senaste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Antal bucketar"
-          },
-          "source_fields": {
-            "name": "Källfält"
-          },
-          "source_unit": {
-            "name": "Källenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Senaste återställning"
-          },
-          "update_pending": {
-            "name": "Uppdatering väntar"
           }
         }
       },
       "site_grid_import": {
         "name": "Platsnät-import",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Senaste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Antal bucketar"
-          },
-          "source_fields": {
-            "name": "Källfält"
-          },
-          "source_unit": {
-            "name": "Källenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Senaste återställning"
-          },
-          "update_pending": {
-            "name": "Uppdatering väntar"
           }
         }
       },
@@ -734,8 +617,8 @@
           "last_window_seconds": {
             "name": "Senaste fönster (s)"
           },
-          "last_report_date": {
-            "name": "Senaste rapportdatum"
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Senaste återställning"
@@ -751,87 +634,33 @@
       "site_grid_export": {
         "name": "Platsnät-export",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Senaste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Antal bucketar"
-          },
-          "source_fields": {
-            "name": "Källfält"
-          },
-          "source_unit": {
-            "name": "Källenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Senaste återställning"
-          },
-          "update_pending": {
-            "name": "Uppdatering väntar"
           }
         }
       },
       "site_battery_charge": {
         "name": "Platsbatteriladdning",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Senaste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Antal bucketar"
-          },
-          "source_fields": {
-            "name": "Källfält"
-          },
-          "source_unit": {
-            "name": "Källenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Senaste återställning"
-          },
-          "update_pending": {
-            "name": "Uppdatering väntar"
           }
         }
       },
       "site_battery_discharge": {
         "name": "Platsbatteriurladdning",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Senaste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Antal bucketar"
-          },
-          "source_fields": {
-            "name": "Källfält"
-          },
-          "source_unit": {
-            "name": "Källenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Senaste återställning"
-          },
-          "update_pending": {
-            "name": "Uppdatering väntar"
           }
         }
       },
@@ -853,8 +682,8 @@
           "last_window_seconds": {
             "name": "Senaste fönster (s)"
           },
-          "last_report_date": {
-            "name": "Senaste rapportdatum"
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Senaste återställning"
@@ -1045,87 +874,33 @@
       "site_evse_charging": {
         "name": "Anläggningens EVSE-laddning",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Senaste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Antal bucketar"
-          },
-          "source_fields": {
-            "name": "Källfält"
-          },
-          "source_unit": {
-            "name": "Källenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Senaste återställning"
-          },
-          "update_pending": {
-            "name": "Uppdatering väntar"
           }
         }
       },
       "site_heat_pump_consumption": {
         "name": "Anläggningens värmepumpsförbrukning",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Senaste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Antal bucketar"
-          },
-          "source_fields": {
-            "name": "Källfält"
-          },
-          "source_unit": {
-            "name": "Källenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Senaste återställning"
-          },
-          "update_pending": {
-            "name": "Uppdatering väntar"
           }
         }
       },
       "site_water_heater_consumption": {
         "name": "Anläggningens varmvattenberedarförbrukning",
         "state_attributes": {
-          "start_date": {
-            "name": "Startdatum"
-          },
-          "last_report_date": {
-            "name": "Senaste rapportdatum"
-          },
-          "bucket_count": {
-            "name": "Antal bucketar"
-          },
-          "source_fields": {
-            "name": "Källfält"
-          },
-          "source_unit": {
-            "name": "Källenhet"
-          },
-          "interval_minutes": {
-            "name": "Intervall (min)"
+          "sampled_at_utc": {
+            "name": "Samplad kl. (UTC)"
           },
           "last_reset_at": {
             "name": "Senaste återställning"
-          },
-          "update_pending": {
-            "name": "Uppdatering väntar"
           }
         }
       },
@@ -1263,27 +1038,7 @@
         "name": "Värmepumpens SG-Ready aktiv"
       },
       "cloud_reachable": {
-        "name": "Moln nåbart",
-        "state_attributes": {
-          "last_failure_utc": {
-            "name": "Senaste fel (UTC)"
-          },
-          "last_failure_status": {
-            "name": "Senaste felstatus"
-          },
-          "code_description": {
-            "name": "Kodbeskrivning"
-          },
-          "last_failure_response": {
-            "name": "Senaste felrespons"
-          },
-          "last_failure_source": {
-            "name": "Senaste felkälla"
-          },
-          "backoff_ends_utc": {
-            "name": "Backoff slutar (UTC)"
-          }
-        }
+        "name": "Moln nåbart"
       },
       "connected": {
         "name": "Anslutning",

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -176,8 +176,6 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
             "locale_used": self._locale_used,
             "catalog_source_scope": self._source_scope,
             "catalog_generated_at": self._catalog_generated_at,
-            "raw_installed_version": self._raw_installed_version,
-            "raw_latest_version": self._raw_latest_version,
             "catalog_last_fetch_utc": status.get("last_fetch_utc"),
             "catalog_last_error": status.get("last_error"),
         }
@@ -323,8 +321,6 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
     def extra_state_attributes(self) -> dict[str, Any]:
         status = self._manager.status_snapshot()
         return {
-            "raw_installed_version": self._raw_installed_version,
-            "raw_latest_version": self._raw_latest_version,
             "upgrade_status": self._upgrade_status,
             "status_detail": self._status_detail,
             "last_successful_upgrade_date": self._last_successful_upgrade_date,

--- a/tests/components/enphase_ev/test_binary_sensor_module.py
+++ b/tests/components/enphase_ev/test_binary_sensor_module.py
@@ -789,12 +789,7 @@ def test_site_cloud_reachable_binary_sensor_metadata(
 
     attrs = sensor.extra_state_attributes
     assert "last_success_utc" not in attrs
-    assert attrs["last_failure_utc"] == failure_time.isoformat()
-    assert attrs["last_failure_status"] == 503
-    assert attrs["code_description"] == "Gateway error"
-    assert attrs["last_failure_response"] == {"retry": True}
-    assert attrs["last_failure_source"] == "http"
-    assert attrs["backoff_ends_utc"] == coord.backoff_ends_utc.isoformat()
+    assert attrs == {}
 
     info = sensor.device_info
     assert info["identifiers"] == {(DOMAIN, f"type:{coord.site_id}:cloud")}
@@ -819,9 +814,7 @@ def test_site_cloud_reachable_binary_sensor_metadata_includes_optional_failure_f
     coord.payload_using_stale = True
 
     attrs = sensor.extra_state_attributes
-    assert attrs["last_failure_endpoint"] == "/ivp/meters"
-    assert attrs["payload_failure_kind"] == "schema"
-    assert attrs["payload_using_stale"] is True
+    assert attrs == {}
 
 
 def test_binary_sensor_helper_type_available_uses_inventory_view() -> None:
@@ -880,19 +873,7 @@ def test_heatpump_sg_ready_active_binary_sensor_metadata(
     assert sensor.available is True
     assert sensor.is_on is True
 
-    attrs = sensor.extra_state_attributes
-    assert attrs["device_uid"] == "HP-1"
-    assert attrs["heatpump_status_raw"] == "RUNNING"
-    assert attrs["sg_ready_mode_raw"] == "MODE_3"
-    assert attrs["sg_ready_mode_label"] == "Recommended"
-    assert attrs["sg_ready_active"] is True
-    assert attrs["sg_ready_mode"] == 3
-    assert attrs["sg_ready_contact_state"] == "closed"
-    assert attrs["status_explanation"] == (
-        "Recommended means the SG Ready contact is closed."
-    )
-    assert attrs["last_report_at"] == "2026-03-03T07:30:00Z"
-    assert attrs["source"] == "hems_heatpump_state:HP-1"
+    assert sensor.extra_state_attributes == {}
 
     info = sensor.device_info
     assert info["name"] == "Heat Pump"
@@ -968,7 +949,7 @@ def test_heatpump_sg_ready_active_binary_sensor_uses_dedicated_hems_inventory(
     assert (
         sensor.unique_id == f"{DOMAIN}_site_{coord.site_id}_heat_pump_sg_ready_active"
     )
-    assert sensor.extra_state_attributes["last_report_at"] == "2026-03-03T07:30:00Z"
+    assert sensor.extra_state_attributes == {}
 
 
 def test_heatpump_sg_ready_active_binary_sensor_stays_on_for_mixed_member_statuses(
@@ -1018,9 +999,7 @@ def test_heatpump_sg_ready_active_binary_sensor_stays_on_for_mixed_member_status
     sensor = HeatPumpSgReadyActiveBinarySensor(coord)
     assert sensor.available is True
     assert sensor.is_on is True
-    attrs = sensor.extra_state_attributes
-    assert attrs["sg_ready_mode_label"] == "Recommended"
-    assert attrs["sg_ready_active"] is True
+    assert sensor.extra_state_attributes == {}
 
 
 def test_heatpump_sg_ready_active_binary_sensor_helper_edge_cases(

--- a/tests/components/enphase_ev/test_latency_and_connectivity.py
+++ b/tests/components/enphase_ev/test_latency_and_connectivity.py
@@ -84,9 +84,13 @@ def test_cloud_site_sensors_are_not_gated_by_envoy_type():
     assert EnphaseCloudLatencySensor(coord).available is True
     assert EnphaseCurrentPowerConsumptionSensor(coord).available is True
     assert SiteCloudReachableBinarySensor(coord).available is True
-    assert _SiteBaseEntity(
-        coord, "cloud_base", "Cloud Base", type_key=None
-    ).device_info["identifiers"] == {("enphase_ev", f"type:{coord.site_id}:cloud")}
+    base_entity = _SiteBaseEntity(coord, "cloud_base", "Cloud Base", type_key=None)
+    assert base_entity.device_info["identifiers"] == {
+        ("enphase_ev", f"type:{coord.site_id}:cloud")
+    }
+    assert base_entity.extra_state_attributes == {
+        "last_success_utc": "2026-03-11T05:41:00+00:00"
+    }
 
 
 def test_current_power_consumption_sensor_edge_paths():
@@ -245,14 +249,7 @@ def test_site_cloud_reachable_binary_sensor_states():
     coord.last_failure_utc = now
 
     attrs = bs.extra_state_attributes
-    assert attrs["last_failure_status"] == 500
-    assert attrs["code_description"] == "Server error"
-    assert attrs["last_failure_response"] == payload
-    assert attrs["last_failure_source"] == "http"
-    assert attrs["last_failure_endpoint"].endswith("/ev_chargers/status")
-    assert attrs["payload_failure_kind"] == "json_decode"
-    assert attrs["payload_using_stale"] is True
-    assert "last_failure_utc" in attrs
+    assert attrs == {}
 
 
 def test_site_error_code_sensor_state_and_attributes():
@@ -280,14 +277,7 @@ def test_site_error_code_sensor_state_and_attributes():
     coord.payload_failure_kind = "json_decode"
 
     assert sensor.native_value == "429"
-    attrs = sensor.extra_state_attributes
-    assert attrs["last_failure_status"] == 429
-    assert attrs["code_description"] == "Rate limited"
-    assert attrs["last_failure_response"] == payload
-    assert attrs["last_failure_source"] == "http"
-    assert attrs["payload_using_stale"] is True
-    assert attrs["payload_failure_kind"] == "json_decode"
-    assert attrs["last_failure_utc"] == failure_time.isoformat()
+    assert sensor.extra_state_attributes == {}
 
     coord.last_success_utc = failure_time + timedelta(seconds=1)
     assert sensor.native_value == "none"
@@ -331,9 +321,7 @@ def test_site_backoff_sensor_handles_none_and_datetime(monkeypatch):
 
     value = sensor.native_value
     assert value == backoff_until
-    attrs = sensor.extra_state_attributes
-    assert attrs["backoff_ends_utc"] == backoff_until.isoformat()
-    assert "backoff_seconds" not in attrs
+    assert sensor.extra_state_attributes == {}
 
     # Once the backoff window has elapsed the sensor should reset to none
     monkeypatch.setattr(dt_util, "utcnow", lambda: backoff_until + timedelta(seconds=1))

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -270,7 +270,7 @@ def test_ac_battery_target_state_of_charge_select_state_and_options(
     assert sel.available is True
     assert "25-30%" in sel.options
     assert sel.current_option == "25-30%"
-    assert sel.extra_state_attributes["control_pending"] is True
+    assert sel.extra_state_attributes["selected_sleep_min_soc"] == 25
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -2032,7 +2032,6 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
     sg_sensor = EnphaseHeatPumpSgReadyModeSensor(coord)
     assert sg_sensor.native_value == "Recommended"
     sg_attrs = sg_sensor.extra_state_attributes
-    assert sg_attrs["device_uid"] == "HP-1"
     assert sg_attrs["heatpump_status_raw"] == "RUNNING"
     assert sg_attrs["sg_ready_mode_raw"] == "MODE_3"
     assert sg_attrs["sg_ready_mode"] == 3
@@ -2053,11 +2052,7 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
     assert last_reported_sensor.native_value == datetime(
         2026, 2, 27, 9, 15, 59, tzinfo=timezone.utc
     )
-    assert last_reported_sensor.extra_state_attributes["device_uid"] == "HP-1"
-    assert (
-        last_reported_sensor.extra_state_attributes["source"]
-        == "hems_heatpump_state:HP-1"
-    )
+    assert last_reported_sensor.extra_state_attributes == {}
 
     power_sensor = EnphaseHeatPumpPowerSensor(coord)
     assert power_sensor.available is True
@@ -2277,6 +2272,36 @@ def test_heatpump_sensor_availability_edge_paths(
         "Site Heat Pump Consumption",
     )
     assert site_sensor.extra_state_attributes["heat_pump_power_w"] is None
+
+
+def test_site_heat_pump_energy_attributes_without_daily_snapshot(
+    coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseSiteEnergySensor
+
+    coord = coordinator_factory(serials=[])
+    coord.energy.site_energy = {
+        "heat_pump": {
+            "value_kwh": 0.75,
+            "last_report_date": "2026-02-27T09:15:00Z",
+        }
+    }
+    monkeypatch.setattr(
+        type(coord),
+        "heatpump_daily_consumption",
+        property(lambda _self: None),
+    )
+
+    sensor = EnphaseSiteEnergySensor(
+        coord,
+        "heat_pump",
+        "site_heat_pump_consumption",
+        "Site Heat Pump Consumption",
+    )
+
+    assert sensor.extra_state_attributes == {
+        "sampled_at_utc": "2026-02-27T09:15:00+00:00"
+    }
 
 
 def test_heatpump_runtime_sensor_uid_fallback_and_error_paths(

--- a/tests/components/enphase_ev/test_sensor_edge_cases.py
+++ b/tests/components/enphase_ev/test_sensor_edge_cases.py
@@ -878,6 +878,8 @@ def test_site_base_entity_diagnostics(monkeypatch, coordinator_factory):
 
     coord.backoff_ends_utc = dt_util.utcnow() + timedelta(seconds=0.4)
     assert site_sensor._backoff_remaining_seconds() == 1
+    attrs = site_sensor._cloud_diag_attrs(include_last_success=False)
+    assert attrs["backoff_ends_utc"] == coord.backoff_ends_utc.isoformat()
     assert site_sensor.device_info["identifiers"]
 
     coord.last_success_utc = None

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -453,11 +453,7 @@ def test_battery_overall_charge_sensor_states():
     provided = {"identifiers": {("enphase_ev", "type:site:encharge")}}
     coord.inventory_view.type_device_info = lambda _key: provided
     assert sensor.device_info is provided
-    attrs = sensor.extra_state_attributes
-    assert attrs["aggregate_status"] == "normal"
-    assert attrs["aggregate_charge_source"] == "computed"
-    assert attrs["included_count"] == 2
-    assert attrs["contributing_count"] == 2
+    assert sensor.extra_state_attributes == {}
 
     coord.battery_aggregate_charge_pct = None
     assert sensor.available is False
@@ -502,7 +498,6 @@ def test_battery_overall_status_sensor_states():
     assert sensor.available is True
     assert sensor.native_value == "warning"
     attrs = sensor.extra_state_attributes
-    assert attrs["aggregate_charge_source"] == "computed"
     assert attrs["worst_storage_key"] == "BAT-2"
     assert attrs["per_battery_status"]["BAT-2"] == "warning"
 
@@ -838,14 +833,12 @@ def test_battery_site_summary_sensors_state_and_attributes():
     assert energy.state_class is None
     assert energy.available is True
     assert energy.native_value == 4.75
-    assert energy.extra_state_attributes["site_max_capacity_kwh"] == 10.0
     assert (
         energy.extra_state_attributes["sampled_at_utc"] == "2026-03-11T05:40:00+00:00"
     )
 
     assert power.available is True
     assert power.native_value == 7.68
-    assert power.extra_state_attributes["site_max_power_kw"] == 7.68
     assert power.extra_state_attributes["sampled_at_utc"] == "2026-03-11T05:40:00+00:00"
 
     coord.battery_status_summary = {}
@@ -1115,7 +1108,7 @@ def test_ac_battery_site_summary_sensors_state_and_attributes():
 
     assert overall.available is True
     assert overall.native_value == "warning"
-    assert overall.extra_state_attributes["control_pending"] is True
+    assert overall.extra_state_attributes["battery_count"] == 1
     assert power.available is True
     assert power.native_value == 260.0
     assert power.extra_state_attributes["sampled_at_utc"] == "2026-04-09T03:16:00+00:00"
@@ -1124,7 +1117,6 @@ def test_ac_battery_site_summary_sensors_state_and_attributes():
         2026, 4, 9, 3, 15, tzinfo=timezone.utc
     )
     attrs = last_reported.extra_state_attributes
-    assert attrs["latest_reported_utc"] == "2026-04-09T03:15:00+00:00"
     assert attrs["total_batteries"] == 1
 
 
@@ -1420,7 +1412,6 @@ def test_battery_mode_sensor_states():
     assert attrs["mode_raw"] == "ImportExport"
     assert attrs["charge_from_grid_allowed"] is True
     assert attrs["discharge_to_grid_allowed"] is True
-    assert attrs["charge_from_grid_start_time"] == "02:00:00"
     assert attrs["shutdown_level"] == 15
     assert attrs["use_battery_for_self_consumption"] is True
 
@@ -2588,7 +2579,6 @@ def test_connector_status_reports_reason_attribute():
     assert sensor.extra_state_attributes == {
         "status_reason": "INSUFFICIENT_SOLAR",
         "connector_status_info": "see manual",
-        "suspended_by_evse": None,
     }
 
 
@@ -2608,7 +2598,6 @@ def test_connector_status_reason_absent_returns_empty_attributes():
     assert sensor.extra_state_attributes == {
         "status_reason": None,
         "connector_status_info": None,
-        "suspended_by_evse": None,
     }
 
 
@@ -2629,7 +2618,6 @@ def test_connector_status_reason_numeric_gets_stringified():
     assert sensor.extra_state_attributes == {
         "status_reason": "123",
         "connector_status_info": None,
-        "suspended_by_evse": None,
     }
 
 
@@ -2655,7 +2643,6 @@ def test_connector_status_reason_handles_non_string_value():
     assert sensor.extra_state_attributes == {
         "status_reason": sentinel,
         "connector_status_info": None,
-        "suspended_by_evse": None,
     }
 
 
@@ -2673,14 +2660,14 @@ def test_connector_status_reports_suspended_by_evse():
         },
     )
     sensor = EnphaseConnectorStatusSensor(coord, sn)
-    assert sensor.extra_state_attributes["suspended_by_evse"] is True
+    assert "suspended_by_evse" not in sensor.extra_state_attributes
 
     class BadBool:
         def __bool__(self):
             raise ValueError("boom")
 
     coord.data[sn]["suspended_by_evse"] = BadBool()
-    assert sensor.extra_state_attributes["suspended_by_evse"] is None
+    assert "suspended_by_evse" not in sensor.extra_state_attributes
 
 
 def test_charge_mode_sensor_attributes():

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -702,9 +702,10 @@ def test_site_power_state_attribute_strings_exist_for_all_locales() -> None:
     paths = [
         "entity.sensor.site_grid_power.state_attributes.last_flow_kwh.name",
         "entity.sensor.site_grid_power.state_attributes.source_flows.name",
-        "entity.sensor.site_grid_power.state_attributes.last_report_date.name",
+        "entity.sensor.site_grid_power.state_attributes.sampled_at_utc.name",
         "entity.sensor.site_battery_power.state_attributes.last_flow_kwh.name",
         "entity.sensor.site_battery_power.state_attributes.source_flows.name",
+        "entity.sensor.site_battery_power.state_attributes.sampled_at_utc.name",
     ]
     for locale in translations_dir.glob("*.json"):
         name = locale.name

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -315,8 +315,8 @@ def test_site_energy_sampled_at_utc_requires_parseable_timestamp(
     )
     attrs = sensor.extra_state_attributes
 
-    assert attrs["last_report_date"] == "soon"
-    assert attrs["sampled_at_utc"] is None
+    assert "last_report_date" not in attrs
+    assert "sampled_at_utc" not in attrs
 
 
 def test_diff_energy_fields_when_neg_exceeds(coordinator_factory) -> None:
@@ -999,14 +999,9 @@ async def test_site_energy_sensor_attributes(hass, coordinator_factory):
     assert sensor.available is True
     assert sensor.native_value == pytest.approx(1.23)
     attrs = sensor.extra_state_attributes
-    assert attrs["bucket_count"] == 3
-    assert attrs["source_fields"] == ["production"]
-    assert attrs["start_date"] == "2024-01-01"
-    assert attrs["last_report_date"].startswith("2024-01-02")
     assert attrs["last_reset_at"] == "2024-01-03T00:00:00+00:00"
-    assert attrs["source_unit"] == "Wh"
-    assert attrs["interval_minutes"] == 60
-    assert attrs["evse_charging_kwh"] == pytest.approx(0.46)
+    assert attrs["sampled_at_utc"].startswith("2024-01-02")
+    assert "evse_charging_kwh" not in attrs
     assert sensor.entity_registry_enabled_default is True
 
 
@@ -2816,15 +2811,15 @@ async def test_site_energy_sensor_restoration(monkeypatch, hass, coordinator_fac
     sensor._restored_value = 1.0
     coord.energy.site_energy = {}
     attrs = sensor.extra_state_attributes
-    assert attrs["last_report_date"] is None
-    assert attrs["sampled_at_utc"] is None
+    assert "last_report_date" not in attrs
+    assert "sampled_at_utc" not in attrs
     assert sensor.native_value == 1.0
 
     coord.energy.site_energy = {
         "grid_import": {"value_kwh": 3.0, "last_report_date": "soon"}
     }
-    assert sensor.extra_state_attributes["last_report_date"] == "soon"
-    assert sensor.extra_state_attributes["sampled_at_utc"] is None
+    assert "last_report_date" not in sensor.extra_state_attributes
+    assert "sampled_at_utc" not in sensor.extra_state_attributes
 
     sensor2 = EnphaseSiteEnergySensor(
         coord, "grid_export", "site_grid_export", "Grid Export"
@@ -2878,7 +2873,7 @@ async def test_site_energy_sensor_restoration(monkeypatch, hass, coordinator_fac
         "battery_charge": {"value_kwh": 1.0, "last_report_date": BadStr()}
     }
     attrs = sensor3.extra_state_attributes
-    assert attrs["last_report_date"] is None
+    assert "last_report_date" not in attrs
 
 
 @pytest.mark.asyncio
@@ -2998,7 +2993,7 @@ async def test_site_energy_sensor_evse_attribute_edge_cases(hass, coordinator_fa
     )
     sensor.hass = hass
     attrs = sensor.extra_state_attributes
-    assert attrs["evse_charging_kwh"] is None
+    assert "evse_charging_kwh" not in attrs
 
     class BadEnergy:
         @property

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -240,7 +240,6 @@ def test_ac_battery_sleep_mode_switch_state_and_attributes(coordinator_factory) 
 
     assert sw.available is True
     assert sw.is_on is True
-    assert sw.extra_state_attributes["selected_sleep_min_soc"] == 25
     assert sw.extra_state_attributes["pending"] is True
 
 
@@ -1565,12 +1564,7 @@ def test_charge_from_grid_switch_exposes_schedule_attributes(
 
     attrs = ChargeFromGridSwitch(coord).extra_state_attributes
 
-    assert attrs["start_time"] == "02:00"
-    assert attrs["end_time"] == "05:00"
-    assert attrs["schedule_limit"] == 95
-    assert attrs["schedule_status"] == "pending"
-    assert attrs["schedule_pending"] is True
-    assert attrs["schedule_enabled"] is True
+    assert attrs == {"write_pending": False, "write_age_seconds": None}
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_type_device_entity_fallbacks.py
+++ b/tests/components/enphase_ev/test_type_device_entity_fallbacks.py
@@ -407,4 +407,4 @@ def test_cloud_site_sensor_last_success_attrs_not_type_gated() -> None:
     sensor = EnphaseSiteLastUpdateSensor(coord)
     assert sensor.available is True
     attrs = sensor.extra_state_attributes
-    assert "last_success_utc" in attrs
+    assert "last_success_utc" not in attrs

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -410,7 +410,6 @@ async def test_microinverter_update_entity_uses_normalized_versions(hass) -> Non
     assert attrs["locale_used"] == "fr-fr"
     assert attrs["catalog_source_scope"] == "locale"
     assert attrs["catalog_generated_at"] == "2026-03-01T00:00:00Z"
-    assert attrs["raw_installed_version"] == "v04.30.31"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Deduplicate repeated Enphase entity attributes across cloud, site energy, battery, AC battery, heat pump, EVSE, and update entities.

This trims redundant state/attribute duplication, keeps one canonical source for shared diagnostics or schedule metadata where appropriate, and aligns translations and tests with the reduced attribute surface.

## Related Issues

- None

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/binary_sensor.py custom_components/enphase_ev/select.py custom_components/enphase_ev/sensor.py custom_components/enphase_ev/switch.py custom_components/enphase_ev/update.py tests/components/enphase_ev/test_binary_sensor_module.py tests/components/enphase_ev/test_latency_and_connectivity.py tests/components/enphase_ev/test_select_charge_mode.py tests/components/enphase_ev/test_sensor_additional_coverage.py tests/components/enphase_ev/test_sensor_edge_cases.py tests/components/enphase_ev/test_sensors.py tests/components/enphase_ev/test_service_translations.py tests/components/enphase_ev/test_site_energy.py tests/components/enphase_ev/test_switch_module.py tests/components/enphase_ev/test_type_device_entity_fallbacks.py tests/components/enphase_ev/test_update_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_service_translations.py -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/binary_sensor.py,custom_components/enphase_ev/select.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/switch.py,custom_components/enphase_ev/update.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc 'tmpdir=$(mktemp -d) && cp -a /workspace/. "$tmpdir"/ && cd "$tmpdir" && rm -f .git && git init -q && git config user.email codex@example.com && git config user.name Codex && git add -A && pre-commit run --all-files'
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Notes:
- `pre-commit run --all-files` cannot operate directly on this Codex worktree inside the container because `.git` points at a host-only worktree metadata path. The command above reruns the same hooks against a temporary in-container git repo snapshot of the current tree.
- `pytest` and the temporary-repo `pre-commit` command were rerun after rebasing onto `origin/main`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Touched-module targeted coverage is 100% for `custom_components/enphase_ev/binary_sensor.py`, `custom_components/enphase_ev/select.py`, `custom_components/enphase_ev/sensor.py`, `custom_components/enphase_ev/switch.py`, and `custom_components/enphase_ev/update.py`.
