### PR TITLE
Bootstrap BatteryConfig XSRF via GET response header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed `Battery settings update was rejected by Enphase (HTTP 403 Forbidden)` loops on EMEA sites where the legacy BatteryConfig bootstrap failed to acquire an XSRF token. The client now performs a GET against `siteSettings` and reads the `x-csrf-token` response header — matching the `battery-profile-ui.enphaseenergy.com` web UI — before falling back to the previous POST `schedules/isValid` shape.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -3488,81 +3488,148 @@ class EnphaseEVClient:
             raise last_error
         raise aiohttp.ClientError("BatteryConfig request exhausted variants")
 
+    @staticmethod
+    def _extract_xsrf_from_response_header(response: object) -> str | None:
+        """Return the XSRF token from a response's ``x-csrf-token`` header.
+
+        The Enphase BatteryConfig service emits ``x-csrf-token`` on every
+        response; the ``battery-profile-ui.enphaseenergy.com`` web UI relies
+        on this as its primary bootstrap mechanism (see PR description for
+        HAR evidence).
+        """
+
+        headers_get = getattr(getattr(response, "headers", None), "get", None)
+        if not callable(headers_get):
+            return None
+        token = headers_get("x-csrf-token") or headers_get("X-CSRF-Token")
+        if isinstance(token, str) and token.strip():
+            return token.strip()
+        return None
+
+    @staticmethod
+    def _extract_xsrf_from_response_cookies(response: object) -> str | None:
+        """Return the XSRF token from Set-Cookie headers or response cookies."""
+
+        header_values: list[str] = []
+        headers = getattr(response, "headers", None)
+        getall = getattr(headers, "getall", None)
+        headers_get = getattr(headers, "get", None)
+        if callable(getall):
+            header_values = list(getall("Set-Cookie", []))
+        elif callable(headers_get):
+            header_value = headers_get("Set-Cookie")
+            if isinstance(header_value, str) and header_value:
+                header_values = [header_value]
+        for value in header_values:
+            match = re.search(r"(?i)(?:^|;\s*)(?:bp-)?xsrf-token=([^;]+)", value)
+            if match:
+                try:
+                    decoded = unquote(match.group(1))
+                except Exception:  # noqa: BLE001 - defensive decoding
+                    decoded = match.group(1)
+                if decoded:
+                    return decoded
+
+        response_cookie_token = _extract_xsrf_token(
+            _coerce_cookie_map(getattr(response, "cookies", None))
+        )
+        if response_cookie_token:
+            return response_cookie_token
+
+        return None
+
     async def _acquire_xsrf_token(
         self,
         schedule_type: str = "cfg",
         *,
         variant: str = _BATTERY_CONFIG_VARIANT_PRIMARY,
     ) -> str | None:
-        """Acquire a BP-XSRF-Token by POSTing to the schedules isValid endpoint.
+        """Acquire an XSRF token for BatteryConfig write operations.
 
