### PR TITLE
Harden IQ Battery schedule validation paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Fixed `Battery settings update was rejected by Enphase (HTTP 403 Forbidden)` loops on EMEA sites where the legacy BatteryConfig bootstrap failed to acquire an XSRF token. The client now performs a GET against `siteSettings` and reads the `x-csrf-token` response header — matching the `battery-profile-ui.enphaseenergy.com` web UI — before falling back to the previous POST `schedules/isValid` shape.
+- Fixed the standalone IQ Battery schedule validation service so it correctly interprets Enphase's raw `isValid` responses and reports validation failures consistently.
+- Stopped battery schedule refreshes from overwriting control-derived enabled state with conflicting `/schedules` entry flags, and prevented disabled CFG/DTG/RBD families from selecting the wrong schedule record when Enphase echoes temporary schedule entries as `isEnabled: true`.
+- Added local IQ Battery schedule overlap validation before schedule create/update writes so Home Assistant rejects conflicting windows consistently even when Enphase returns misleading cross-family `409` errors, and treated profile-cancel `409 ALREADY_PROCESSED` responses as benign no-op results.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -17,6 +17,7 @@ from homeassistant.util import dt as dt_util
 from .ac_battery_runtime import AcBatteryRuntime
 from .battery_schedule_editor import (
     battery_schedule_overlap_message,
+    battery_schedule_overlap_placeholders,
     battery_schedule_overlap_record,
 )
 from .const import (
@@ -1358,7 +1359,18 @@ class BatteryRuntime:
             exclude_schedule_id=exclude_schedule_id,
         )
         if overlapping is not None:
-            raise ServiceValidationError(battery_schedule_overlap_message(overlapping))
+            raise_translated_service_validation(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.battery_schedule_overlap",
+                translation_placeholders=battery_schedule_overlap_placeholders(
+                    overlapping,
+                    hass=getattr(self.coordinator, "hass", None),
+                ),
+                message=battery_schedule_overlap_message(
+                    overlapping,
+                    hass=getattr(self.coordinator, "hass", None),
+                ),
+            )
 
     @staticmethod
     def _is_already_processed_profile_cancel_error(

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -15,6 +15,10 @@ from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import dt as dt_util
 
 from .ac_battery_runtime import AcBatteryRuntime
+from .battery_schedule_editor import (
+    battery_schedule_overlap_message,
+    battery_schedule_overlap_record,
+)
 from .const import (
     BATTERY_BACKUP_HISTORY_CACHE_TTL,
     BATTERY_BACKUP_HISTORY_FAILURE_CACHE_TTL,
@@ -1323,6 +1327,61 @@ class BatteryRuntime:
             return current
         return dt_util.utcnow().isoformat()
 
+    def _schedule_overlap_record(
+        self,
+        *,
+        start_time: object,
+        end_time: object,
+        days: list[int],
+        exclude_schedule_id: str | None = None,
+    ):
+        return battery_schedule_overlap_record(
+            self.coordinator,
+            start_time=start_time,
+            end_time=end_time,
+            days=days,
+            exclude_schedule_id=exclude_schedule_id,
+        )
+
+    def _raise_schedule_overlap_validation_error(
+        self,
+        *,
+        start_time: object,
+        end_time: object,
+        days: list[int],
+        exclude_schedule_id: str | None = None,
+    ) -> None:
+        overlapping = self._schedule_overlap_record(
+            start_time=start_time,
+            end_time=end_time,
+            days=days,
+            exclude_schedule_id=exclude_schedule_id,
+        )
+        if overlapping is not None:
+            raise ServiceValidationError(battery_schedule_overlap_message(overlapping))
+
+    @staticmethod
+    def _is_already_processed_profile_cancel_error(
+        err: aiohttp.ClientResponseError,
+    ) -> bool:
+        if err.status != HTTPStatus.CONFLICT:
+            return False
+        raw_message = getattr(err, "message", None)
+        if not isinstance(raw_message, str) or not raw_message.strip():
+            return False
+        try:
+            parsed = json.loads(raw_message)
+        except ValueError:
+            return "ALREADY_PROCESSED" in raw_message.upper()
+        error_block = parsed.get("error")
+        if not isinstance(error_block, dict):
+            return False
+        status_value = error_block.get("status")
+        return (
+            isinstance(status_value, str)
+            and status_value.strip().upper() == "ALREADY_PROCESSED"
+        )
+
     def raise_schedule_update_validation_error(
         self, err: aiohttp.ClientResponseError
     ) -> None:
@@ -1389,6 +1448,12 @@ class BatteryRuntime:
         is_enabled: bool | None = None,
         is_deleted: bool | None = None,
     ) -> None:
+        self._raise_schedule_overlap_validation_error(
+            start_time=start_time,
+            end_time=end_time,
+            days=days,
+            exclude_schedule_id=str(schedule_id),
+        )
         try:
             await self.coordinator.client.update_battery_schedule(
                 schedule_id,
@@ -2099,6 +2164,17 @@ class BatteryRuntime:
 
     def parse_battery_schedules_payload(self, payload: object) -> None:
         state = self.battery_state
+        coord = self.coordinator
+
+        def _control_enabled(schedule_type: str) -> bool | None:
+            normalized = str(schedule_type).lower()
+            attr_name = {
+                "cfg": "battery_charge_from_grid_schedule_enabled",
+                "dtg": "battery_dtg_control_enabled",
+                "rbd": "battery_rbd_control_enabled",
+            }.get(normalized, "")
+            value = getattr(coord, attr_name, None)
+            return value if isinstance(value, bool) else None
 
         def _reset_family(schedule_type: str) -> None:
             setattr(state, self._battery_schedule_limit_attr(schedule_type), None)
@@ -2126,12 +2202,19 @@ class BatteryRuntime:
             details = family_payload.get("details")
             if not isinstance(details, list) or not details:
                 return
+            preferred_enabled = _control_enabled(schedule_type)
             chosen = None
             for entry in details:
                 if not isinstance(entry, dict):
                     continue
                 if chosen is None:
                     chosen = entry
+                entry_enabled = self._coerce_optional_bool(entry.get("isEnabled"))
+                if preferred_enabled is not None:
+                    if entry_enabled is preferred_enabled:
+                        chosen = entry
+                        break
+                    continue
                 if entry.get("isEnabled") is True:
                     chosen = entry
                     break
@@ -2192,7 +2275,7 @@ class BatteryRuntime:
                     int(limit),
                 )
             enabled = self._coerce_optional_bool(chosen.get("isEnabled"))
-            if enabled is not None:
+            if enabled is not None and _control_enabled(schedule_type) is None:
                 setattr(
                     state,
                     self._battery_schedule_enabled_attr(schedule_type),
@@ -3221,7 +3304,15 @@ class BatteryRuntime:
         await self.async_assert_battery_profile_write_allowed()
         async with state._battery_profile_write_lock:
             state._battery_profile_last_write_mono = time.monotonic()
-            await coord.client.cancel_battery_profile_update()
+            try:
+                await coord.client.cancel_battery_profile_update()
+            except aiohttp.ClientResponseError as err:
+                if not self._is_already_processed_profile_cancel_error(err):
+                    raise
+                _LOGGER.debug(
+                    "Ignoring already-processed battery profile cancel on site %s",
+                    redact_site_id(coord.site_id),
+                )
         self.clear_battery_pending()
         state._storm_guard_cache_until = None
         coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
@@ -3408,6 +3499,11 @@ class BatteryRuntime:
                     end_hhmm,
                     tz,
                 )
+                self._raise_schedule_overlap_validation_error(
+                    start_time=start_hhmm,
+                    end_time=end_hhmm,
+                    days=days,
+                )
                 await coord.client.create_battery_schedule(
                     schedule_type="CFG",
                     start_time=start_hhmm,
@@ -3415,6 +3511,11 @@ class BatteryRuntime:
                     limit=100,
                     days=days,
                     timezone=tz,
+                    is_enabled=bool(
+                        getattr(
+                            coord, "_battery_charge_from_grid_schedule_enabled", None
+                        )
+                    ),
                 )
             state._battery_charge_begin_time = next_start
             state._battery_charge_end_time = next_end
@@ -3806,7 +3907,6 @@ class BatteryRuntime:
                 limit=limit,
                 days=days,
                 timezone=timezone,
-                is_enabled=is_enabled,
             )
             return
         if not self._schedule_create_supported():
@@ -3816,6 +3916,11 @@ class BatteryRuntime:
         create_limit = limit
         if create_limit is None:
             create_limit = self._schedule_default_limit_for_create(schedule_type)