-        The Enphase BatteryConfig API requires an XSRF token for write operations.
-        This token is obtained from the ``Set-Cookie`` header in the response to
-        a POST to ``/schedules/isValid``.
+        Tries two bootstrap shapes, in order:
+
+        1. **GET** ``siteSettings/{site}?userId={userId}`` and read the
+           ``x-csrf-token`` response header. This matches the Enphase web UI
+           (``battery-profile-ui.enphaseenergy.com``) and works on EMEA sites
+           that do not set a ``BP-XSRF-Token`` cookie.
+        2. **POST** ``schedules/isValid`` and read ``Set-Cookie`` /
+           ``response.cookies`` — the legacy bootstrap, kept as a fallback
+           for sites that still expose the token that way.
         """
 
-        url = (
-            f"{BASE_URL}/service/batteryConfig/api/v1/battery/sites/"
-            f"{self._site}/schedules/isValid"
-        )
         headers = self._battery_config_headers(
             include_xsrf=True,
             variant=variant,
         )
-        headers["Content-Type"] = "application/json"
         request_headers = self._merge_request_headers({}, headers)
-        payload = self._battery_schedule_validation_payload(schedule_type)
+
+        def _remember_xsrf(token: str, source: str) -> str:
+            self._bp_xsrf_token = token
+            _LOGGER.debug("Acquired BP-XSRF-Token from %s", source)
+            return token
 
         try:
             _seed_cookie_jar(self._s, _cookie_map_from_header(self._cookie))
 
-            def _remember_xsrf(token: str | None, source: str) -> str | None:
-                if not token:
-                    return None
-                self._bp_xsrf_token = token
-                _LOGGER.debug("Acquired BP-XSRF-Token from %s", source)
-                return token
+            # Preferred path: GET siteSettings. The response includes
+            # ``x-csrf-token`` on success without requiring an XSRF token
+            # itself, so this avoids the chicken-and-egg problem when the
+            # legacy POST bootstrap is rejected with 403.
+            user_id = self._battery_config_user_id_for_token() or ""
+            site_settings_url = (
+                f"{BASE_URL}/service/batteryConfig/api/v1/siteSettings/" f"{self._site}"
+            )
+            site_settings_params = {"userId": user_id} if user_id else None
+            async with asyncio.timeout(self._timeout):
+                async with self._s.request(
+                    "GET",
+                    site_settings_url,
+                    headers=request_headers,
+                    params=site_settings_params,
+                ) as r:
+                    if r.status < HTTPStatus.BAD_REQUEST:
+                        token = self._extract_xsrf_from_response_header(r)
+                        if token:
+                            return _remember_xsrf(token, "siteSettings response header")
+                    else:
+                        _LOGGER.debug(
+                            "BatteryConfig GET bootstrap returned %s for %s; "
+                            "falling back to POST isValid",
+                            r.status,
+                            _request_label("GET", site_settings_url),
+                        )
+
+            # Legacy fallback: POST /schedules/isValid and parse Set-Cookie.
+            isvalid_url = (
+                f"{BASE_URL}/service/batteryConfig/api/v1/battery/sites/"
+                f"{self._site}/schedules/isValid"
+            )
+            isvalid_headers = dict(request_headers)
+            isvalid_headers["Content-Type"] = "application/json"
+            payload = self._battery_schedule_validation_payload(schedule_type)
 
             async with asyncio.timeout(self._timeout):
                 async with self._s.request(
-                    "POST", url, json=payload, headers=request_headers
+                    "POST", isvalid_url, json=payload, headers=isvalid_headers
                 ) as r:
                     if r.status >= HTTPStatus.BAD_REQUEST:
                         _LOGGER.debug(
                             "BatteryConfig bootstrap returned %s for %s; "
                             "keeping existing XSRF token",
                             r.status,
-                            _request_label("POST", url),
+                            _request_label("POST", isvalid_url),
                         )
                         return None
 
-                    header_values: list[str] = []
-                    getall = getattr(r.headers, "getall", None)
-                    if callable(getall):
-                        header_values = list(getall("Set-Cookie", []))
-                    else:
-                        header_value = getattr(
-                            r.headers, "get", lambda *_a, **_k: None
-                        )("Set-Cookie")
-                        if isinstance(header_value, str) and header_value:
-                            header_values = [header_value]
-                    for value in header_values:
-                        match = re.search(
-                            r"(?i)(?:^|;\s*)(?:bp-)?xsrf-token=([^;]+)", value
-                        )
-                        if match:
-                            return _remember_xsrf(
-                                unquote(match.group(1)), "Set-Cookie header"
-                            )
-
-                    response_cookie_token = _extract_xsrf_token(
-                        _coerce_cookie_map(getattr(r, "cookies", None))
-                    )
-                    if response_cookie_token:
-                        return _remember_xsrf(response_cookie_token, "response cookies")
+                    token = self._extract_xsrf_from_response_header(r)
+                    if token:
+                        return _remember_xsrf(token, "isValid response header")
+                    cookie_token = self._extract_xsrf_from_response_cookies(r)
+                    if cookie_token:
+                        return _remember_xsrf(cookie_token, "isValid Set-Cookie")
 
                     cookie_header, cookie_map = _serialize_cookie_jar(
-                        self._s.cookie_jar, (url, BASE_URL, ENTREZ_URL)
+                        self._s.cookie_jar, (isvalid_url, BASE_URL, ENTREZ_URL)
                     )
                     session_cookie_token = _extract_xsrf_token(cookie_map)
                     if session_cookie_token:

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -136,7 +136,7 @@ Example response:
 | BatteryConfig third-party settings | `GET` | `/service/batteryConfig/api/v1/<site_id>/thirdPartyControlSettings` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Safari-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI) |
 | BatteryConfig schedules | `GET` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | official-web BatteryConfig read shape: `Accept`, `Origin`, `Referer`, Safari-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI) |
 | BatteryConfig schedule create | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | BatteryConfig write shape plus `X-XSRF-Token`; on affected sites the verified working shape is the raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`) sent from a stateless client session so aiohttp does not merge cookie-jar state; current client falls back across cookie-backed, primary, lean, and mixed-auth variants | No |
-| BatteryConfig schedule validation / XSRF bootstrap | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid` | explicit validation uses the official-web BatteryConfig write shape without `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`, or `X-XSRF-Token`; the internal XSRF-bootstrap helper hits the same route and may include the currently held `X-XSRF-Token` while harvesting a fresh `BP-XSRF-Token` from `Set-Cookie`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI and live verification) |
+| BatteryConfig schedule validation / XSRF bootstrap | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid` | explicit validation uses the official-web BatteryConfig write shape without `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`, or `X-XSRF-Token`; the internal XSRF-bootstrap helper now prefers `GET /siteSettings/<site_id>?userId=<user_id>` and reads `x-csrf-token`, then falls back to this route where it may include the currently held `X-XSRF-Token` while harvesting a fresh token from the response header, `Set-Cookie`, or the session cookie jar; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI and live verification) |
 | BatteryConfig schedule update | `PUT` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>` | BatteryConfig write shape plus `X-XSRF-Token`; verified working update uses the raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`) from a stateless client session; current client falls back across cookie-backed, primary, lean, and mixed-auth variants | No (documented from live verification) |
 | BatteryConfig schedule legacy delete alias | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>/delete` | same BatteryConfig write planner as schedule create/update; cookie-backed browser request is the verified working compatibility shape on affected sites | No |
 | BatteryConfig disclaimer accept | `POST` | `/service/batteryConfig/api/v1/batterySettings/acceptDisclaimer/<site_id>` | documented write pattern only; when used, current client will try the same cookie-backed, primary, lean, and mixed-auth BatteryConfig write variants | No (not currently used by runtime) |
@@ -4216,7 +4216,8 @@ Updates the system profile and reserve percentage. Observed profile keys include
 `self-consumption`, `cost_savings`, `backup_only`, and `ai_optimisation`.
 
 Implementation auth notes:
-- The current client first acquires a fresh `BP-XSRF-Token` by POSTing to `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid`.
+- The current client first attempts `GET /service/batteryConfig/api/v1/siteSettings/<site_id>?userId=<user_id>` and reads the `x-csrf-token` response header.
+- If that GET does not yield a token, it falls back to `POST /service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid`, where it accepts `x-csrf-token`, `Set-Cookie`, response cookies, or the session cookie jar.
 - On affected issue `#460` sites, the verified working write uses the raw stored BatteryConfig cookie (`Cookie`), `e-auth-token` from `enlighten_manager_token_production`, `Username`, `X-XSRF-Token` from the raw cookie header, and `X-Requested-With: XMLHttpRequest`.
 - That cookie-backed write must be sent from a stateless request session so aiohttp does not merge cookie-jar state into the raw `Cookie` header.
 - Verified write planner order:
@@ -4410,7 +4411,8 @@ Headers:
 Updates battery settings. Captured requests used partial payloads to change individual controls.
 
 Implementation auth notes:
-- The current client first acquires a fresh `BP-XSRF-Token` via `/battery/sites/<site_id>/schedules/isValid`.
+- The current client first attempts `GET /service/batteryConfig/api/v1/siteSettings/<site_id>?userId=<user_id>` and reads the `x-csrf-token` response header.
+- If that GET does not yield a token, it falls back to `POST /battery/sites/<site_id>/schedules/isValid`, where it accepts `x-csrf-token`, `Set-Cookie`, response cookies, or the session cookie jar.
 - On affected issue `#460` sites, the verified working write uses the raw stored BatteryConfig cookie (`Cookie`), `e-auth-token` from `enlighten_manager_token_production`, `Username`, `X-XSRF-Token` from the raw cookie header, and `X-Requested-With: XMLHttpRequest`.
 - That cookie-backed write must be sent from a stateless request session so aiohttp does not merge cookie-jar state into the raw `Cookie` header.
 - Verified write planner order:
@@ -4763,7 +4765,7 @@ Body: {
 Creates a new battery schedule entry. The same endpoint is used for CFG, DTG, and RBD schedule creation and schedule restore flows.
 
 Implementation auth notes:
-- The current client acquires fresh XSRF first, then sends the official-web BatteryConfig shape plus `X-XSRF-Token`.
+- The current client acquires fresh XSRF first by preferring `GET /service/batteryConfig/api/v1/siteSettings/<site_id>?userId=<user_id>` and its `x-csrf-token` response header, then falling back to `/battery/sites/<site_id>/schedules/isValid` when needed before sending the write plus `X-XSRF-Token`.
 - On affected issue `#460` sites, the verified working write instead reuses the raw stored BatteryConfig cookie (`Cookie`), `e-auth-token`, `Username`, `X-XSRF-Token`, and `X-Requested-With: XMLHttpRequest`.
 - That cookie-backed create/update/delete flow is sent from a stateless request session so aiohttp does not merge cookie-jar state into the raw `Cookie` header.
 - The current client now tries the cookie-backed compatibility write first when the raw cookie/XSRF pair is available, then falls back through official-web primary, official-web lean, and mixed-auth variants.
@@ -4813,7 +4815,8 @@ Performs server-side validation before enabling a battery schedule.
 
 The current codebase uses this endpoint in two distinct ways:
 - Explicit validation requests (`validate_battery_schedule`) send the lowercase family payload below using the official-web primary request shape first, then retry with the lean variant on `403`. These requests do not require `X-XSRF-Token`.
-- Internal XSRF bootstrap requests (`_acquire_xsrf_token`) hit the same route immediately before BatteryConfig writes. That helper sends the same JSON payload, includes the currently held `X-XSRF-Token` when present, and harvests a fresh `BP-XSRF-Token` from `Set-Cookie` or the session cookie jar.
+- Internal XSRF bootstrap requests (`_acquire_xsrf_token`) now first try `GET /service/batteryConfig/api/v1/siteSettings/<site_id>?userId=<user_id>` and read the `x-csrf-token` response header, matching the homeowner web UI flow on affected EMEA sites.
+- If the GET bootstrap does not yield a token, the helper still hits `/schedules/isValid` immediately before BatteryConfig writes. That fallback sends the same JSON payload, includes the currently held `X-XSRF-Token` when present, and harvests a fresh token from the response header, `Set-Cookie`, response cookies, or the session cookie jar.
 
 Additional request shapes observed:
 
@@ -4876,7 +4879,7 @@ the Enlighten battery profile UI when the user modifies a CFG schedule.
 - Safari-style browser `User-Agent`
 
 Implementation auth notes:
-- The current client acquires fresh XSRF via `/schedules/isValid` immediately before issuing this `PUT`.
+- The current client acquires fresh XSRF immediately before issuing this `PUT`, preferring `GET /siteSettings/<site_id>?userId=<user_id>` and its `x-csrf-token` response header before falling back to `/schedules/isValid`.
 - On affected issue `#460` sites, the verified working request is the raw-cookie browser shape:
   - `Cookie: <serialized stored cookie>`
   - `e-auth-token: <enlighten_manager_token_production>`
@@ -5165,7 +5168,7 @@ There is no single universal header set; the implementation varies headers by en
 | System dashboard reads | authenticated cookies; may also include bearer auth opportunistically |
 | HEMS | bearer-preferred auth plus cookies/base headers; `username` and `requestId` when available |
 | BatteryConfig reads | official-web BatteryConfig shape: `Accept`, `Username`, battery-profile `Origin`/`Referer`, Safari-style `User-Agent`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, and `X-Requested-With`; current client prefers the `e-auth-token` + `requestid` variant and falls back to the lean variant if needed |
-| BatteryConfig writes | acquire fresh XSRF via `/battery/sites/<site_id>/schedules/isValid`, keep the existing `BP-XSRF-Token` if bootstrap returns `4xx`, then use an endpoint-specific compatibility planner; on affected sites the verified working shape is a stateless raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`), with official-web primary, official-web lean, and mixed-auth fallbacks retained |
+| BatteryConfig writes | acquire fresh XSRF by preferring `GET /service/batteryConfig/api/v1/siteSettings/<site_id>?userId=<user_id>` and its `x-csrf-token` response header, then falling back to `/battery/sites/<site_id>/schedules/isValid`; keep the existing `BP-XSRF-Token` if bootstrap still returns `4xx`, then use an endpoint-specific compatibility planner; on affected sites the verified working shape is a stateless raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`), with official-web primary, official-web lean, and mixed-auth fallbacks retained |
 
 - Base Enlighten reads:
   - `Cookie: <serialized cookie jar>`

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3824,6 +3824,11 @@ async def test_set_battery_settings_uses_requested_schedule_type_for_xsrf() -> N
 async def test_set_battery_settings_retries_403_with_lean_official_web_variant(
     caplog,
 ) -> None:
+    def _get_bootstrap() -> _FakeResponse:
+        response = _FakeResponse(status=500, json_body={})
+        response.headers = CIMultiDict()
+        return response
+
     validate_primary = _FakeResponse(status=200, json_body={"isValid": True})
     validate_primary.headers = CIMultiDict(
         [("Set-Cookie", "BP-XSRF-Token=cfg-token; Path=/; Secure")]
@@ -3860,14 +3865,21 @@ async def test_set_battery_settings_retries_403_with_lean_official_web_variant(
         json_body={},
         text_body='{"timestamp":"2026-04-11T06:16:00.687+00:00","status":403}',
     )
+    # Each _acquire_xsrf_token attempt now issues a GET siteSettings bootstrap
+    # first, falling back to the legacy POST isValid when the response lacks
+    # an ``x-csrf-token`` header. Feed a failing GET ahead of every validate.
     session = _FakeSession(
         [
+            _get_bootstrap(),
             validate_primary,
             initial_write,
+            _get_bootstrap(),
             validate_fallback,
             fallback_write,
+            _get_bootstrap(),
             validate_cookie,
             cookie_write,
+            _get_bootstrap(),
             validate_mixed,
             mixed_write,
         ]
@@ -3890,19 +3902,26 @@ async def test_set_battery_settings_retries_403_with_lean_official_web_variant(
             await client.set_battery_settings({"veryLowSoc": 15})
 
     assert err.value.status == 403
-    assert len(session.calls) == 8
-    assert session.calls[0][0] == "POST"
-    assert session.calls[1][0] == "PUT"
-    assert session.calls[2][0] == "POST"
-    assert session.calls[3][0] == "PUT"
-    assert session.calls[4][0] == "POST"
-    assert session.calls[5][0] == "PUT"
-    assert session.calls[6][0] == "POST"
-    assert session.calls[7][0] == "PUT"
-    primary_headers = session.calls[1][2]["headers"]
-    fallback_headers = session.calls[3][2]["headers"]
-    cookie_headers = session.calls[5][2]["headers"]
-    mixed_headers = session.calls[7][2]["headers"]
+    assert len(session.calls) == 12
+    # Each attempt: GET siteSettings (bootstrap) + POST isValid + PUT write.
+    assert [call[0] for call in session.calls] == [
+        "GET",
+        "POST",
+        "PUT",
+        "GET",
+        "POST",
+        "PUT",
+        "GET",
+        "POST",
+        "PUT",
+        "GET",
+        "POST",
+        "PUT",
+    ]
+    primary_headers = session.calls[2][2]["headers"]
+    fallback_headers = session.calls[5][2]["headers"]
+    cookie_headers = session.calls[8][2]["headers"]
+    mixed_headers = session.calls[11][2]["headers"]
     assert "Authorization" not in primary_headers
     assert primary_headers["e-auth-token"] == primary_token
     assert "requestid" in primary_headers
@@ -4635,11 +4654,13 @@ async def test_request_session_cookie_header_only_uses_ephemeral_client_session(
 @pytest.mark.asyncio
 async def test_acquire_xsrf_token_uses_requested_validation_payload() -> None:
     token = _make_token({"user_id": "88"})
+    bootstrap = _FakeResponse(status=500, json_body={})
+    bootstrap.headers = CIMultiDict()
     response = _FakeResponse(status=200, json_body={"isValid": True})
     response.headers = CIMultiDict(
         [("Set-Cookie", "BP-XSRF-Token=fresh-token; Path=/; Secure")]
     )
-    session = _FakeSession([response])
+    session = _FakeSession([bootstrap, response])
     client = _make_client(session)
     client.update_credentials(
         eauth=token,
@@ -4649,7 +4670,7 @@ async def test_acquire_xsrf_token_uses_requested_validation_payload() -> None:
     out = await client._acquire_xsrf_token("dtg")  # noqa: SLF001
 
     assert out == "fresh-token"
-    method, url, kwargs = session.calls[0]
+    method, url, kwargs = session.calls[1]
     assert method == "POST"
     assert url.endswith(
         "/service/batteryConfig/api/v1/battery/sites/SITE/schedules/isValid"
@@ -4704,17 +4725,19 @@ async def test_validate_battery_schedule_cfg_payload_keeps_force_schedule_opted(
 @pytest.mark.asyncio
 async def test_acquire_xsrf_token_uses_official_web_headers() -> None:
     token = _make_token({"user_id": "88"})
+    bootstrap = _FakeResponse(status=500, json_body={})
+    bootstrap.headers = CIMultiDict()
     response = _FakeResponse(status=200, json_body={"isValid": True})
     response.headers = CIMultiDict(
         [("Set-Cookie", "BP-XSRF-Token=fresh-token; Path=/; Secure")]
     )
-    session = _FakeSession([response])
+    session = _FakeSession([bootstrap, response])
     client = _make_client(session)
     client.update_credentials(eauth=token, cookie="session=1")
 
     await client._acquire_xsrf_token()  # noqa: SLF001
 
-    headers = session.calls[0][2]["headers"]
+    headers = session.calls[1][2]["headers"]
     assert "Authorization" not in headers
     assert headers["e-auth-token"] == token
     assert headers["Username"] == "88"
@@ -4735,6 +4758,8 @@ async def test_acquire_xsrf_token_uses_getall_fallback_and_handles_bad_cookie() 
         def __str__(self) -> str:
             raise RuntimeError("boom")
 
+    bootstrap = _FakeResponse(status=500, json_body={})
+    bootstrap.headers = CIMultiDict()
     response = _FakeResponse(status=200, json_body={"isValid": True})
     response.headers = CIMultiDict(
         [
@@ -4742,7 +4767,7 @@ async def test_acquire_xsrf_token_uses_getall_fallback_and_handles_bad_cookie() 
             ("Set-Cookie", "BP-XSRF-Token=fallback-token; Path=/; Secure"),
         ]
     )
-    session = _FakeSession([response])
+    session = _FakeSession([bootstrap, response])
     client = _make_client(session)
     client.update_credentials(eauth=token, cookie="session=1")
     client._cookie = _BadStringCookie()  # noqa: SLF001
@@ -4750,14 +4775,16 @@ async def test_acquire_xsrf_token_uses_getall_fallback_and_handles_bad_cookie() 
     out = await client._acquire_xsrf_token()  # noqa: SLF001
 
     assert out == "fallback-token"
-    assert "Cookie" not in session.calls[0][2]["headers"]
+    assert "Cookie" not in session.calls[1][2]["headers"]
 
 
 @pytest.mark.asyncio
 async def test_acquire_xsrf_token_uses_plain_header_get_fallback() -> None:
+    bootstrap = _FakeResponse(status=500, json_body={})
+    bootstrap.headers = {}
     response = _FakeResponse(status=200, json_body={"isValid": True})
     response.headers = {"Set-Cookie": "BP-XSRF-Token=plain-header-token; Path=/;"}
-    session = _FakeSession([response])
+    session = _FakeSession([bootstrap, response])
     client = _make_client(session)
 
     out = await client._acquire_xsrf_token()  # noqa: SLF001
@@ -4767,9 +4794,11 @@ async def test_acquire_xsrf_token_uses_plain_header_get_fallback() -> None:
 
 @pytest.mark.asyncio
 async def test_acquire_xsrf_token_returns_none_when_cookie_missing() -> None:
+    bootstrap = _FakeResponse(status=500, json_body={})
+    bootstrap.headers = CIMultiDict()
     response = _FakeResponse(status=200, json_body={"isValid": True})
     response.headers = CIMultiDict()
-    session = _FakeSession([response])
+    session = _FakeSession([bootstrap, response])
     client = _make_client(session)
 
     assert await client._acquire_xsrf_token() is None  # noqa: SLF001
@@ -4791,11 +4820,13 @@ async def test_acquire_xsrf_token_returns_none_when_request_raises(caplog) -> No
 
 @pytest.mark.asyncio
 async def test_acquire_xsrf_token_returns_none_for_empty_decoded_cookie() -> None:
+    bootstrap = _FakeResponse(status=500, json_body={})
+    bootstrap.headers = CIMultiDict()
     response = _FakeResponse(status=200, json_body={"isValid": True})
     response.headers = CIMultiDict(
         [("Set-Cookie", "BP-XSRF-Token=fresh-token; Path=/; Secure")]
     )
-    session = _FakeSession([response])
+    session = _FakeSession([bootstrap, response])
     client = _make_client(session)
 
     with pytest.MonkeyPatch.context() as monkeypatch:
@@ -4805,10 +4836,12 @@ async def test_acquire_xsrf_token_returns_none_for_empty_decoded_cookie() -> Non
 
 @pytest.mark.asyncio
 async def test_acquire_xsrf_token_uses_response_cookies_when_header_missing() -> None:
+    bootstrap = _FakeResponse(status=500, json_body={})
+    bootstrap.headers = CIMultiDict()
     response = _FakeResponse(status=200, json_body={"isValid": True})
     response.headers = CIMultiDict()
     response.cookies = {"bp-xsrf-token": SimpleNamespace(value="fresh-token")}
-    session = _FakeSession([response])
+    session = _FakeSession([bootstrap, response])
     client = _make_client(session)
 
     assert await client._acquire_xsrf_token() == "fresh-token"  # noqa: SLF001
@@ -4816,9 +4849,11 @@ async def test_acquire_xsrf_token_uses_response_cookies_when_header_missing() ->
 
 @pytest.mark.asyncio
 async def test_acquire_xsrf_token_falls_back_to_session_cookie_jar() -> None:
+    bootstrap = _FakeResponse(status=500, json_body={})
+    bootstrap.headers = CIMultiDict()
     response = _FakeResponse(status=200, json_body={"isValid": True})
     response.headers = CIMultiDict()
-    session = _FakeSession([response])
+    session = _FakeSession([bootstrap, response])
     request_url = URL(
         f"{api.BASE_URL}/service/batteryConfig/api/v1/battery/sites/SITE/schedules/isValid"
     )
@@ -4840,10 +4875,201 @@ async def test_acquire_xsrf_token_falls_back_to_session_cookie_jar() -> None:
 
 
 @pytest.mark.asyncio
+async def test_acquire_xsrf_token_uses_get_bootstrap_response_header() -> None:
+    """GET siteSettings returns x-csrf-token header — the EMEA web UI flow.
+
+    Regression coverage for BatteryConfig 403 loops on sites where the
+    legacy POST ``schedules/isValid`` bootstrap is rejected without ever
+    issuing a Set-Cookie. See GitHub issue #460.
+    """
+
+    token = _make_token({"user_id": "88"})
+    bootstrap = _FakeResponse(status=200, json_body={"settings": {}})
+    bootstrap.headers = CIMultiDict([("x-csrf-token", "header-token")])
+    session = _FakeSession([bootstrap])
+    client = _make_client(session)
+    client.update_credentials(eauth=token, cookie="session=1")
+
+    out = await client._acquire_xsrf_token()  # noqa: SLF001
+
+    assert out == "header-token"
+    assert len(session.calls) == 1
+    method, url, kwargs = session.calls[0]
+    assert method == "GET"
+    assert url.endswith("/service/batteryConfig/api/v1/siteSettings/SITE")
+    assert kwargs.get("params") == {"userId": "88"}
+
+
+@pytest.mark.asyncio
+async def test_acquire_xsrf_token_get_bootstrap_trims_header_whitespace() -> None:
+    token = _make_token({"user_id": "88"})
+    bootstrap = _FakeResponse(status=200, json_body={})
+    bootstrap.headers = CIMultiDict([("X-CSRF-Token", "  padded-token  ")])
+    session = _FakeSession([bootstrap])
+    client = _make_client(session)
+    client.update_credentials(eauth=token, cookie="session=1")
+
+    assert await client._acquire_xsrf_token() == "padded-token"  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_acquire_xsrf_token_get_bootstrap_falls_back_to_post_on_failure() -> None:
+    """When the GET bootstrap errors, the legacy POST path still runs."""
+
+    token = _make_token({"user_id": "88"})
+    bootstrap = _FakeResponse(status=500, json_body={})
+    bootstrap.headers = CIMultiDict()
+    isvalid = _FakeResponse(status=200, json_body={"isValid": True})
+    isvalid.headers = CIMultiDict(
+        [("Set-Cookie", "BP-XSRF-Token=post-token; Path=/; Secure")]
+    )
+    session = _FakeSession([bootstrap, isvalid])
+    client = _make_client(session)
+    client.update_credentials(eauth=token, cookie="session=1")
+
+    out = await client._acquire_xsrf_token()  # noqa: SLF001
+
+    assert out == "post-token"
+    assert len(session.calls) == 2
+    assert session.calls[0][0] == "GET"
+    assert session.calls[1][0] == "POST"
+
+
+@pytest.mark.asyncio
+async def test_acquire_xsrf_token_get_bootstrap_ignores_set_cookie_fallthrough() -> (
+    None
+):
+    """GET bootstrap only honors x-csrf-token header; Set-Cookie is for the POST path.
+
+    This preserves the existing retry semantics in ``_battery_config_write_request``
+    which counts each ``_acquire_xsrf_token`` call as one POST validate attempt
+    when the GET does not return the header.
+    """
+
+    token = _make_token({"user_id": "88"})
+    bootstrap = _FakeResponse(status=200, json_body={})
+    bootstrap.headers = CIMultiDict(
+        [("Set-Cookie", "BP-XSRF-Token=get-cookie-token; Path=/; Secure")]
+    )
+    isvalid = _FakeResponse(status=200, json_body={"isValid": True})
+    isvalid.headers = CIMultiDict(
+        [("Set-Cookie", "BP-XSRF-Token=post-cookie-token; Path=/; Secure")]
+    )
+    session = _FakeSession([bootstrap, isvalid])
+    client = _make_client(session)
+    client.update_credentials(eauth=token, cookie="session=1")
+
+    out = await client._acquire_xsrf_token()  # noqa: SLF001
+
+    assert out == "post-cookie-token"
+    assert len(session.calls) == 2
+    assert session.calls[0][0] == "GET"
+    assert session.calls[1][0] == "POST"
+
+
+@pytest.mark.asyncio
+async def test_acquire_xsrf_token_get_bootstrap_no_user_id_skips_params() -> None:
+    bootstrap = _FakeResponse(status=200, json_body={})
+    bootstrap.headers = CIMultiDict([("x-csrf-token", "header-token")])
+    session = _FakeSession([bootstrap])
+    client = _make_client(session)
+
+    assert await client._acquire_xsrf_token() == "header-token"  # noqa: SLF001
+    assert session.calls[0][2].get("params") is None
+
+
+@pytest.mark.asyncio
+async def test_acquire_xsrf_token_post_fallback_reads_response_header() -> None:
+    """POST isValid path also accepts x-csrf-token in the response header."""
+
+    token = _make_token({"user_id": "88"})
+    bootstrap = _FakeResponse(status=500, json_body={})
+    bootstrap.headers = CIMultiDict()
+    isvalid = _FakeResponse(status=200, json_body={"isValid": True})
+    isvalid.headers = CIMultiDict([("x-csrf-token", "post-header-token")])
+    session = _FakeSession([bootstrap, isvalid])
+    client = _make_client(session)
+    client.update_credentials(eauth=token, cookie="session=1")
+
+    out = await client._acquire_xsrf_token()  # noqa: SLF001
+
+    assert out == "post-header-token"
+    assert [call[0] for call in session.calls] == ["GET", "POST"]
+
+
+@pytest.mark.asyncio
+async def test_acquire_xsrf_token_get_bootstrap_without_headers_attr() -> None:
+    """Defensive: response objects missing a mapping-style ``headers`` attribute."""
+
+    class _HeaderlessResponse:
+        def __init__(self) -> None:
+            self.status = 200
+            self.headers = None
+            self.cookies = None
+
+        async def __aenter__(self) -> "_HeaderlessResponse":
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb) -> bool:
+            return False
+
+        async def json(self):
+            return {}
+
+    isvalid = _FakeResponse(status=200, json_body={"isValid": True})
+    isvalid.headers = CIMultiDict(
+        [("Set-Cookie", "BP-XSRF-Token=post-token; Path=/; Secure")]
+    )
+
+    class _MixedSession:
+        def __init__(self) -> None:
+            self._responses: list[object] = [_HeaderlessResponse(), isvalid]
+            self.calls: list[tuple[str, str, dict]] = []
+            self.cookie_jar = aiohttp.CookieJar()
+
+        def request(self, method: str, url: str, **kwargs):
+            resp = self._responses.pop(0)
+            self.calls.append((method, url, kwargs))
+            return resp
+
+    session = _MixedSession()
+    client = _make_client(session)
+
+    out = await client._acquire_xsrf_token()  # noqa: SLF001
+
+    assert out == "post-token"
+
+
+@pytest.mark.asyncio
+async def test_acquire_xsrf_token_post_fallback_tolerates_unquote_errors(
+    monkeypatch,
+) -> None:
+    """The POST Set-Cookie parser tolerates ``unquote`` raising."""
+
+    bootstrap = _FakeResponse(status=500, json_body={})
+    bootstrap.headers = CIMultiDict()
+    isvalid = _FakeResponse(status=200, json_body={"isValid": True})
+    isvalid.headers = CIMultiDict(
+        [("Set-Cookie", "BP-XSRF-Token=raw-token; Path=/; Secure")]
+    )
+    session = _FakeSession([bootstrap, isvalid])
+    client = _make_client(session)
+
+    def _boom(_value: str) -> str:
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(api, "unquote", _boom)
+
+    assert await client._acquire_xsrf_token() == "raw-token"  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_acquire_xsrf_token_keeps_existing_token_on_bootstrap_403() -> None:
+    bootstrap = _FakeResponse(status=403, json_body={"error": "Forbidden"})
+    bootstrap.headers = CIMultiDict()
     response = _FakeResponse(status=403, json_body={"error": "Forbidden"})
     response.headers = CIMultiDict()
-    session = _FakeSession([response])
+    session = _FakeSession([bootstrap, response])
     request_url = URL(
         f"{api.BASE_URL}/service/batteryConfig/api/v1/battery/sites/SITE/schedules/isValid"
     )


### PR DESCRIPTION
## Summary

Fixes the residual `Battery settings update was rejected by Enphase (HTTP 403 Forbidden)` loops on EMEA sites where every BatteryConfig write keeps failing on v2.8.4.

The Enphase BatteryConfig service emits the CSRF token via an `x-csrf-token` response header on any GET. The `battery-profile-ui.enphaseenergy.com` web UI uses exactly this: it hits `GET /service/batteryConfig/api/v1/siteSettings/{site}?userId={userId}` (or another BatteryConfig GET) first, reads `x-csrf-token`, then echoes the value back as `X-XSRF-Token` on the subsequent PUT to `batterySettings`. No cookies are involved; the request-side auth is `e-auth-token` + `username` + `x-xsrf-token`.

The integration's bootstrap in `_acquire_xsrf_token` did the opposite: it POSTed `/schedules/isValid` (which itself requires `X-XSRF-Token`) and tried to harvest the token from `Set-Cookie`. On affected EMEA sites the POST is rejected with 403 before a `Set-Cookie` can be issued, so the retry loop logs `has_x_xsrf_token: False` across every compatibility variant and the write raises `ServiceValidationError`.

## Fix

- Add a GET bootstrap against `/service/batteryConfig/api/v1/siteSettings/{site}?userId={userId}` that only trusts the `x-csrf-token` response header. No extra auth is required for this GET beyond the existing JWT + username, so it avoids the chicken-and-egg problem.
- If the GET does not yield an `x-csrf-token` header, fall through to the existing POST `/schedules/isValid` path and keep the legacy compatibility behavior.
- Split response-token extraction into two helpers so the GET path is narrowly scoped to response headers while the POST path still handles `Set-Cookie`, `response.cookies`, and the session jar.
- Update `docs/api/api_spec.md` to document the GET-first BatteryConfig XSRF bootstrap and POST fallback flow.

## Related Issues

- #460 — lingering reports on v2.8.4 for sites on `battery-profile-ui.enphaseenergy.com` / `source=enho`.

## HAR evidence

Captured on a 2×IQ Battery 5P EMEA site (`source=enho`). Every BatteryConfig response carries `x-csrf-token`; none of them set a `BP-XSRF-Token` cookie:

```
GET  /service/batteryConfig/api/v1/mqttSignedUrl/{site}           → 200, x-csrf-token: <uuid>
GET  /service/batteryConfig/api/v1/siteSettings/{site}            → 200, x-csrf-token: <uuid>
GET  /service/batteryConfig/api/v1/batterySettings/{site}         → 200, x-csrf-token: <uuid>
POST /service/batteryConfig/api/v1/.../schedules/isValid          → 200, sent with X-XSRF-Token
PUT  /service/batteryConfig/api/v1/batterySettings/{site}         → 200, sent with X-XSRF-Token
```

Request-side auth across the whole flow (no cookies, no Authorization header):
- `e-auth-token: <JWT>`
- `username: <user_id>`
- `x-xsrf-token: <uuid>` (echoed from the response header on every mutation)

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py tests/components/enphase_ev/test_api_client_methods.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "cd /workspace && pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py --fail-under=100"
```

All green locally:
- `ruff check .`: passed
- `black custom_components/enphase_ev/api.py tests/components/enphase_ev/test_api_client_methods.py`: no changes
- `python scripts/validate_quality_scale.py`: passed
- `pre-commit run --all-files`: passed
- `pytest -q tests/components/enphase_ev`: `2741 passed in 33.52s`
- coverage on `custom_components/enphase_ev/api.py`: `100%`

Manual validation on a real account:
- BatteryConfig reads succeeded
- same-value BatteryConfig writes for profile/settings/schedules succeeded
- temporary real-account schedule create, update, and delete succeeded with cleanup

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. (no strings changed)
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Debug log excerpt from a site that reproduces the 403 loop on v2.8.4 (same site the HAR above is captured from):

```
DEBUG  BatteryConfig bootstrap returned 403 for POST /service/batteryConfig/api/v1/battery/sites/{site}/schedules/isValid; keeping existing XSRF token
DEBUG  BatteryConfig write failed for PUT /service/batteryConfig/api/v1/batterySettings/{site}: status=403 ... header_flags={'has_x_csrf_token': False, 'has_x_xsrf_token': False, ...}
...
DEBUG  Retrying BatteryConfig write for PUT ... with attempt battery_settings_lean_source
DEBUG  Retrying BatteryConfig write for PUT ... with attempt battery_settings_cookie_eauth_source
...
homeassistant.exceptions.ServiceValidationError: Battery settings update was rejected by Enphase (HTTP 403 Forbidden).
```

The `has_x_xsrf_token: False` on every variant is the fingerprint: bootstrap cannot acquire a token because the POST path requires one, and `Set-Cookie` is never emitted.