+        self._raise_schedule_overlap_validation_error(
+            start_time=start_time,
+            end_time=end_time,
+            days=days,
+        )
         try:
             await coord.client.create_battery_schedule(
                 schedule_type=str(schedule_type).upper(),
@@ -3843,6 +3948,20 @@ class BatteryRuntime:
         if not getattr(coord, self._schedule_supported_property_name(schedule_type)):
             raise ServiceValidationError(f"{label} schedule is unavailable.")
         await self.async_assert_battery_settings_write_allowed()
+        if normalized_schedule_type == "cfg":
+            if getattr(coord, self._schedule_pending_property_name(schedule_type)):
+                raise ServiceValidationError(
+                    "A schedule change is pending Envoy sync. Please wait."
+                )
+            current_start, current_end = self._current_battery_schedule_window_for_type(
+                schedule_type,
+            )
+            if current_start == current_end:
+                raise ServiceValidationError(
+                    f"{label} schedule start and end times must be different."
+                )
+            await self.async_set_charge_from_grid_schedule_enabled(enabled)
+            return
         schedule_id = getattr(
             state, self._battery_schedule_id_attr(schedule_type), None
         )
@@ -3853,12 +3972,6 @@ class BatteryRuntime:
         if use_battery_settings_toggle:
             self._set_schedule_family_toggle_target(schedule_type, enabled)
         try:
-            if not use_battery_settings_toggle and getattr(
-                coord, self._schedule_pending_property_name(schedule_type)
-            ):
-                raise ServiceValidationError(
-                    "A schedule change is pending Envoy sync. Please wait."
-                )
             current_start, current_end = self._current_battery_schedule_window_for_type(
                 schedule_type,
             )
@@ -3924,36 +4037,11 @@ class BatteryRuntime:
                     )
                 self.clear_battery_settings_write_pending()
                 await coord.async_request_refresh()
-            else:
-                if current_start == current_end:
-                    raise ServiceValidationError(
-                        f"{label} schedule start and end times must be different."
-                    )
-                current_limit = getattr(
-                    state, self._battery_schedule_limit_attr(schedule_type), None
-                )
-                next_limit = (
-                    int(current_limit)
-                    if current_limit is not None
-                    else self._schedule_default_limit_for_create(schedule_type)
-                )
-                async with state._battery_settings_write_lock:
-                    state._battery_settings_last_write_mono = time.monotonic()
-                    await self._async_create_or_update_schedule_family(
-                        schedule_type,
-                        start_minutes=current_start,
-                        end_minutes=current_end,
-                        limit=next_limit,
-                        is_enabled=enabled,
-                    )
-                state._battery_settings_cache_until = None
-                coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
-                await coord.async_request_refresh()
             setattr(state, self._battery_schedule_enabled_attr(schedule_type), enabled)
         finally:
             if use_battery_settings_toggle:
                 self._clear_schedule_family_toggle_target(schedule_type)
-        if schedule_id is not None or not use_battery_settings_toggle:
+        if schedule_id is not None:
             setattr(
                 state, self._battery_schedule_start_attr(schedule_type), current_start
             )

--- a/custom_components/enphase_ev/battery_schedule_editor.py
+++ b/custom_components/enphase_ev/battery_schedule_editor.py
@@ -161,16 +161,22 @@ def battery_schedule_overlap_record(
 def battery_schedule_overlap_message(
     schedule: BatteryScheduleRecord, *, hass: object | None = None
 ) -> str:
-    schedule_type = battery_schedule_type_label(schedule.schedule_type, hass=hass)
-    if not schedule_type:
-        schedule_type = str(schedule.schedule_type).strip() or "Battery"
-    label = schedule_type.lower()
+    label = battery_schedule_overlap_placeholders(schedule, hass=hass)["schedule_label"]
     if not label.endswith("schedule"):
         label = f"{label} schedule"
     return (
         f"Schedule overlaps with the existing {label}. "
         "Adjust or disable that schedule first."
     )
+
+
+def battery_schedule_overlap_placeholders(
+    schedule: BatteryScheduleRecord, *, hass: object | None = None
+) -> dict[str, str]:
+    schedule_type = battery_schedule_type_label(schedule.schedule_type, hass=hass)
+    if not schedule_type:
+        schedule_type = str(schedule.schedule_type).strip() or "battery"
+    return {"schedule_label": schedule_type.lower()}
 
 
 def editor_days_from_list(days: list[int]) -> dict[str, bool]:

--- a/custom_components/enphase_ev/battery_schedule_editor.py
+++ b/custom_components/enphase_ev/battery_schedule_editor.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import time as dt_time
-from typing import Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 from homeassistant.core import CALLBACK_TYPE, callback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
@@ -11,9 +11,11 @@ from .const import (
     DEFAULT_BATTERY_SCHEDULES_ENABLED,
     OPT_BATTERY_SCHEDULES_ENABLED,
 )
-from .coordinator import EnphaseCoordinator
 from .labels import battery_schedule_type_label
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
+
+if TYPE_CHECKING:  # pragma: no cover
+    from .coordinator import EnphaseCoordinator
 
 DAY_ORDER: list[tuple[str, int]] = [
     ("mon", 1),
@@ -27,6 +29,7 @@ DAY_ORDER: list[tuple[str, int]] = [
 DAY_KEY_BY_INDEX = {index: key for key, index in DAY_ORDER}
 NEW_SCHEDULE_OPTION = "new_schedule"
 SCHEDULE_TYPE_KEYS: tuple[str, ...] = ("cfg", "dtg", "rbd")
+_DAY_MINUTES = 24 * 60
 
 
 def default_day_flags() -> dict[str, bool]:
@@ -61,6 +64,115 @@ def _normalize_days(raw: object) -> list[int]:
     return sorted(days)
 
 
+def _minutes_of_day(value: object) -> int | None:
+    if isinstance(value, dt_time):
+        return value.hour * 60 + value.minute
+    if isinstance(value, (int, float)):
+        minutes = int(value)
+        if 0 <= minutes < _DAY_MINUTES:
+            return minutes
+        return None
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    parts = text.split(":")
+    if len(parts) < 2:
+        return None
+    try:
+        hours = int(parts[0])
+        minutes = int(parts[1])
+    except ValueError:
+        return None
+    if not 0 <= hours < 24 or not 0 <= minutes < 60:
+        return None
+    return hours * 60 + minutes
+
+
+def _weekly_schedule_segments(
+    days: list[int], start_minutes: int, end_minutes: int
+) -> list[tuple[int, int]]:
+    if start_minutes == end_minutes:
+        return []
+    segments: list[tuple[int, int]] = []
+    for day in _normalize_days(days):
+        offset = (day - 1) * _DAY_MINUTES
+        if start_minutes < end_minutes:
+            segments.append((offset + start_minutes, offset + end_minutes))
+            continue
+        segments.append((offset + start_minutes, offset + _DAY_MINUTES))
+        next_day_offset = (day % 7) * _DAY_MINUTES
+        segments.append((next_day_offset, next_day_offset + end_minutes))
+    return segments
+
+
+def _segments_overlap(
+    left: list[tuple[int, int]], right: list[tuple[int, int]]
+) -> bool:
+    return any(
+        left_start < right_end and right_start < left_end
+        for left_start, left_end in left
+        for right_start, right_end in right
+    )
+
+
+def battery_schedule_overlap_record(
+    coord: EnphaseCoordinator,
+    *,
+    start_time: object,
+    end_time: object,
+    days: list[int],
+    exclude_schedule_id: str | None = None,
+) -> BatteryScheduleRecord | None:
+    candidate_days = _normalize_days(days)
+    candidate_start = _minutes_of_day(start_time)
+    candidate_end = _minutes_of_day(end_time)
+    if not candidate_days or candidate_start is None or candidate_end is None:
+        return None
+    candidate_segments = _weekly_schedule_segments(
+        candidate_days,
+        candidate_start,
+        candidate_end,
+    )
+    if not candidate_segments:
+        return None
+    for schedule in battery_schedule_inventory(coord):
+        if exclude_schedule_id is not None and schedule.schedule_id == str(
+            exclude_schedule_id
+        ):
+            continue
+        existing_start = _minutes_of_day(schedule.start_time)
+        existing_end = _minutes_of_day(schedule.end_time)
+        if existing_start is None or existing_end is None:
+            continue
+        existing_segments = _weekly_schedule_segments(
+            schedule.days,
+            existing_start,
+            existing_end,
+        )
+        if existing_segments and _segments_overlap(
+            candidate_segments, existing_segments
+        ):
+            return schedule
+    return None
+
+
+def battery_schedule_overlap_message(
+    schedule: BatteryScheduleRecord, *, hass: object | None = None
+) -> str:
+    schedule_type = battery_schedule_type_label(schedule.schedule_type, hass=hass)
+    if not schedule_type:
+        schedule_type = str(schedule.schedule_type).strip() or "Battery"
+    label = schedule_type.lower()
+    if not label.endswith("schedule"):
+        label = f"{label} schedule"
+    return (
+        f"Schedule overlaps with the existing {label}. "
+        "Adjust or disable that schedule first."
+    )
+
+
 def editor_days_from_list(days: list[int]) -> dict[str, bool]:
     flags = {key: False for key, _ in DAY_ORDER}
     for day in days:
@@ -72,6 +184,19 @@ def editor_days_from_list(days: list[int]) -> dict[str, bool]:
 
 def days_list_from_editor(flags: dict[str, bool]) -> list[int]:
     return [index for key, index in DAY_ORDER if flags.get(key)]
+
+
+def _family_control_enabled(
+    coord: EnphaseCoordinator, schedule_type: str
+) -> bool | None:
+    normalized = str(schedule_type).lower()
+    attr_name = {
+        "cfg": "battery_charge_from_grid_schedule_enabled",
+        "dtg": "battery_dtg_control_enabled",
+        "rbd": "battery_rbd_control_enabled",
+    }.get(normalized, "")
+    value = getattr(coord, attr_name, None)
+    return value if isinstance(value, bool) else None
 
 
 def battery_scheduler_enabled(entry: EnphaseConfigEntry | None) -> bool:
@@ -181,7 +306,9 @@ def battery_schedule_inventory(
                 if isinstance(limit_raw, (int, float)):
                     limit = int(limit_raw)
                 enabled_raw = item.get("isEnabled")
-                enabled = enabled_raw if isinstance(enabled_raw, bool) else None
+                enabled = _family_control_enabled(coord, schedule_type)
+                if enabled is None and isinstance(enabled_raw, bool):
+                    enabled = enabled_raw
                 status_raw = item.get("scheduleStatus")
                 status = (
                     str(status_raw).strip().lower()
@@ -492,7 +619,7 @@ class BatteryScheduleEditorManager:
         self._notify_listeners()
 
 
-class BatteryScheduleEditorEntity(CoordinatorEntity[EnphaseCoordinator]):
+class BatteryScheduleEditorEntity(CoordinatorEntity[Any]):
     def __init__(self, coord: EnphaseCoordinator, entry: EnphaseConfigEntry) -> None:
         super().__init__(coord)
         self._coord = coord

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -16,12 +16,14 @@ from homeassistant.helpers import service as ha_service
 from .battery_schedule_editor import (
     battery_schedule_inventory,
     battery_schedule_overlap_message,
+    battery_schedule_overlap_placeholders,
     battery_schedule_overlap_record,
 )
 from .const import DOMAIN, ISSUE_AUTH_BLOCKED, ISSUE_REAUTH_REQUIRED
 from .device_types import parse_type_identifier
 from .parsing_helpers import coerce_optional_bool
 from .runtime_data import EnphaseRuntimeData, iter_coordinators
+from .service_validation import raise_translated_service_validation
 
 if TYPE_CHECKING:  # pragma: no cover
     from .coordinator import EnphaseCoordinator
@@ -306,8 +308,13 @@ def async_setup_services(
             exclude_schedule_id=exclude_schedule_id,
         )
         if overlapping is not None:
-            raise ServiceValidationError(
-                battery_schedule_overlap_message(overlapping, hass=hass)
+            raise_translated_service_validation(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.battery_schedule_overlap",
+                translation_placeholders=battery_schedule_overlap_placeholders(
+                    overlapping, hass=hass
+                ),
+                message=battery_schedule_overlap_message(overlapping, hass=hass),
             )
 
     def _validate_cfg_schedule(data: dict) -> dict:

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -13,9 +13,14 @@ from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers import service as ha_service
 
-from .battery_schedule_editor import battery_schedule_inventory
+from .battery_schedule_editor import (
+    battery_schedule_inventory,
+    battery_schedule_overlap_message,
+    battery_schedule_overlap_record,
+)
 from .const import DOMAIN, ISSUE_AUTH_BLOCKED, ISSUE_REAUTH_REQUIRED
 from .device_types import parse_type_identifier
+from .parsing_helpers import coerce_optional_bool
 from .runtime_data import EnphaseRuntimeData, iter_coordinators
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -258,7 +263,12 @@ def async_setup_services(
                 )
                 return {}
             raise
-        if isinstance(result, dict) and result.get("valid") is False:
+        if not isinstance(result, dict):
+            return {}
+        valid = coerce_optional_bool(result.get("valid"))
+        if valid is None and "isValid" in result:
+            valid = coerce_optional_bool(result.get("isValid"))
+        if valid is False:
             raise ServiceValidationError(
                 str(
                     result.get(
@@ -267,7 +277,9 @@ def async_setup_services(
                     )
                 )
             )
-        return result if isinstance(result, dict) else {}
+        if valid is not None and "valid" not in result:
+            return {**result, "valid": bool(valid)}
+        return result
 
     def _known_schedule_ids(coord: EnphaseCoordinator) -> set[str]:
         return {schedule.schedule_id for schedule in battery_schedule_inventory(coord)}
@@ -277,6 +289,26 @@ def async_setup_services(
             schedule.schedule_id: schedule
             for schedule in battery_schedule_inventory(coord)
         }
+
+    def _validate_schedule_overlap(
+        coord: EnphaseCoordinator,
+        *,
+        start_time: str,
+        end_time: str,
+        days: list[int],
+        exclude_schedule_id: str | None = None,
+    ) -> None:
+        overlapping = battery_schedule_overlap_record(
+            coord,
+            start_time=start_time,
+            end_time=end_time,
+            days=days,
+            exclude_schedule_id=exclude_schedule_id,
+        )
+        if overlapping is not None:
+            raise ServiceValidationError(
+                battery_schedule_overlap_message(overlapping, hass=hass)
+            )
 
     def _validate_cfg_schedule(data: dict) -> dict:
         if not any(k in data for k in ("start_time", "end_time", "limit")):
@@ -489,6 +521,12 @@ def async_setup_services(
             days=days,
             limit=limit,
         )
+        _validate_schedule_overlap(
+            coord,
+            start_time=start_str,
+            end_time=end_str,
+            days=days,
+        )
         await _validate_schedule_with_api(coord, schedule_type)
         creator = getattr(coord.client, "create_battery_schedule", None)
         if not callable(creator):
@@ -542,6 +580,13 @@ def async_setup_services(
             days=days,
             limit=limit,
         )
+        _validate_schedule_overlap(
+            coord,
+            start_time=start_str,
+            end_time=end_str,
+            days=days,
+            exclude_schedule_id=schedule_id,
+        )
         await _validate_schedule_with_api(coord, schedule_type)
         updater = getattr(coord.client, "update_battery_schedule", None)
         if not callable(updater):
@@ -562,9 +607,6 @@ def async_setup_services(
                     )
                     or hass.config.time_zone
                     or "UTC"
-                ),
-                is_enabled=(
-                    existing_schedule.enabled if existing_schedule is not None else True
                 ),
             )
         except aiohttp.ClientResponseError as err:

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase rejected the schedule change."
+    },
+    "battery_schedule_overlap": {
+      "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase отхвърли промяната на графика."
+    },
+    "battery_schedule_overlap": {
+      "message": "Графикът се припокрива със съществуващия {schedule_label}. Коригирайте го или го деактивирайте първо."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase zamítl změnu harmonogramu."
+    },
+    "battery_schedule_overlap": {
+      "message": "Plán se překrývá se stávajícím {schedule_label}. Nejprve tento plán upravte nebo deaktivujte."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase afviste ændringen af tidsplanen."
+    },
+    "battery_schedule_overlap": {
+      "message": "Tidsplanen overlapper den eksisterende {schedule_label}. Juster eller deaktiver først den pågældende tidsplan."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase hat die Zeitplanänderung abgelehnt."
+    },
+    "battery_schedule_overlap": {
+      "message": "Der Zeitplan überschneidet sich mit dem vorhandenen {schedule_label}. Passe diesen Zeitplan zuerst an oder deaktiviere ihn."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Το Enphase απέρριψε την αλλαγή του προγράμματος."
+    },
+    "battery_schedule_overlap": {
+      "message": "Το πρόγραμμα επικαλύπτεται με το υπάρχον {schedule_label}. Προσαρμόστε ή απενεργοποιήστε πρώτα αυτό το πρόγραμμα."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase rejected the schedule change."
+    },
+    "battery_schedule_overlap": {
+      "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase rejected the schedule change."
+    },
+    "battery_schedule_overlap": {
+      "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase rejected the schedule change."
+    },
+    "battery_schedule_overlap": {
+      "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase rejected the schedule change."
+    },
+    "battery_schedule_overlap": {
+      "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase rejected the schedule change."
+    },
+    "battery_schedule_overlap": {
+      "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase rejected the schedule change."
+    },
+    "battery_schedule_overlap": {
+      "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase rechazó el cambio del horario."
+    },
+    "battery_schedule_overlap": {
+      "message": "El horario se superpone con el {schedule_label} existente. Ajusta o desactiva primero ese horario."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase lükkas ajakava muudatuse tagasi."
+    },
+    "battery_schedule_overlap": {
+      "message": "Ajakava kattub olemasoleva {schedule_label}-ga. Kohanda või keela see ajakava enne."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase hylkäsi aikataulumuutoksen."
+    },
+    "battery_schedule_overlap": {
+      "message": "Aikataulu on päällekkäinen olemassa olevan {schedule_label} kanssa. Muokkaa tai poista kyseinen aikataulu ensin käytöstä."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase a rejeté la modification de la programmation."
+    },
+    "battery_schedule_overlap": {
+      "message": "Le planning chevauche le {schedule_label} existant. Ajustez ou désactivez d’abord ce planning."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Az Enphase elutasította az ütemezés módosítását."
+    },
+    "battery_schedule_overlap": {
+      "message": "Az ütemezés átfedésben van a meglévő {schedule_label} elemmel. Először módosítsa vagy tiltsa le azt az ütemezést."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase ha rifiutato la modifica della pianificazione."
+    },
+    "battery_schedule_overlap": {
+      "message": "La pianificazione si sovrappone alla {schedule_label} esistente. Regola o disattiva prima quella pianificazione."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase atmetė tvarkaraščio pakeitimą."
+    },
+    "battery_schedule_overlap": {
+      "message": "Tvarkaraštis persidengia su esamu {schedule_label}. Pirmiausia pakoreguokite arba išjunkite tą tvarkaraštį."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase noraidīja grafika izmaiņas."
+    },
+    "battery_schedule_overlap": {
+      "message": "Grafiks pārklājas ar esošo {schedule_label}. Vispirms pielāgojiet vai atspējojiet šo grafiku."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase avviste endringen i tidsplanen."
+    },
+    "battery_schedule_overlap": {
+      "message": "Tidsplanen overlapper den eksisterende {schedule_label}. Juster eller deaktiver den tidsplanen først."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase heeft de schemawijziging afgewezen."
+    },
+    "battery_schedule_overlap": {
+      "message": "Het schema overlapt met het bestaande {schedule_label}. Pas dat schema eerst aan of schakel het uit."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase odrzucił zmianę harmonogramu."
+    },
+    "battery_schedule_overlap": {
+      "message": "Harmonogram nakłada się z istniejącym {schedule_label}. Najpierw dostosuj lub wyłącz ten harmonogram."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "A Enphase rejeitou a alteração da programação."
+    },
+    "battery_schedule_overlap": {
+      "message": "A programação se sobrepõe à {schedule_label} existente. Ajuste ou desative essa programação primeiro."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase a respins modificarea programării."
+    },
+    "battery_schedule_overlap": {
+      "message": "Programul se suprapune peste {schedule_label} existent. Ajustați sau dezactivați mai întâi acel program."
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -128,6 +128,9 @@
     },
     "evse_schedule_change_rejected": {
       "message": "Enphase avvisade schemaändringen."
+    },
+    "battery_schedule_overlap": {
+      "message": "Schemat överlappar det befintliga {schedule_label}. Justera eller inaktivera det schemat först."
     }
   },
   "options": {

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -135,9 +135,9 @@ Example response:
 | BatteryConfig MQTT authorizer bootstrap | `GET` | `/service/batteryConfig/api/v1/mqttSignedUrl/<site_id>` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Safari-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No |
 | BatteryConfig third-party settings | `GET` | `/service/batteryConfig/api/v1/<site_id>/thirdPartyControlSettings` | official-web BatteryConfig shape: `Accept`, `Origin`, `Referer`, Safari-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI) |
 | BatteryConfig schedules | `GET` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | official-web BatteryConfig read shape: `Accept`, `Origin`, `Referer`, Safari-style `User-Agent`, `Username`; suppress `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI) |
-| BatteryConfig schedule create | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | BatteryConfig write shape plus `X-XSRF-Token`; on affected sites the verified working shape is the raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`) sent from a stateless client session so aiohttp does not merge cookie-jar state; current client falls back across cookie-backed, primary, lean, and mixed-auth variants | No |
-| BatteryConfig schedule validation / XSRF bootstrap | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid` | explicit validation uses the official-web BatteryConfig write shape without `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`, or `X-XSRF-Token`; the internal XSRF-bootstrap helper now prefers `GET /siteSettings/<site_id>?userId=<user_id>` and reads `x-csrf-token`, then falls back to this route where it may include the currently held `X-XSRF-Token` while harvesting a fresh token from the response header, `Set-Cookie`, or the session cookie jar; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI and live verification) |
-| BatteryConfig schedule update | `PUT` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>` | BatteryConfig write shape plus `X-XSRF-Token`; verified working update uses the raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`) from a stateless client session; current client falls back across cookie-backed, primary, lean, and mixed-auth variants | No (documented from live verification) |
+| BatteryConfig schedule create | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules` | BatteryConfig write shape plus `X-XSRF-Token`; live verification on the affected site showed create should send explicit `isEnabled`; on affected sites the verified working shape is the raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`) sent from a stateless client session so aiohttp does not merge cookie-jar state; current client falls back across cookie-backed, primary, lean, and mixed-auth variants | No |
+| BatteryConfig schedule validation / XSRF bootstrap | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/isValid` | explicit validation uses the official-web BatteryConfig write shape without `Authorization`, `Cookie`, `X-CSRF-Token`, `X-Requested-With`, or `X-XSRF-Token`; success shape is `{"isValid": true}` while affected sites may return `403`; the internal XSRF-bootstrap helper now prefers `GET /siteSettings/<site_id>?userId=<user_id>` and reads `x-csrf-token`, then falls back to this route where it may include the currently held `X-XSRF-Token` while harvesting a fresh token from the response header, `Set-Cookie`, response cookies, or the session cookie jar; current client uses primary variant with `e-auth-token` + `requestid` and lean fallback without them | No (documented from web UI and live verification) |
+| BatteryConfig schedule update | `PUT` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>` | BatteryConfig write shape plus `X-XSRF-Token`; ordinary time/limit edits can omit `isEnabled`, while explicit schedule-entry toggle writes may include it; verified working update uses the raw-cookie browser request (`Cookie`, `e-auth-token`, `Username`, `X-XSRF-Token`, `X-Requested-With`) from a stateless client session; current client falls back across cookie-backed, primary, lean, and mixed-auth variants | No (documented from live verification) |
 | BatteryConfig schedule legacy delete alias | `POST` | `/service/batteryConfig/api/v1/battery/sites/<site_id>/schedules/<schedule_id>/delete` | same BatteryConfig write planner as schedule create/update; cookie-backed browser request is the verified working compatibility shape on affected sites | No |
 | BatteryConfig disclaimer accept | `POST` | `/service/batteryConfig/api/v1/batterySettings/acceptDisclaimer/<site_id>` | documented write pattern only; when used, current client will try the same cookie-backed, primary, lean, and mixed-auth BatteryConfig write variants | No (not currently used by runtime) |
 | PES in-app banner/status | `GET` | `/service/pes_management/systems/<site_id>/inapp?type=<type>` | authenticated session cookies | No (documented from mobile/web HAR) |
@@ -4747,6 +4747,7 @@ Observed structure:
 - `cfg`, `dtg`, and `rbd` are separate schedule families; later captures showed all three families carrying populated `details[]` entries at the same time.
 - The captured `days` field used numeric weekday values, but the exact weekday-to-number mapping was not explicit in the trace.
 - `scheduleStatus` and per-entry `isEnabled` are separate flags; preserve both rather than collapsing them.
+- Live verification on the affected site showed that `/schedules` entry `isEnabled` is not authoritative for disabled families: temporary CFG/DTG/RBD schedules created with `isEnabled: false` were still echoed back as `isEnabled: true` while the corresponding family control in `batterySettings` stayed disabled.
 
 ### 5.8.1 Create Battery Schedule
 ```
@@ -4773,7 +4774,8 @@ Implementation auth notes:
 Observed behavior:
 - `scheduleType` is sent uppercase (`CFG`, `DTG`, `RBD`).
 - `limit` is included for charge-oriented schedules and omitted for pure RBD recreate flows.
-- `isEnabled` is optional on create; some clients rely on the backend default when omitted.
+- Live verification on the affected site showed that `isEnabled` should be sent explicitly on create; omitting it caused a CFG create attempt to fail with `409 CONFLICTING_SCHEDULE_CFG`.
+- Disabled temp creates (`isEnabled: false`) for CFG/DTG/RBD were still echoed back by `/schedules` as `isEnabled: true`, so create responses and follow-up `/schedules` entry flags are not sufficient to infer the effective enabled state.
 - `startTime` and `endTime` are `HH:MM` strings, while `days` uses the same numeric weekday array returned by `GET /schedules`.
 - The current integration treats the create response body as opaque JSON and reconciles authoritative state from the subsequent `GET /schedules` refresh.
 
@@ -4835,6 +4837,8 @@ Example response (anonymized):
 }
 ```
 
+The current integration normalizes this success shape to `valid: true` for the standalone Home Assistant service response.
+
 Observed `403` response shape from the live affected site:
 ```json
 {
@@ -4870,6 +4874,19 @@ Body: {
 ```
 Updates an existing battery schedule in place.  This is the endpoint used by
 the Enlighten battery profile UI when the user modifies a CFG schedule.
+
+Alternate toggle-style request shape used by explicit schedule-entry helper paths:
+```json
+{
+  "timezone": "Europe/Lisbon",
+  "startTime": "02:00",
+  "endTime": "08:00",
+  "limit": 61,
+  "scheduleType": "CFG",
+  "days": [1, 2, 3, 4, 5, 6, 7],
+  "isEnabled": false
+}
+```
 
 **Headers** (same as other BatteryConfig calls in the current implementation):
 - `Username`: Enphase user ID when decodable from the active auth context
@@ -4941,6 +4958,9 @@ Observed behavior:
   - disable/off reconciliation may need to treat the family as already off when `rbdControl` is also absent on the paired `batterySettings` read
   - enable/on should be blocked by the client until a real RBD schedule is created
 - This replaces the delete+create pattern previously used for schedule modifications.
+- Ordinary time/limit edits on the affected site preserved `isEnabled: false` when updating the existing real disabled CFG/DTG/RBD schedules without sending `isEnabled`.
+- Temporary disabled schedules created with `isEnabled: false` were still echoed back from later update/readback calls as `isEnabled: true` even when the follow-up `PUT` omitted `isEnabled`.
+- Explicit CFG schedule-entry toggle writes that included `isEnabled: true` or `isEnabled: false` still read back as `false` for the existing real schedule on the affected site, indicating that effective CFG enablement is controlled by `batterySettings.chargeFromGridScheduleEnabled`, not reliably by the `/schedules` entry flag.
 - Captured DTG/RBD enablement toggles were also observed as partial `PUT /batterySettings/<site_id>` payloads (`dtgControl.enabled` / `rbdControl.enabled`), so clients should not assume all schedule-family toggles go through `PUT /battery/sites/<site_id>/schedules/<schedule_id>`.
 - The current DTG runtime now follows that split explicitly:
   - toggle enable/disable uses `PUT /batterySettings/<site_id>`
@@ -4949,6 +4969,7 @@ Observed behavior:
   - toggle disable uses `PUT /batterySettings/<site_id>` and may reconcile to off when the backend exposes no `rbdControl` and no saved RBD schedule
   - toggle enable should require an existing RBD schedule entry
   - schedule creation, time edits, and deletes use `/battery/sites/<site_id>/schedules`
+- Live verification on 2026-04-19 showed that overlapping temporary schedule creates can be rejected with misleading cross-family `409` statuses such as `CONFLICTING_SCHEDULE_CFG` even when the attempted write was DTG. The current integration now performs local overlap validation against the cached battery schedule inventory before calling create/update so users see a deterministic conflict message.
 
 ### 5.11 ITC Disclaimer Acknowledgement
 ```
@@ -4967,6 +4988,7 @@ Example response (anonymized):
 Observed behavior:
 - This call preceded `PUT /batterySettings/<site_id>` in the captured sequence.
 - A subsequent battery-settings update used `acceptedItcDisclaimer: true`; later `GET /batterySettings/<site_id>` returned `acceptedItcDisclaimer` as a timestamp string, so the backend normalizes the acknowledgement internally.
+- Repeating the disclaimer-accept call on an already-accepted site refreshed the returned `acceptedItcDisclaimer` timestamp on later `GET /batterySettings/<site_id>` reads.
 - The runtime no longer preflights this route before `PUT /batterySettings/<site_id>`, because the affected site accepted direct battery-settings writes without the extra disclaimer POST.
 - If used again in the future, it should follow the same compatibility planner as the other BatteryConfig mutation endpoints, including the raw-cookie browser request on affected sites.
 

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -2140,6 +2140,169 @@ def test_parse_battery_schedules_payload_tracks_dtg_and_rbd_families(
     assert coord.battery_rbd_schedule_status == "active"
 
 
+def test_parse_battery_schedules_payload_preserves_enabled_state_from_controls(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    coord.battery_runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "chargeFromGridScheduleEnabled": False,
+                "dtgControl": {"enabled": False},
+                "rbdControl": {"enabled": True},
+            }
+        },
+        clear_missing_schedule_times=False,
+        clear_missing_reserve_bounds=False,
+    )
+    coord.battery_runtime.parse_battery_schedules_payload(
+        {
+            "cfg": {
+                "details": [
+                    {
+                        "scheduleId": "sched-cfg",
+                        "startTime": "00:00",
+                        "endTime": "07:30",
+                        "limit": 90,
+                        "days": [1, 7],
+                        "timezone": "Europe/Lisbon",
+                        "isEnabled": True,
+                    }
+                ]
+            },
+            "dtg": {
+                "details": [
+                    {
+                        "scheduleId": "sched-dtg",
+                        "startTime": "18:00",
+                        "endTime": "23:59",
+                        "limit": 5,
+                        "days": [1, 2, 3, 4, 5, 6, 7],
+                        "timezone": "Europe/London",
+                        "isEnabled": True,
+                    }
+                ]
+            },
+            "rbd": {
+                "details": [
+                    {
+                        "scheduleId": "sched-rbd",
+                        "startTime": "01:00",
+                        "endTime": "16:00",
+                        "limit": 100,
+                        "days": [1, 2, 3, 4, 5, 6, 7],
+                        "timezone": "Europe/London",
+                        "isEnabled": False,
+                    }
+                ]
+            },
+        }
+    )
+
+    assert coord.battery_charge_from_grid_schedule_enabled is False
+    assert coord.battery_discharge_to_grid_schedule_enabled is False
+    assert coord.battery_restrict_battery_discharge_schedule_enabled is True
+
+
+def test_parse_battery_schedules_payload_prefers_control_matching_detail(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    coord.battery_runtime.parse_battery_settings_payload(
+        {
+            "data": {
+                "chargeFromGridScheduleEnabled": False,
+                "dtgControl": {"enabled": False},
+                "rbdControl": {"enabled": True},
+            }
+        },
+        clear_missing_schedule_times=False,
+        clear_missing_reserve_bounds=False,
+    )
+    coord.battery_runtime.parse_battery_schedules_payload(
+        {
+            "cfg": {
+                "details": [
+                    {
+                        "scheduleId": "cfg-temp",
+                        "startTime": "00:10",
+                        "endTime": "00:40",
+                        "limit": 100,
+                        "days": [6],
+                        "timezone": "Australia/Melbourne",
+                        "isEnabled": True,
+                    },
+                    {
+                        "scheduleId": "cfg-real",
+                        "startTime": "02:00",
+                        "endTime": "05:00",
+                        "limit": 100,
+                        "days": [1, 2, 3, 4, 5, 6, 7],
+                        "timezone": "Australia/Melbourne",
+                        "isEnabled": False,
+                    },
+                ]
+            },
+            "dtg": {
+                "details": [
+                    {
+                        "scheduleId": "dtg-temp",
+                        "startTime": "00:15",
+                        "endTime": "00:45",
+                        "limit": 21,
+                        "days": [6],
+                        "timezone": "Australia/Melbourne",
+                        "isEnabled": True,
+                    },
+                    {
+                        "scheduleId": "dtg-real",
+                        "startTime": "18:15",
+                        "endTime": "23:45",
+                        "limit": 21,
+                        "days": [1, 2, 3, 4, 5],
+                        "timezone": "Australia/Melbourne",
+                        "isEnabled": False,
+                    },
+                ]
+            },
+            "rbd": {
+                "details": [
+                    {
+                        "scheduleId": "rbd-temp",
+                        "startTime": "00:50",
+                        "endTime": "01:20",
+                        "limit": 100,
+                        "days": [6],
+                        "timezone": "Australia/Melbourne",
+                        "isEnabled": False,
+                    },
+                    {
+                        "scheduleId": "rbd-real",
+                        "startTime": "06:30",
+                        "endTime": "11:00",
+                        "limit": 100,
+                        "days": [1, 2, 3, 4, 5, 6, 7],
+                        "timezone": "Australia/Melbourne",
+                        "isEnabled": True,
+                    },
+                ]
+            },
+        }
+    )
+
+    assert coord._battery_cfg_schedule_id == "cfg-real"  # noqa: SLF001
+    assert coord._battery_charge_begin_time == 120  # noqa: SLF001
+    assert coord._battery_charge_end_time == 300  # noqa: SLF001
+    assert coord._battery_dtg_schedule_id == "dtg-real"  # noqa: SLF001
+    assert coord._battery_dtg_begin_time == 1095  # noqa: SLF001
+    assert coord._battery_dtg_end_time == 1425  # noqa: SLF001
+    assert coord._battery_rbd_schedule_id == "rbd-real"  # noqa: SLF001
+    assert coord._battery_rbd_begin_time == 390  # noqa: SLF001
+    assert coord._battery_rbd_end_time == 660  # noqa: SLF001
+
+
 # ---------------------------------------------------------------------------
 # CFG schedule CRUD – lock/debounce, restore-on-failure, availability guards
 # ---------------------------------------------------------------------------
@@ -2761,7 +2924,7 @@ async def test_dtg_schedule_time_update_omits_enabled_flag(
 
 
 @pytest.mark.asyncio
-async def test_dtg_schedule_time_update_preserves_disabled_state(
+async def test_dtg_schedule_time_update_still_omits_enabled_flag_when_disabled(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -2771,7 +2934,7 @@ async def test_dtg_schedule_time_update_preserves_disabled_state(
     await coord.async_set_discharge_to_grid_schedule_time(start=dt_time(17, 30))
 
     call = coord.client.update_battery_schedule.await_args
-    assert call.kwargs["is_enabled"] is False
+    assert call.kwargs["is_enabled"] is None
 
 
 @pytest.mark.asyncio
@@ -2965,7 +3128,7 @@ async def test_rbd_schedule_enabled_without_schedule_or_window_uses_battery_sett
 
 
 @pytest.mark.asyncio
-async def test_rbd_schedule_limit_update_preserves_disabled_state(
+async def test_rbd_schedule_limit_update_still_omits_enabled_flag_when_disabled(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -2975,7 +3138,7 @@ async def test_rbd_schedule_limit_update_preserves_disabled_state(
     await coord.async_set_restrict_battery_discharge_schedule_limit(80)
 
     call = coord.client.update_battery_schedule.await_args
-    assert call.kwargs["is_enabled"] is False
+    assert call.kwargs["is_enabled"] is None
 
 
 @pytest.mark.asyncio
@@ -3179,6 +3342,58 @@ def test_raise_schedule_update_validation_error_parses_conflict_payloads(
         runtime.raise_schedule_update_validation_error(err)  # noqa: SLF001
 
 
+def test_is_already_processed_profile_cancel_error_parsing(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.battery_runtime
+
+    assert (
+        runtime._is_already_processed_profile_cancel_error(  # noqa: SLF001
+            aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=HTTPStatus.BAD_REQUEST,
+                message='{"error":{"status":"ALREADY_PROCESSED"}}',
+            )
+        )
+        is False
+    )
+    assert (
+        runtime._is_already_processed_profile_cancel_error(  # noqa: SLF001
+            aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=HTTPStatus.CONFLICT,
+                message="",
+            )
+        )
+        is False
+    )
+    assert (
+        runtime._is_already_processed_profile_cancel_error(  # noqa: SLF001
+            aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=HTTPStatus.CONFLICT,
+                message="ALREADY_PROCESSED raw conflict",
+            )
+        )
+        is True
+    )
+    assert (
+        runtime._is_already_processed_profile_cancel_error(  # noqa: SLF001
+            aiohttp.ClientResponseError(
+                request_info=None,
+                history=(),
+                status=HTTPStatus.CONFLICT,
+                message='{"error": []}',
+            )
+        )
+        is False
+    )
+
+
 @pytest.mark.asyncio
 async def test_async_apply_battery_settings_compat_handles_payload_and_auth_errors(
     coordinator_factory,
@@ -3233,23 +3448,32 @@ async def test_dtg_schedule_toggle_unexpected_client_error_reraises(
 
 
 @pytest.mark.asyncio
-async def test_cfg_schedule_enabled_helper_still_uses_schedule_write_path(
+async def test_cfg_schedule_enabled_helper_delegates_to_cfg_settings_toggle(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
-    _seed_cfg_schedule(coord)
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_cfg_control = BatteryControlCapability(
+        show=True,
+        locked=False,
+        show_day_schedule=True,
+        schedule_supported=True,
+        force_schedule_supported=True,
+    )
+    coord._battery_charge_begin_time = 120  # noqa: SLF001
+    coord._battery_charge_end_time = 300  # noqa: SLF001
+    coord.battery_runtime.async_set_charge_from_grid_schedule_enabled = (
+        AsyncMock()
+    )  # noqa: SLF001
 
     await coord.battery_runtime._async_set_schedule_family_enabled(  # noqa: SLF001
         "cfg", False
     )
 
-    call = coord.client.update_battery_schedule.await_args
-    assert call.args[0] == "sched-1"
-    assert call.kwargs["schedule_type"] == "CFG"
-    assert call.kwargs["start_time"] == "02:00"
-    assert call.kwargs["end_time"] == "05:00"
-    assert call.kwargs["limit"] == 80
-    assert call.kwargs["is_enabled"] is False
+    coord.battery_runtime.async_set_charge_from_grid_schedule_enabled.assert_awaited_once_with(  # noqa: SLF001
+        False
+    )
 
 
 @pytest.mark.asyncio
@@ -3563,6 +3787,44 @@ async def test_create_schedule_family_uses_validation_error_on_client_failure(
 
 
 @pytest.mark.asyncio
+async def test_create_schedule_family_rejects_local_overlap_before_client_call(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_no_schedule_family(coord, "dtg")
+    coord._battery_schedules_payload = {  # noqa: SLF001
+        "cfg": {
+            "details": [
+                {
+                    "scheduleId": "sched-cfg",
+                    "startTime": "02:00",
+                    "endTime": "05:00",
+                    "limit": 100,
+                    "days": [1, 2, 3, 4, 5, 6, 7],
+                    "timezone": "Australia/Melbourne",
+                    "isEnabled": False,
+                }
+            ]
+        },
+        "dtg": {"details": []},
+        "rbd": {"details": []},
+    }
+
+    with pytest.raises(
+        ServiceValidationError, match="existing charge from grid schedule"
+    ):
+        await coord.battery_runtime._async_create_or_update_schedule_family(  # noqa: SLF001
+            "dtg",
+            start_minutes=150,
+            end_minutes=240,
+            limit=10,
+            is_enabled=False,
+        )
+
+    coord.client.create_battery_schedule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_create_schedule_family_reraises_client_error_when_helper_does_not(
     coordinator_factory,
 ) -> None:
@@ -3587,6 +3849,58 @@ async def test_create_schedule_family_reraises_client_error_when_helper_does_not
             limit=10,
             is_enabled=True,
         )
+
+
+@pytest.mark.asyncio
+async def test_async_update_battery_schedule_rejects_local_overlap_before_client_call(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_schedule_family(coord, "dtg")
+    coord._battery_schedules_payload = {  # noqa: SLF001
+        "cfg": {
+            "details": [
+                {
+                    "scheduleId": "sched-cfg",
+                    "startTime": "02:00",
+                    "endTime": "05:00",
+                    "limit": 100,
+                    "days": [1, 2, 3, 4, 5, 6, 7],
+                    "timezone": "Australia/Melbourne",
+                    "isEnabled": False,
+                }
+            ]
+        },
+        "dtg": {
+            "details": [
+                {
+                    "scheduleId": "sched-dtg",
+                    "startTime": "18:00",
+                    "endTime": "23:00",
+                    "limit": 5,
+                    "days": [1, 2, 3, 4, 5, 6, 7],
+                    "timezone": "Europe/London",
+                    "isEnabled": True,
+                }
+            ]
+        },
+        "rbd": {"details": []},
+    }
+
+    with pytest.raises(
+        ServiceValidationError, match="existing charge from grid schedule"
+    ):
+        await coord.battery_runtime.async_update_battery_schedule(
+            "sched-dtg",
+            schedule_type="DTG",
+            start_time="02:30",
+            end_time="04:00",
+            limit=5,
+            days=[1],
+            timezone="Europe/London",
+        )
+
+    coord.client.update_battery_schedule.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -3840,6 +4154,7 @@ def _seed_no_cfg_schedule(coord):
     coord._battery_has_encharge = True  # noqa: SLF001
     coord._battery_hide_charge_from_grid = False  # noqa: SLF001
     coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_charge_from_grid_schedule_enabled = False  # noqa: SLF001
     coord._battery_charge_begin_time = 120  # noqa: SLF001
     coord._battery_charge_end_time = 300  # noqa: SLF001
     coord._battery_cfg_schedule_id = None  # noqa: SLF001
@@ -3870,6 +4185,7 @@ async def test_cfg_schedule_creates_when_none_exists(
         limit=100,
         days=[1, 2, 3, 4, 5, 6, 7],
         timezone="UTC",
+        is_enabled=False,
     )
     # Legacy set_battery_settings should NOT have been called.
     coord.client.set_battery_settings.assert_not_awaited()

--- a/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
+++ b/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
@@ -14,6 +14,9 @@ from custom_components.enphase_ev.battery_schedule_editor import (
     BatteryScheduleEditorManager,
     BatteryScheduleRecord,
     NEW_SCHEDULE_OPTION,
+    _minutes_of_day,
+    battery_schedule_overlap_message,
+    battery_schedule_overlap_record,
     battery_scheduler_enabled,
     editor_days_from_list,
     _normalize_days,
@@ -165,6 +168,206 @@ def test_battery_schedule_inventory_normalizes_payload_and_fallbacks() -> None:
     assert [record.schedule_id for record in fallback_records] == ["789abc", "fedcba"]
     assert fallback_records[1].start_time == "18:00"
     assert fallback_records[1].end_time == "22:00"
+
+
+def test_battery_schedule_overlap_record_detects_same_day_and_wraparound() -> None:
+    coord = SimpleNamespace(_battery_schedules_payload=_schedule_payload())
+
+    conflict = battery_schedule_overlap_record(
+        coord,
+        start_time="02:30",
+        end_time="04:00",
+        days=[1],
+    )
+
+    assert conflict is not None
+    assert conflict.schedule_id == "abc123"
+    assert "charge from grid schedule" in battery_schedule_overlap_message(conflict)
+
+    assert (
+        battery_schedule_overlap_record(
+            coord,
+            start_time="03:30",
+            end_time="04:30",
+            days=[1],
+        )
+        is None
+    )
+
+    wraparound_coord = SimpleNamespace(
+        _battery_schedules_payload={
+            "dtg": {
+                "scheduleStatus": "pending",
+                "details": [
+                    {
+                        "scheduleId": "wrap",
+                        "startTime": "23:00",
+                        "endTime": "01:00",
+                        "limit": 30,
+                        "days": [7],
+                        "timezone": "UTC",
+                        "isEnabled": False,
+                    }
+                ],
+            }
+        }
+    )
+
+    wrap_conflict = battery_schedule_overlap_record(
+        wraparound_coord,
+        start_time="00:30",
+        end_time="00:45",
+        days=[1],
+    )
+
+    assert wrap_conflict is not None
+    assert wrap_conflict.schedule_id == "wrap"
+
+
+def test_battery_schedule_overlap_helpers_cover_invalid_and_fallback_paths() -> None:
+    coord = SimpleNamespace(
+        _battery_schedules_payload={
+            "cfg": {
+                "details": [
+                    {
+                        "scheduleId": "invalid",
+                        "startTime": "bad",
+                        "endTime": "02:00",
+                        "limit": 90,
+                        "days": [1],
+                        "timezone": "UTC",
+                        "isEnabled": True,
+                    },
+                    {
+                        "scheduleId": "invalid-end",
+                        "startTime": "01:00",
+                        "endTime": "bad",
+                        "limit": 90,
+                        "days": [1],
+                        "timezone": "UTC",
+                        "isEnabled": True,
+                    },
+                ]
+            }
+        }
+    )
+
+    assert _minutes_of_day(dt_time(2, 15)) == 135
+    assert _minutes_of_day(75) == 75
+    assert _minutes_of_day(-1) is None
+    assert _minutes_of_day(24 * 60) is None
+    assert _minutes_of_day(object()) is None
+    assert _minutes_of_day("") is None
+    assert _minutes_of_day("nope") is None
+    assert _minutes_of_day("ab:cd") is None
+    assert _minutes_of_day("24:00") is None
+
+    assert (
+        battery_schedule_overlap_record(
+            coord,
+            start_time=None,
+            end_time="02:00",
+            days=[1],
+        )
+        is None
+    )
+    assert (
+        battery_schedule_overlap_record(
+            coord,
+            start_time="01:00",
+            end_time="01:00",
+            days=[1],
+        )
+        is None
+    )
+    assert (
+        battery_schedule_overlap_record(
+            coord,
+            start_time="01:00",
+            end_time="02:00",
+            days=[],
+        )
+        is None
+    )
+
+    message = battery_schedule_overlap_message(
+        BatteryScheduleRecord(
+            schedule_id="fallback",
+            schedule_type="",
+            start_time="00:00",
+            end_time="01:00",
+            limit=None,
+            days=[1],
+            timezone="UTC",
+            enabled=None,
+            schedule_status=None,
+        )
+    )
+    assert message == (
+        "Schedule overlaps with the existing battery schedule. "
+        "Adjust or disable that schedule first."
+    )
+
+    assert (
+        battery_schedule_overlap_message(
+            BatteryScheduleRecord(
+                schedule_id="already",
+                schedule_type="schedule",
+                start_time="00:00",
+                end_time="01:00",
+                limit=None,
+                days=[1],
+                timezone="UTC",
+                enabled=None,
+                schedule_status=None,
+            )
+        )
+        == "Schedule overlaps with the existing schedule. Adjust or disable that schedule first."
+    )
+
+
+def test_battery_schedule_overlap_record_skips_existing_records_with_invalid_times(
+    monkeypatch,
+) -> None:
+    invalid_record = BatteryScheduleRecord(
+        schedule_id="bad-record",
+        schedule_type="cfg",
+        start_time="01:00",
+        end_time="bad",
+        limit=90,
+        days=[1],
+        timezone="UTC",
+        enabled=True,
+        schedule_status="active",
+    )
+
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.battery_schedule_editor.battery_schedule_inventory",
+        lambda _coord: [invalid_record],
+    )
+
+    assert (
+        battery_schedule_overlap_record(
+            SimpleNamespace(),
+            start_time="01:30",
+            end_time="02:00",
+            days=[1],
+        )
+        is None
+    )
+
+
+def test_battery_schedule_inventory_prefers_control_enabled_state_when_known() -> None:
+    records = battery_schedule_inventory(
+        SimpleNamespace(
+            _battery_schedules_payload=_schedule_payload(),
+            battery_charge_from_grid_schedule_enabled=False,
+            battery_dtg_control_enabled=True,
+        )
+    )
+
+    assert records[0].enabled is False
+    assert records[1].enabled is True
 
 
 def test_battery_scheduler_enabled_defaults_true_when_option_missing() -> None:
@@ -1363,7 +1566,15 @@ async def test_battery_schedule_services_support_crud_and_validation(
     )
 
     coord.async_request_refresh.assert_awaited()
-    coord.client.create_battery_schedule.assert_awaited_once()
+    coord.client.create_battery_schedule.assert_awaited_once_with(
+        schedule_type="CFG",
+        start_time="05:00",
+        end_time="07:00",
+        limit=88,
+        days=[1, 2, 3],
+        timezone="US/Pacific",
+        is_enabled=True,
+    )
     coord.client.update_battery_schedule.assert_awaited_once_with(
         "abc123",
         schedule_type="CFG",
@@ -1372,7 +1583,6 @@ async def test_battery_schedule_services_support_crud_and_validation(
         limit=91,
         days=[1, 5],
         timezone="Australia/Melbourne",
-        is_enabled=True,
     )
     assert coord.client.delete_battery_schedule.await_count == 2
     assert coord.client.delete_battery_schedule.await_args_list[0].kwargs == {
@@ -1472,7 +1682,93 @@ async def test_battery_schedule_services_update_uses_inventory_schedule_family(
         limit=41,
         days=[2, 4],
         timezone="UTC",
-        is_enabled=False,
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_schedule_services_reject_local_overlaps_before_client_calls(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from homeassistant.exceptions import ServiceValidationError
+
+    from custom_components.enphase_ev.services import async_setup_services
+
+    coord = coordinator_factory()
+    _prepare_battery_schedule_coord(coord)
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    registered: dict[tuple[str, str], dict[str, object]] = {}
+
+    def fake_register(self, domain, service, handler, schema=None, **kwargs):
+        registered[(domain, service)] = {"handler": handler}
+
+    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    async_setup_services(hass)
+
+    add_schedule = registered[(DOMAIN, "add_schedule")]["handler"]
+    update_schedule = registered[(DOMAIN, "update_schedule")]["handler"]
+
+    with pytest.raises(
+        ServiceValidationError, match="existing charge from grid schedule"
+    ):
+        await add_schedule(
+            SimpleNamespace(
+                data={
+                    "config_entry_id": config_entry.entry_id,
+                    "schedule_type": "rbd",
+                    "start_time": dt_time(2, 0),
+                    "end_time": dt_time(4, 0),
+                    "limit": 100,
+                    "days": [1],
+                }
+            )
+        )
+
+    coord.client.create_battery_schedule.assert_not_awaited()
+
+    with pytest.raises(
+        ServiceValidationError, match="existing charge from grid schedule"
+    ):
+        await update_schedule(
+            SimpleNamespace(
+                data={
+                    "config_entry_id": config_entry.entry_id,
+                    "schedule_id": "def456",
+                    "schedule_type": "dtg",
+                    "start_time": dt_time(2, 0),
+                    "end_time": dt_time(4, 0),
+                    "limit": 41,
+                    "days": [1],
+                    "confirm": True,
+                }
+            )
+        )
+
+    coord.client.update_battery_schedule.assert_not_awaited()
+
+    await update_schedule(
+        SimpleNamespace(
+            data={
+                "config_entry_id": config_entry.entry_id,
+                "schedule_id": "abc123",
+                "schedule_type": "cfg",
+                "start_time": dt_time(1, 30),
+                "end_time": dt_time(3, 0),
+                "limit": 90,
+                "days": [1, 3, 5],
+                "confirm": True,
+            }
+        )
+    )
+
+    coord.client.update_battery_schedule.assert_awaited_once_with(
+        "abc123",
+        schedule_type="CFG",
+        start_time="01:30",
+        end_time="03:00",
+        limit=90,
+        days=[1, 3, 5],
+        timezone="Australia/Melbourne",
     )
 
 
@@ -1566,8 +1862,8 @@ async def test_battery_schedule_services_cover_failure_paths(
                 data={
                     "config_entry_id": config_entry.entry_id,
                     "schedule_type": "cfg",
-                    "start_time": dt_time(1, 0),
-                    "end_time": dt_time(2, 0),
+                    "start_time": dt_time(4, 0),
+                    "end_time": dt_time(5, 0),
                     "limit": 50,
                     "days": [1],
                 }
@@ -1637,8 +1933,8 @@ async def test_battery_schedule_services_cover_failure_paths(
                     "config_entry_id": config_entry.entry_id,
                     "schedule_id": "abc123",
                     "schedule_type": "cfg",
-                    "start_time": dt_time(1, 0),
-                    "end_time": dt_time(2, 0),
+                    "start_time": dt_time(4, 0),
+                    "end_time": dt_time(5, 0),
                     "limit": 50,
                     "days": [1],
                     "confirm": True,
@@ -1735,6 +2031,69 @@ async def test_battery_schedule_services_cover_failure_paths(
                 }
             )
         )
+
+    coord.client.validate_battery_schedule = AsyncMock(
+        return_value={"isValid": True, "message": "ok"}
+    )
+    assert await validate_schedule(
+        SimpleNamespace(
+            data={
+                "config_entry_id": config_entry.entry_id,
+                "schedule_type": "cfg",
+            }
+        )
+    ) == {"isValid": True, "message": "ok", "valid": True}
+
+    coord.client.validate_battery_schedule = AsyncMock(
+        return_value={"isValid": False, "message": "raw invalid schedule"}
+    )
+    with pytest.raises(ServiceValidationError, match="raw invalid schedule"):
+        await validate_schedule(
+            SimpleNamespace(
+                data={
+                    "config_entry_id": config_entry.entry_id,
+                    "schedule_type": "cfg",
+                }
+            )
+        )
+
+    coord.client.validate_battery_schedule = AsyncMock(
+        return_value={"isValid": "false", "message": "string invalid schedule"}
+    )
+    with pytest.raises(ServiceValidationError, match="string invalid schedule"):
+        await validate_schedule(
+            SimpleNamespace(
+                data={
+                    "config_entry_id": config_entry.entry_id,
+                    "schedule_type": "cfg",
+                }
+            )
+        )
+
+    coord.client.validate_battery_schedule = AsyncMock(
+        return_value={"isValid": "true", "message": "string ok"}
+    )
+    assert await validate_schedule(
+        SimpleNamespace(
+            data={
+                "config_entry_id": config_entry.entry_id,
+                "schedule_type": "cfg",
+            }
+        )
+    ) == {"isValid": "true", "message": "string ok", "valid": True}
+
+    coord.client.validate_battery_schedule = AsyncMock(return_value=["unexpected"])
+    assert (
+        await validate_schedule(
+            SimpleNamespace(
+                data={
+                    "config_entry_id": config_entry.entry_id,
+                    "schedule_type": "cfg",
+                }
+            )
+        )
+        == {}
+    )
 
     coord.client.validate_battery_schedule = AsyncMock(
         side_effect=aiohttp.ClientResponseError(

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -213,6 +213,54 @@ async def test_cancel_pending_profile_change(
     assert (DOMAIN, ISSUE_BATTERY_PROFILE_PENDING) in mock_issue_registry.deleted
 
 
+@pytest.mark.asyncio
+async def test_cancel_pending_profile_change_ignores_already_processed_conflict(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_pending_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_pending_reserve = 20  # noqa: SLF001
+    coord._battery_pending_requested_at = datetime.now(timezone.utc)  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord.client.cancel_battery_profile_update = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=409,
+            message='{"error":{"status":"ALREADY_PROCESSED","message":"Changes already processed."}}',
+        )
+    )
+
+    await coord.async_cancel_pending_profile_change()
+
+    coord.client.cancel_battery_profile_update.assert_awaited_once()
+    assert coord.battery_profile_pending is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_pending_profile_change_reraises_non_benign_conflict(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_pending_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_pending_reserve = 20  # noqa: SLF001
+    coord._battery_pending_requested_at = datetime.now(timezone.utc)  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+    coord.client.cancel_battery_profile_update = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=409,
+            message='{"error":{"status":"NOT_ALLOWED","message":"Denied."}}',
+        )
+    )
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await coord.async_cancel_pending_profile_change()
+
+
 def test_pending_profile_timeout_issue_lifecycle(
     coordinator_factory, mock_issue_registry
 ) -> None:


### PR DESCRIPTION
## Summary

Harden the IQ Battery schedule and profile flows around live Enphase quirks.

This change adds local overlap validation before battery schedule create/update writes so Home Assistant rejects conflicting windows consistently even when Enphase returns misleading cross-family `409` errors. It also treats profile-cancel `409 ALREADY_PROCESSED` responses as benign no-op results, and documents the verified live request/response behavior.

## Related Issues

- Follow-up hardening for the IQ Battery schedule validation and `isEnabled` investigation work.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_battery_schedule_editor_parity.py tests/components/enphase_ev/test_coordinator_battery_profile.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/battery_schedule_editor.py custom_components/enphase_ev/services.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_battery_schedule_editor_parity.py tests/components/enphase_ev/test_coordinator_battery_profile.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/battery_schedule_editor.py custom_components/enphase_ev/services.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_battery_schedule_editor_parity.py tests/components/enphase_ev/test_coordinator_battery_profile.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/battery_schedule_editor.py,custom_components/enphase_ev/services.py --fail-under=100"
```

Additional manual validation:
- Live dev-environment verification against the stored Enphase account.
- Confirmed local overlap validation blocks a conflicting DTG create before any backend write.
- Confirmed runtime no-op updates still work for existing live `cfg`, `dtg`, and `rbd` schedules.
- Confirmed live `cancel_battery_profile_update()` still returns `409 ALREADY_PROCESSED` and is now classified as benign.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Live Enphase quirks remain unchanged: `/schedules/isValid` still returns `403`, and disabled temp schedule create/update still reads back as `isEnabled: true` on affected sites.
- Repeating the ITC disclaimer accept call refreshed the returned `acceptedItcDisclaimer` timestamp on the live site.
