### PR TITLE
Localize battery schedule translations and error messages

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,27 @@ jobs:
             pre-commit run --all-files
           fi
 
+  translation-regressions:
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: .github/workflows/tests.yml
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade pytest pytest-homeassistant-custom-component "homeassistant>=2024.12.0" aiohttp async-timeout voluptuous
+      - name: Run translation regression tests
+        run: |
+          pytest -q tests/components/enphase_ev/test_service_translations.py
+
   pytest:
     runs-on: ubuntu-latest
     needs: pre-commit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Fixed the standalone IQ Battery schedule validation service so it correctly interprets Enphase's raw `isValid` responses and reports validation failures consistently.
 - Stopped battery schedule refreshes from overwriting control-derived enabled state with conflicting `/schedules` entry flags, and prevented disabled CFG/DTG/RBD families from selecting the wrong schedule record when Enphase echoes temporary schedule entries as `isEnabled: true`.
 - Added local IQ Battery schedule overlap validation before schedule create/update writes so Home Assistant rejects conflicting windows consistently even when Enphase returns misleading cross-family `409` errors, and treated profile-cancel `409 ALREADY_PROCESSED` responses as benign no-op results.
+- Localized the IQ Battery scheduler UI and runtime validation errors across all shipped locales, and tightened translation tests so untranslated user-facing error paths cannot regress silently.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/ac_battery_runtime.py
+++ b/custom_components/enphase_ev/ac_battery_runtime.py
@@ -6,8 +6,10 @@ from datetime import datetime, timezone as _tz
 from html import unescape
 from zoneinfo import ZoneInfo
 
-from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+from .service_validation import raise_translated_service_validation
 
 _AC_BATTERY_TABLE_RE = re.compile(
     r"<table[^>]*id=['\"]ac_batteries['\"][^>]*>(?P<table>.*?)</table>",
@@ -585,8 +587,10 @@ class AcBatteryRuntime:
         state = self.battery_state
         rows = dict(getattr(state, "_ac_battery_data", {}) or {})
         if not rows:
-            raise ServiceValidationError(
-                "No AC Battery devices are currently available."
+            raise_translated_service_validation(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.ac_battery_unavailable",
+                message="No AC Battery devices are currently available.",
             )
         target_soc = None
         if enabled:

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -993,33 +993,53 @@ class BatteryRuntime:
         self._apply_battery_user_details(data.get("userDetails"))
 
     def _assert_battery_system_not_busy(
-        self, unavailable_message: str = "Battery updates are unavailable."
+        self,
+        unavailable_message: str = "Battery updates are unavailable.",
+        *,
+        unavailable_key: str = "battery_updates_unavailable",
     ) -> None:
         if self.coordinator.battery_system_task is True:
-            raise ServiceValidationError(unavailable_message)
+            self._raise_validation(
+                unavailable_key,
+                message=unavailable_message,
+            )
 
     def _assert_battery_profile_feature_writable(
-        self, unavailable_message: str
+        self,
+        unavailable_message: str,
+        *,
+        unavailable_key: str = "battery_profile_unavailable",
     ) -> None:
         coord = self.coordinator
-        self._assert_battery_system_not_busy(unavailable_message)
+        self._assert_battery_system_not_busy(
+            unavailable_message,
+            unavailable_key=unavailable_key,
+        )
         owner = coord.battery_user_is_owner
         installer = coord.battery_user_is_installer
         if owner is False and installer is False:
-            raise ServiceValidationError(
-                "Battery profile updates are not permitted for this account."
+            self._raise_validation(
+                "battery_profile_update_not_permitted",
+                message="Battery profile updates are not permitted for this account.",
             )
 
     def _assert_battery_settings_feature_writable(
-        self, unavailable_message: str
+        self,
+        unavailable_message: str,
+        *,
+        unavailable_key: str = "battery_settings_unavailable",
     ) -> None:
         coord = self.coordinator
-        self._assert_battery_system_not_busy(unavailable_message)
+        self._assert_battery_system_not_busy(
+            unavailable_message,
+            unavailable_key=unavailable_key,
+        )
         owner = coord.battery_user_is_owner
         installer = coord.battery_user_is_installer
         if owner is False and installer is False:
-            raise ServiceValidationError(
-                "Battery settings updates are not permitted for this account."
+            self._raise_validation(
+                "battery_settings_update_not_permitted",
+                message="Battery settings updates are not permitted for this account.",
             )
 
     def assert_battery_profile_write_allowed(self) -> None:
@@ -1027,16 +1047,21 @@ class BatteryRuntime:
         state = self.battery_state
         lock = getattr(state, "_battery_profile_write_lock", None)
         if lock is not None and lock.locked():
-            raise ServiceValidationError(
-                "Another battery profile update is already in progress."
+            self._raise_validation(
+                "battery_profile_update_in_progress",
+                message="Another battery profile update is already in progress.",
             )
         owner = coord.battery_user_is_owner
         installer = coord.battery_user_is_installer
         if owner is False and installer is False:
-            raise ServiceValidationError(
-                "Battery profile updates are not permitted for this account."
+            self._raise_validation(
+                "battery_profile_update_not_permitted",
+                message="Battery profile updates are not permitted for this account.",
             )
-        self._assert_battery_system_not_busy("Battery profile updates are unavailable.")
+        self._assert_battery_system_not_busy(
+            "Battery profile updates are unavailable.",
+            unavailable_key="battery_profile_updates_unavailable",
+        )
 
         now = time.monotonic()
         last = getattr(state, "_battery_profile_last_write_mono", None)
@@ -1045,14 +1070,19 @@ class BatteryRuntime:
             and now >= last
             and (now - last) < BATTERY_PROFILE_WRITE_DEBOUNCE_S
         ):
-            raise ServiceValidationError(
-                "Battery profile update requested too quickly. Please wait and try again."
+            self._raise_validation(
+                "battery_profile_update_debounced",
+                message=(
+                    "Battery profile update requested too quickly. Please wait and "
+                    "try again."
+                ),
             )
 
     async def async_ensure_battery_write_access_confirmed(
         self,
         *,
         denied_message: str = "Battery updates are not permitted for this account.",
+        denied_key: str = "battery_updates_not_permitted",
     ) -> None:
         coord = self.coordinator
         state = self.battery_state
@@ -1061,7 +1091,7 @@ class BatteryRuntime:
         owner = coord.battery_user_is_owner
         installer = coord.battery_user_is_installer
         if owner is False and installer is False:
-            raise ServiceValidationError(denied_message)
+            self._raise_validation(denied_key, message=denied_message)
         fetcher = getattr(coord.client, "battery_site_settings", None)
         if callable(fetcher):
             try:
@@ -1083,9 +1113,10 @@ class BatteryRuntime:
         owner = coord.battery_user_is_owner
         installer = coord.battery_user_is_installer
         if owner is False and installer is False:
-            raise ServiceValidationError(denied_message)
-        raise ServiceValidationError(
-            "Battery write access could not be confirmed. Refresh and try again."
+            self._raise_validation(denied_key, message=denied_message)
+        self._raise_validation(
+            "battery_write_access_unconfirmed",
+            message="Battery write access could not be confirmed. Refresh and try again.",
         )
 
     async def async_assert_battery_profile_write_allowed(self) -> None:
@@ -1098,17 +1129,20 @@ class BatteryRuntime:
         state = self.battery_state
         lock = getattr(state, "_battery_settings_write_lock", None)
         if lock is not None and lock.locked():
-            raise ServiceValidationError(
-                "Another battery settings update is already in progress."
+            self._raise_validation(
+                "battery_settings_update_in_progress",
+                message="Another battery settings update is already in progress.",
             )
         owner = coord.battery_user_is_owner
         installer = coord.battery_user_is_installer
         if owner is False and installer is False:
-            raise ServiceValidationError(
-                "Battery settings updates are not permitted for this account."
+            self._raise_validation(
+                "battery_settings_update_not_permitted",
+                message="Battery settings updates are not permitted for this account.",
             )
         self._assert_battery_system_not_busy(
-            "Battery settings updates are unavailable."
+            "Battery settings updates are unavailable.",
+            unavailable_key="battery_settings_updates_unavailable",
         )
         now = time.monotonic()
         last = getattr(state, "_battery_settings_last_write_mono", None)
@@ -1117,8 +1151,12 @@ class BatteryRuntime:
             and now >= last
             and (now - last) < BATTERY_SETTINGS_WRITE_DEBOUNCE_S
         ):
-            raise ServiceValidationError(
-                "Battery settings update requested too quickly. Please wait and try again."
+            self._raise_validation(
+                "battery_settings_update_debounced",
+                message=(
+                    "Battery settings update requested too quickly. Please wait and "
+                    "try again."
+                ),
             )
 
     async def async_assert_battery_settings_write_allowed(self) -> None:
@@ -1372,6 +1410,27 @@ class BatteryRuntime:
                 ),
             )
 
+    def _raise_validation(
+        self,
+        key: str,
+        *,
+        placeholders: dict[str, object] | None = None,
+        message: str | None = None,
+    ) -> None:
+        raise_translated_service_validation(
+            translation_domain=DOMAIN,
+            translation_key=f"exceptions.{key}",
+            translation_placeholders=placeholders,
+            message=message,
+        )
+
+    def _schedule_label_placeholders(self, schedule_type: str) -> dict[str, object]:
+        schedule_label = self._battery_schedule_label(schedule_type)
+        return {
+            "schedule_label": schedule_label,
+            "schedule_label_lower": schedule_label.lower(),
+        }
+
     @staticmethod
     def _is_already_processed_profile_cancel_error(
         err: aiohttp.ClientResponseError,
@@ -1398,13 +1457,18 @@ class BatteryRuntime:
         self, err: aiohttp.ClientResponseError
     ) -> None:
         if err.status == HTTPStatus.FORBIDDEN:
-            raise ServiceValidationError(
-                "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
-            ) from err
+            self._raise_validation(
+                "schedule_update_forbidden",
+                message="Schedule update was rejected by Enphase (HTTP 403 Forbidden).",
+            )
         if err.status == HTTPStatus.UNAUTHORIZED:
-            raise ServiceValidationError(
-                "Schedule update could not be authenticated. Reauthenticate and try again."
-            ) from err
+            self._raise_validation(
+                "schedule_update_unauthorized",
+                message=(
+                    "Schedule update could not be authenticated. Reauthenticate and "
+                    "try again."
+                ),
+            )
         if err.status == HTTPStatus.CONFLICT:
             backend_status: str | None = None
             backend_message: str | None = None
@@ -1425,27 +1489,45 @@ class BatteryRuntime:
                             backend_message = message_value.strip()
 
             if backend_status == "CONFLICTING_SCHEDULE_DTG":
-                raise ServiceValidationError(
-                    "Schedule conflicts with the existing discharge-to-grid schedule. "
-                    "Adjust or disable that schedule first."
-                ) from err
+                self._raise_validation(
+                    "schedule_conflict_dtg",
+                    message=(
+                        "Schedule conflicts with the existing discharge-to-grid "
+                        "schedule. Adjust or disable that schedule first."
+                    ),
+                )
             if backend_status == "CONFLICTING_SCHEDULE_RBD":
-                raise ServiceValidationError(
-                    "Schedule conflicts with the existing restrict-battery-discharge "
-                    "schedule. Adjust or disable that schedule first."
-                ) from err
+                self._raise_validation(
+                    "schedule_conflict_rbd",
+                    message=(
+                        "Schedule conflicts with the existing "
+                        "restrict-battery-discharge schedule. Adjust or disable that "
+                        "schedule first."
+                    ),
+                )
             if backend_status == "CONFLICTING_SCHEDULE_CFG":
-                raise ServiceValidationError(
-                    "Schedule conflicts with the existing charge-from-grid schedule. "
-                    "Adjust or disable that schedule first."
-                ) from err
+                self._raise_validation(
+                    "schedule_conflict_cfg",
+                    message=(
+                        "Schedule conflicts with the existing charge-from-grid "
+                        "schedule. Adjust or disable that schedule first."
+                    ),
+                )
             if backend_message:
                 if not backend_message.endswith("."):
                     backend_message = f"{backend_message}."
-                raise ServiceValidationError(backend_message) from err
-            raise ServiceValidationError(
-                "Schedule update conflicts with an existing battery schedule."
-            ) from err
+                self._raise_validation(
+                    "schedule_update_conflict_detail",
+                    placeholders={"message": backend_message},
+                    message=(
+                        "Schedule update conflicts with an existing battery "
+                        f"schedule: {backend_message}"
+                    ),
+                )
+            self._raise_validation(
+                "schedule_update_conflict",
+                message="Schedule update conflicts with an existing battery schedule.",
+            )
 
     async def async_update_battery_schedule(
         self,
@@ -1494,7 +1576,10 @@ class BatteryRuntime:
         state = self.battery_state
         normalized_profile = self.normalize_battery_profile_key(profile)
         if not normalized_profile:
-            raise ServiceValidationError("Battery profile is unavailable.")
+            self._raise_validation(
+                "battery_profile_unavailable",
+                message="Battery profile is unavailable.",
+            )
         await self.async_assert_battery_profile_write_allowed()
         normalized_reserve = self.normalize_battery_reserve_for_profile(
             normalized_profile, reserve
@@ -1523,16 +1608,28 @@ class BatteryRuntime:
                     owner = coord.battery_user_is_owner
                     installer = coord.battery_user_is_installer
                     if owner is False and installer is False:
-                        raise ServiceValidationError(
-                            "Battery profile updates are not permitted for this account."
-                        ) from err
-                    raise ServiceValidationError(
-                        "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
-                    ) from err
+                        self._raise_validation(
+                            "battery_profile_update_not_permitted",
+                            message=(
+                                "Battery profile updates are not permitted for this "
+                                "account."
+                            ),
+                        )
+                    self._raise_validation(
+                        "battery_profile_update_forbidden",
+                        message=(
+                            "Battery profile update was rejected by Enphase "
+                            "(HTTP 403 Forbidden)."
+                        ),
+                    )
                 if err.status == HTTPStatus.UNAUTHORIZED:
-                    raise ServiceValidationError(
-                        "Battery profile update could not be authenticated. Reauthenticate and try again."
-                    ) from err
+                    self._raise_validation(
+                        "battery_profile_update_unauthorized",
+                        message=(
+                            "Battery profile update could not be authenticated. "
+                            "Reauthenticate and try again."
+                        ),
+                    )
                 raise
         self.remember_battery_reserve(normalized_profile, normalized_reserve)
         self.set_battery_pending(
@@ -1550,7 +1647,10 @@ class BatteryRuntime:
         coord = self.coordinator
         state = self.battery_state
         if not isinstance(payload, dict) or not payload:
-            raise ServiceValidationError("Battery settings payload is unavailable.")
+            self._raise_validation(
+                "battery_settings_payload_unavailable",
+                message="Battery settings payload is unavailable.",
+            )
         await self.async_assert_battery_settings_write_allowed()
         async with state._battery_settings_write_lock:
             state._battery_settings_last_write_mono = time.monotonic()
@@ -1558,13 +1658,21 @@ class BatteryRuntime:
                 await coord.client.set_battery_settings(payload)
             except aiohttp.ClientResponseError as err:
                 if err.status == HTTPStatus.FORBIDDEN:
-                    raise ServiceValidationError(
-                        "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
-                    ) from err
+                    self._raise_validation(
+                        "battery_settings_update_forbidden",
+                        message=(
+                            "Battery settings update was rejected by Enphase "
+                            "(HTTP 403 Forbidden)."
+                        ),
+                    )
                 if err.status == HTTPStatus.UNAUTHORIZED:
-                    raise ServiceValidationError(
-                        "Battery settings update could not be authenticated. Reauthenticate and try again."
-                    ) from err
+                    self._raise_validation(
+                        "battery_settings_update_unauthorized",
+                        message=(
+                            "Battery settings update could not be authenticated. "
+                            "Reauthenticate and try again."
+                        ),
+                    )
                 raise
         self.parse_battery_settings_payload(
             payload,
@@ -1588,7 +1696,10 @@ class BatteryRuntime:
         coord = self.coordinator
         state = self.battery_state
         if not isinstance(payload, dict) or not payload:
-            raise ServiceValidationError("Battery settings payload is unavailable.")
+            self._raise_validation(
+                "battery_settings_payload_unavailable",
+                message="Battery settings payload is unavailable.",
+            )
         await self.async_assert_battery_settings_write_allowed()
         async with state._battery_settings_write_lock:
             state._battery_settings_last_write_mono = time.monotonic()
@@ -1602,13 +1713,21 @@ class BatteryRuntime:
                 )
             except aiohttp.ClientResponseError as err:
                 if err.status == HTTPStatus.FORBIDDEN:
-                    raise ServiceValidationError(
-                        "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
-                    ) from err
+                    self._raise_validation(
+                        "battery_settings_update_forbidden",
+                        message=(
+                            "Battery settings update was rejected by Enphase "
+                            "(HTTP 403 Forbidden)."
+                        ),
+                    )
                 if err.status == HTTPStatus.UNAUTHORIZED:
-                    raise ServiceValidationError(
-                        "Battery settings update could not be authenticated. Reauthenticate and try again."
-                    ) from err
+                    self._raise_validation(
+                        "battery_settings_update_unauthorized",
+                        message=(
+                            "Battery settings update could not be authenticated. "
+                            "Reauthenticate and try again."
+                        ),
+                    )
                 raise
         self.parse_battery_settings_payload(
             payload,
@@ -3256,12 +3375,24 @@ class BatteryRuntime:
         coord = self.coordinator
         profile = coord.battery_selected_profile
         if not profile:
-            raise ServiceValidationError("Battery profile is unavailable.")
+            self._raise_validation(
+                "battery_profile_unavailable",
+                message="Battery profile is unavailable.",
+            )
         if profile == "backup_only":
-            raise ServiceValidationError("Full Backup reserve is fixed at 100%.")
-        self._assert_battery_profile_feature_writable("Battery reserve is unavailable.")
+            self._raise_validation(
+                "full_backup_reserve_fixed",
+                message="Full Backup reserve is fixed at 100%.",
+            )
+        self._assert_battery_profile_feature_writable(
+            "Battery reserve is unavailable.",
+            unavailable_key="battery_reserve_unavailable",
+        )
         if not coord.battery_reserve_editable:
-            raise ServiceValidationError("Battery reserve is unavailable.")
+            self._raise_validation(
+                "battery_reserve_unavailable",
+                message="Battery reserve is unavailable.",
+            )
         normalized = self.normalize_battery_reserve_for_profile(profile, reserve)
         sub_type = self.target_operation_mode_sub_type(profile)
         await self.async_apply_battery_profile(
@@ -3274,12 +3405,19 @@ class BatteryRuntime:
         coord = self.coordinator
         profile = coord.battery_selected_profile
         if profile != "cost_savings":
-            raise ServiceValidationError("Savings profile must be active.")
+            self._raise_validation(
+                "savings_profile_required",
+                message="Savings profile must be active.",
+            )
         self._assert_battery_profile_feature_writable(
-            "Savings profile settings are unavailable."
+            "Savings profile settings are unavailable.",
+            unavailable_key="savings_profile_settings_unavailable",
         )
         if not coord.savings_use_battery_switch_available:
-            raise ServiceValidationError("Savings profile settings are unavailable.")
+            self._raise_validation(
+                "savings_profile_settings_unavailable",
+                message="Savings profile settings are unavailable.",
+            )
         reserve = coord.battery_selected_backup_percentage
         if reserve is None:
             reserve = self.target_reserve_for_profile("cost_savings")
@@ -3294,10 +3432,19 @@ class BatteryRuntime:
         coord = self.coordinator
         profile = self.normalize_battery_profile_key(profile_key)
         if not profile:
-            raise ServiceValidationError("Battery profile is unavailable.")
+            self._raise_validation(
+                "battery_profile_unavailable",
+                message="Battery profile is unavailable.",
+            )
         if profile not in coord.battery_profile_option_keys:
-            raise ServiceValidationError("Selected battery profile is not supported.")
-        self._assert_battery_profile_feature_writable("Battery profile is unavailable.")
+            self._raise_validation(
+                "battery_profile_unsupported",
+                message="Selected battery profile is not supported.",
+            )
+        self._assert_battery_profile_feature_writable(
+            "Battery profile is unavailable.",
+            unavailable_key="battery_profile_unavailable",
+        )
         reserve = self.target_reserve_for_profile(profile)
         sub_type = self.target_operation_mode_sub_type(profile)
         await self.async_apply_battery_profile(
@@ -3333,10 +3480,14 @@ class BatteryRuntime:
     async def async_set_charge_from_grid(self, enabled: bool) -> None:
         coord = self.coordinator
         self._assert_battery_settings_feature_writable(
-            "Charge from grid setting is unavailable."
+            "Charge from grid setting is unavailable.",
+            unavailable_key="charge_from_grid_unavailable",
         )
         if not coord.charge_from_grid_control_available:
-            raise ServiceValidationError("Charge from grid setting is unavailable.")
+            self._raise_validation(
+                "charge_from_grid_unavailable",
+                message="Charge from grid setting is unavailable.",
+            )
         payload: dict[str, object] = {"chargeFromGrid": bool(enabled)}
         if enabled:
             payload["acceptedItcDisclaimer"] = self.battery_itc_disclaimer_value()
@@ -3356,21 +3507,29 @@ class BatteryRuntime:
             if attempt < 3:
                 await asyncio.sleep(0.75)
 
-        raise ServiceValidationError(
-            "Charge from grid toggle was not applied by Enphase."
+        self._raise_validation(
+            "charge_from_grid_toggle_not_applied",
+            message="Charge from grid toggle was not applied by Enphase.",
         )
 
     async def async_set_charge_from_grid_schedule_enabled(self, enabled: bool) -> None:
         coord = self.coordinator
         self._assert_battery_settings_feature_writable(
-            "Charge from grid schedule is unavailable."
+            "Charge from grid schedule is unavailable.",
+            unavailable_key="charge_from_grid_schedule_unavailable",
         )
         if not coord.charge_from_grid_force_schedule_supported:
-            raise ServiceValidationError("Charge from grid schedule is unavailable.")
+            self._raise_validation(
+                "charge_from_grid_schedule_unavailable",
+                message="Charge from grid schedule is unavailable.",
+            )
         start, end = self.current_charge_from_grid_schedule_window()
         if start == end:
-            raise ServiceValidationError(
-                "Charge-from-grid schedule start and end times must be different."
+            self._raise_validation(
+                "charge_from_grid_schedule_times_different",
+                message=(
+                    "Charge-from-grid schedule start and end times must be different."
+                ),
             )
         charge_from_grid_enabled = coord.battery_charge_from_grid_enabled is True
         payload: dict[str, object] = {
@@ -3424,8 +3583,9 @@ class BatteryRuntime:
         if await _verify():
             return
 
-        raise ServiceValidationError(
-            "Charge-from-grid schedule toggle was not applied by Enphase."
+        self._raise_validation(
+            "charge_from_grid_schedule_toggle_not_applied",
+            message="Charge-from-grid schedule toggle was not applied by Enphase.",
         )
 
     async def async_set_charge_from_grid_schedule_time(
@@ -3437,15 +3597,23 @@ class BatteryRuntime:
         coord = self.coordinator
         state = self.battery_state
         self._assert_battery_settings_feature_writable(
-            "Charge from grid schedule is unavailable."
+            "Charge from grid schedule is unavailable.",
+            unavailable_key="charge_from_grid_schedule_unavailable",
         )
         if not coord.charge_from_grid_schedule_supported:
-            raise ServiceValidationError("Charge from grid schedule is unavailable.")
+            self._raise_validation(
+                "charge_from_grid_schedule_unavailable",
+                message="Charge from grid schedule is unavailable.",
+            )
         if coord.battery_charge_from_grid_enabled is not True:
-            raise ServiceValidationError("Charge from grid must be enabled first.")
+            self._raise_validation(
+                "charge_from_grid_required",
+                message="Charge from grid must be enabled first.",
+            )
         if coord.battery_cfg_schedule_pending:
-            raise ServiceValidationError(
-                "A schedule change is pending Envoy sync. Please wait."
+            self._raise_validation(
+                "schedule_change_pending",
+                message="A schedule change is pending Envoy sync. Please wait.",
             )
         current_start, current_end = self.current_charge_from_grid_schedule_window()
         next_start = (
@@ -3453,10 +3621,16 @@ class BatteryRuntime:
         )
         next_end = coord.time_to_minutes_of_day(end) if end is not None else current_end
         if next_start is None or next_end is None:
-            raise ServiceValidationError("Charge-from-grid schedule time is invalid.")
+            self._raise_validation(
+                "charge_from_grid_schedule_time_invalid",
+                message="Charge-from-grid schedule time is invalid.",
+            )
         if next_start == next_end:
-            raise ServiceValidationError(
-                "Charge-from-grid schedule start and end times must be different."
+            self._raise_validation(
+                "charge_from_grid_schedule_times_different",
+                message=(
+                    "Charge-from-grid schedule start and end times must be different."
+                ),
             )
 
         schedule_id = getattr(coord, "_battery_cfg_schedule_id", None)
@@ -3552,17 +3726,23 @@ class BatteryRuntime:
         coord = self.coordinator
         state = self.battery_state
         self._assert_battery_settings_feature_writable(
-            "Charge from grid schedule is unavailable."
+            "Charge from grid schedule is unavailable.",
+            unavailable_key="charge_from_grid_schedule_unavailable",
         )
         if coord.battery_cfg_control_force_schedule_supported is False:
-            raise ServiceValidationError("Charge from grid schedule is unavailable.")
+            self._raise_validation(
+                "charge_from_grid_schedule_unavailable",
+                message="Charge from grid schedule is unavailable.",
+            )
         if not hasattr(coord.client, "update_battery_schedule"):
-            raise ServiceValidationError(
-                "Schedule API not available on this client version."
+            self._raise_validation(
+                "schedule_api_unavailable",
+                message="Schedule API not available on this client version.",
             )
         if coord.battery_cfg_schedule_pending:
-            raise ServiceValidationError(
-                "A schedule change is pending Envoy sync. Please wait."
+            self._raise_validation(
+                "schedule_change_pending",
+                message="A schedule change is pending Envoy sync. Please wait.",
             )
         if (
             getattr(coord, "_battery_cfg_schedule_id", None) is None
@@ -3570,8 +3750,9 @@ class BatteryRuntime:
             or getattr(coord, "_battery_charge_begin_time", None) is None
             or getattr(coord, "_battery_charge_end_time", None) is None
         ):
-            raise ServiceValidationError(
-                "No existing charge-from-grid schedule is available."
+            self._raise_validation(
+                "charge_from_grid_schedule_missing",
+                message="No existing charge-from-grid schedule is available.",
             )
         await self.async_assert_battery_settings_write_allowed()
         async with state._battery_settings_write_lock:
@@ -3627,6 +3808,51 @@ class BatteryRuntime:
             return coord.battery_rbd_control_enabled
         return getattr(coord, self._battery_schedule_enabled_attr(schedule_type), None)
 
+    def _schedule_family_toggle_validation_details(
+        self,
+        schedule_type: str,
+        *,
+        enabled: bool,
+        schedule_id: object | None,
+        current_start: int | None,
+        current_end: int | None,
+    ) -> tuple[str, dict[str, object], str]:
+        normalized = str(schedule_type).lower()
+        coord = self.coordinator
+        placeholders = self._schedule_label_placeholders(schedule_type)
+
+        if normalized == "rbd" and enabled:
+            if schedule_id is None or current_start is None or current_end is None:
+                return (
+                    "schedule_toggle_create_before_enable",
+                    {"schedule_label": "restrict battery discharge schedule"},
+                    "Create a restrict battery discharge schedule in the IQ Battery "
+                    "scheduler before enabling it.",
+                )
+            if coord.battery_rbd_control is None:
+                return (
+                    "schedule_not_exposed",
+                    {"schedule_label": "Restrict battery discharge"},
+                    "Restrict battery discharge is not currently exposed by Enphase "
+                    "for this site. Wait for the schedule sync to complete, then "
+                    "refresh and try again.",
+                )
+
+        if normalized == "dtg" and enabled and coord.battery_dtg_control is None:
+            return (
+                "schedule_not_exposed",
+                {"schedule_label": "Discharge to grid"},
+                "Discharge to grid is not currently exposed by Enphase for this "
+                "site. Wait for the schedule sync to complete, then refresh and "
+                "try again.",
+            )
+
+        return (
+            "schedule_toggle_not_applied",
+            placeholders,
+            (f"{placeholders['schedule_label']} toggle was not applied by " "Enphase."),
+        )
+
     def _schedule_family_toggle_validation_error(
         self,
         schedule_type: str,
@@ -3635,32 +3861,17 @@ class BatteryRuntime:
         schedule_id: object | None,
         current_start: int | None,
         current_end: int | None,
-    ) -> str | None:
-        normalized = str(schedule_type).lower()
-        label = self._battery_schedule_label(schedule_type)
-        coord = self.coordinator
+    ) -> str:
+        """Backward-compatible message helper used by tests."""
 
-        if normalized == "rbd" and enabled:
-            if schedule_id is None or current_start is None or current_end is None:
-                return (
-                    "Create a restrict battery discharge schedule in the IQ Battery "
-                    "scheduler before enabling it."
-                )
-            if coord.battery_rbd_control is None:
-                return (
-                    "Restrict battery discharge is not currently exposed by Enphase "
-                    "for this site. Wait for the schedule sync to complete, then "
-                    "refresh and try again."
-                )
-
-        if normalized == "dtg" and enabled and coord.battery_dtg_control is None:
-            return (
-                "Discharge to grid is not currently exposed by Enphase for this "
-                "site. Wait for the schedule sync to complete, then refresh and "
-                "try again."
-            )
-
-        return f"{label} toggle was not applied by Enphase."
+        _key, _placeholders, message = self._schedule_family_toggle_validation_details(
+            schedule_type,
+            enabled=enabled,
+            schedule_id=schedule_id,
+            current_start=current_start,
+            current_end=current_end,
+        )
+        return message
 
     def _schedule_family_toggle_effective_state(
         self, schedule_type: str
@@ -3764,27 +3975,26 @@ class BatteryRuntime:
                 getattr(state, self._battery_schedule_status_attr(schedule_type), None),
             )
 
-        raise ServiceValidationError(
-            self._schedule_family_toggle_validation_error(
-                schedule_type,
-                enabled=enabled,
-                schedule_id=getattr(
-                    self.battery_state,
-                    self._battery_schedule_id_attr(schedule_type),
-                    None,
-                ),
-                current_start=getattr(
-                    self.battery_state,
-                    self._battery_schedule_start_attr(schedule_type),
-                    None,
-                ),
-                current_end=getattr(
-                    self.battery_state,
-                    self._battery_schedule_end_attr(schedule_type),
-                    None,
-                ),
-            )
+        key, placeholders, message = self._schedule_family_toggle_validation_details(
+            schedule_type,
+            enabled=enabled,
+            schedule_id=getattr(
+                self.battery_state,
+                self._battery_schedule_id_attr(schedule_type),
+                None,
+            ),
+            current_start=getattr(
+                self.battery_state,
+                self._battery_schedule_start_attr(schedule_type),
+                None,
+            ),
+            current_end=getattr(
+                self.battery_state,
+                self._battery_schedule_end_attr(schedule_type),
+                None,
+            ),
         )
+        self._raise_validation(key, placeholders=placeholders, message=message)
 
     def _schedule_family_control_payload(
         self,
@@ -3828,8 +4038,14 @@ class BatteryRuntime:
             and current_end is not None
         ):
             if current_start == current_end:
-                raise ServiceValidationError(
-                    f"{self._battery_schedule_label(schedule_type)} start and end times must be different."
+                placeholders = self._schedule_label_placeholders(schedule_type)
+                self._raise_validation(
+                    "schedule_family_times_different",
+                    placeholders=placeholders,
+                    message=(
+                        f"{placeholders['schedule_label']} start and end times must "
+                        "be different."
+                    ),
                 )
             payload["scheduleSupported"] = True
             payload["startTime"] = current_start
@@ -3837,8 +4053,9 @@ class BatteryRuntime:
 
         if normalized == "dtg" and enabled:
             if current_start is None or current_end is None:
-                raise ServiceValidationError(
-                    "Discharge to grid schedule time is invalid."
+                self._raise_validation(
+                    "discharge_to_grid_schedule_time_invalid",
+                    message="Discharge to grid schedule time is invalid.",
                 )
 
         return payload
@@ -3922,8 +4139,14 @@ class BatteryRuntime:
             )
             return
         if not self._schedule_create_supported():
-            raise ServiceValidationError(
-                f"No existing {self._battery_schedule_label(schedule_type).lower()} schedule is available."
+            placeholders = self._schedule_label_placeholders(schedule_type)
+            self._raise_validation(
+                "schedule_missing",
+                placeholders=placeholders,
+                message=(
+                    f"No existing {placeholders['schedule_label_lower']} schedule is "
+                    "available."
+                ),
             )
         create_limit = limit
         if create_limit is None:
@@ -3955,22 +4178,30 @@ class BatteryRuntime:
         label = self._battery_schedule_label(schedule_type)
         normalized_schedule_type = str(schedule_type).lower()
         self._assert_battery_settings_feature_writable(
-            f"{label} schedule is unavailable."
+            f"{label} schedule is unavailable.",
+            unavailable_key="schedule_unavailable",
         )
         if not getattr(coord, self._schedule_supported_property_name(schedule_type)):
-            raise ServiceValidationError(f"{label} schedule is unavailable.")
+            self._raise_validation(
+                "schedule_unavailable",
+                placeholders=self._schedule_label_placeholders(schedule_type),
+                message=f"{label} schedule is unavailable.",
+            )
         await self.async_assert_battery_settings_write_allowed()
         if normalized_schedule_type == "cfg":
             if getattr(coord, self._schedule_pending_property_name(schedule_type)):
-                raise ServiceValidationError(
-                    "A schedule change is pending Envoy sync. Please wait."
+                self._raise_validation(
+                    "schedule_change_pending",
+                    message="A schedule change is pending Envoy sync. Please wait.",
                 )
             current_start, current_end = self._current_battery_schedule_window_for_type(
                 schedule_type,
             )
             if current_start == current_end:
-                raise ServiceValidationError(
-                    f"{label} schedule start and end times must be different."
+                self._raise_validation(
+                    "schedule_family_times_different",
+                    placeholders=self._schedule_label_placeholders(schedule_type),
+                    message=f"{label} schedule start and end times must be different.",
                 )
             await self.async_set_charge_from_grid_schedule_enabled(enabled)
             return
@@ -3989,15 +4220,25 @@ class BatteryRuntime:
             )
             if normalized_schedule_type == "rbd" and enabled:
                 if schedule_id is None or current_start is None or current_end is None:
-                    raise ServiceValidationError(
-                        "Create a restrict battery discharge schedule in the IQ Battery "
-                        "scheduler before enabling it."
+                    self._raise_validation(
+                        "schedule_toggle_create_before_enable",
+                        placeholders={
+                            "schedule_label": "restrict battery discharge schedule"
+                        },
+                        message=(
+                            "Create a restrict battery discharge schedule in the IQ "
+                            "Battery scheduler before enabling it."
+                        ),
                     )
                 if coord.battery_rbd_control is None:
-                    raise ServiceValidationError(
-                        "Restrict battery discharge is not currently exposed by Enphase "
-                        "for this site. Wait for the schedule sync to complete, then "
-                        "refresh and try again."
+                    self._raise_validation(
+                        "schedule_not_exposed",
+                        placeholders={"schedule_label": "Restrict battery discharge"},
+                        message=(
+                            "Restrict battery discharge is not currently exposed by "
+                            "Enphase for this site. Wait for the schedule sync to "
+                            "complete, then refresh and try again."
+                        ),
                     )
             if use_battery_settings_toggle:
                 control_key = f"{normalized_schedule_type}Control"
@@ -4029,7 +4270,10 @@ class BatteryRuntime:
                 coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
                 try:
                     if primary_write_rejected:
-                        raise ServiceValidationError("primary write rejected")
+                        self._raise_validation(
+                            "schedule_primary_write_rejected",
+                            message="primary write rejected",
+                        )
                     await self._async_verify_schedule_family_toggle_applied(
                         schedule_type,
                         enabled=enabled,
@@ -4070,13 +4314,19 @@ class BatteryRuntime:
         state = self.battery_state
         label = self._battery_schedule_label(schedule_type)
         self._assert_battery_settings_feature_writable(
-            f"{label} schedule is unavailable."
+            f"{label} schedule is unavailable.",
+            unavailable_key="schedule_unavailable",
         )
         if not getattr(coord, self._schedule_supported_property_name(schedule_type)):
-            raise ServiceValidationError(f"{label} schedule is unavailable.")
+            self._raise_validation(
+                "schedule_unavailable",
+                placeholders=self._schedule_label_placeholders(schedule_type),
+                message=f"{label} schedule is unavailable.",
+            )
         if getattr(coord, self._schedule_pending_property_name(schedule_type)):
-            raise ServiceValidationError(
-                "A schedule change is pending Envoy sync. Please wait."
+            self._raise_validation(
+                "schedule_change_pending",
+                message="A schedule change is pending Envoy sync. Please wait.",
             )
 
         current_start, current_end = self._current_battery_schedule_window_for_type(
@@ -4089,15 +4339,21 @@ class BatteryRuntime:
         if next_start is None or next_end is None:
             default_window = self._schedule_default_window_for_create(schedule_type)
             if default_window is None:
-                raise ServiceValidationError(f"{label} schedule time is invalid.")
+                self._raise_validation(
+                    "schedule_time_invalid",
+                    placeholders=self._schedule_label_placeholders(schedule_type),
+                    message=f"{label} schedule time is invalid.",
+                )
             default_start, default_end = default_window
             if next_start is None:
                 next_start = default_start
             if next_end is None:
                 next_end = default_end
         if next_start == next_end:
-            raise ServiceValidationError(
-                f"{label} schedule start and end times must be different."
+            self._raise_validation(
+                "schedule_family_times_different",
+                placeholders=self._schedule_label_placeholders(schedule_type),
+                message=f"{label} schedule start and end times must be different.",
             )
         current_limit = getattr(
             state, self._battery_schedule_limit_attr(schedule_type), None
@@ -4133,29 +4389,48 @@ class BatteryRuntime:
         state = self.battery_state
         label = self._battery_schedule_label(schedule_type)
         self._assert_battery_settings_feature_writable(
-            f"{label} schedule is unavailable."
+            f"{label} schedule is unavailable.",
+            unavailable_key="schedule_unavailable",
         )
         if not getattr(coord, self._schedule_supported_property_name(schedule_type)):
-            raise ServiceValidationError(f"{label} schedule is unavailable.")
+            self._raise_validation(
+                "schedule_unavailable",
+                placeholders=self._schedule_label_placeholders(schedule_type),
+                message=f"{label} schedule is unavailable.",
+            )
         if getattr(coord, self._schedule_pending_property_name(schedule_type)):
-            raise ServiceValidationError(
-                "A schedule change is pending Envoy sync. Please wait."
+            self._raise_validation(
+                "schedule_change_pending",
+                message="A schedule change is pending Envoy sync. Please wait.",
             )
         current_start, current_end = self._current_battery_schedule_window_for_type(
             schedule_type
         )
         if current_start is None or current_end is None:
-            raise ServiceValidationError(
-                f"Current {label.lower()} schedule time is invalid."
+            self._raise_validation(
+                "current_schedule_time_invalid",
+                placeholders=self._schedule_label_placeholders(schedule_type),
+                message=f"Current {label.lower()} schedule time is invalid.",
             )
         if not 5 <= int(limit) <= 100:
-            raise ServiceValidationError(
-                f"{label} schedule limit must be between 5 and 100."
+            self._raise_validation(
+                "schedule_limit_range",
+                placeholders={
+                    **self._schedule_label_placeholders(schedule_type),
+                    "minimum": "5",
+                    "maximum": "100",
+                },
+                message=f"{label} schedule limit must be between 5 and 100.",
             )
         shutdown_floor = coord.battery_shutdown_level
         if shutdown_floor is not None and int(limit) < shutdown_floor:
-            raise ServiceValidationError(
-                f"{label} schedule limit must be at least {shutdown_floor}%."
+            self._raise_validation(
+                "schedule_limit_minimum",
+                placeholders={
+                    **self._schedule_label_placeholders(schedule_type),
+                    "minimum": str(shutdown_floor),
+                },
+                message=f"{label} schedule limit must be at least {shutdown_floor}%.",
             )
         current_enabled = getattr(
             state, self._battery_schedule_enabled_attr(schedule_type), None
@@ -4219,24 +4494,31 @@ class BatteryRuntime:
         coord = self.coordinator
         state = self.battery_state
         self._assert_battery_settings_feature_writable(
-            "Charge from grid schedule is unavailable."
+            "Charge from grid schedule is unavailable.",
+            unavailable_key="charge_from_grid_schedule_unavailable",
         )
         if not hasattr(coord.client, "update_battery_schedule"):
-            raise ServiceValidationError(
-                "Schedule API not available on this client version."
+            self._raise_validation(
+                "schedule_api_unavailable",
+                message="Schedule API not available on this client version.",
             )
         if coord.battery_cfg_schedule_pending:
-            raise ServiceValidationError(
-                "A schedule change is pending Envoy sync. Please wait."
+            self._raise_validation(
+                "schedule_change_pending",
+                message="A schedule change is pending Envoy sync. Please wait.",
             )
         schedule_id = getattr(state, "_battery_cfg_schedule_id", None)
         if schedule_id is None:
-            raise ServiceValidationError(
-                "No existing charge-from-grid schedule is available."
+            self._raise_validation(
+                "charge_from_grid_schedule_missing",
+                message="No existing charge-from-grid schedule is available.",
             )
         current_start, current_end = self._current_schedule_window_from_coordinator()
         if current_start is None or current_end is None:
-            raise ServiceValidationError("Current schedule times are not available.")
+            self._raise_validation(
+                "current_schedule_times_unavailable",
+                message="Current schedule times are not available.",
+            )
         next_start = (
             coord.time_to_minutes_of_day(start) if start is not None else current_start
         )
@@ -4247,20 +4529,32 @@ class BatteryRuntime:
             else getattr(state, "_battery_cfg_schedule_limit", None) or 100
         )
         if next_start is None or next_end is None:
-            raise ServiceValidationError("Charge-from-grid schedule time is invalid.")
+            self._raise_validation(
+                "charge_from_grid_schedule_time_invalid",
+                message="Charge-from-grid schedule time is invalid.",
+            )
         if next_start == next_end:
-            raise ServiceValidationError(
-                "Charge-from-grid schedule start and end times must be different."
+            self._raise_validation(
+                "charge_from_grid_schedule_times_different",
+                message=(
+                    "Charge-from-grid schedule start and end times must be different."
+                ),
             )
         if not 5 <= next_limit <= 100:
-            raise ServiceValidationError(
-                "Charge-from-grid schedule limit must be between 5 and 100."
+            self._raise_validation(
+                "charge_from_grid_schedule_limit_range",
+                placeholders={"minimum": "5", "maximum": "100"},
+                message="Charge-from-grid schedule limit must be between 5 and 100.",
             )
         shutdown_floor = coord.battery_shutdown_level
         if shutdown_floor is not None and next_limit < shutdown_floor:
-            raise ServiceValidationError(
-                "Charge-from-grid schedule limit must be at least "
-                f"{shutdown_floor}%."
+            self._raise_validation(
+                "charge_from_grid_schedule_limit_minimum",
+                placeholders={"minimum": str(shutdown_floor)},
+                message=(
+                    "Charge-from-grid schedule limit must be at least "
+                    f"{shutdown_floor}%."
+                ),
             )
         await self.async_assert_battery_settings_write_allowed()
         async with state._battery_settings_write_lock:
@@ -4462,19 +4756,34 @@ class BatteryRuntime:
     async def async_set_battery_shutdown_level(self, level: int) -> None:
         coord = self.coordinator
         self._assert_battery_settings_feature_writable(
-            "Battery shutdown level is unavailable."
+            "Battery shutdown level is unavailable.",
+            unavailable_key="battery_shutdown_level_unavailable",
         )
         if not coord.battery_shutdown_level_available:
-            raise ServiceValidationError("Battery shutdown level is unavailable.")
+            self._raise_validation(
+                "battery_shutdown_level_unavailable",
+                message="Battery shutdown level is unavailable.",
+            )
         try:
             normalized = int(level)
-        except Exception as err:  # noqa: BLE001
-            raise ServiceValidationError("Battery shutdown level is invalid.") from err
+        except Exception:  # noqa: BLE001
+            self._raise_validation(
+                "battery_shutdown_level_invalid",
+                message="Battery shutdown level is invalid.",
+            )
         min_level = coord.battery_shutdown_level_min
         max_level = coord.battery_shutdown_level_max
         if normalized < min_level or normalized > max_level:
-            raise ServiceValidationError(
-                f"Battery shutdown level must be between {min_level} and {max_level}."
+            self._raise_validation(
+                "battery_shutdown_level_range",
+                placeholders={
+                    "minimum": str(min_level),
+                    "maximum": str(max_level),
+                },
+                message=(
+                    f"Battery shutdown level must be between {min_level} and "
+                    f"{max_level}."
+                ),
             )
         await self.async_apply_battery_settings({"veryLowSoc": normalized})
 
@@ -4503,7 +4812,10 @@ class BatteryRuntime:
 
         opt_out = getattr(coord.client, "opt_out_storm_alert", None)
         if not callable(opt_out):
-            raise ServiceValidationError("Storm Alert opt-out is unavailable.")
+            self._raise_validation(
+                "storm_alert_opt_out_unavailable",
+                message="Storm Alert opt-out is unavailable.",
+            )
 
         failures: list[tuple[str, Exception]] = []
         for alert_id, name in actionable:
@@ -4537,8 +4849,10 @@ class BatteryRuntime:
             )
 
         if failures:
-            raise ServiceValidationError(
-                f"Storm Alert opt-out failed for {len(failures)} alert(s)."
+            self._raise_validation(
+                "storm_alert_opt_out_failed",
+                placeholders={"count": str(len(failures))},
+                message=f"Storm Alert opt-out failed for {len(failures)} alert(s).",
             )
         if refresh_err is not None:
             raise refresh_err
@@ -4546,11 +4860,15 @@ class BatteryRuntime:
     async def async_set_storm_guard_enabled(self, enabled: bool) -> None:
         coord = self.coordinator
         await self.async_ensure_battery_write_access_confirmed(
-            denied_message="Storm Guard updates are not permitted for this account."
+            denied_message="Storm Guard updates are not permitted for this account.",
+            denied_key="storm_guard_update_not_permitted",
         )
         await coord.async_refresh_storm_guard_profile(force=True)
         if getattr(coord, "_storm_evse_enabled", None) is None:
-            raise ServiceValidationError("Storm Guard settings are unavailable.")
+            self._raise_validation(
+                "storm_guard_settings_unavailable",
+                message="Storm Guard settings are unavailable.",
+            )
         target_state = "enabled" if enabled else "disabled"
         self.set_storm_guard_pending(target_state)
         try:
@@ -4564,16 +4882,27 @@ class BatteryRuntime:
                 owner = coord.battery_user_is_owner
                 installer = coord.battery_user_is_installer
                 if owner is False and installer is False:
-                    raise ServiceValidationError(
-                        "Storm Guard updates are not permitted for this account."
-                    ) from err
-                raise ServiceValidationError(
-                    "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
-                ) from err
+                    self._raise_validation(
+                        "storm_guard_update_not_permitted",
+                        message=(
+                            "Storm Guard updates are not permitted for this account."
+                        ),
+                    )
+                self._raise_validation(
+                    "storm_guard_update_forbidden",
+                    message=(
+                        "Storm Guard update was rejected by Enphase "
+                        "(HTTP 403 Forbidden)."
+                    ),
+                )
             if err.status == HTTPStatus.UNAUTHORIZED:
-                raise ServiceValidationError(
-                    "Storm Guard update could not be authenticated. Reauthenticate and try again."
-                ) from err
+                self._raise_validation(
+                    "storm_guard_update_unauthorized",
+                    message=(
+                        "Storm Guard update could not be authenticated. "
+                        "Reauthenticate and try again."
+                    ),
+                )
             raise
         except Exception:
             self.clear_storm_guard_pending()
@@ -4584,11 +4913,15 @@ class BatteryRuntime:
     async def async_set_storm_evse_enabled(self, enabled: bool) -> None:
         coord = self.coordinator
         await self.async_ensure_battery_write_access_confirmed(
-            denied_message="Storm Guard updates are not permitted for this account."
+            denied_message="Storm Guard updates are not permitted for this account.",
+            denied_key="storm_guard_update_not_permitted",
         )
         await coord.async_refresh_storm_guard_profile(force=True)
         if getattr(coord, "_storm_guard_state", None) is None:
-            raise ServiceValidationError("Storm Guard settings are unavailable.")
+            self._raise_validation(
+                "storm_guard_settings_unavailable",
+                message="Storm Guard settings are unavailable.",
+            )
         try:
             await coord.client.set_storm_guard(
                 enabled=getattr(coord, "_storm_guard_state", None) == "enabled",
@@ -4599,16 +4932,27 @@ class BatteryRuntime:
                 owner = coord.battery_user_is_owner
                 installer = coord.battery_user_is_installer
                 if owner is False and installer is False:
-                    raise ServiceValidationError(
-                        "Storm Guard updates are not permitted for this account."
-                    ) from err
-                raise ServiceValidationError(
-                    "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
-                ) from err
+                    self._raise_validation(
+                        "storm_guard_update_not_permitted",
+                        message=(
+                            "Storm Guard updates are not permitted for this account."
+                        ),
+                    )
+                self._raise_validation(
+                    "storm_guard_update_forbidden",
+                    message=(
+                        "Storm Guard update was rejected by Enphase "
+                        "(HTTP 403 Forbidden)."
+                    ),
+                )
             if err.status == HTTPStatus.UNAUTHORIZED:
-                raise ServiceValidationError(
-                    "Storm Guard update could not be authenticated. Reauthenticate and try again."
-                ) from err
+                self._raise_validation(
+                    "storm_guard_update_unauthorized",
+                    message=(
+                        "Storm Guard update could not be authenticated. "
+                        "Reauthenticate and try again."
+                    ),
+                )
             raise
         self.battery_state._storm_evse_enabled = bool(enabled)
         self.battery_state._storm_guard_cache_until = (

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -6,7 +6,7 @@ import json
 import aiohttp
 from homeassistant.components.select import SelectEntity
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -47,6 +47,7 @@ from .runtime_helpers import (
     inventory_type_device_info as _type_device_info,
 )
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
+from .service_validation import raise_translated_service_validation
 
 PARALLEL_UPDATES = 0
 
@@ -377,30 +378,51 @@ class SystemProfileSelect(CoordinatorEntity, SelectEntity):
                 selected_key = key
                 break
         if selected_key is None:
-            raise ServiceValidationError("Selected system profile is not available.")
+            raise_translated_service_validation(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.selected_system_profile_unavailable",
+                message="Selected system profile is not available.",
+            )
         try:
             await self._coord.battery_runtime.async_set_system_profile(selected_key)
-        except ServiceValidationError as err:
-            message = str(err).strip() or "System profile update failed."
-            raise ServiceValidationError(message) from err
+        except ServiceValidationError:
+            raise
         except aiohttp.ClientResponseError as err:
             if err.status == 403:
-                raise ServiceValidationError(
-                    "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
-                ) from err
+                raise_translated_service_validation(
+                    translation_domain=DOMAIN,
+                    translation_key="exceptions.system_profile_update_forbidden",
+                    message=(
+                        "System profile update was rejected by Enphase "
+                        "(HTTP 403 Forbidden)."
+                    ),
+                )
             if err.status == 401:
-                raise ServiceValidationError(
-                    "System profile update could not be authenticated. Reauthenticate and try again."
-                ) from err
-            raise ServiceValidationError("System profile update failed.") from err
-        except aiohttp.ClientError as err:
-            raise ServiceValidationError(
-                "System profile update failed due to a network error. Try again."
-            ) from err
-        except asyncio.TimeoutError as err:
-            raise ServiceValidationError(
-                "System profile update timed out. Try again."
-            ) from err
+                raise_translated_service_validation(
+                    translation_domain=DOMAIN,
+                    translation_key="exceptions.system_profile_update_unauthorized",
+                    message=(
+                        "System profile update could not be authenticated. "
+                        "Reauthenticate and try again."
+                    ),
+                )
+            raise_translated_service_validation(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.system_profile_update_failed",
+                message="System profile update failed.",
+            )
+        except aiohttp.ClientError:
+            raise_translated_service_validation(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.system_profile_update_network",
+                message="System profile update failed due to a network error. Try again.",
+            )
+        except asyncio.TimeoutError:
+            raise_translated_service_validation(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.system_profile_update_timeout",
+                message="System profile update timed out. Try again.",
+            )
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -630,8 +652,13 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         if not self._coord.scheduler_available:
-            raise HomeAssistantError(
-                "Charging mode selection is unavailable while the Enphase scheduler service is down."
+            raise_translated_service_validation(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.scheduler_service_unavailable",
+                message=(
+                    "Charging mode selection is unavailable while the Enphase "
+                    "scheduler service is down."
+                ),
             )
         hass = getattr(self, "hass", None) or self._coord.hass
         solar_mode_key, solar_label = _solar_mode(self._coord, self._sn)
@@ -661,9 +688,14 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
             self._coord.mark_scheduler_available()
         except SchedulerUnavailable as err:
             self._coord.note_scheduler_unavailable(err)
-            raise HomeAssistantError(
-                "Charging mode selection is unavailable while the Enphase scheduler service is down."
-            ) from err
+            raise_translated_service_validation(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.scheduler_service_unavailable",
+                message=(
+                    "Charging mode selection is unavailable while the Enphase "
+                    "scheduler service is down."
+                ),
+            )
         except aiohttp.ClientResponseError as err:
             code, display = _parse_scheduler_error(err.message)
             if err.status == 400 and (
@@ -674,7 +706,7 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
                     "Enable at least one schedule before selecting Scheduled charging.",
                     translation_domain=DOMAIN,
                     translation_key="exceptions.schedule_required",
-                ) from err
+                )
             raise
         # Update cache immediately to reflect in UI, then refresh
         self._coord.set_charge_mode_cache(self._sn, mode)
@@ -727,8 +759,12 @@ class AcBatteryTargetStateOfChargeSelect(CoordinatorEntity, SelectEntity):
                 selected_value = value
                 break
         if selected_value is None:
-            raise ServiceValidationError(
-                "Selected AC Battery target state of charge is not available."
+            raise_translated_service_validation(
+                translation_domain=DOMAIN,
+                translation_key=(
+                    "exceptions.selected_ac_battery_target_state_of_charge_unavailable"
+                ),
+                message="Selected AC Battery target state of charge is not available.",
             )
         await self._coord.async_set_ac_battery_target_soc(selected_value)
 

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -65,6 +65,19 @@ def async_setup_services(
     )
     SCHEDULE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,127}$")
 
+    def _raise_service_validation(
+        key: str,
+        *,
+        placeholders: dict[str, object] | None = None,
+        message: str | None = None,
+    ) -> None:
+        raise_translated_service_validation(
+            translation_domain=DOMAIN,
+            translation_key=f"exceptions.{key}",
+            translation_placeholders=placeholders,
+            message=message,
+        )
+
     async def _resolve_sn(device_id: str) -> str | None:
         dev_reg = dr.async_get(hass)
         dev = dev_reg.async_get(device_id)
@@ -234,16 +247,29 @@ def async_setup_services(
         limit: int,
     ) -> tuple[str, str]:
         if not days:
-            raise ServiceValidationError("Select at least one day for the schedule.")
+            _raise_service_validation(
+                "battery_schedule_day_required",
+                message="Select at least one day for the schedule.",
+            )
         start_str = start_time.strftime("%H:%M")
         end_str = end_time.strftime("%H:%M")
         if start_str == end_str:
-            raise ServiceValidationError(
-                "Schedule start and end times must be different."
+            _raise_service_validation(
+                "battery_schedule_times_different",
+                message="Schedule start and end times must be different.",
             )
         if not 5 <= int(limit) <= 100:
-            raise ServiceValidationError(
-                f"{str(schedule_type).upper()} schedule limit must be between 5 and 100."
+            schedule_type_label = str(schedule_type).upper()
+            _raise_service_validation(
+                "battery_schedule_limit_range",
+                placeholders={
+                    "schedule_type": schedule_type_label,
+                    "minimum": "5",
+                    "maximum": "100",
+                },
+                message=(
+                    f"{schedule_type_label} schedule limit must be between 5 and 100."
+                ),
             )
         return start_str, end_str
 
@@ -271,13 +297,20 @@ def async_setup_services(
         if valid is None and "isValid" in result:
             valid = coerce_optional_bool(result.get("isValid"))
         if valid is False:
-            raise ServiceValidationError(
-                str(
-                    result.get(
-                        "message",
-                        "Schedule rejected by the Enphase validation endpoint.",
-                    )
+            raw_message = result.get("message")
+            if isinstance(raw_message, str) and raw_message.strip():
+                detail = raw_message.strip()
+                _raise_service_validation(
+                    "battery_schedule_validation_rejected_detail",
+                    placeholders={"message": detail},
+                    message=(
+                        "Schedule rejected by the Enphase validation endpoint: "
+                        f"{detail}"
+                    ),
                 )
+            _raise_service_validation(
+                "battery_schedule_validation_rejected",
+                message="Schedule rejected by the Enphase validation endpoint.",
             )
         if valid is not None and "valid" not in result:
             return {**result, "valid": bool(valid)}
@@ -517,7 +550,10 @@ def async_setup_services(
     async def _svc_add_schedule(call: ServiceCall) -> None:
         coord = await _resolve_single_site_coordinator(call)
         if not coord.battery_write_access_confirmed:
-            raise ServiceValidationError("Battery schedule editing is unavailable.")
+            _raise_service_validation(
+                "battery_schedule_editing_unavailable",
+                message="Battery schedule editing is unavailable.",
+            )
         schedule_type = str(call.data["schedule_type"]).lower()
         days = sorted({int(day) for day in call.data["days"]})
         limit = int(call.data["limit"])
@@ -537,7 +573,10 @@ def async_setup_services(
         await _validate_schedule_with_api(coord, schedule_type)
         creator = getattr(coord.client, "create_battery_schedule", None)
         if not callable(creator):
-            raise ServiceValidationError("Battery schedule API is unavailable.")
+            _raise_service_validation(
+                "battery_schedule_api_unavailable",
+                message="Battery schedule API is unavailable.",
+            )
         try:
             await creator(
                 schedule_type=str(schedule_type).upper(),
@@ -560,17 +599,29 @@ def async_setup_services(
     async def _svc_update_schedule(call: ServiceCall) -> None:
         coord = await _resolve_single_site_coordinator(call)
         if not coord.battery_write_access_confirmed:
-            raise ServiceValidationError("Battery schedule editing is unavailable.")
+            _raise_service_validation(
+                "battery_schedule_editing_unavailable",
+                message="Battery schedule editing is unavailable.",
+            )
         if not call.data.get("confirm"):
-            raise ServiceValidationError("Confirmation required to update a schedule.")
+            _raise_service_validation(
+                "battery_schedule_update_confirm_required",
+                message="Confirmation required to update a schedule.",
+            )
         schedule_id = str(call.data["schedule_id"]).strip()
         if not SCHEDULE_ID_PATTERN.match(schedule_id):
-            raise ServiceValidationError(f"Invalid schedule ID: {schedule_id}")
+            _raise_service_validation(
+                "battery_schedule_id_invalid",
+                placeholders={"schedule_id": schedule_id},
+                message=f"Invalid schedule ID: {schedule_id}",
+            )
         schedule_inventory = _schedule_inventory_by_id(coord)
         known_ids = set(schedule_inventory)
         if known_ids and schedule_id not in known_ids:
-            raise ServiceValidationError(
-                f"Schedule ID not found in current data: {schedule_id}"
+            _raise_service_validation(
+                "battery_schedule_id_not_found",
+                placeholders={"schedule_id": schedule_id},
+                message=f"Schedule ID not found in current data: {schedule_id}",
             )
         existing_schedule = schedule_inventory.get(schedule_id)
         schedule_type = (
@@ -597,7 +648,10 @@ def async_setup_services(
         await _validate_schedule_with_api(coord, schedule_type)
         updater = getattr(coord.client, "update_battery_schedule", None)
         if not callable(updater):
-            raise ServiceValidationError("Battery schedule API is unavailable.")
+            _raise_service_validation(
+                "battery_schedule_api_unavailable",
+                message="Battery schedule API is unavailable.",
+            )
         try:
             await updater(
                 schedule_id,
@@ -624,24 +678,36 @@ def async_setup_services(
     async def _svc_delete_schedule(call: ServiceCall) -> None:
         coord = await _resolve_single_site_coordinator(call)
         if not coord.battery_write_access_confirmed:
-            raise ServiceValidationError("Battery schedule editing is unavailable.")
+            _raise_service_validation(
+                "battery_schedule_editing_unavailable",
+                message="Battery schedule editing is unavailable.",
+            )
         if not call.data.get("confirm"):
-            raise ServiceValidationError("Confirmation required to delete a schedule.")
+            _raise_service_validation(
+                "battery_schedule_delete_confirm_required",
+                message="Confirmation required to delete a schedule.",
+            )
         raw_schedule_ids = call.data.get("schedule_ids")
         if raw_schedule_ids:
             schedule_ids = _normalize_schedule_ids(raw_schedule_ids)
         else:
             schedule_ids = _normalize_schedule_ids(call.data.get("schedule_id"))
         if not schedule_ids:
-            raise ServiceValidationError("Provide at least one schedule ID to delete.")
+            _raise_service_validation(
+                "battery_schedule_ids_required",
+                message="Provide at least one schedule ID to delete.",
+            )
         invalid_ids = [
             schedule_id
             for schedule_id in schedule_ids
             if not SCHEDULE_ID_PATTERN.match(schedule_id)
         ]
         if invalid_ids:
-            raise ServiceValidationError(
-                f"Invalid schedule ID(s): {', '.join(invalid_ids)}"
+            ids = ", ".join(invalid_ids)
+            _raise_service_validation(
+                "battery_schedule_ids_invalid",
+                placeholders={"schedule_ids": ids},
+                message=f"Invalid schedule ID(s): {ids}",
             )
         known_ids = _known_schedule_ids(coord)
         if known_ids:
@@ -651,12 +717,18 @@ def async_setup_services(
                 if schedule_id not in known_ids
             ]
             if missing:
-                raise ServiceValidationError(
-                    f"Schedule ID(s) not found in current data: {', '.join(missing)}"
+                ids = ", ".join(missing)
+                _raise_service_validation(
+                    "battery_schedule_ids_not_found",
+                    placeholders={"schedule_ids": ids},
+                    message=f"Schedule ID(s) not found in current data: {ids}",
                 )
         deleter = getattr(coord.client, "delete_battery_schedule", None)
         if not callable(deleter):
-            raise ServiceValidationError("Battery schedule API is unavailable.")
+            _raise_service_validation(
+                "battery_schedule_api_unavailable",
+                message="Battery schedule API is unavailable.",
+            )
         schedule_inventory = _schedule_inventory_by_id(coord)
         requested_schedule_type = call.data.get("schedule_type")
         for schedule_id in schedule_ids:
@@ -683,7 +755,10 @@ def async_setup_services(
     async def _svc_validate_schedule(call: ServiceCall) -> dict[str, object]:
         coord = await _resolve_single_site_coordinator(call)
         if not coord.battery_write_access_confirmed:
-            raise ServiceValidationError("Battery schedule editing is unavailable.")
+            _raise_service_validation(
+                "battery_schedule_editing_unavailable",
+                message="Battery schedule editing is unavailable.",
+            )
         result = await _validate_schedule_with_api(
             coord, str(call.data["schedule_type"]).lower()
         )

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Schedule update conflicts with an existing battery schedule."
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Schedule update conflicts with an existing battery schedule: {message}"
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Charging mode selection is unavailable while the Enphase scheduler service is down."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Select at least one day for the schedule."
+    },
+    "battery_schedule_times_different": {
+      "message": "Schedule start and end times must be different."
+    },
+    "battery_schedule_limit_range": {
+      "message": "{schedule_type} schedule limit must be between {minimum} and {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Schedule rejected by the Enphase validation endpoint."
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Schedule rejected by the Enphase validation endpoint: {message}"
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Battery schedule editing is unavailable."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Battery schedule API is unavailable."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Confirmation required to update a schedule."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Confirmation required to delete a schedule."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Invalid schedule ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Schedule ID not found in current data: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Provide at least one schedule ID to delete."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Invalid schedule ID(s): {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Schedule ID(s) not found in current data: {schedule_ids}"
     }
   },
   "options": {

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -6,7 +6,7 @@ import re
 from homeassistant.components.switch import SwitchEntity
 from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError, ServiceValidationError
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -40,6 +40,7 @@ from .runtime_helpers import (
     inventory_type_device_info as _type_device_info,
 )
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
+from .service_validation import raise_translated_service_validation
 
 PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
@@ -955,9 +956,14 @@ class AppAuthenticationSwitch(EnphaseBaseEntity, SwitchEntity):
             self._coord.mark_auth_settings_available()
         except AuthSettingsUnavailable as err:
             self._coord.note_auth_settings_unavailable(err)
-            raise HomeAssistantError(
-                "Authentication settings are unavailable while the Enphase service is down."
-            ) from err
+            raise_translated_service_validation(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.auth_settings_service_unavailable",
+                message=(
+                    "Authentication settings are unavailable while the Enphase "
+                    "service is down."
+                ),
+            )
         self._coord.set_app_auth_cache(self._sn, True)
         await self._coord.async_request_refresh()
 
@@ -967,9 +973,14 @@ class AppAuthenticationSwitch(EnphaseBaseEntity, SwitchEntity):
             self._coord.mark_auth_settings_available()
         except AuthSettingsUnavailable as err:
             self._coord.note_auth_settings_unavailable(err)
-            raise HomeAssistantError(
-                "Authentication settings are unavailable while the Enphase service is down."
-            ) from err
+            raise_translated_service_validation(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.auth_settings_service_unavailable",
+                message=(
+                    "Authentication settings are unavailable while the Enphase "
+                    "service is down."
+                ),
+            )
         self._coord.set_app_auth_cache(self._sn, False)
         await self._coord.async_request_refresh()
 

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -133,220 +133,220 @@
       "message": "Графикът се припокрива със съществуващия {schedule_label}. Коригирайте го или го деактивирайте първо."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Понастоящем няма налични устройства с AC батерия."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Настройките за удостоверяване не са налични, докато услугата Enphase не работи."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Актуализациите на профила на батерията не са разрешени за този акаунт."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Актуализациите на настройките на батерията не са разрешени за този акаунт."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Друга актуализация на профила на батерията вече е в ход."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Друга актуализация на настройките на батерията вече е в ход."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Актуализациите на профила на батерията не са налични."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Не са налични актуализации на настройките на батерията."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Не са налични актуализации на батерията."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Актуализациите на батерията не са разрешени за този акаунт."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Актуализацията на профила на батерията е заявена твърде бързо. Моля, изчакайте и опитайте отново."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Актуализацията на настройките на батерията е заявена твърде бързо. Моля, изчакайте и опитайте отново."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Достъпът за запис на батерията не можа да бъде потвърден. Опреснете и опитайте отново."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Актуализацията на графика беше отхвърлена от Enphase (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Актуализацията на графика не можа да бъде удостоверена. Повторно удостоверяване и опитайте отново."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Графикът е в конфликт със съществуващия график за заустване към мрежата. Първо коригирайте или деактивирайте този график."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Графикът е в конфликт със съществуващия график за ограничаване на разреждането на батерията. Първо коригирайте или деактивирайте този график."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Графикът е в конфликт със съществуващия график за таксуване от мрежата. Първо коригирайте или деактивирайте този график."
     },
     "schedule_update_conflict": {
       "message": "Актуализацията на графика е в конфликт със съществуващ график на батерията."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Профилът на батерията не е наличен."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Актуализацията на профила на батерията беше отхвърлена от Enphase (HTTP 403 забранен)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Актуализацията на профила на батерията не може да бъде удостоверена. Повторно удостоверяване и опитайте отново."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Полезният товар на настройките на батерията не е наличен."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Актуализацията на настройките на батерията беше отхвърлена от Enphase (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Актуализацията на настройките на батерията не може да бъде удостоверена. Повторно удостоверяване и опитайте отново."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Пълният резервен резерв е фиксиран на 100%."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Резервът на батерията не е наличен."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Спестовният профил трябва да е активен."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Настройките на профила за спестявания не са налични."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Избраният профил на батерията не се поддържа."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Настройката за зареждане от мрежата не е налична."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Зареждането от превключване на мрежата не е приложено от Enphase."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Таксуването от графика на мрежата не е налично."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Началният и крайният час на графика за зареждане от мрежата трябва да са различни."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Превключването на графика за таксуване от мрежата не е приложено от Enphase."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Първо трябва да се активира таксуването от мрежата."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Промяна в графика чака синхронизиране на Envoy. моля изчакайте"
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Графикът за зареждане от мрежата е невалиден."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "API за график не е наличен за тази клиентска версия."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Няма съществуващ график за зареждане от мрежата."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Създайте {schedule_label} в планировчика на IQ Battery, преди да го активирате."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} в момента не се излага от Enphase за този сайт. Изчакайте синхронизирането на графика да завърши, след това опреснете и опитайте отново."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Превключването {schedule_label} не е приложено от Enphase."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "първичният запис е отхвърлен"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "Началният и крайният час на {schedule_label} трябва да са различни."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Графикът за изхвърляне към мрежата е невалиден."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Няма наличен съществуващ график за {schedule_label_lower}."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "Графикът на {schedule_label} не е наличен."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "Графикът на {schedule_label} е невалиден."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Текущият график на {schedule_label_lower} е невалиден."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "Графикът на {schedule_label} трябва да бъде между {minimum} и {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "Графикът за {schedule_label} трябва да бъде поне {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Текущите часове по график не са налични."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Графикът за таксуване от мрежата трябва да бъде между {minimum} и {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Графикът за таксуване от мрежата трябва да бъде поне {minimum}%."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Нивото на изключване на батерията не е налично."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Нивото на изключване на батерията е невалидно."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Нивото на изключване на батерията трябва да е между {minimum} и {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Отказът за предупреждение за буря не е наличен."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Неуспешно отказване за предупреждение за буря за предупреждение(я) за {count}."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Актуализациите на Storm Guard не са разрешени за този акаунт."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Настройките на Storm Guard не са налични."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Актуализацията на Storm Guard беше отхвърлена от Enphase (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Актуализацията на Storm Guard не можа да бъде удостоверена. Повторно удостоверяване и опитайте отново."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Избраният системен профил не е наличен."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Актуализацията на системния профил беше отхвърлена от Enphase (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Актуализацията на системния профил не можа да бъде удостоверена. Повторно удостоверяване и опитайте отново."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Неуспешна актуализация на системния профил."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Актуализирането на системния профил не бе успешно поради мрежова грешка. Опитайте отново."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Актуализацията на системния профил изтече. Опитайте отново."
     },
     "scheduler_service_unavailable": {
       "message": "Изборът на режим на зареждане не е наличен, докато услугата за планиране на Enphase не работи."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "Избраното целево състояние на зареждане на променливотокова батерия не е налично."
     },
     "battery_schedule_day_required": {
       "message": "Изберете поне един ден за графика."

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Графикът се припокрива със съществуващия {schedule_label}. Коригирайте го или го деактивирайте първо."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Актуализацията на графика е в конфликт със съществуващ график на батерията."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Изборът на режим на зареждане не е наличен, докато услугата за планиране на Enphase не работи."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Изберете поне един ден за графика."
+    },
+    "battery_schedule_times_different": {
+      "message": "Началният и крайният час на графика трябва да са различни."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Графикът на {schedule_type} трябва да бъде между {minimum} и {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Графикът е отхвърлен от крайната точка за валидиране на Enphase."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Редактирането на графика на батерията не е налично."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "API за график на батерията не е наличен."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Необходимо е потвърждение за актуализиране на график."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Изисква се потвърждение за изтриване на график."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Невалиден ID на графика: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "ИД на график не е намерен в текущите данни: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Предоставете поне един идентификатор на график за изтриване."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Невалидни ИД на графика: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Идентификационните номера на графика не са намерени в текущите данни: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Графикът е отхвърлен от крайната точка за валидиране на Enphase: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Актуализацията на графика е в конфликт със съществуващ график на батерията: {message}"
     }
   },
   "options": {
@@ -157,11 +418,12 @@
           "api_timeout": "Изчакване на API (s)",
           "nominal_voltage": "Номинално напрежение (V)",
           "session_history_interval": "Интервал на историята на сесиите (min)",
-          "schedule_sync_enabled": "Активирайте поддръжката на Scheduler",
+          "schedule_sync_enabled": "Активиране на EV Charger Scheduler",
           "reauth": "Стартиране на повторна автентикация",
           "forget_password": "Забрави запазената парола",
           "type_heatpump": "Термопомпа",
-          "type_ac_battery": "AC батерия"
+          "type_ac_battery": "AC батерия",
+          "battery_schedules_enabled": "Активирайте програмата за планиране на батерията"
         },
         "data_description": {
           "type_envoy": "Включва диагностика за свързаността на шлюза и електромерите.",
@@ -174,11 +436,12 @@
           "api_timeout": "Секунди преди заявките към API да изтекат.",
           "nominal_voltage": "Резервно напрежение за оценка на мощността на зарядното.",
           "session_history_interval": "Минути за изчакване между извличанията на историята на сесиите в облака.",
-          "schedule_sync_enabled": "Управление на управлението на графика на Enphase",
+          "schedule_sync_enabled": "Управлявайте графици за зарядно за IQ EV",
           "reauth": "Стартирайте процеса на вход за обновяване на данните без да премахвате интеграцията.",
           "forget_password": "Премахва запазената парола. Автоматичното обновяване вече няма да се опитва.",
           "type_heatpump": "Включва сензори за състояние, диагностика и потребление на термопомпата.",
-          "type_ac_battery": "Включва сензори за AC батерията и контроли за режим на заспиване, когато са налични."
+          "type_ac_battery": "Включва сензори за AC батерията и контроли за режим на заспиване, когато са налични.",
+          "battery_schedules_enabled": "Управлявайте графици за IQ батерия"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Стартиране на повторна автентикация",
           "forget_password": "Забрави запазената парола",
           "type_heatpump": "Термопомпа",
-          "type_ac_battery": "AC батерия"
+          "type_ac_battery": "AC батерия",
+          "battery_schedules_enabled": "Активирайте програмата за планиране на батерията"
         },
         "data_description": {
           "type_envoy": "Включва диагностика за свързаността на шлюза и електромерите.",
@@ -216,7 +480,8 @@
           "reauth": "Стартирайте процеса на вход за обновяване на данните без да премахвате интеграцията.",
           "forget_password": "Премахва запазената парола. Автоматичното обновяване вече няма да се опитва.",
           "type_heatpump": "Включва сензори за състояние, диагностика и потребление на термопомпата.",
-          "type_ac_battery": "Включва сензори за AC батерията и контроли за режим на заспиване, когато са налични."
+          "type_ac_battery": "Включва сензори за AC батерията и контроли за режим на заспиване, когато са налични.",
+          "battery_schedules_enabled": "Управлявайте графици за IQ батерия"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Износ към мрежата",
           "battery_charge": "Зареждане на батерията",
           "battery_discharge": "Разреждане на батерията"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Последен отчет на {serial}"
+      },
+      "battery_cfg_schedules": {
+        "name": "Графици за CFG на батерията"
+      },
+      "battery_dtg_schedules": {
+        "name": "Графици за DTG на батерията"
+      },
+      "battery_rbd_schedules": {
+        "name": "Графици за RBD на батерията"
+      },
+      "battery_schedule_summary": {
+        "name": "Резюме на графика на батерията"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Лимит за ограничаване на разреждането на батерията"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Нов график на батерията"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "График на батерията"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "График за неделя"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Нов график на батерията в понеделник"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Нов график на батерията във вторник"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Нов график на батерията в сряда"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Нов график на батерията в четвъртък"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Нов график на батерията в петък"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Нов график на батерията в събота"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Нов график на батерията в неделя"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "График на батерията в понеделник"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "График на батерията във вторник"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "График на батерията в сряда"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "График на батерията в четвъртък"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "График за батерията в петък"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "График на батериите в събота"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "График на батериите в неделя"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "График"
+      },
+      "battery_new_schedule_type": {
+        "name": "Тип график на батерията"
+      },
+      "battery_schedule_selected": {
+        "name": "График на батерията"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Създаване на нов график"
+      },
+      "battery_schedule_add": {
+        "name": "Добавяне на график на батерията"
+      },
+      "battery_schedule_delete": {
+        "name": "Изтриване на графика на батерията"
+      },
+      "battery_schedule_refresh": {
+        "name": "Обновяване на графика на батерията"
+      },
+      "battery_schedule_save": {
+        "name": "Запазване на графика на батерията"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Краен час на графика"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Батерия Нов график Начално време"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Краен час на новия график на батерията"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Начално време по график на батерията"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Краен час на графика на батерията"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "ID на обекта",
           "description": "Enphase ID на обекта (по избор; определя се от целевото устройство)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Принудително опресняване",
+      "description": "Обновете незабавно данните за графика на батерията от облака Enphase.",
+      "sections": {
+        "advanced": {
+          "name": "Разширени опции"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Идентификатор на обекта",
+          "description": "Незадължителен идентификатор на обекта; открива се автоматично, когато е избрано устройство на обекта."
+        },
+        "config_entry_id": {
+          "name": "Конфигуриране на идентификатор на запис",
+          "description": "Незадължителен идентификатор за въвеждане на конфигурация за единичен запис в Enphase сайт."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Добавяне на график за батерията",
+      "description": "Създайте график на батерията за CFG, DTG или RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Разширени опции"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Вид график",
+          "description": "Семейство график на батерията: cfg, dtg или rbd."
+        },
+        "start_time": {
+          "name": "Начално време",
+          "description": "Насрочете начален час."
+        },
+        "end_time": {
+          "name": "Краен час",
+          "description": "Насрочване на краен час."
+        },
+        "limit": {
+          "name": "Лимит на таксуване",
+          "description": "Максимално ниво на зареждане на батерията (%)."
+        },
+        "days": {
+          "name": "Дни",
+          "description": "Списък на активните делнични дни, използващи понеделник=1 до неделя=7."
+        },
+        "site_id": {
+          "name": "Идентификатор на обекта",
+          "description": "Незадължителен идентификатор на обекта; открива се автоматично, когато е избрано устройство на обекта."
+        },
+        "config_entry_id": {
+          "name": "Конфигуриране на идентификатор на запис",
+          "description": "Незадължителен идентификатор за въвеждане на конфигурация за единичен запис в Enphase сайт."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Актуализиране на графика на батерията",
+      "description": "Актуализирайте график на батерията по ID на графика.",
+      "sections": {
+        "advanced": {
+          "name": "Разширени опции"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Насрочване на документ за самоличност",
+          "description": "Съществуващ идентификатор на графика на Enphase батерията."
+        },
+        "schedule_type": {
+          "name": "Вид график",
+          "description": "Семейство график на батерията: cfg, dtg или rbd."
+        },
+        "start_time": {
+          "name": "Начално време",
+          "description": "Насрочете начален час."
+        },
+        "end_time": {
+          "name": "Краен час",
+          "description": "Насрочване на краен час."
+        },
+        "limit": {
+          "name": "Лимит на таксуване",
+          "description": "Максимално ниво на зареждане на батерията (%)."
+        },
+        "days": {
+          "name": "Дни",
+          "description": "Списък на активните делнични дни, използващи понеделник=1 до неделя=7."
+        },
+        "confirm": {
+          "name": "Потвърждаване",
+          "description": "Задайте на „вярно “, за да потвърдите актуализацията на графика."
+        },
+        "site_id": {
+          "name": "Идентификатор на обекта",
+          "description": "Незадължителен идентификатор на обекта; открива се автоматично, когато е избрано устройство на обекта."
+        },
+        "config_entry_id": {
+          "name": "Конфигуриране на идентификатор на запис",
+          "description": "Незадължителен идентификатор за въвеждане на конфигурация за единичен запис в Enphase сайт."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Изтриване на графика на батерията",
+      "description": "Изтрийте един или повече графици на батерията по ID на график.",
+      "sections": {
+        "advanced": {
+          "name": "Разширени опции"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Насрочване на документ за самоличност",
+          "description": "Идентификатор на график на единична Enphase батерия за изтриване."
+        },
+        "schedule_ids": {
+          "name": "Насрочване на документи за самоличност",
+          "description": "Незадължително въвеждане, разделено със запетая, или въвеждане на списък за множество идентификатори на график."
+        },
+        "confirm": {
+          "name": "Потвърждаване",
+          "description": "Задайте на „вярно “, за да потвърдите изтриването на графика."
+        },
+        "site_id": {
+          "name": "Идентификатор на обекта",
+          "description": "Незадължителен идентификатор на обекта; открива се автоматично, когато е избрано устройство на обекта."
+        },
+        "config_entry_id": {
+          "name": "Конфигуриране на идентификатор на запис",
+          "description": "Незадължителен идентификатор за въвеждане на конфигурация за единичен запис в Enphase сайт."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Потвърдете графика на батерията",
+      "description": "Проверете дали редактирането на графика на батерията е налично за избраното семейство графици.",
+      "sections": {
+        "advanced": {
+          "name": "Разширени опции"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Вид график",
+          "description": "Семейство график на батерията: cfg, dtg или rbd."
+        },
+        "site_id": {
+          "name": "Идентификатор на обекта",
+          "description": "Незадължителен идентификатор на обекта; открива се автоматично, когато е избрано устройство на обекта."
+        },
+        "config_entry_id": {
+          "name": "Конфигуриране на идентификатор на запис",
+          "description": "Незадължителен идентификатор за въвеждане на конфигурация за единичен запис в Enphase сайт."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -133,220 +133,220 @@
       "message": "Plán se překrývá se stávajícím {schedule_label}. Nejprve tento plán upravte nebo deaktivujte."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Aktuálně nejsou k dispozici žádná zařízení AC Battery."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Když je služba Enphase mimo provoz, nastavení ověřování není k dispozici."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Aktualizace profilu baterie nejsou pro tento účet povoleny."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Aktualizace nastavení baterie nejsou pro tento účet povoleny."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Další aktualizace profilu baterie již probíhá."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Další aktualizace nastavení baterie již probíhá."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Aktualizace profilu baterie nejsou k dispozici."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Aktualizace nastavení baterie nejsou k dispozici."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Aktualizace baterie nejsou k dispozici."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Aktualizace baterie nejsou pro tento účet povoleny."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Aktualizace profilu baterie byla požadována příliš rychle. Počkejte prosím a zkuste to znovu."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Aktualizace nastavení baterie byla požadována příliš rychle. Počkejte prosím a zkuste to znovu."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Přístup k zápisu z baterie nelze potvrdit. Obnovte a zkuste to znovu."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Aktualizace plánu byla zamítnuta Enphase (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Aktualizaci plánu se nepodařilo ověřit. Znovu se ověřte a zkuste to znovu."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Plán je v konfliktu se stávajícím plánem vybíjení do sítě. Nejprve upravte nebo deaktivujte tento plán."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Plán je v konfliktu se stávajícím plánem omezení vybití baterie. Nejprve upravte nebo deaktivujte tento plán."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Plán je v konfliktu se stávajícím plánem nabíjení ze sítě. Nejprve upravte nebo deaktivujte tento plán."
     },
     "schedule_update_conflict": {
       "message": "Aktualizace plánu je v konfliktu se stávajícím plánem baterie."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Profil baterie není k dispozici."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Aktualizace profilu baterie byla zamítnuta Enphase (HTTP 403 zakázáno)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Aktualizaci profilu baterie se nepodařilo ověřit. Znovu se ověřte a zkuste to znovu."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Užitečná zátěž nastavení baterie není k dispozici."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Aktualizace nastavení baterie byla zamítnuta Enphase (HTTP 403 zakázáno)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Aktualizaci nastavení baterie se nepodařilo ověřit. Znovu se ověřte a zkuste to znovu."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Plná záloha je pevně nastavena na 100 %."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Rezerva baterie není k dispozici."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Spořicí profil musí být aktivní."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Nastavení profilu ukládání nejsou k dispozici."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Vybraný profil baterie není podporován."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Nabíjení z nastavení sítě není k dispozici."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Enphase nepoužilo nabíjení z přepínače mřížky."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Poplatek ze sítě není k dispozici."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Čas začátku a konce plánu nabíjení ze sítě se musí lišit."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Enphase nepoužil přepínač plánu nabíjení z mřížky."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Nejprve musí být povoleno nabíjení ze sítě."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Změna plánu čeká na synchronizaci Envoy. Čekejte prosím."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Čas plánu nabíjení ze sítě je neplatný."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Rozhraní API není v této klientské verzi k dispozici."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Není k dispozici žádný stávající plán nabíjení ze sítě."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Před aktivací vytvořte {schedule_label} v plánovači baterie IQ."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} aktuálně není pro tento web vystaven Enphase. Počkejte na dokončení synchronizace plánu, poté obnovte stránku a zkuste to znovu."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Enphase nepoužil přepínač {schedule_label}."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "primární zápis zamítnut"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "Čas začátku a konce {schedule_label} se musí lišit."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Plánovaný čas vypouštění do sítě je neplatný."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Není k dispozici žádný stávající rozvrh {schedule_label_lower}."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "Plán {schedule_label} není k dispozici."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "Čas plánu {schedule_label} je neplatný."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Aktuální plánovací čas {schedule_label_lower} je neplatný."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "Limit plánu {schedule_label} musí být mezi {minimum} a {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "Limit plánu {schedule_label} musí být alespoň {minimum} %."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Aktuální rozvrhové časy nejsou k dispozici."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Limit plánu nabíjení ze sítě musí být mezi {minimum} a {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Limit plánu nabíjení ze sítě musí být alespoň {minimum} %."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Úroveň vypínání baterie není k dispozici."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Úroveň vypínání baterie je neplatná."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Úroveň vypínání baterie musí být mezi {minimum} a {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Odhlášení Storm Alert není dostupné."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Odhlášení Storm Alert selhalo pro {count} výstrahy."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Aktualizace Storm Guard nejsou pro tento účet povoleny."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Nastavení Storm Guard nejsou dostupná."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Aktualizace Storm Guard byla zamítnuta Enphase (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Aktualizaci Storm Guard nebylo možné ověřit. Znovu se ověřte a zkuste to znovu."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Vybraný systémový profil není k dispozici."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Aktualizace systémového profilu byla zamítnuta Enphase (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Aktualizaci systémového profilu se nepodařilo ověřit. Znovu se ověřte a zkuste to znovu."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Aktualizace systémového profilu se nezdařila."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Aktualizace systémového profilu se nezdařila kvůli chybě sítě. Zkuste to znovu."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Časový limit aktualizace systémového profilu vypršel. Zkuste to znovu."
     },
     "scheduler_service_unavailable": {
       "message": "Výběr režimu nabíjení není dostupný, pokud je služba plánovače Enphase mimo provoz."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "Vybraný cílový stav nabití AC baterie není k dispozici."
     },
     "battery_schedule_day_required": {
       "message": "Vyberte pro rozvrh alespoň jeden den."
@@ -1420,7 +1420,7 @@
         "name": "Baterie - nový harmonogram sobota"
       },
       "battery_new_schedule_sun": {
-        "name": "Battery New Schedule Sunday"
+        "name": "Baterie Nový rozvrh neděle"
       },
       "battery_schedule_edit_mon": {
         "name": "Plán baterií v pondělí"
@@ -1441,7 +1441,7 @@
         "name": "Plán baterie na sobotu"
       },
       "battery_schedule_edit_sun": {
-        "name": "Battery Schedule Sunday"
+        "name": "Plán baterie v neděli"
       }
     },
     "select": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Plán se překrývá se stávajícím {schedule_label}. Nejprve tento plán upravte nebo deaktivujte."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Aktualizace plánu je v konfliktu se stávajícím plánem baterie."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Výběr režimu nabíjení není dostupný, pokud je služba plánovače Enphase mimo provoz."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Vyberte pro rozvrh alespoň jeden den."
+    },
+    "battery_schedule_times_different": {
+      "message": "Čas začátku a konce plánu se musí lišit."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Limit plánu {schedule_type} musí být mezi {minimum} a {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Plán byl zamítnut koncovým bodem ověření Enphase."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Úprava plánu baterie není k dispozici."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Rozhraní API rozvrhu baterie není k dispozici."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "K aktualizaci plánu je vyžadováno potvrzení."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Pro smazání plánu je vyžadováno potvrzení."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Neplatné ID plánu: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "ID plánu nebylo v aktuálních datech nalezeno: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Zadejte alespoň jedno ID plánu, které chcete odstranit."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Neplatná ID plánu: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "ID plánu nenalezeno v aktuálních datech: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Plán zamítnut koncovým bodem ověření Enphase: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Aktualizace plánu je v konfliktu se stávajícím plánem baterie: {message}"
     }
   },
   "options": {
@@ -157,11 +418,12 @@
           "api_timeout": "Časový limit API (s)",
           "nominal_voltage": "Jmenovité napětí (V)",
           "session_history_interval": "Interval historie relací (min)",
-          "schedule_sync_enabled": "Povolit podporu plánovače",
+          "schedule_sync_enabled": "Povolit plánovač EV Charger Scheduler",
           "reauth": "Spustit reautentizaci",
           "forget_password": "Zapomenout uložené heslo",
           "type_heatpump": "Tepelné čerpadlo",
-          "type_ac_battery": "AC baterie"
+          "type_ac_battery": "AC baterie",
+          "battery_schedules_enabled": "Povolit Plánovač baterie"
         },
         "data_description": {
           "type_envoy": "Zahrnuje diagnostiku konektivity brány a měřidel.",
@@ -174,11 +436,12 @@
           "api_timeout": "Sekundy, než požadavky API vyprší.",
           "nominal_voltage": "Záložní napětí pro odhad výkonu nabíječky.",
           "session_history_interval": "Minuty čekání mezi načítáním historie relací z cloudu.",
-          "schedule_sync_enabled": "Správa správy plánu Enphase",
+          "schedule_sync_enabled": "Správa plánů nabíječek IQ EV",
           "reauth": "Spusťte přihlašovací tok pro obnovení údajů bez odebrání integrace.",
           "forget_password": "Odstraní uložené heslo. Automatické obnovení již nebude prováděno.",
           "type_heatpump": "Zahrnuje senzory stavu, diagnostiky a spotřeby tepelného čerpadla.",
-          "type_ac_battery": "Zahrnuje senzory AC baterie a ovládání režimu spánku, pokud jsou k dispozici."
+          "type_ac_battery": "Zahrnuje senzory AC baterie a ovládání režimu spánku, pokud jsou k dispozici.",
+          "battery_schedules_enabled": "Správa rozvrhů baterií IQ"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Spustit reautentizaci",
           "forget_password": "Zapomenout uložené heslo",
           "type_heatpump": "Tepelné čerpadlo",
-          "type_ac_battery": "AC baterie"
+          "type_ac_battery": "AC baterie",
+          "battery_schedules_enabled": "Povolit Plánovač baterie"
         },
         "data_description": {
           "type_envoy": "Zahrnuje diagnostiku konektivity brány a měřidel.",
@@ -216,7 +480,8 @@
           "reauth": "Spusťte přihlašovací tok pro obnovení údajů bez odebrání integrace.",
           "forget_password": "Odstraní uložené heslo. Automatické obnovení již nebude prováděno.",
           "type_heatpump": "Zahrnuje senzory stavu, diagnostiky a spotřeby tepelného čerpadla.",
-          "type_ac_battery": "Zahrnuje senzory AC baterie a ovládání režimu spánku, pokud jsou k dispozici."
+          "type_ac_battery": "Zahrnuje senzory AC baterie a ovládání režimu spánku, pokud jsou k dispozici.",
+          "battery_schedules_enabled": "Správa rozvrhů baterií IQ"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Export do sítě",
           "battery_charge": "Nabíjení baterie",
           "battery_discharge": "Vybíjení baterie"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Naposledy hlášeno u {serial}"
+      },
+      "battery_cfg_schedules": {
+        "name": "Plány CFG baterií"
+      },
+      "battery_dtg_schedules": {
+        "name": "Plány DTG baterie"
+      },
+      "battery_rbd_schedules": {
+        "name": "Plány RBD baterií"
+      },
+      "battery_schedule_summary": {
+        "name": "Shrnutí plánu baterie"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Limit omezení vybíjení baterie"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Limit pro nový plán baterie"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Limit baterie"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Harmonogram neděle"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Baterie - nový harmonogram pondělí"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Úterý s novým rozvrhem baterií"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Battery New Schedule Středa"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Nový rozvrh baterií ve čtvrtek"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Pátek s novým rozvrhem baterií"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Baterie - nový harmonogram sobota"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Battery New Schedule Sunday"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Plán baterií v pondělí"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Plán baterií Úterý"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Plán baterií Středa"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Plán baterií ve čtvrtek"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Plán baterie v pátek"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Plán baterie na sobotu"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Battery Schedule Sunday"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Harmonogram"
+      },
+      "battery_new_schedule_type": {
+        "name": "Typ plánu baterie"
+      },
+      "battery_schedule_selected": {
+        "name": "Plán baterie"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Vytvořit nový harmonogram"
+      },
+      "battery_schedule_add": {
+        "name": "Plán baterie Přidat"
+      },
+      "battery_schedule_delete": {
+        "name": "Smazat plán baterie"
+      },
+      "battery_schedule_refresh": {
+        "name": "Obnovení plánu baterie"
+      },
+      "battery_schedule_save": {
+        "name": "Uložení rozvrhu baterie"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Čas konce harmonogramu"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Doba spuštění nového plánu"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Baterie Nový čas konce plánu"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Čas spuštění plánu baterie"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Čas ukončení plánu baterie"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "ID lokality",
           "description": "ID lokality Enphase (volitelné; určí se z cílového zařízení)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Vynutit aktualizaci",
+      "description": "Okamžitě obnovte data plánu baterie z cloudu Enphase.",
+      "sections": {
+        "advanced": {
+          "name": "Pokročilé možnosti"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "ID webu",
+          "description": "Volitelný identifikátor pracoviště; detekován automaticky, když je vybráno zařízení pracoviště."
+        },
+        "config_entry_id": {
+          "name": "ID vstupu konfigurace",
+          "description": "Volitelný identifikátor položky konfigurace pro jednu položku webu Enphase."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Přidat plán baterie",
+      "description": "Vytvořte plán baterie pro CFG, DTG nebo RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Pokročilé možnosti"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Typ plánu",
+          "description": "Rodina rozvrhu baterií: cfg, dtg nebo rbd."
+        },
+        "start_time": {
+          "name": "Čas zahájení",
+          "description": "Naplánujte datum/čas začátku"
+        },
+        "end_time": {
+          "name": "Čas ukončení",
+          "description": "Naplánujte čas ukončení"
+        },
+        "limit": {
+          "name": "Limit nabití",
+          "description": "Maximální stav nabití baterie (%)."
+        },
+        "days": {
+          "name": "Dny",
+          "description": "Seznam aktivních pracovních dnů s použitím pondělí=1 až neděle=7."
+        },
+        "site_id": {
+          "name": "ID webu",
+          "description": "Volitelný identifikátor pracoviště; detekován automaticky, když je vybráno zařízení pracoviště."
+        },
+        "config_entry_id": {
+          "name": "ID vstupu konfigurace",
+          "description": "Volitelný identifikátor položky konfigurace pro jednu položku webu Enphase."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Aktualizujte plán baterie",
+      "description": "Aktualizujte plán baterie podle ID plánu.",
+      "sections": {
+        "advanced": {
+          "name": "Pokročilé možnosti"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "ID rozvrhu",
+          "description": "Existující identifikátor plánu baterie Enphase."
+        },
+        "schedule_type": {
+          "name": "Typ plánu",
+          "description": "Rodina rozvrhu baterií: cfg, dtg nebo rbd."
+        },
+        "start_time": {
+          "name": "Čas zahájení",
+          "description": "Naplánujte datum/čas začátku"
+        },
+        "end_time": {
+          "name": "Čas ukončení",
+          "description": "Naplánujte čas ukončení"
+        },
+        "limit": {
+          "name": "Limit nabití",
+          "description": "Maximální stav nabití baterie (%)."
+        },
+        "days": {
+          "name": "Dny",
+          "description": "Seznam aktivních pracovních dnů s použitím pondělí=1 až neděle=7."
+        },
+        "confirm": {
+          "name": "Potvrdit",
+          "description": "Nastavením na hodnotu true potvrdíte aktualizaci plánu."
+        },
+        "site_id": {
+          "name": "ID webu",
+          "description": "Volitelný identifikátor pracoviště; detekován automaticky, když je vybráno zařízení pracoviště."
+        },
+        "config_entry_id": {
+          "name": "ID vstupu konfigurace",
+          "description": "Volitelný identifikátor položky konfigurace pro jednu položku webu Enphase."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Smazat Plán baterie",
+      "description": "Odstraňte jeden nebo více plánů baterie podle ID plánu.",
+      "sections": {
+        "advanced": {
+          "name": "Pokročilé možnosti"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "ID rozvrhu",
+          "description": "Identifikátor rozvrhu baterie Single Enphase, který chcete odstranit."
+        },
+        "schedule_ids": {
+          "name": "ID plánů",
+          "description": "Volitelný vstup oddělený čárkami nebo seznamem pro více identifikátorů plánu."
+        },
+        "confirm": {
+          "name": "Potvrdit",
+          "description": "Nastavením na hodnotu true potvrdíte odstranění plánu."
+        },
+        "site_id": {
+          "name": "ID webu",
+          "description": "Volitelný identifikátor pracoviště; detekován automaticky, když je vybráno zařízení pracoviště."
+        },
+        "config_entry_id": {
+          "name": "ID vstupu konfigurace",
+          "description": "Volitelný identifikátor položky konfigurace pro jednu položku webu Enphase."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Ověřte plán baterie",
+      "description": "Zkontrolujte, zda je pro vybranou rodinu plánů k dispozici úprava plánu baterie.",
+      "sections": {
+        "advanced": {
+          "name": "Pokročilé možnosti"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Typ plánu",
+          "description": "Rodina rozvrhu baterií: cfg, dtg nebo rbd."
+        },
+        "site_id": {
+          "name": "ID webu",
+          "description": "Volitelný identifikátor pracoviště; detekován automaticky, když je vybráno zařízení pracoviště."
+        },
+        "config_entry_id": {
+          "name": "ID vstupu konfigurace",
+          "description": "Volitelný identifikátor položky konfigurace pro jednu položku webu Enphase."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Tidsplanen overlapper den eksisterende {schedule_label}. Juster eller deaktiver først den pågældende tidsplan."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Planlæg opdatering er i konflikt med en eksisterende batteritidsplan."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Valg af opladningstilstand er ikke tilgængelig, mens Enphase-planlægningstjenesten er nede."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Vælg mindst én dag til tidsplanen."
+    },
+    "battery_schedule_times_different": {
+      "message": "Start- og sluttidspunkterne skal være forskellige."
+    },
+    "battery_schedule_limit_range": {
+      "message": "{schedule_type}-tidsplangrænsen skal være mellem {minimum} og {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Tidsplan afvist af Enphase-valideringsslutpunktet."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Redigering af batteritidsplan er ikke tilgængelig."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Batteritidsplan API er ikke tilgængelig."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Bekræftelse påkrævet for at opdatere en tidsplan."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Bekræftelse påkrævet for at slette en tidsplan."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Ugyldigt tidsplan-id: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Skema-id ikke fundet i aktuelle data: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Angiv mindst ét ​​tidsplan-id, der skal slettes."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Ugyldige tidsplan-id(er): {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Skema-id(er) ikke fundet i aktuelle data: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Tidsplan afvist af Enphase-valideringsslutpunktet: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Planlæg opdatering er i konflikt med en eksisterende batteritidsplan: {message}"
     }
   },
   "options": {
@@ -157,11 +418,12 @@
           "api_timeout": "API-timeout (s)",
           "nominal_voltage": "Nominel spænding (V)",
           "session_history_interval": "Sessionshistorik-interval (min)",
-          "schedule_sync_enabled": "Aktiver Scheduler Support",
+          "schedule_sync_enabled": "Aktiver EV Charger Scheduler",
           "reauth": "Start reautentificering",
           "forget_password": "Glem gemt adgangskode",
           "type_heatpump": "Varmepumpe",
-          "type_ac_battery": "AC-batteri"
+          "type_ac_battery": "AC-batteri",
+          "battery_schedules_enabled": "Aktiver Battery Scheduler"
         },
         "data_description": {
           "type_envoy": "Inkluderer gateway-forbindelse og målerdiagnostik.",
@@ -174,11 +436,12 @@
           "api_timeout": "Sekunder før API-anmodninger udløber.",
           "nominal_voltage": "Fallback-spænding brugt til effektestimat for laderen.",
           "session_history_interval": "Minutter at vente mellem hentninger af cloud-sessionhistorik.",
-          "schedule_sync_enabled": "Administrer Enphase tidsplanstyring",
+          "schedule_sync_enabled": "Administrer IQ EV Charger Schedules",
           "reauth": "Start loginflowet for at opdatere legitimationsoplysninger uden at fjerne integrationen.",
           "forget_password": "Fjerner den gemte adgangskode. Automatisk opdatering forsøges ikke længere.",
           "type_heatpump": "Inkluderer sensorer for varmepumpens status, diagnostik og forbrug.",
-          "type_ac_battery": "Omfatter AC-batterisensorer og styring af dvaletilstand, når de er tilgængelige."
+          "type_ac_battery": "Omfatter AC-batterisensorer og styring af dvaletilstand, når de er tilgængelige.",
+          "battery_schedules_enabled": "Administrer IQ batteri tidsplaner"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Start reautentificering",
           "forget_password": "Glem gemt adgangskode",
           "type_heatpump": "Varmepumpe",
-          "type_ac_battery": "AC-batteri"
+          "type_ac_battery": "AC-batteri",
+          "battery_schedules_enabled": "Aktiver Battery Scheduler"
         },
         "data_description": {
           "type_envoy": "Inkluderer gateway-forbindelse og målerdiagnostik.",
@@ -216,7 +480,8 @@
           "reauth": "Start loginflowet for at opdatere legitimationsoplysninger uden at fjerne integrationen.",
           "forget_password": "Fjerner den gemte adgangskode. Automatisk opdatering forsøges ikke længere.",
           "type_heatpump": "Inkluderer sensorer for varmepumpens status, diagnostik og forbrug.",
-          "type_ac_battery": "Omfatter AC-batterisensorer og styring af dvaletilstand, når de er tilgængelige."
+          "type_ac_battery": "Omfatter AC-batterisensorer og styring af dvaletilstand, når de er tilgængelige.",
+          "battery_schedules_enabled": "Administrer IQ batteri tidsplaner"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Neteksport",
           "battery_charge": "Batteriopladning",
           "battery_discharge": "Batteriafladning"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "{serial} sidst rapporteret"
+      },
+      "battery_cfg_schedules": {
+        "name": "Batteri CFG skemaer"
+      },
+      "battery_dtg_schedules": {
+        "name": "Batteri DTG tidsplaner"
+      },
+      "battery_rbd_schedules": {
+        "name": "Batteri RBD skemaer"
+      },
+      "battery_schedule_summary": {
+        "name": "Oversigt over batteritidsplan"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Grænse for begrænset batteriafladning"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Batteri Ny tidsplangrænse"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Batteritidsplangrænse"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Tidsplan søndag"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Batteri nyt skema mandag"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Batteri nyt skema tirsdag"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Batteri nyt skema onsdag"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Batteri nyt skema torsdag"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Batteri nyt skema fredag"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Batteri nyt skema lørdag"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Batteri nyt skema søndag"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Batteriplan mandag"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Batteriplan tirsdag"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Batteriplan onsdag"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Batteriplan torsdag"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Batteriplan fredag"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Batteriplan lørdag"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Batteri tidsplan søndag"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Tidsplan"
+      },
+      "battery_new_schedule_type": {
+        "name": "Batteritidsplantype"
+      },
+      "battery_schedule_selected": {
+        "name": "Batteritidsplan"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Opret ny tidsplan"
+      },
+      "battery_schedule_add": {
+        "name": "Batteritidsplan Tilføj"
+      },
+      "battery_schedule_delete": {
+        "name": "Batteriplan Slet"
+      },
+      "battery_schedule_refresh": {
+        "name": "Opdatering af batteritidsplan"
+      },
+      "battery_schedule_save": {
+        "name": "Batteritidsplanspare"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Sluttid for tidsplan"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Batteri Nyt Tidsplan Starttid"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Batteri Ny tidsplan Sluttid"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Starttid for batteriplan"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Sluttid for batteriplanlægning"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "Site-id",
           "description": "Enphase-site-id (valgfrit; findes via målenheden)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Tving opdatering",
+      "description": "Opdater batteritidsplandata fra Enphase-skyen med det samme.",
+      "sections": {
+        "advanced": {
+          "name": "Avancerede muligheder"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Side ID",
+          "description": "Valgfri webstedsidentifikator; registreres automatisk, når en webstedsenhed vælges."
+        },
+        "config_entry_id": {
+          "name": "Konfigurer indtastnings-id",
+          "description": "Valgfri konfigurationsindtastningsidentifikator for en enkelt Enphase-webstedsindtastning."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Tilføj batteritidsplan",
+      "description": "Opret en batteritidsplan for CFG, DTG eller RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Avancerede muligheder"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Tidsplan type",
+          "description": "Batteri tidsplan familie: cfg, dtg eller rbd."
+        },
+        "start_time": {
+          "name": "Starttid",
+          "description": "Planlagt Start dato/Tidspunkt"
+        },
+        "end_time": {
+          "name": "Sluttid",
+          "description": "Planlæg sluttidspunkt."
+        },
+        "limit": {
+          "name": "ladningsgrænse",
+          "description": "Maksimal batteriladningstilstand (%)."
+        },
+        "days": {
+          "name": "Dage",
+          "description": "Liste over aktive hverdage med mandag=1 til søndag=7."
+        },
+        "site_id": {
+          "name": "Side ID",
+          "description": "Valgfri webstedsidentifikator; registreres automatisk, når en webstedsenhed vælges."
+        },
+        "config_entry_id": {
+          "name": "Konfigurer indtastnings-id",
+          "description": "Valgfri konfigurationsindtastningsidentifikator for en enkelt Enphase-webstedsindtastning."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Opdater batteritidsplan",
+      "description": "Opdater en batteritidsplan efter tidsplan-id.",
+      "sections": {
+        "advanced": {
+          "name": "Avancerede muligheder"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Planlægnings-id",
+          "description": "Eksisterende Enphase batteri tidsplan identifikator."
+        },
+        "schedule_type": {
+          "name": "Tidsplan type",
+          "description": "Batteri tidsplan familie: cfg, dtg eller rbd."
+        },
+        "start_time": {
+          "name": "Starttid",
+          "description": "Planlagt Start dato/Tidspunkt"
+        },
+        "end_time": {
+          "name": "Sluttid",
+          "description": "Planlæg sluttidspunkt."
+        },
+        "limit": {
+          "name": "ladningsgrænse",
+          "description": "Maksimal batteriladningstilstand (%)."
+        },
+        "days": {
+          "name": "Dage",
+          "description": "Liste over aktive hverdage med mandag=1 til søndag=7."
+        },
+        "confirm": {
+          "name": "Bekræft",
+          "description": "Indstil til true for at bekræfte tidsplanopdateringen."
+        },
+        "site_id": {
+          "name": "Side ID",
+          "description": "Valgfri webstedsidentifikator; registreres automatisk, når en webstedsenhed vælges."
+        },
+        "config_entry_id": {
+          "name": "Konfigurer indtastnings-id",
+          "description": "Valgfri konfigurationsindtastningsidentifikator for en enkelt Enphase-webstedsindtastning."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Slet batteritidsplan",
+      "description": "Slet en eller flere batteriplaner efter tidsplan-id.",
+      "sections": {
+        "advanced": {
+          "name": "Avancerede muligheder"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Planlægnings-id",
+          "description": "Enkeltfaset batteri tidsplanidentifikator, der skal slettes."
+        },
+        "schedule_ids": {
+          "name": "Planlæg ID'er",
+          "description": "Valgfri kommasepareret eller listeindtastning for flere tidsplanidentifikatorer."
+        },
+        "confirm": {
+          "name": "Bekræft",
+          "description": "Indstil til true for at bekræfte sletning af tidsplanen."
+        },
+        "site_id": {
+          "name": "Side ID",
+          "description": "Valgfri webstedsidentifikator; registreres automatisk, når en webstedsenhed vælges."
+        },
+        "config_entry_id": {
+          "name": "Konfigurer indtastnings-id",
+          "description": "Valgfri konfigurationsindtastningsidentifikator for en enkelt Enphase-webstedsindtastning."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Valider batteritidsplan",
+      "description": "Kontroller, om redigering af batteritidsplan er tilgængelig for den valgte tidsplanfamilie.",
+      "sections": {
+        "advanced": {
+          "name": "Avancerede muligheder"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Tidsplan type",
+          "description": "Batteri tidsplan familie: cfg, dtg eller rbd."
+        },
+        "site_id": {
+          "name": "Side ID",
+          "description": "Valgfri webstedsidentifikator; registreres automatisk, når en webstedsenhed vælges."
+        },
+        "config_entry_id": {
+          "name": "Konfigurer indtastnings-id",
+          "description": "Valgfri konfigurationsindtastningsidentifikator for en enkelt Enphase-webstedsindtastning."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -133,220 +133,220 @@
       "message": "Tidsplanen overlapper den eksisterende {schedule_label}. Juster eller deaktiver først den pågældende tidsplan."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Ingen AC-batterienheder er tilgængelige i øjeblikket."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Godkendelsesindstillinger er ikke tilgængelige, mens Enphase-tjenesten er nede."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Batteriprofilopdateringer er ikke tilladt for denne konto."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Opdateringer af batteriindstillinger er ikke tilladt for denne konto."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Endnu en batteriprofilopdatering er allerede i gang."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "En anden opdatering af batteriindstillinger er allerede i gang."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Batteriprofilopdateringer er ikke tilgængelige."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Opdateringer af batteriindstillinger er ikke tilgængelige."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Batteriopdateringer er ikke tilgængelige."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Batteriopdateringer er ikke tilladt for denne konto."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Batteriprofilopdatering blev anmodet for hurtigt. Vent venligst og prøv igen."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Opdatering af batteriindstillinger blev anmodet om for hurtigt. Vent venligst og prøv igen."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Batteri skriveadgang kunne ikke bekræftes. Opdater og prøv igen."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Skemaopdatering blev afvist af Enphase (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Planlæg opdatering kunne ikke godkendes. Genautentificer og prøv igen."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Tidsplan er i konflikt med den eksisterende tidsplan for udledning til net. Juster eller deaktiver den tidsplan først."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Tidsplan er i konflikt med den eksisterende tidsplan for begrænsning af batteriafladning. Juster eller deaktiver den tidsplan først."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Tidsplan er i konflikt med den eksisterende afgift-fra-net-plan. Juster eller deaktiver den tidsplan først."
     },
     "schedule_update_conflict": {
       "message": "Planlæg opdatering er i konflikt med en eksisterende batteritidsplan."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Batteriprofil er ikke tilgængelig."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Opdatering af batteriprofilen blev afvist af Enphase (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Batteriprofilopdatering kunne ikke godkendes. Genautentificer og prøv igen."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Nyttelasten for batteriindstillinger er ikke tilgængelig."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Opdatering af batteriindstillinger blev afvist af Enphase (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Opdatering af batteriindstillinger kunne ikke godkendes. Genautentificer og prøv igen."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Fuld backup reserve er fastsat til 100%."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Batterireserve er ikke tilgængelig."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Opsparingsprofil skal være aktiv."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Opsparingsprofilindstillinger er ikke tilgængelige."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Den valgte batteriprofil understøttes ikke."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Opladning fra gitterindstillingen er ikke tilgængelig."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Charge from grid toggle blev ikke anvendt af Enphase."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Opkrævning fra netplan er ikke tilgængelig."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Start- og sluttidspunkter for gebyr-fra-gitter skal være forskellige."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Til/fra-til-fra-net-planlægning blev ikke anvendt af Enphase."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Opladning fra nettet skal aktiveres først."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "En tidsplanændring afventer Envoy-synkronisering. Vent venligst."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Tidsplan for opkrævning fra nettet er ugyldig."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Schedule API er ikke tilgængelig på denne klientversion."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Der er ingen eksisterende afgift-fra-net-plan tilgængelig."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Opret en {schedule_label} i IQ Battery Scheduler, før du aktiverer den."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} er i øjeblikket ikke eksponeret af Enphase for dette websted. Vent på, at tidsplansynkroniseringen er fuldført, og opdater derefter, og prøv igen."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "{schedule_label} toggle blev ikke anvendt af Enphase."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "primær skrivelse afvist"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "{schedule_label} start- og sluttidspunkter skal være forskellige."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Tidsplan for udledning til nettet er ugyldig."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Ingen eksisterende {schedule_label_lower} tidsplan er tilgængelig."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "{schedule_label} tidsplan er ikke tilgængelig."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "{schedule_label} tidsplan er ugyldig."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Den aktuelle {schedule_label_lower}-tidsplan er ugyldig."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "{schedule_label}-tidsplangrænsen skal være mellem {minimum} og {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "{schedule_label}-tidsplangrænsen skal være mindst {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Aktuelle tidsplaner er ikke tilgængelige."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Tidsplangrænsen for gebyr fra nettet skal være mellem {minimum} og {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Tidsplangrænsen for afgift fra nettet skal være mindst {minimum} %."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Batteriets nedlukningsniveau er ikke tilgængeligt."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Batteriets nedlukningsniveau er ugyldigt."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Batteriets nedlukningsniveau skal være mellem {minimum} og {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Storm Alert fravalg er ikke tilgængelig."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Storm Alert fravalg mislykkedes for {count}-advarsler."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Storm Guard-opdateringer er ikke tilladt for denne konto."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Storm Guard-indstillinger er ikke tilgængelige."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Storm Guard-opdateringen blev afvist af Enphase (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Storm Guard-opdateringen kunne ikke godkendes. Genautentificer og prøv igen."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Den valgte systemprofil er ikke tilgængelig."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Systemprofilopdatering blev afvist af Enphase (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Systemprofilopdatering kunne ikke godkendes. Genautentificer og prøv igen."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Opdatering af systemprofil mislykkedes."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Opdatering af systemprofil mislykkedes på grund af en netværksfejl. Prøv igen."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Systemprofilopdateringen fik timeout. Prøv igen."
     },
     "scheduler_service_unavailable": {
       "message": "Valg af opladningstilstand er ikke tilgængelig, mens Enphase-planlægningstjenesten er nede."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "Den valgte opladningstilstand for AC-batteri er ikke tilgængelig."
     },
     "battery_schedule_day_required": {
       "message": "Vælg mindst én dag til tidsplanen."

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Der Zeitplan überschneidet sich mit dem vorhandenen {schedule_label}. Passe diesen Zeitplan zuerst an oder deaktiviere ihn."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Der Zeitplan für die Aktualisierung steht in Konflikt mit einem vorhandenen Batterieplan."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Die Auswahl des Lademodus ist nicht verfügbar, solange der Enphase-Planungsdienst nicht verfügbar ist."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Wählen Sie mindestens einen Tag für den Zeitplan aus."
+    },
+    "battery_schedule_times_different": {
+      "message": "Die Start- und Endzeiten des Zeitplans müssen unterschiedlich sein."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Das {schedule_type}-Zeitplanlimit muss zwischen {minimum} und {maximum} liegen."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Zeitplan vom Enphase-Validierungsendpunkt abgelehnt."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Die Bearbeitung des Batteriezeitplans ist nicht verfügbar."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Die Batterieplan-API ist nicht verfügbar."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Zum Aktualisieren eines Zeitplans ist eine Bestätigung erforderlich."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Zum Löschen eines Zeitplans ist eine Bestätigung erforderlich."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Ungültige Zeitplan-ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Zeitplan-ID in den aktuellen Daten nicht gefunden: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Geben Sie mindestens eine Zeitplan-ID zum Löschen an."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Ungültige Zeitplan-ID(s): {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Zeitplan-ID(s) in den aktuellen Daten nicht gefunden: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Zeitplan vom Enphase-Validierungsendpunkt abgelehnt: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Konflikte bei der Aktualisierung des Zeitplans mit einem vorhandenen Batterieplan: {message}"
     }
   },
   "options": {
@@ -157,11 +418,12 @@
           "api_timeout": "API-Zeitlimit (s)",
           "nominal_voltage": "Nennspannung (V)",
           "session_history_interval": "Intervall für Sitzungsverlauf (min)",
-          "schedule_sync_enabled": "Aktivieren Sie die Scheduler-Unterstützung",
+          "schedule_sync_enabled": "Aktivieren Sie den EV-Ladeplaner",
           "reauth": "Reauthentifizierung starten",
           "forget_password": "Gespeichertes Passwort löschen",
           "type_heatpump": "Wärmepumpe",
-          "type_ac_battery": "AC-Batterie"
+          "type_ac_battery": "AC-Batterie",
+          "battery_schedules_enabled": "Aktivieren Sie den Batterieplaner"
         },
         "data_description": {
           "type_envoy": "Enthält Gateway-Konnektivitäts- und Zählerdiagnosen.",
@@ -174,11 +436,12 @@
           "api_timeout": "Sekunden, bevor API-Anfragen abbrechen.",
           "nominal_voltage": "Ersatzspannung für die Leistungsberechnung des Ladegeräts.",
           "session_history_interval": "Minuten zwischen Abrufen des Cloud-Sitzungsverlaufs.",
-          "schedule_sync_enabled": "Verwalten Sie die Enphase-Zeitplanverwaltung",
+          "schedule_sync_enabled": "Verwalten Sie die Zeitpläne für IQ-Ladegeräte für Elektrofahrzeuge",
           "reauth": "Startet den Login-Ablauf, um Zugangsdaten zu erneuern, ohne die Integration zu entfernen.",
           "forget_password": "Entfernt das gespeicherte Passwort. Automatische Aktualisierung wird nicht mehr versucht.",
           "type_heatpump": "Enthält Sensoren für Wärmepumpenstatus, Diagnose und Verbrauch.",
-          "type_ac_battery": "Enthält AC-Batterie-Sensoren und Steuerelemente für den Schlafmodus, wenn verfügbar."
+          "type_ac_battery": "Enthält AC-Batterie-Sensoren und Steuerelemente für den Schlafmodus, wenn verfügbar.",
+          "battery_schedules_enabled": "IQ-Batteriepläne verwalten"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Reauthentifizierung starten",
           "forget_password": "Gespeichertes Passwort löschen",
           "type_heatpump": "Wärmepumpe",
-          "type_ac_battery": "AC-Batterie"
+          "type_ac_battery": "AC-Batterie",
+          "battery_schedules_enabled": "Aktivieren Sie den Batterieplaner"
         },
         "data_description": {
           "type_envoy": "Enthält Gateway-Konnektivitäts- und Zählerdiagnosen.",
@@ -216,7 +480,8 @@
           "reauth": "Startet den Login-Ablauf, um Zugangsdaten zu erneuern, ohne die Integration zu entfernen.",
           "forget_password": "Entfernt das gespeicherte Passwort. Automatische Aktualisierung wird nicht mehr versucht.",
           "type_heatpump": "Enthält Sensoren für Wärmepumpenstatus, Diagnose und Verbrauch.",
-          "type_ac_battery": "Enthält AC-Batterie-Sensoren und Steuerelemente für den Schlafmodus, wenn verfügbar."
+          "type_ac_battery": "Enthält AC-Batterie-Sensoren und Steuerelemente für den Schlafmodus, wenn verfügbar.",
+          "battery_schedules_enabled": "IQ-Batteriepläne verwalten"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Netzeinspeisung",
           "battery_charge": "Batterieladung",
           "battery_discharge": "Batterieentladung"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "{serial} zuletzt gemeldet"
+      },
+      "battery_cfg_schedules": {
+        "name": "Batterie-CFG-Zeitpläne"
+      },
+      "battery_dtg_schedules": {
+        "name": "Batterie-DTG-Zeitpläne"
+      },
+      "battery_rbd_schedules": {
+        "name": "Batterie-RBD-Zeitpläne"
+      },
+      "battery_schedule_summary": {
+        "name": "Zusammenfassung des Batterieplans"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Grenzwert für eingeschränkte Batterieentladung"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Neues Zeitplanlimit für die Batterie"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Batteriezeitplanbegrenzung"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Zeitplan Sonntag"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Battery New Schedule Monday"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Battery New Schedule Tuesday"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Battery New Schedule Wednesday"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Battery New Schedule Thursday"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Battery New Schedule Friday"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Battery New Schedule Saturday"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Battery New Schedule Sunday"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Battery Schedule Monday"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Battery Schedule Tuesday"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Battery Schedule Wednesday"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Battery Schedule Thursday"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Battery Schedule Friday"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Battery Schedule Saturday"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Battery Schedule Sunday"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Zeitplan"
+      },
+      "battery_new_schedule_type": {
+        "name": "Typ des Batterieplans"
+      },
+      "battery_schedule_selected": {
+        "name": "Batterieplan"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Neuen Zeitplan erstellen"
+      },
+      "battery_schedule_add": {
+        "name": "Batterieplan hinzufügen"
+      },
+      "battery_schedule_delete": {
+        "name": "Batterieplan löschen"
+      },
+      "battery_schedule_refresh": {
+        "name": "Aktualisierung des Batterieplans"
+      },
+      "battery_schedule_save": {
+        "name": "Speichern des Batterieplans"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Endzeit des Zeitplans"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Startzeit des neuen Batterieplans"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Endzeit des neuen Batterieplans"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Startzeit des Batterieplans"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Endzeit des Batterieplans"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "Standort-ID",
           "description": "Enphase-Standort-ID (optional; wird aus dem Zielgerät ermittelt)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Aktualisierung erzwingen",
+      "description": "Aktualisieren Sie die Batterieplandaten sofort aus der Enphase-Cloud.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Batterieplan hinzufügen",
+      "description": "Erstellen Sie einen Batterieplan für CFG, DTG oder RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Schedule Type",
+          "description": "Battery schedule family: cfg, dtg, or rbd."
+        },
+        "start_time": {
+          "name": "Start Time",
+          "description": "Schedule start time."
+        },
+        "end_time": {
+          "name": "End Time",
+          "description": "Schedule end time."
+        },
+        "limit": {
+          "name": "Charge Limit",
+          "description": "Maximum battery state of charge (%)."
+        },
+        "days": {
+          "name": "Days",
+          "description": "List of active weekdays using Monday=1 through Sunday=7."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Batterieplan aktualisieren",
+      "description": "Aktualisieren Sie einen Batteriezeitplan anhand der Zeitplan-ID.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Schedule ID",
+          "description": "Existing Enphase battery schedule identifier."
+        },
+        "schedule_type": {
+          "name": "Schedule Type",
+          "description": "Battery schedule family: cfg, dtg, or rbd."
+        },
+        "start_time": {
+          "name": "Start Time",
+          "description": "Schedule start time."
+        },
+        "end_time": {
+          "name": "End Time",
+          "description": "Schedule end time."
+        },
+        "limit": {
+          "name": "Charge Limit",
+          "description": "Maximum battery state of charge (%)."
+        },
+        "days": {
+          "name": "Days",
+          "description": "List of active weekdays using Monday=1 through Sunday=7."
+        },
+        "confirm": {
+          "name": "Confirm",
+          "description": "Set to true to confirm the schedule update."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Batterieplan löschen",
+      "description": "Löschen Sie einen oder mehrere Batteriepläne nach Zeitplan-ID.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Schedule ID",
+          "description": "Single Enphase battery schedule identifier to delete."
+        },
+        "schedule_ids": {
+          "name": "Schedule IDs",
+          "description": "Optional comma-separated or list input for multiple schedule identifiers."
+        },
+        "confirm": {
+          "name": "Confirm",
+          "description": "Set to true to confirm the schedule deletion."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Batterieplan validieren",
+      "description": "Überprüfen Sie, ob die Bearbeitung des Batterieplans für die ausgewählte Zeitplanfamilie verfügbar ist.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Schedule Type",
+          "description": "Battery schedule family: cfg, dtg, or rbd."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -133,220 +133,220 @@
       "message": "Der Zeitplan überschneidet sich mit dem vorhandenen {schedule_label}. Passe diesen Zeitplan zuerst an oder deaktiviere ihn."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Derzeit sind keine Geräte mit Wechselstrombatterie verfügbar."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Die Authentifizierungseinstellungen sind nicht verfügbar, während der Enphase-Dienst ausgefallen ist."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Aktualisierungen des Batterieprofils sind für dieses Konto nicht zulässig."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Aktualisierungen der Batterieeinstellungen sind für dieses Konto nicht zulässig."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Eine weitere Aktualisierung des Batterieprofils ist bereits in Bearbeitung."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Ein weiteres Update der Batterieeinstellungen ist bereits in Bearbeitung."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Aktualisierungen des Batterieprofils sind nicht verfügbar."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Aktualisierungen der Batterieeinstellungen sind nicht verfügbar."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Batterieaktualisierungen sind nicht verfügbar."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Batterieaktualisierungen sind für dieses Konto nicht zulässig."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Die Aktualisierung des Batterieprofils wurde zu schnell angefordert. Bitte warten Sie und versuchen Sie es erneut."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Die Aktualisierung der Batterieeinstellungen wurde zu schnell angefordert. Bitte warten Sie und versuchen Sie es erneut."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Der Schreibzugriff auf die Batterie konnte nicht bestätigt werden. Aktualisieren Sie und versuchen Sie es erneut."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Die Zeitplanaktualisierung wurde von Enphase abgelehnt (HTTP 403 verboten)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Die Zeitplanaktualisierung konnte nicht authentifiziert werden. Authentifizieren Sie sich erneut und versuchen Sie es erneut."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Der Zeitplan steht im Konflikt mit dem bestehenden Zeitplan für die Einspeisung ins Netz. Passen Sie diesen Zeitplan zuerst an oder deaktivieren Sie ihn."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Der Zeitplan steht in Konflikt mit dem bestehenden Zeitplan für die Einschränkung der Batterieentladung. Passen Sie diesen Zeitplan zuerst an oder deaktivieren Sie ihn."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Der Zeitplan steht in Konflikt mit dem vorhandenen Netzladeplan. Passen Sie diesen Zeitplan zuerst an oder deaktivieren Sie ihn."
     },
     "schedule_update_conflict": {
       "message": "Der Zeitplan für die Aktualisierung steht in Konflikt mit einem vorhandenen Batterieplan."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Das Batterieprofil ist nicht verfügbar."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Die Aktualisierung des Batterieprofils wurde von Enphase abgelehnt (HTTP 403 verboten)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Die Aktualisierung des Batterieprofils konnte nicht authentifiziert werden. Authentifizieren Sie sich erneut und versuchen Sie es erneut."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Die Nutzlast „Batterieeinstellungen“ ist nicht verfügbar."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Die Aktualisierung der Batterieeinstellungen wurde von Enphase abgelehnt (HTTP 403 verboten)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Die Aktualisierung der Batterieeinstellungen konnte nicht authentifiziert werden. Authentifizieren Sie sich erneut und versuchen Sie es erneut."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Die vollständige Backup-Reserve ist auf 100 % festgelegt."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Batteriereserve ist nicht verfügbar."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Das Sparprofil muss aktiv sein."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Die Einstellungen für das Sparprofil sind nicht verfügbar."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Das ausgewählte Batterieprofil wird nicht unterstützt."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Die Einstellung „Laden aus dem Netz“ ist nicht verfügbar."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Die Ladung durch Netzumschaltung wurde von Enphase nicht angewendet."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Der Zeitplan für die Ladung aus dem Netz ist nicht verfügbar."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Die Start- und Endzeiten des Charge-from-Grid-Zeitplans müssen unterschiedlich sein."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Die Umschaltung des Lade-vom-Netz-Zeitplans wurde von Enphase nicht angewendet."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Die Ladung aus dem Netz muss zuerst aktiviert werden."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Eine Zeitplanänderung steht zur Envoy-Synchronisierung an. Bitte warten."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Die Ladezeit aus dem Netz ist ungültig."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Die Zeitplan-API ist in dieser Clientversion nicht verfügbar."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Es ist kein Zeitplan für die Ladung aus dem Netz verfügbar."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Erstellen Sie im IQ Battery Scheduler ein {schedule_label}, bevor Sie es aktivieren."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} wird derzeit von Enphase für diese Site nicht bereitgestellt. Warten Sie, bis die Zeitplansynchronisierung abgeschlossen ist, aktualisieren Sie dann den Vorgang und versuchen Sie es erneut."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "{schedule_label}-Umschaltung wurde von Enphase nicht angewendet."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "Primärer Schreibvorgang abgelehnt"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "Die Start- und Endzeiten von {schedule_label} müssen unterschiedlich sein."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Der Zeitplan für die Einspeisung ins Netz ist ungültig."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Es ist kein vorhandener {schedule_label_lower}-Zeitplan verfügbar."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "Der {schedule_label}-Zeitplan ist nicht verfügbar."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "Die {schedule_label}-Zeitplanung ist ungültig."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Die aktuelle {schedule_label_lower}-Zeitplanung ist ungültig."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "Das {schedule_label}-Zeitplanlimit muss zwischen {minimum} und {maximum} liegen."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "Das {schedule_label}-Zeitplanlimit muss mindestens {minimum} % betragen."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Aktuelle Fahrzeiten sind nicht verfügbar."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Das Limit für die Ladung aus dem Netz muss zwischen {minimum} und {maximum} liegen."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Das Limit für die Ladung aus dem Netz muss mindestens {minimum} % betragen."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Der Akku-Abschaltpegel ist nicht verfügbar."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Der Akku-Abschaltwert ist ungültig."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Der Batterieabschaltwert muss zwischen {minimum} und {maximum} liegen."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Die Abmeldung von der Sturmwarnung ist nicht möglich."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Die Abmeldung der Sturmwarnung für {count}-Warnungen ist fehlgeschlagen."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Storm Guard-Updates sind für dieses Konto nicht zulässig."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Storm Guard-Einstellungen sind nicht verfügbar."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Das Storm Guard-Update wurde von Enphase abgelehnt (HTTP 403 verboten)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Storm Guard-Update konnte nicht authentifiziert werden. Authentifizieren Sie sich erneut und versuchen Sie es erneut."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Das ausgewählte Systemprofil ist nicht verfügbar."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Die Aktualisierung des Systemprofils wurde von Enphase abgelehnt (HTTP 403 verboten)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Die Aktualisierung des Systemprofils konnte nicht authentifiziert werden. Authentifizieren Sie sich erneut und versuchen Sie es erneut."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Die Aktualisierung des Systemprofils ist fehlgeschlagen."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Die Aktualisierung des Systemprofils ist aufgrund eines Netzwerkfehlers fehlgeschlagen. Versuchen Sie es erneut."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Zeitüberschreitung bei der Aktualisierung des Systemprofils. Versuchen Sie es erneut."
     },
     "scheduler_service_unavailable": {
       "message": "Die Auswahl des Lademodus ist nicht verfügbar, solange der Enphase-Planungsdienst nicht verfügbar ist."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "Der ausgewählte Zielladezustand der Wechselstrombatterie ist nicht verfügbar."
     },
     "battery_schedule_day_required": {
       "message": "Wählen Sie mindestens einen Tag für den Zeitplan aus."
@@ -1402,46 +1402,46 @@
         "name": "Zeitplan Sonntag"
       },
       "battery_new_schedule_mon": {
-        "name": "Battery New Schedule Monday"
+        "name": "Batterie neuer Zeitplan Montag"
       },
       "battery_new_schedule_tue": {
-        "name": "Battery New Schedule Tuesday"
+        "name": "Batterie neuer Zeitplan am Dienstag"
       },
       "battery_new_schedule_wed": {
-        "name": "Battery New Schedule Wednesday"
+        "name": "Batterie neuer Zeitplan Mittwoch"
       },
       "battery_new_schedule_thu": {
-        "name": "Battery New Schedule Thursday"
+        "name": "Batterie-Neuplan am Donnerstag"
       },
       "battery_new_schedule_fri": {
-        "name": "Battery New Schedule Friday"
+        "name": "Batterie neuer Zeitplan am Freitag"
       },
       "battery_new_schedule_sat": {
-        "name": "Battery New Schedule Saturday"
+        "name": "Batterie neuer Zeitplan Samstag"
       },
       "battery_new_schedule_sun": {
-        "name": "Battery New Schedule Sunday"
+        "name": "Batterie neuer Zeitplan am Sonntag"
       },
       "battery_schedule_edit_mon": {
-        "name": "Battery Schedule Monday"
+        "name": "Batterieplan Montag"
       },
       "battery_schedule_edit_tue": {
-        "name": "Battery Schedule Tuesday"
+        "name": "Batterieplan Dienstag"
       },
       "battery_schedule_edit_wed": {
-        "name": "Battery Schedule Wednesday"
+        "name": "Batterieplan Mittwoch"
       },
       "battery_schedule_edit_thu": {
-        "name": "Battery Schedule Thursday"
+        "name": "Batterieplan Donnerstag"
       },
       "battery_schedule_edit_fri": {
-        "name": "Battery Schedule Friday"
+        "name": "Batterieplan Freitag"
       },
       "battery_schedule_edit_sat": {
-        "name": "Battery Schedule Saturday"
+        "name": "Batterieplan Samstag"
       },
       "battery_schedule_edit_sun": {
-        "name": "Battery Schedule Sunday"
+        "name": "Batterieplan Sonntag"
       }
     },
     "select": {
@@ -1826,17 +1826,17 @@
       "description": "Aktualisieren Sie die Batterieplandaten sofort aus der Enphase-Cloud.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Erweiterte Optionen"
         }
       },
       "fields": {
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "Site-ID",
+          "description": "Optionale Site-ID; automatisch erkannt, wenn ein Standortgerät ausgewählt wird."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "Konfigurationseintrags-ID",
+          "description": "Optionaler Konfigurationseintragsbezeichner für einen einzelnen Enphase-Site-Eintrag."
         }
       }
     },
@@ -1845,37 +1845,37 @@
       "description": "Erstellen Sie einen Batterieplan für CFG, DTG oder RBD.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Erweiterte Optionen"
         }
       },
       "fields": {
         "schedule_type": {
-          "name": "Schedule Type",
-          "description": "Battery schedule family: cfg, dtg, or rbd."
+          "name": "Zeitplantyp",
+          "description": "Batterieplanfamilie: cfg, dtg oder rbd."
         },
         "start_time": {
-          "name": "Start Time",
-          "description": "Schedule start time."
+          "name": "Startzeit",
+          "description": "Planen Sie die Startzeit."
         },
         "end_time": {
-          "name": "End Time",
-          "description": "Schedule end time."
+          "name": "Endzeit",
+          "description": "Planen Sie die Endzeit ein."
         },
         "limit": {
-          "name": "Charge Limit",
-          "description": "Maximum battery state of charge (%)."
+          "name": "Gebührenlimit",
+          "description": "Maximaler Ladezustand der Batterie (%)."
         },
         "days": {
-          "name": "Days",
-          "description": "List of active weekdays using Monday=1 through Sunday=7."
+          "name": "Tage",
+          "description": "Liste der aktiven Wochentage mit Montag=1 bis Sonntag=7."
         },
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "Site-ID",
+          "description": "Optionale Site-ID; automatisch erkannt, wenn ein Standortgerät ausgewählt wird."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "Konfigurationseintrags-ID",
+          "description": "Optionaler Konfigurationseintragsbezeichner für einen einzelnen Enphase-Site-Eintrag."
         }
       }
     },
@@ -1884,45 +1884,45 @@
       "description": "Aktualisieren Sie einen Batteriezeitplan anhand der Zeitplan-ID.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Erweiterte Optionen"
         }
       },
       "fields": {
         "schedule_id": {
-          "name": "Schedule ID",
-          "description": "Existing Enphase battery schedule identifier."
+          "name": "Zeitplan-ID",
+          "description": "Kennung des vorhandenen Enphase-Batterieplans."
         },
         "schedule_type": {
-          "name": "Schedule Type",
-          "description": "Battery schedule family: cfg, dtg, or rbd."
+          "name": "Zeitplantyp",
+          "description": "Batterieplanfamilie: cfg, dtg oder rbd."
         },
         "start_time": {
-          "name": "Start Time",
-          "description": "Schedule start time."
+          "name": "Startzeit",
+          "description": "Planen Sie die Startzeit."
         },
         "end_time": {
-          "name": "End Time",
-          "description": "Schedule end time."
+          "name": "Endzeit",
+          "description": "Planen Sie die Endzeit ein."
         },
         "limit": {
-          "name": "Charge Limit",
-          "description": "Maximum battery state of charge (%)."
+          "name": "Gebührenlimit",
+          "description": "Maximaler Ladezustand der Batterie (%)."
         },
         "days": {
-          "name": "Days",
-          "description": "List of active weekdays using Monday=1 through Sunday=7."
+          "name": "Tage",
+          "description": "Liste der aktiven Wochentage mit Montag=1 bis Sonntag=7."
         },
         "confirm": {
-          "name": "Confirm",
-          "description": "Set to true to confirm the schedule update."
+          "name": "Bestätigen",
+          "description": "Auf „true“ setzen, um die Zeitplanaktualisierung zu bestätigen."
         },
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "Site-ID",
+          "description": "Optionale Site-ID; automatisch erkannt, wenn ein Standortgerät ausgewählt wird."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "Konfigurationseintrags-ID",
+          "description": "Optionaler Konfigurationseintragsbezeichner für einen einzelnen Enphase-Site-Eintrag."
         }
       }
     },
@@ -1931,29 +1931,29 @@
       "description": "Löschen Sie einen oder mehrere Batteriepläne nach Zeitplan-ID.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Erweiterte Optionen"
         }
       },
       "fields": {
         "schedule_id": {
-          "name": "Schedule ID",
-          "description": "Single Enphase battery schedule identifier to delete."
+          "name": "Zeitplan-ID",
+          "description": "Einzelne zu löschende Enphase-Batterieplan-ID."
         },
         "schedule_ids": {
-          "name": "Schedule IDs",
-          "description": "Optional comma-separated or list input for multiple schedule identifiers."
+          "name": "Zeitplan-IDs",
+          "description": "Optionale durch Kommas getrennte Eingabe oder Listeneingabe für mehrere Zeitplan-IDs."
         },
         "confirm": {
-          "name": "Confirm",
-          "description": "Set to true to confirm the schedule deletion."
+          "name": "Bestätigen",
+          "description": "Auf „true“ setzen, um das Löschen des Zeitplans zu bestätigen."
         },
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "Site-ID",
+          "description": "Optionale Site-ID; automatisch erkannt, wenn ein Standortgerät ausgewählt wird."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "Konfigurationseintrags-ID",
+          "description": "Optionaler Konfigurationseintragsbezeichner für einen einzelnen Enphase-Site-Eintrag."
         }
       }
     },
@@ -1962,21 +1962,21 @@
       "description": "Überprüfen Sie, ob die Bearbeitung des Batterieplans für die ausgewählte Zeitplanfamilie verfügbar ist.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Erweiterte Optionen"
         }
       },
       "fields": {
         "schedule_type": {
-          "name": "Schedule Type",
-          "description": "Battery schedule family: cfg, dtg, or rbd."
+          "name": "Zeitplantyp",
+          "description": "Batterieplanfamilie: cfg, dtg oder rbd."
         },
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "Site-ID",
+          "description": "Optionale Site-ID; automatisch erkannt, wenn ein Standortgerät ausgewählt wird."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "Konfigurationseintrags-ID",
+          "description": "Optionaler Konfigurationseintragsbezeichner für einen einzelnen Enphase-Site-Eintrag."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -133,214 +133,214 @@
       "message": "Το πρόγραμμα επικαλύπτεται με το υπάρχον {schedule_label}. Προσαρμόστε ή απενεργοποιήστε πρώτα αυτό το πρόγραμμα."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Δεν υπάρχουν αυτή τη στιγμή διαθέσιμες συσκευές AC Battery."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Οι ρυθμίσεις ελέγχου ταυτότητας δεν είναι διαθέσιμες όσο η υπηρεσία Enphase είναι εκτός λειτουργίας."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Οι ενημερώσεις προφίλ μπαταρίας δεν επιτρέπονται για αυτόν τον λογαριασμό."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Οι ενημερώσεις ρυθμίσεων μπαταρίας δεν επιτρέπονται για αυτόν τον λογαριασμό."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Μια άλλη ενημέρωση προφίλ μπαταρίας βρίσκεται ήδη σε εξέλιξη."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Μια άλλη ενημέρωση ρυθμίσεων μπαταρίας βρίσκεται ήδη σε εξέλιξη."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Οι ενημερώσεις προφίλ μπαταρίας δεν είναι διαθέσιμες."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Οι ενημερώσεις ρυθμίσεων μπαταρίας δεν είναι διαθέσιμες."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Οι ενημερώσεις μπαταρίας δεν είναι διαθέσιμες."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Οι ενημερώσεις μπαταρίας δεν επιτρέπονται για αυτόν τον λογαριασμό."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Η ενημέρωση προφίλ μπαταρίας ζητήθηκε πολύ γρήγορα. Περιμένετε και δοκιμάστε ξανά."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Η ενημέρωση ρυθμίσεων μπαταρίας ζητήθηκε πολύ γρήγορα. Περιμένετε και δοκιμάστε ξανά."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Δεν ήταν δυνατή η επιβεβαίωση πρόσβασης εγγραφής στη μπαταρία. Ανανεώστε και δοκιμάστε ξανά."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Η ενημέρωση χρονοδιαγράμματος απορρίφθηκε από το Enphase (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Δεν ήταν δυνατή η ταυτοποίηση της ενημέρωσης χρονοδιαγράμματος. Κάντε ξανά έλεγχο ταυτότητας και δοκιμάστε ξανά."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Το χρονοδιάγραμμα έρχεται σε σύγκρουση με το υπάρχον χρονοδιάγραμμα discharge-to-grid. Προσαρμόστε ή απενεργοποιήστε πρώτα αυτό το χρονοδιάγραμμα."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Το χρονοδιάγραμμα έρχεται σε σύγκρουση με το υπάρχον χρονοδιάγραμμα restrict-battery-discharge. Προσαρμόστε ή απενεργοποιήστε πρώτα αυτό το χρονοδιάγραμμα."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Το χρονοδιάγραμμα έρχεται σε σύγκρουση με το υπάρχον χρονοδιάγραμμα charge-from-grid. Προσαρμόστε ή απενεργοποιήστε πρώτα αυτό το χρονοδιάγραμμα."
     },
     "schedule_update_conflict": {
       "message": "Η ενημέρωση του χρονοδιαγράμματος έρχεται σε διένεξη με ένα υπάρχον χρονοδιάγραμμα μπαταρίας."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Το προφίλ μπαταρίας δεν είναι διαθέσιμο."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Η ενημέρωση προφίλ μπαταρίας απορρίφθηκε από το Enphase (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Δεν ήταν δυνατή η ταυτοποίηση της ενημέρωσης προφίλ μπαταρίας. Κάντε ξανά έλεγχο ταυτότητας και δοκιμάστε ξανά."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Το payload ρυθμίσεων μπαταρίας δεν είναι διαθέσιμο."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Η ενημέρωση ρυθμίσεων μπαταρίας απορρίφθηκε από το Enphase (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Δεν ήταν δυνατή η ταυτοποίηση της ενημέρωσης ρυθμίσεων μπαταρίας. Κάντε ξανά έλεγχο ταυτότητας και δοκιμάστε ξανά."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Το απόθεμα Full Backup είναι σταθερό στο 100%."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Το απόθεμα μπαταρίας δεν είναι διαθέσιμο."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Το προφίλ Savings πρέπει να είναι ενεργό."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Οι ρυθμίσεις προφίλ Savings δεν είναι διαθέσιμες."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Το επιλεγμένο προφίλ μπαταρίας δεν υποστηρίζεται."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Η ρύθμιση φόρτισης από το δίκτυο δεν είναι διαθέσιμη."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Η εναλλαγή φόρτισης από το δίκτυο δεν εφαρμόστηκε από το Enphase."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Το χρονοδιάγραμμα φόρτισης από το δίκτυο δεν είναι διαθέσιμο."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Οι ώρες έναρξης και λήξης του χρονοδιαγράμματος charge-from-grid πρέπει να είναι διαφορετικές."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Η εναλλαγή του χρονοδιαγράμματος charge-from-grid δεν εφαρμόστηκε από το Enphase."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Πρέπει πρώτα να ενεργοποιηθεί η φόρτιση από το δίκτυο."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Εκκρεμεί συγχρονισμός Envoy για αλλαγή χρονοδιαγράμματος. Περιμένετε."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Η ώρα του χρονοδιαγράμματος charge-from-grid δεν είναι έγκυρη."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Το API χρονοδιαγράμματος δεν είναι διαθέσιμο σε αυτήν την έκδοση πελάτη."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Δεν υπάρχει διαθέσιμο υπάρχον χρονοδιάγραμμα charge-from-grid."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Δημιουργήστε ένα {schedule_label} στον προγραμματιστή IQ Battery πριν το ενεργοποιήσετε."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "Το {schedule_label} δεν εκτίθεται αυτή τη στιγμή από το Enphase για αυτόν τον ιστότοπο. Περιμένετε να ολοκληρωθεί ο συγχρονισμός χρονοδιαγράμματος, έπειτα ανανεώστε και δοκιμάστε ξανά."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Η εναλλαγή {schedule_label} δεν εφαρμόστηκε από το Enphase."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "Η κύρια εγγραφή απορρίφθηκε."
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "Οι ώρες έναρξης και λήξης του {schedule_label} πρέπει να είναι διαφορετικές."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Η ώρα του χρονοδιαγράμματος discharge-to-grid δεν είναι έγκυρη."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Δεν υπάρχει διαθέσιμο υπάρχον χρονοδιάγραμμα {schedule_label_lower}."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "Το χρονοδιάγραμμα {schedule_label} δεν είναι διαθέσιμο."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "Η ώρα του χρονοδιαγράμματος {schedule_label} δεν είναι έγκυρη."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Η τρέχουσα ώρα του χρονοδιαγράμματος {schedule_label_lower} δεν είναι έγκυρη."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "Το όριο του χρονοδιαγράμματος {schedule_label} πρέπει να είναι μεταξύ {minimum} και {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "Το όριο του χρονοδιαγράμματος {schedule_label} πρέπει να είναι τουλάχιστον {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Οι τρέχουσες ώρες χρονοδιαγράμματος δεν είναι διαθέσιμες."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Το όριο του χρονοδιαγράμματος charge-from-grid πρέπει να είναι μεταξύ {minimum} και {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Το όριο του χρονοδιαγράμματος charge-from-grid πρέπει να είναι τουλάχιστον {minimum}%."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Το επίπεδο απενεργοποίησης της μπαταρίας δεν είναι διαθέσιμο."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Το επίπεδο απενεργοποίησης της μπαταρίας δεν είναι έγκυρο."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Το επίπεδο απενεργοποίησης της μπαταρίας πρέπει να είναι μεταξύ {minimum} και {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Η εξαίρεση από το Storm Alert δεν είναι διαθέσιμη."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Η εξαίρεση από το Storm Alert απέτυχε για {count} ειδοποίηση(εις)."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Οι ενημερώσεις Storm Guard δεν επιτρέπονται για αυτόν τον λογαριασμό."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Οι ρυθμίσεις Storm Guard δεν είναι διαθέσιμες."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Η ενημέρωση Storm Guard απορρίφθηκε από το Enphase (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Δεν ήταν δυνατή η ταυτοποίηση της ενημέρωσης Storm Guard. Κάντε ξανά έλεγχο ταυτότητας και δοκιμάστε ξανά."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Το επιλεγμένο προφίλ συστήματος δεν είναι διαθέσιμο."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Η ενημέρωση προφίλ συστήματος απορρίφθηκε από το Enphase (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Δεν ήταν δυνατή η ταυτοποίηση της ενημέρωσης προφίλ συστήματος. Κάντε ξανά έλεγχο ταυτότητας και δοκιμάστε ξανά."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Η ενημέρωση προφίλ συστήματος απέτυχε."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Η ενημέρωση προφίλ συστήματος απέτυχε λόγω σφάλματος δικτύου. Δοκιμάστε ξανά."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Η ενημέρωση προφίλ συστήματος έληξε χρονικά. Δοκιμάστε ξανά."
     },
     "scheduler_service_unavailable": {
       "message": "Η επιλογή τρόπου φόρτισης δεν είναι διαθέσιμη όταν η υπηρεσία προγραμματισμού Enphase είναι απενεργοποιημένη."
@@ -514,8 +514,8 @@
           "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
           "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
           "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
-          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
-          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
+          "battery_charge": "Αντιστοιχίστε ένα αθροιστικό σύνολο φόρτισης μπαταρίας στον αισθητήρα Enphase Energy Site Battery Charge. Μην επιλέξετε ημερήσια ενέργεια ή ζωντανή ισχύ.",
+          "battery_discharge": "Αντιστοιχίστε ένα αθροιστικό σύνολο εκφόρτισης μπαταρίας στον αισθητήρα Enphase Energy Site Battery Discharge. Μην επιλέξετε ημερήσια ενέργεια ή ζωντανή ισχύ."
         }
       },
       "migrate_envoy_confirm": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Το πρόγραμμα επικαλύπτεται με το υπάρχον {schedule_label}. Προσαρμόστε ή απενεργοποιήστε πρώτα αυτό το πρόγραμμα."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Η ενημέρωση του χρονοδιαγράμματος έρχεται σε διένεξη με ένα υπάρχον χρονοδιάγραμμα μπαταρίας."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Η επιλογή τρόπου φόρτισης δεν είναι διαθέσιμη όταν η υπηρεσία προγραμματισμού Enphase είναι απενεργοποιημένη."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Η επιλεγμένη τιμή στόχου κατάστασης φόρτισης της μπαταρίας AC δεν είναι διαθέσιμη."
+    },
+    "battery_schedule_day_required": {
+      "message": "Επιλέξτε τουλάχιστον μία ημέρα για το πρόγραμμα."
+    },
+    "battery_schedule_times_different": {
+      "message": "Οι ώρες έναρξης και λήξης του προγράμματος πρέπει να είναι διαφορετικές."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Το όριο προγράμματος {schedule_type} πρέπει να είναι μεταξύ {minimum} και {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Το χρονοδιάγραμμα απορρίφθηκε από το τελικό σημείο επικύρωσης Enphase."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Η επεξεργασία του προγράμματος μπαταρίας δεν είναι διαθέσιμη."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Το API χρονοδιαγράμματος μπαταρίας δεν είναι διαθέσιμο."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Απαιτείται επιβεβαίωση για την ενημέρωση ενός χρονοδιαγράμματος."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Απαιτείται επιβεβαίωση για τη διαγραφή ενός προγράμματος."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Μη έγκυρο αναγνωριστικό προγράμματος: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Το αναγνωριστικό χρονοδιαγράμματος δεν βρέθηκε στα τρέχοντα δεδομένα: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Καταχωρίστε τουλάχιστον ένα αναγνωριστικό προγράμματος για διαγραφή."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Μη έγκυρο αναγνωριστικό προγράμματος: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Τα αναγνωριστικά χρονοδιαγράμματος δεν βρέθηκαν στα τρέχοντα δεδομένα: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Το πρόγραμμα απορρίφθηκε από το τελικό σημείο επικύρωσης Enphase: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Η ενημέρωση του χρονοδιαγράμματος έρχεται σε διένεξη με ένα υπάρχον πρόγραμμα μπαταρίας: {message}"
     }
   },
   "options": {
@@ -157,11 +418,12 @@
           "api_timeout": "Χρονικό όριο API (s)",
           "nominal_voltage": "Ονομαστική τάση (V)",
           "session_history_interval": "Διάστημα ιστορικού συνεδριών (min)",
-          "schedule_sync_enabled": "Ενεργοποιήστε την Υποστήριξη Προγραμματιστή",
+          "schedule_sync_enabled": "Ενεργοποιήστε το EV Charger Scheduler",
           "reauth": "Έναρξη επαλήθευσης",
           "forget_password": "Διαγραφή αποθηκευμένου κωδικού",
           "type_heatpump": "Αντλία θερμότητας",
-          "type_ac_battery": "Μπαταρία AC"
+          "type_ac_battery": "Μπαταρία AC",
+          "battery_schedules_enabled": "Ενεργοποιήστε τον προγραμματισμό μπαταρίας"
         },
         "data_description": {
           "type_envoy": "Περιλαμβάνει διαγνωστικά συνδεσιμότητας πύλης και μετρητών.",
@@ -174,11 +436,12 @@
           "api_timeout": "Δευτερόλεπτα πριν λήξουν τα αιτήματα API.",
           "nominal_voltage": "Εφεδρική τάση για εκτίμηση ισχύος φορτιστή.",
           "session_history_interval": "Λεπτά αναμονής μεταξύ ανακτήσεων ιστορικού συνεδριών cloud.",
-          "schedule_sync_enabled": "Διαχείριση χρονοδιαγράμματος Enphase",
+          "schedule_sync_enabled": "Διαχειριστείτε τα χρονοδιαγράμματα φορτιστή IQ EV",
           "reauth": "Εκκινήστε τη ροή σύνδεσης για ανανέωση διαπιστευτηρίων χωρίς αφαίρεση της ενσωμάτωσης.",
           "forget_password": "Αφαιρεί τον αποθηκευμένο κωδικό. Δεν θα επιχειρείται πλέον αυτόματη ανανέωση.",
           "type_heatpump": "Περιλαμβάνει αισθητήρες κατάστασης, διαγνωστικών και κατανάλωσης της αντλίας θερμότητας.",
-          "type_ac_battery": "Περιλαμβάνει αισθητήρες μπαταρίας AC και χειριστήρια λειτουργίας ύπνου όταν είναι διαθέσιμα."
+          "type_ac_battery": "Περιλαμβάνει αισθητήρες μπαταρίας AC και χειριστήρια λειτουργίας ύπνου όταν είναι διαθέσιμα.",
+          "battery_schedules_enabled": "Διαχειριστείτε τα χρονοδιαγράμματα μπαταριών IQ"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Έναρξη επαλήθευσης",
           "forget_password": "Διαγραφή αποθηκευμένου κωδικού",
           "type_heatpump": "Αντλία θερμότητας",
-          "type_ac_battery": "Μπαταρία AC"
+          "type_ac_battery": "Μπαταρία AC",
+          "battery_schedules_enabled": "Ενεργοποιήστε τον προγραμματισμό μπαταρίας"
         },
         "data_description": {
           "type_envoy": "Περιλαμβάνει διαγνωστικά συνδεσιμότητας πύλης και μετρητών.",
@@ -216,7 +480,8 @@
           "reauth": "Εκκινήστε τη ροή σύνδεσης για ανανέωση διαπιστευτηρίων χωρίς αφαίρεση της ενσωμάτωσης.",
           "forget_password": "Αφαιρεί τον αποθηκευμένο κωδικό. Δεν θα επιχειρείται πλέον αυτόματη ανανέωση.",
           "type_heatpump": "Περιλαμβάνει αισθητήρες κατάστασης, διαγνωστικών και κατανάλωσης της αντλίας θερμότητας.",
-          "type_ac_battery": "Περιλαμβάνει αισθητήρες μπαταρίας AC και χειριστήρια λειτουργίας ύπνου όταν είναι διαθέσιμα."
+          "type_ac_battery": "Περιλαμβάνει αισθητήρες μπαταρίας AC και χειριστήρια λειτουργίας ύπνου όταν είναι διαθέσιμα.",
+          "battery_schedules_enabled": "Διαχειριστείτε τα χρονοδιαγράμματα μπαταριών IQ"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Εξαγωγή προς δίκτυο",
           "battery_charge": "Φόρτιση μπαταρίας",
           "battery_discharge": "Εκφόρτιση μπαταρίας"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Τελευταία αναφορά {serial}"
+      },
+      "battery_cfg_schedules": {
+        "name": "Προγράμματα CFG μπαταρίας"
+      },
+      "battery_dtg_schedules": {
+        "name": "Χρονοδιαγράμματα DTG μπαταρίας"
+      },
+      "battery_rbd_schedules": {
+        "name": "Προγράμματα RBD μπαταρίας"
+      },
+      "battery_schedule_summary": {
+        "name": "Περίληψη χρονοδιαγράμματος μπαταρίας"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Όριο περιορισμού εκφόρτισης μπαταρίας"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Μπαταρία Νέο όριο χρονοδιαγράμματος"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Όριο χρονοδιαγράμματος μπαταρίας"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Πρόγραμμα Κυριακής"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Νέο πρόγραμμα μπαταρίας Δευτέρα"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Νέο πρόγραμμα μπαταρίας Τρίτη"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Νέο πρόγραμμα μπαταρίας Τετάρτη"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Νέο πρόγραμμα μπαταρίας Πέμπτη"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Νέο πρόγραμμα μπαταρίας Παρασκευή"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Νέο πρόγραμμα μπαταρίας Σάββατο"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Νέο πρόγραμμα μπαταρίας Κυριακή"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Πρόγραμμα μπαταρίας Δευτέρα"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Πρόγραμμα μπαταρίας Τρίτη"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Πρόγραμμα μπαταρίας Τετάρτη"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Πρόγραμμα μπαταρίας Πέμπτη"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Πρόγραμμα μπαταρίας Παρασκευή"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Πρόγραμμα μπαταρίας Σάββατο"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Πρόγραμμα μπαταρίας Κυριακή"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Πρόγραμμα"
+      },
+      "battery_new_schedule_type": {
+        "name": "Τύπος χρονοδιαγράμματος μπαταρίας"
+      },
+      "battery_schedule_selected": {
+        "name": "Χρονοδιάγραμμα μπαταρίας"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Δημιουργία νέου προγράμματος"
+      },
+      "battery_schedule_add": {
+        "name": "Προσθήκη χρονοδιαγράμματος μπαταρίας"
+      },
+      "battery_schedule_delete": {
+        "name": "Διαγραφή χρονοδιαγράμματος μπαταρίας"
+      },
+      "battery_schedule_refresh": {
+        "name": "Ανανέωση χρονοδιαγράμματος μπαταρίας"
+      },
+      "battery_schedule_save": {
+        "name": "Αποθήκευση χρονοδιαγράμματος μπαταρίας"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Ώρα λήξης προγράμματος"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Μπαταρία Νέο χρονοδιάγραμμα Ώρα έναρξης"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Μπαταρία Νέο χρονοδιάγραμμα Ώρα λήξης"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Χρονοδιάγραμμα μπαταρίας Ώρα έναρξης"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Χρόνος λήξης χρονοδιαγράμματος μπαταρίας"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "ID τοποθεσίας",
           "description": "ID τοποθεσίας Enphase (προαιρετικό· επιλύεται από τη συσκευή στόχο)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Αναγκαστική ανανέωση",
+      "description": "Ανανεώστε αμέσως τα δεδομένα του προγράμματος μπαταρίας από το Enphase cloud.",
+      "sections": {
+        "advanced": {
+          "name": "Σύνθετες επιλογές"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Αναγνωριστικό τοποθεσίας",
+          "description": "Προαιρετικό αναγνωριστικό τοποθεσίας. Εντοπίζεται αυτόματα όταν επιλέγεται συσκευή τοποθεσίας."
+        },
+        "config_entry_id": {
+          "name": "Αναγνωριστικό καταχώρισης ρύθμισης",
+          "description": "Προαιρετικό αναγνωριστικό καταχώρισης ρύθμισης για μία καταχώριση τοποθεσίας Enphase."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Προσθήκη χρονοδιαγράμματος μπαταρίας",
+      "description": "Δημιουργήστε ένα πρόγραμμα μπαταρίας για CFG, DTG ή RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Σύνθετες επιλογές"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Τύπος προγράμματος",
+          "description": "Οικογένεια προγράμματος μπαταρίας: cfg, dtg ή rbd."
+        },
+        "start_time": {
+          "name": "Ώρα έναρξης",
+          "description": "Ώρα έναρξης του προγράμματος."
+        },
+        "end_time": {
+          "name": "Ώρα λήξης",
+          "description": "Ώρα λήξης του προγράμματος."
+        },
+        "limit": {
+          "name": "Όριο φόρτισης",
+          "description": "Μέγιστη κατάσταση φόρτισης μπαταρίας (%)."
+        },
+        "days": {
+          "name": "Ημέρες",
+          "description": "Λίστα ενεργών ημερών της εβδομάδας με αντιστοίχιση Δευτέρα=1 έως Κυριακή=7."
+        },
+        "site_id": {
+          "name": "Αναγνωριστικό τοποθεσίας",
+          "description": "Προαιρετικό αναγνωριστικό τοποθεσίας. Εντοπίζεται αυτόματα όταν επιλέγεται συσκευή τοποθεσίας."
+        },
+        "config_entry_id": {
+          "name": "Αναγνωριστικό καταχώρισης ρύθμισης",
+          "description": "Προαιρετικό αναγνωριστικό καταχώρισης ρύθμισης για μία καταχώριση τοποθεσίας Enphase."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Ενημέρωση χρονοδιαγράμματος μπαταρίας",
+      "description": "Ενημερώστε ένα χρονοδιάγραμμα μπαταρίας κατά ID χρονοδιαγράμματος.",
+      "sections": {
+        "advanced": {
+          "name": "Σύνθετες επιλογές"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Αναγνωριστικό προγράμματος",
+          "description": "Υπάρχον αναγνωριστικό προγράμματος μπαταρίας Enphase."
+        },
+        "schedule_type": {
+          "name": "Τύπος προγράμματος",
+          "description": "Οικογένεια προγράμματος μπαταρίας: cfg, dtg ή rbd."
+        },
+        "start_time": {
+          "name": "Ώρα έναρξης",
+          "description": "Ώρα έναρξης του προγράμματος."
+        },
+        "end_time": {
+          "name": "Ώρα λήξης",
+          "description": "Ώρα λήξης του προγράμματος."
+        },
+        "limit": {
+          "name": "Όριο φόρτισης",
+          "description": "Μέγιστη κατάσταση φόρτισης μπαταρίας (%)."
+        },
+        "days": {
+          "name": "Ημέρες",
+          "description": "Λίστα ενεργών ημερών της εβδομάδας με αντιστοίχιση Δευτέρα=1 έως Κυριακή=7."
+        },
+        "confirm": {
+          "name": "Επιβεβαίωση",
+          "description": "Ορίστε την τιμή σε true για να επιβεβαιώσετε την ενημέρωση του προγράμματος."
+        },
+        "site_id": {
+          "name": "Αναγνωριστικό τοποθεσίας",
+          "description": "Προαιρετικό αναγνωριστικό τοποθεσίας. Εντοπίζεται αυτόματα όταν επιλέγεται συσκευή τοποθεσίας."
+        },
+        "config_entry_id": {
+          "name": "Αναγνωριστικό καταχώρισης ρύθμισης",
+          "description": "Προαιρετικό αναγνωριστικό καταχώρισης ρύθμισης για μία καταχώριση τοποθεσίας Enphase."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Διαγραφή χρονοδιαγράμματος μπαταρίας",
+      "description": "Διαγράψτε ένα ή περισσότερα χρονοδιαγράμματα μπαταρίας κατά αναγνωριστικό προγράμματος.",
+      "sections": {
+        "advanced": {
+          "name": "Σύνθετες επιλογές"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Αναγνωριστικό προγράμματος",
+          "description": "Ένα μεμονωμένο αναγνωριστικό προγράμματος μπαταρίας Enphase προς διαγραφή."
+        },
+        "schedule_ids": {
+          "name": "Αναγνωριστικά προγραμμάτων",
+          "description": "Προαιρετική είσοδος λίστας ή τιμών χωρισμένων με κόμματα για πολλά αναγνωριστικά προγραμμάτων."
+        },
+        "confirm": {
+          "name": "Επιβεβαίωση",
+          "description": "Ορίστε την τιμή σε true για να επιβεβαιώσετε τη διαγραφή του προγράμματος."
+        },
+        "site_id": {
+          "name": "Αναγνωριστικό τοποθεσίας",
+          "description": "Προαιρετικό αναγνωριστικό τοποθεσίας. Εντοπίζεται αυτόματα όταν επιλέγεται συσκευή τοποθεσίας."
+        },
+        "config_entry_id": {
+          "name": "Αναγνωριστικό καταχώρισης ρύθμισης",
+          "description": "Προαιρετικό αναγνωριστικό καταχώρισης ρύθμισης για μία καταχώριση τοποθεσίας Enphase."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Επικύρωση χρονοδιαγράμματος μπαταρίας",
+      "description": "Ελέγξτε εάν η επεξεργασία προγράμματος μπαταρίας είναι διαθέσιμη για την επιλεγμένη οικογένεια χρονοδιαγράμματος.",
+      "sections": {
+        "advanced": {
+          "name": "Σύνθετες επιλογές"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Τύπος προγράμματος",
+          "description": "Οικογένεια προγράμματος μπαταρίας: cfg, dtg ή rbd."
+        },
+        "site_id": {
+          "name": "Αναγνωριστικό τοποθεσίας",
+          "description": "Προαιρετικό αναγνωριστικό τοποθεσίας. Εντοπίζεται αυτόματα όταν επιλέγεται συσκευή τοποθεσίας."
+        },
+        "config_entry_id": {
+          "name": "Αναγνωριστικό καταχώρισης ρύθμισης",
+          "description": "Προαιρετικό αναγνωριστικό καταχώρισης ρύθμισης για μία καταχώριση τοποθεσίας Enphase."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Schedule update conflicts with an existing battery schedule."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Charging mode selection is unavailable while the Enphase scheduler service is down."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Select at least one day for the schedule."
+    },
+    "battery_schedule_times_different": {
+      "message": "Schedule start and end times must be different."
+    },
+    "battery_schedule_limit_range": {
+      "message": "{schedule_type} schedule limit must be between {minimum} and {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Schedule rejected by the Enphase validation endpoint."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Battery schedule editing is unavailable."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Battery schedule API is unavailable."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Confirmation required to update a schedule."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Confirmation required to delete a schedule."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Invalid schedule ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Schedule ID not found in current data: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Provide at least one schedule ID to delete."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Invalid schedule ID(s): {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Schedule ID(s) not found in current data: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Schedule rejected by the Enphase validation endpoint: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Schedule update conflicts with an existing battery schedule: {message}"
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Schedule update conflicts with an existing battery schedule."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Charging mode selection is unavailable while the Enphase scheduler service is down."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Select at least one day for the schedule."
+    },
+    "battery_schedule_times_different": {
+      "message": "Schedule start and end times must be different."
+    },
+    "battery_schedule_limit_range": {
+      "message": "{schedule_type} schedule limit must be between {minimum} and {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Schedule rejected by the Enphase validation endpoint."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Battery schedule editing is unavailable."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Battery schedule API is unavailable."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Confirmation required to update a schedule."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Confirmation required to delete a schedule."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Invalid schedule ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Schedule ID not found in current data: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Provide at least one schedule ID to delete."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Invalid schedule ID(s): {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Schedule ID(s) not found in current data: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Schedule rejected by the Enphase validation endpoint: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Schedule update conflicts with an existing battery schedule: {message}"
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Schedule update conflicts with an existing battery schedule."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Charging mode selection is unavailable while the Enphase scheduler service is down."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Select at least one day for the schedule."
+    },
+    "battery_schedule_times_different": {
+      "message": "Schedule start and end times must be different."
+    },
+    "battery_schedule_limit_range": {
+      "message": "{schedule_type} schedule limit must be between {minimum} and {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Schedule rejected by the Enphase validation endpoint."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Battery schedule editing is unavailable."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Battery schedule API is unavailable."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Confirmation required to update a schedule."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Confirmation required to delete a schedule."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Invalid schedule ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Schedule ID not found in current data: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Provide at least one schedule ID to delete."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Invalid schedule ID(s): {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Schedule ID(s) not found in current data: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Schedule rejected by the Enphase validation endpoint: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Schedule update conflicts with an existing battery schedule: {message}"
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Schedule update conflicts with an existing battery schedule."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Charging mode selection is unavailable while the Enphase scheduler service is down."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Select at least one day for the schedule."
+    },
+    "battery_schedule_times_different": {
+      "message": "Schedule start and end times must be different."
+    },
+    "battery_schedule_limit_range": {
+      "message": "{schedule_type} schedule limit must be between {minimum} and {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Schedule rejected by the Enphase validation endpoint."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Battery schedule editing is unavailable."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Battery schedule API is unavailable."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Confirmation required to update a schedule."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Confirmation required to delete a schedule."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Invalid schedule ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Schedule ID not found in current data: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Provide at least one schedule ID to delete."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Invalid schedule ID(s): {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Schedule ID(s) not found in current data: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Schedule rejected by the Enphase validation endpoint: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Schedule update conflicts with an existing battery schedule: {message}"
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Schedule update conflicts with an existing battery schedule."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Charging mode selection is unavailable while the Enphase scheduler service is down."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Select at least one day for the schedule."
+    },
+    "battery_schedule_times_different": {
+      "message": "Schedule start and end times must be different."
+    },
+    "battery_schedule_limit_range": {
+      "message": "{schedule_type} schedule limit must be between {minimum} and {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Schedule rejected by the Enphase validation endpoint."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Battery schedule editing is unavailable."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Battery schedule API is unavailable."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Confirmation required to update a schedule."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Confirmation required to delete a schedule."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Invalid schedule ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Schedule ID not found in current data: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Provide at least one schedule ID to delete."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Invalid schedule ID(s): {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Schedule ID(s) not found in current data: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Schedule rejected by the Enphase validation endpoint: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Schedule update conflicts with an existing battery schedule: {message}"
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Schedule overlaps with the existing {schedule_label}. Adjust or disable that schedule first."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Schedule update conflicts with an existing battery schedule."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Charging mode selection is unavailable while the Enphase scheduler service is down."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Select at least one day for the schedule."
+    },
+    "battery_schedule_times_different": {
+      "message": "Schedule start and end times must be different."
+    },
+    "battery_schedule_limit_range": {
+      "message": "{schedule_type} schedule limit must be between {minimum} and {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Schedule rejected by the Enphase validation endpoint."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Battery schedule editing is unavailable."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Battery schedule API is unavailable."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Confirmation required to update a schedule."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Confirmation required to delete a schedule."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Invalid schedule ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Schedule ID not found in current data: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Provide at least one schedule ID to delete."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Invalid schedule ID(s): {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Schedule ID(s) not found in current data: {schedule_ids}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Schedule update conflicts with an existing battery schedule: {message}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Schedule rejected by the Enphase validation endpoint: {message}"
     }
   },
   "options": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "El horario se superpone con el {schedule_label} existente. Ajusta o desactiva primero ese horario."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "La actualización del horario entra en conflicto con un horario de batería existente."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "La selección del modo de carga no está disponible mientras el servicio de programación de Enphase no esté disponible."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "El estado de carga objetivo seleccionado de la batería CA no está disponible."
+    },
+    "battery_schedule_day_required": {
+      "message": "Selecciona al menos un día para el horario."
+    },
+    "battery_schedule_times_different": {
+      "message": "Las horas de inicio y fin del horario deben ser distintas."
+    },
+    "battery_schedule_limit_range": {
+      "message": "El límite del horario {schedule_type} debe estar entre {minimum} y {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Horario rechazado por el endpoint de validación de Enphase."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "La edición de horarios de batería no está disponible."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "La API de horarios de batería no está disponible."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Se requiere confirmación para actualizar un horario."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Se requiere confirmación para eliminar un horario."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "ID de horario no válido: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "ID de horario no encontrado en los datos actuales: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Proporciona al menos un ID de horario para eliminar."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "ID de horario no válidos: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "IDs de horario no encontrados en los datos actuales: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Horario rechazado por el endpoint de validación de Enphase: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "La actualización del horario entra en conflicto con un horario de batería existente: {message}"
     }
   },
   "options": {
@@ -161,7 +422,8 @@
           "reauth": "Iniciar reautenticación",
           "forget_password": "Olvidar contraseña almacenada",
           "type_heatpump": "Bomba de calor",
-          "type_ac_battery": "Batería CA"
+          "type_ac_battery": "Batería CA",
+          "battery_schedules_enabled": "Activar programador de batería"
         },
         "data_description": {
           "type_envoy": "Incluye conectividad de la puerta de enlace y diagnósticos de medidores.",
@@ -178,7 +440,8 @@
           "reauth": "Inicia el flujo de inicio de sesión para actualizar credenciales sin eliminar la integración.",
           "forget_password": "Elimina la contraseña almacenada. Ya no se intentará la actualización automática.",
           "type_heatpump": "Incluye sensores de estado, diagnóstico y consumo de la bomba de calor.",
-          "type_ac_battery": "Incluye sensores de batería CA y controles del modo de reposo cuando están disponibles."
+          "type_ac_battery": "Incluye sensores de batería CA y controles del modo de reposo cuando están disponibles.",
+          "battery_schedules_enabled": "Gestionar horarios de batería IQ"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Iniciar reautenticación",
           "forget_password": "Olvidar contraseña almacenada",
           "type_heatpump": "Bomba de calor",
-          "type_ac_battery": "Batería CA"
+          "type_ac_battery": "Batería CA",
+          "battery_schedules_enabled": "Activar programador de batería"
         },
         "data_description": {
           "type_envoy": "Incluye conectividad de la puerta de enlace y diagnósticos de medidores.",
@@ -216,7 +480,8 @@
           "reauth": "Inicia el flujo de inicio de sesión para actualizar credenciales sin eliminar la integración.",
           "forget_password": "Elimina la contraseña almacenada. Ya no se intentará la actualización automática.",
           "type_heatpump": "Incluye sensores de estado, diagnóstico y consumo de la bomba de calor.",
-          "type_ac_battery": "Incluye sensores de batería CA y controles del modo de reposo cuando están disponibles."
+          "type_ac_battery": "Incluye sensores de batería CA y controles del modo de reposo cuando están disponibles.",
+          "battery_schedules_enabled": "Gestionar horarios de batería IQ"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Exportación a red",
           "battery_charge": "Carga de batería",
           "battery_discharge": "Descarga de batería"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Último informe de {serial}"
+      },
+      "battery_cfg_schedules": {
+        "name": "Horarios CFG de la batería"
+      },
+      "battery_dtg_schedules": {
+        "name": "Horarios DTG de la batería"
+      },
+      "battery_rbd_schedules": {
+        "name": "Horarios RBD de la batería"
+      },
+      "battery_schedule_summary": {
+        "name": "Resumen de horarios de la batería"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Límite de restricción de descarga de la batería"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Límite de horario nuevo de la batería"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Límite de horario de la batería"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Horario del domingo"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Horario nuevo de batería lunes"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Horario nuevo de batería martes"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Horario nuevo de batería miércoles"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Horario nuevo de batería jueves"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Horario nuevo de batería viernes"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Horario nuevo de batería sábado"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Horario nuevo de batería domingo"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Horario de batería lunes"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Horario de batería martes"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Horario de batería miércoles"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Horario de batería jueves"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Horario de batería viernes"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Horario de batería sábado"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Horario de batería domingo"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Horario"
+      },
+      "battery_new_schedule_type": {
+        "name": "Tipo de horario de la batería"
+      },
+      "battery_schedule_selected": {
+        "name": "Horario de la batería"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Crear nuevo horario"
+      },
+      "battery_schedule_add": {
+        "name": "Añadir horario de la batería"
+      },
+      "battery_schedule_delete": {
+        "name": "Eliminar horario de la batería"
+      },
+      "battery_schedule_refresh": {
+        "name": "Actualizar horario de la batería"
+      },
+      "battery_schedule_save": {
+        "name": "Guardar horario de la batería"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Hora de fin del horario"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Hora de inicio del horario nuevo de la batería"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Hora de fin del horario nuevo de la batería"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Hora de inicio del horario de la batería"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Hora de fin del horario de la batería"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "ID del sitio",
           "description": "ID del sitio de Enphase (opcional; se resuelve desde el dispositivo de destino)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Forzar actualización",
+      "description": "Actualiza de inmediato los datos de horarios de la batería desde la nube de Enphase.",
+      "sections": {
+        "advanced": {
+          "name": "Opciones avanzadas"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "ID del sitio",
+          "description": "Identificador de sitio opcional; se detecta automáticamente cuando se selecciona un dispositivo del sitio."
+        },
+        "config_entry_id": {
+          "name": "ID de entrada de configuración",
+          "description": "Identificador opcional de entrada de configuración para una única entrada de sitio de Enphase."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Añadir horario de la batería",
+      "description": "Crea un horario de batería para CFG, DTG o RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Opciones avanzadas"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Tipo de horario",
+          "description": "Familia de horarios de batería: cfg, dtg o rbd."
+        },
+        "start_time": {
+          "name": "Hora de inicio",
+          "description": "Hora de inicio del horario."
+        },
+        "end_time": {
+          "name": "Hora de fin",
+          "description": "Hora de fin del horario."
+        },
+        "limit": {
+          "name": "Límite de carga",
+          "description": "Estado máximo de carga de la batería (%)."
+        },
+        "days": {
+          "name": "Días",
+          "description": "Lista de días laborables activos usando lunes=1 hasta domingo=7."
+        },
+        "site_id": {
+          "name": "ID del sitio",
+          "description": "Identificador de sitio opcional; se detecta automáticamente cuando se selecciona un dispositivo del sitio."
+        },
+        "config_entry_id": {
+          "name": "ID de entrada de configuración",
+          "description": "Identificador opcional de entrada de configuración para una única entrada de sitio de Enphase."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Actualizar horario de la batería",
+      "description": "Actualiza un horario de batería por ID de horario.",
+      "sections": {
+        "advanced": {
+          "name": "Opciones avanzadas"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "ID del horario",
+          "description": "Identificador existente de horario de batería de Enphase."
+        },
+        "schedule_type": {
+          "name": "Tipo de horario",
+          "description": "Familia de horarios de batería: cfg, dtg o rbd."
+        },
+        "start_time": {
+          "name": "Hora de inicio",
+          "description": "Hora de inicio del horario."
+        },
+        "end_time": {
+          "name": "Hora de fin",
+          "description": "Hora de fin del horario."
+        },
+        "limit": {
+          "name": "Límite de carga",
+          "description": "Estado máximo de carga de la batería (%)."
+        },
+        "days": {
+          "name": "Días",
+          "description": "Lista de días laborables activos usando lunes=1 hasta domingo=7."
+        },
+        "confirm": {
+          "name": "Confirmar",
+          "description": "Establécelo en true para confirmar la actualización del horario."
+        },
+        "site_id": {
+          "name": "ID del sitio",
+          "description": "Identificador de sitio opcional; se detecta automáticamente cuando se selecciona un dispositivo del sitio."
+        },
+        "config_entry_id": {
+          "name": "ID de entrada de configuración",
+          "description": "Identificador opcional de entrada de configuración para una única entrada de sitio de Enphase."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Eliminar horario de la batería",
+      "description": "Elimina uno o más horarios de batería por ID de horario.",
+      "sections": {
+        "advanced": {
+          "name": "Opciones avanzadas"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "ID del horario",
+          "description": "Identificador de un único horario de batería de Enphase que se va a eliminar."
+        },
+        "schedule_ids": {
+          "name": "IDs de horario",
+          "description": "Entrada opcional como lista o separada por comas para varios identificadores de horario."
+        },
+        "confirm": {
+          "name": "Confirmar",
+          "description": "Establécelo en true para confirmar la eliminación del horario."
+        },
+        "site_id": {
+          "name": "ID del sitio",
+          "description": "Identificador de sitio opcional; se detecta automáticamente cuando se selecciona un dispositivo del sitio."
+        },
+        "config_entry_id": {
+          "name": "ID de entrada de configuración",
+          "description": "Identificador opcional de entrada de configuración para una única entrada de sitio de Enphase."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Validar horario de la batería",
+      "description": "Comprueba si la edición de horarios de batería está disponible para la familia de horarios seleccionada.",
+      "sections": {
+        "advanced": {
+          "name": "Opciones avanzadas"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Tipo de horario",
+          "description": "Familia de horarios de batería: cfg, dtg o rbd."
+        },
+        "site_id": {
+          "name": "ID del sitio",
+          "description": "Identificador de sitio opcional; se detecta automáticamente cuando se selecciona un dispositivo del sitio."
+        },
+        "config_entry_id": {
+          "name": "ID de entrada de configuración",
+          "description": "Identificador opcional de entrada de configuración para una única entrada de sitio de Enphase."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -133,214 +133,214 @@
       "message": "El horario se superpone con el {schedule_label} existente. Ajusta o desactiva primero ese horario."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "No hay dispositivos AC Battery disponibles en este momento."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Los ajustes de autenticación no están disponibles mientras el servicio de Enphase esté caído."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Las actualizaciones del perfil de batería no están permitidas para esta cuenta."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Las actualizaciones de la configuración de la batería no están permitidas para esta cuenta."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Ya hay otra actualización del perfil de batería en curso."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Ya hay otra actualización de la configuración de la batería en curso."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Las actualizaciones del perfil de batería no están disponibles."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Las actualizaciones de la configuración de la batería no están disponibles."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Las actualizaciones de la batería no están disponibles."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Las actualizaciones de la batería no están permitidas para esta cuenta."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "La actualización del perfil de batería se solicitó demasiado rápido. Espera y vuelve a intentarlo."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "La actualización de la configuración de la batería se solicitó demasiado rápido. Espera y vuelve a intentarlo."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "No se pudo confirmar el acceso de escritura a la batería. Actualiza y vuelve a intentarlo."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "La actualización del horario fue rechazada por Enphase (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "No se pudo autenticar la actualización del horario. Vuelve a autenticarte y vuelve a intentarlo."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "El horario entra en conflicto con el horario existente de discharge-to-grid. Ajusta o desactiva primero ese horario."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "El horario entra en conflicto con el horario existente de restrict-battery-discharge. Ajusta o desactiva primero ese horario."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "El horario entra en conflicto con el horario existente de charge-from-grid. Ajusta o desactiva primero ese horario."
     },
     "schedule_update_conflict": {
       "message": "La actualización del horario entra en conflicto con un horario de batería existente."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "El perfil de batería no está disponible."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "La actualización del perfil de batería fue rechazada por Enphase (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "No se pudo autenticar la actualización del perfil de batería. Vuelve a autenticarte y vuelve a intentarlo."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "La carga útil de la configuración de la batería no está disponible."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "La actualización de la configuración de la batería fue rechazada por Enphase (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "No se pudo autenticar la actualización de la configuración de la batería. Vuelve a autenticarte y vuelve a intentarlo."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "La reserva de Full Backup está fijada en el 100%."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "La reserva de batería no está disponible."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "El perfil Savings debe estar activo."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "La configuración del perfil Savings no está disponible."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "El perfil de batería seleccionado no es compatible."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "La opción de cargar desde la red no está disponible."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Enphase no aplicó el conmutador de carga desde la red."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "El horario de carga desde la red no está disponible."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Las horas de inicio y fin del horario de charge-from-grid deben ser distintas."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Enphase no aplicó el conmutador del horario de charge-from-grid."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Primero se debe habilitar la carga desde la red."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Hay un cambio de horario pendiente de sincronización con Envoy. Espera."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "La hora del horario de charge-from-grid no es válida."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "La API de horarios no está disponible en esta versión del cliente."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "No hay ningún horario existente de charge-from-grid disponible."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Crea un {schedule_label} en el programador de IQ Battery antes de habilitarlo."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "Enphase no expone actualmente {schedule_label} para este sitio. Espera a que se complete la sincronización del horario, luego actualiza y vuelve a intentarlo."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Enphase no aplicó el conmutador de {schedule_label}."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "La escritura principal fue rechazada."
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "Las horas de inicio y fin de {schedule_label} deben ser distintas."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "La hora del horario de discharge-to-grid no es válida."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "No hay ningún horario existente de {schedule_label_lower} disponible."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "El horario de {schedule_label} no está disponible."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "La hora del horario de {schedule_label} no es válida."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "La hora actual del horario de {schedule_label_lower} no es válida."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "El límite del horario de {schedule_label} debe estar entre {minimum} y {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "El límite del horario de {schedule_label} debe ser al menos del {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Las horas actuales del horario no están disponibles."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "El límite del horario de charge-from-grid debe estar entre {minimum} y {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "El límite del horario de charge-from-grid debe ser al menos del {minimum}%."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "El nivel de apagado de la batería no está disponible."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "El nivel de apagado de la batería no es válido."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "El nivel de apagado de la batería debe estar entre {minimum} y {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "La exclusión de Storm Alert no está disponible."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "La exclusión de Storm Alert falló para {count} alerta(s)."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Las actualizaciones de Storm Guard no están permitidas para esta cuenta."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "La configuración de Storm Guard no está disponible."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "La actualización de Storm Guard fue rechazada por Enphase (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "No se pudo autenticar la actualización de Storm Guard. Vuelve a autenticarte y vuelve a intentarlo."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "El perfil del sistema seleccionado no está disponible."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "La actualización del perfil del sistema fue rechazada por Enphase (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "No se pudo autenticar la actualización del perfil del sistema. Vuelve a autenticarte y vuelve a intentarlo."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "La actualización del perfil del sistema falló."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "La actualización del perfil del sistema falló debido a un error de red. Vuelve a intentarlo."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Se agotó el tiempo de espera de la actualización del perfil del sistema. Vuelve a intentarlo."
     },
     "scheduler_service_unavailable": {
       "message": "La selección del modo de carga no está disponible mientras el servicio de programación de Enphase no esté disponible."
@@ -514,8 +514,8 @@
           "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
           "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
           "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
-          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
-          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
+          "battery_charge": "Asigna un total acumulado de carga de batería al sensor Enphase Energy Site Battery Charge. No elijas energía diaria ni potencia en vivo.",
+          "battery_discharge": "Asigna un total acumulado de descarga de batería al sensor Enphase Energy Site Battery Discharge. No elijas energía diaria ni potencia en vivo."
         }
       },
       "migrate_envoy_confirm": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Ajakava kattub olemasoleva {schedule_label}-ga. Kohanda või keela see ajakava enne."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Ajakava uuendus on vastuolus olemasoleva aku ajakavaga."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Laadimisrežiimi valik pole saadaval, kui Enphase'i ajastusteenus on maas."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Valitud AC-aku sihtlaetuse tase pole saadaval."
+    },
+    "battery_schedule_day_required": {
+      "message": "Vali ajakava jaoks vähemalt üks päev."
+    },
+    "battery_schedule_times_different": {
+      "message": "Ajakava algus- ja lõpuaeg peavad erinema."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Ajakava {schedule_type} piirang peab olema vahemikus {minimum} kuni {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Enphase'i valideerimise lõpp-punkt lükkas ajakava tagasi."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Aku ajakavade muutmine pole saadaval."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Aku ajakavade API pole saadaval."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Ajakava uuendamiseks on vaja kinnitust."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Ajakava kustutamiseks on vaja kinnitust."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Vigane ajakava ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Ajakava ID-d ei leitud praegustest andmetest: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Kustutamiseks esita vähemalt üks ajakava ID."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Vigased ajakava ID-d: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Ajakava ID-sid ei leitud praegustest andmetest: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Enphase'i valideerimise lõpp-punkt lükkas ajakava tagasi: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Ajakava uuendus on vastuolus olemasoleva aku ajakavaga: {message}"
     }
   },
   "options": {
@@ -161,7 +422,8 @@
           "reauth": "Alusta taasautentimist",
           "forget_password": "Unusta salvestatud parool",
           "type_heatpump": "Soojuspump",
-          "type_ac_battery": "AC-aku"
+          "type_ac_battery": "AC-aku",
+          "battery_schedules_enabled": "Luba aku ajastaja"
         },
         "data_description": {
           "type_envoy": "Sisaldab lüüsi ühenduvuse ja arvestite diagnostikat.",
@@ -178,7 +440,8 @@
           "reauth": "Käivitage sisselogimisvoog, et uuendada mandaate ilma integratsiooni eemaldamata.",
           "forget_password": "Eemaldab salvestatud parooli. Automaatset värskendamist enam ei üritata.",
           "type_heatpump": "Sisaldab soojuspumba oleku-, diagnostika- ja tarbimisandureid.",
-          "type_ac_battery": "Sisaldab AC-aku andureid ja unerežiimi juhtnuppe, kui need on saadaval."
+          "type_ac_battery": "Sisaldab AC-aku andureid ja unerežiimi juhtnuppe, kui need on saadaval.",
+          "battery_schedules_enabled": "Halda IQ aku ajakavasid"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Alusta taasautentimist",
           "forget_password": "Unusta salvestatud parool",
           "type_heatpump": "Soojuspump",
-          "type_ac_battery": "AC-aku"
+          "type_ac_battery": "AC-aku",
+          "battery_schedules_enabled": "Luba aku ajastaja"
         },
         "data_description": {
           "type_envoy": "Sisaldab lüüsi ühenduvuse ja arvestite diagnostikat.",
@@ -216,7 +480,8 @@
           "reauth": "Käivitage sisselogimisvoog, et uuendada mandaate ilma integratsiooni eemaldamata.",
           "forget_password": "Eemaldab salvestatud parooli. Automaatset värskendamist enam ei üritata.",
           "type_heatpump": "Sisaldab soojuspumba oleku-, diagnostika- ja tarbimisandureid.",
-          "type_ac_battery": "Sisaldab AC-aku andureid ja unerežiimi juhtnuppe, kui need on saadaval."
+          "type_ac_battery": "Sisaldab AC-aku andureid ja unerežiimi juhtnuppe, kui need on saadaval.",
+          "battery_schedules_enabled": "Halda IQ aku ajakavasid"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Võrku eksport",
           "battery_charge": "Aku laadimine",
           "battery_discharge": "Aku tühjenemine"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "{serial} viimane raport"
+      },
+      "battery_cfg_schedules": {
+        "name": "Aku CFG ajakavad"
+      },
+      "battery_dtg_schedules": {
+        "name": "Aku DTG ajakavad"
+      },
+      "battery_rbd_schedules": {
+        "name": "Aku RBD ajakavad"
+      },
+      "battery_schedule_summary": {
+        "name": "Aku ajakavade kokkuvõte"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Aku tühjendamise piirangu määr"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Uue aku ajakava piirang"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Aku ajakava piirang"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Pühapäeva ajakava"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Uus aku ajakava esmaspäev"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Uus aku ajakava teisipäev"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Uus aku ajakava kolmapäev"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Uus aku ajakava neljapäev"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Uus aku ajakava reede"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Uus aku ajakava laupäev"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Uus aku ajakava pühapäev"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Aku ajakava esmaspäev"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Aku ajakava teisipäev"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Aku ajakava kolmapäev"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Aku ajakava neljapäev"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Aku ajakava reede"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Aku ajakava laupäev"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Aku ajakava pühapäev"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Ajakava"
+      },
+      "battery_new_schedule_type": {
+        "name": "Aku ajakava tüüp"
+      },
+      "battery_schedule_selected": {
+        "name": "Aku ajakava"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Uue ajakava loomine"
+      },
+      "battery_schedule_add": {
+        "name": "Lisa aku ajakava"
+      },
+      "battery_schedule_delete": {
+        "name": "Kustuta aku ajakava"
+      },
+      "battery_schedule_refresh": {
+        "name": "Värskenda aku ajakava"
+      },
+      "battery_schedule_save": {
+        "name": "Salvesta aku ajakava"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Ajakava lõppaeg"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Uue aku ajakava algusaeg"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Uue aku ajakava lõpuaeg"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Aku ajakava algusaeg"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Aku ajakava lõpuaeg"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "Koha ID",
           "description": "Enphase koha ID (valikuline; leitakse sihtseadmest)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Sunni värskendust",
+      "description": "Värskenda aku ajakavade andmed kohe Enphase'i pilvest.",
+      "sections": {
+        "advanced": {
+          "name": "Lisavalikud"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Saidi ID",
+          "description": "Valikuline saidi identifikaator; tuvastatakse automaatselt, kui valitakse saidi seade."
+        },
+        "config_entry_id": {
+          "name": "Konfiguratsioonikirje ID",
+          "description": "Valikuline konfiguratsioonikirje identifikaator ühe Enphase'i saidikirje jaoks."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Lisa aku ajakava",
+      "description": "Loo aku ajakava CFG, DTG või RBD jaoks.",
+      "sections": {
+        "advanced": {
+          "name": "Lisavalikud"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Ajakava tüüp",
+          "description": "Aku ajakavapere: cfg, dtg või rbd."
+        },
+        "start_time": {
+          "name": "Algusaeg",
+          "description": "Ajakava algusaeg."
+        },
+        "end_time": {
+          "name": "Lõppaeg",
+          "description": "Ajakava lõppaeg."
+        },
+        "limit": {
+          "name": "Laadimispiirang",
+          "description": "Aku maksimaalne laetuse tase (%)."
+        },
+        "days": {
+          "name": "Päevad",
+          "description": "Aktiivsete nädalapäevade loend, kus esmaspäev=1 ja pühapäev=7."
+        },
+        "site_id": {
+          "name": "Saidi ID",
+          "description": "Valikuline saidi identifikaator; tuvastatakse automaatselt, kui valitakse saidi seade."
+        },
+        "config_entry_id": {
+          "name": "Konfiguratsioonikirje ID",
+          "description": "Valikuline konfiguratsioonikirje identifikaator ühe Enphase'i saidikirje jaoks."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Uuenda aku ajakava",
+      "description": "Uuenda aku ajakava ajakava ID järgi.",
+      "sections": {
+        "advanced": {
+          "name": "Lisavalikud"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Ajakava ID",
+          "description": "Olemasolev Enphase'i aku ajakava identifikaator."
+        },
+        "schedule_type": {
+          "name": "Ajakava tüüp",
+          "description": "Aku ajakavapere: cfg, dtg või rbd."
+        },
+        "start_time": {
+          "name": "Algusaeg",
+          "description": "Ajakava algusaeg."
+        },
+        "end_time": {
+          "name": "Lõppaeg",
+          "description": "Ajakava lõppaeg."
+        },
+        "limit": {
+          "name": "Laadimispiirang",
+          "description": "Aku maksimaalne laetuse tase (%)."
+        },
+        "days": {
+          "name": "Päevad",
+          "description": "Aktiivsete nädalapäevade loend, kus esmaspäev=1 ja pühapäev=7."
+        },
+        "confirm": {
+          "name": "Kinnita",
+          "description": "Määra väärtuseks true, et kinnitada ajakava uuendamine."
+        },
+        "site_id": {
+          "name": "Saidi ID",
+          "description": "Valikuline saidi identifikaator; tuvastatakse automaatselt, kui valitakse saidi seade."
+        },
+        "config_entry_id": {
+          "name": "Konfiguratsioonikirje ID",
+          "description": "Valikuline konfiguratsioonikirje identifikaator ühe Enphase'i saidikirje jaoks."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Kustuta aku ajakava",
+      "description": "Kustuta üks või mitu aku ajakava ajakava ID järgi.",
+      "sections": {
+        "advanced": {
+          "name": "Lisavalikud"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Ajakava ID",
+          "description": "Kustutatava üksiku Enphase'i aku ajakava identifikaator."
+        },
+        "schedule_ids": {
+          "name": "Ajakava ID-d",
+          "description": "Valikuline komadega eraldatud või loendina sisend mitme ajakava identifikaatori jaoks."
+        },
+        "confirm": {
+          "name": "Kinnita",
+          "description": "Määra väärtuseks true, et kinnitada ajakava kustutamine."
+        },
+        "site_id": {
+          "name": "Saidi ID",
+          "description": "Valikuline saidi identifikaator; tuvastatakse automaatselt, kui valitakse saidi seade."
+        },
+        "config_entry_id": {
+          "name": "Konfiguratsioonikirje ID",
+          "description": "Valikuline konfiguratsioonikirje identifikaator ühe Enphase'i saidikirje jaoks."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Valideeri aku ajakava",
+      "description": "Kontrolli, kas aku ajakavade muutmine on valitud ajakavapere jaoks saadaval.",
+      "sections": {
+        "advanced": {
+          "name": "Lisavalikud"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Ajakava tüüp",
+          "description": "Aku ajakavapere: cfg, dtg või rbd."
+        },
+        "site_id": {
+          "name": "Saidi ID",
+          "description": "Valikuline saidi identifikaator; tuvastatakse automaatselt, kui valitakse saidi seade."
+        },
+        "config_entry_id": {
+          "name": "Konfiguratsioonikirje ID",
+          "description": "Valikuline konfiguratsioonikirje identifikaator ühe Enphase'i saidikirje jaoks."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -133,214 +133,214 @@
       "message": "Ajakava kattub olemasoleva {schedule_label}-ga. Kohanda või keela see ajakava enne."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Ühtegi AC Battery seadet pole praegu saadaval."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Autentimisseaded pole saadaval, kui Enphase'i teenus on maas."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Aku profiili uuendused pole selle konto jaoks lubatud."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Aku seadete uuendused pole selle konto jaoks lubatud."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Teine aku profiili uuendus on juba käimas."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Teine aku seadete uuendus on juba käimas."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Aku profiili uuendused pole saadaval."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Aku seadete uuendused pole saadaval."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Aku uuendused pole saadaval."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Aku uuendused pole selle konto jaoks lubatud."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Aku profiili uuendust taotleti liiga kiiresti. Palun oota ja proovi uuesti."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Aku seadete uuendust taotleti liiga kiiresti. Palun oota ja proovi uuesti."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Aku kirjutusõigust ei saanud kinnitada. Värskenda ja proovi uuesti."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase lükkas ajakava uuenduse tagasi (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Ajakava uuendust ei saanud autentida. Autendi uuesti ja proovi uuesti."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Ajakava on vastuolus olemasoleva discharge-to-grid ajakavaga. Kohanda või keela see ajakava enne."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Ajakava on vastuolus olemasoleva restrict-battery-discharge ajakavaga. Kohanda või keela see ajakava enne."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Ajakava on vastuolus olemasoleva charge-from-grid ajakavaga. Kohanda või keela see ajakava enne."
     },
     "schedule_update_conflict": {
       "message": "Ajakava uuendus on vastuolus olemasoleva aku ajakavaga."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Aku profiil pole saadaval."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase lükkas aku profiili uuenduse tagasi (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Aku profiili uuendust ei saanud autentida. Autendi uuesti ja proovi uuesti."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Aku seadete koormusandmed pole saadaval."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase lükkas aku seadete uuenduse tagasi (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Aku seadete uuendust ei saanud autentida. Autendi uuesti ja proovi uuesti."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Full Backupi reserv on fikseeritud 100% peale."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Aku reserv pole saadaval."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Savings profiil peab olema aktiivne."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Savings profiili seaded pole saadaval."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Valitud aku profiili ei toetata."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Võrgust laadimise seadistus pole saadaval."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Enphase ei rakendanud võrgust laadimise lülitit."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Võrgust laadimise ajakava pole saadaval."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Charge-from-grid ajakava algus- ja lõpuaeg peavad olema erinevad."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Enphase ei rakendanud charge-from-grid ajakava lülitit."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Võrgust laadimine tuleb enne lubada."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Ajakava muudatus ootab Envoy sünkroonimist. Palun oota."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Charge-from-grid ajakava aeg on vigane."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Ajakava API pole selles kliendiversioonis saadaval."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Olemasolevat charge-from-grid ajakava pole saadaval."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Loo IQ Battery ajastajas {schedule_label} enne selle lubamist."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "Enphase ei kuva praegu selle saidi jaoks {schedule_label}. Oota, kuni ajakava sünkroonimine lõpeb, seejärel värskenda ja proovi uuesti."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Enphase ei rakendanud lülitit {schedule_label}."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "Peamine kirjutamine lükati tagasi."
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "{schedule_label} algus- ja lõpuaeg peavad olema erinevad."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Discharge-to-grid ajakava aeg on vigane."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Olemasolevat ajakava {schedule_label_lower} pole saadaval."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "{schedule_label} ajakava pole saadaval."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "{schedule_label} ajakava aeg on vigane."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Praegune {schedule_label_lower} ajakava aeg on vigane."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "{schedule_label} ajakava piirang peab olema vahemikus {minimum} kuni {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "{schedule_label} ajakava piirang peab olema vähemalt {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Praegused ajakava ajad pole saadaval."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Charge-from-grid ajakava piirang peab olema vahemikus {minimum} kuni {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Charge-from-grid ajakava piirang peab olema vähemalt {minimum}%."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Aku väljalülitustase pole saadaval."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Aku väljalülitustase on vigane."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Aku väljalülitustase peab olema vahemikus {minimum} kuni {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Storm Alertist loobumine pole saadaval."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Storm Alertist loobumine ebaõnnestus {count} hoiatuse puhul."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Storm Guardi uuendused pole selle konto jaoks lubatud."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Storm Guardi seaded pole saadaval."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase lükkas Storm Guardi uuenduse tagasi (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Storm Guardi uuendust ei saanud autentida. Autendi uuesti ja proovi uuesti."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Valitud süsteemiprofiil pole saadaval."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase lükkas süsteemiprofiili uuenduse tagasi (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Süsteemiprofiili uuendust ei saanud autentida. Autendi uuesti ja proovi uuesti."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Süsteemiprofiili uuendus ebaõnnestus."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Süsteemiprofiili uuendus ebaõnnestus võrguvea tõttu. Proovi uuesti."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Süsteemiprofiili uuenduse ajalõpp saabus. Proovi uuesti."
     },
     "scheduler_service_unavailable": {
       "message": "Laadimisrežiimi valik pole saadaval, kui Enphase'i ajastusteenus on maas."
@@ -514,8 +514,8 @@
           "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
           "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
           "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
-          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
-          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
+          "battery_charge": "Määra kumulatiivne aku laadimise kogus andurile Enphase Energy Site Battery Charge. Ära vali päevast energiat ega reaalajas võimsust.",
+          "battery_discharge": "Määra kumulatiivne aku tühjenemise kogus andurile Enphase Energy Site Battery Discharge. Ära vali päevast energiat ega reaalajas võimsust."
         }
       },
       "migrate_envoy_confirm": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Aikataulu on päällekkäinen olemassa olevan {schedule_label} kanssa. Muokkaa tai poista kyseinen aikataulu ensin käytöstä."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Aikataulun päivitys on ristiriidassa olemassa olevan akun aikataulun kanssa."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Lataustilan valinta ei ole käytettävissä, kun Enphase-ajastuspalvelu ei ole käytettävissä."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Valittu AC-akun tavoitevaraustaso ei ole käytettävissä."
+    },
+    "battery_schedule_day_required": {
+      "message": "Valitse aikataululle vähintään yksi päivä."
+    },
+    "battery_schedule_times_different": {
+      "message": "Aikataulun alkamis- ja päättymisaikojen on oltava eri."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Aikataulun {schedule_type} rajan on oltava välillä {minimum} ja {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Enphase-validointipäätepiste hylkäsi aikataulun."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Akun aikataulujen muokkaus ei ole käytettävissä."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Akun aikataulujen API ei ole käytettävissä."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Aikataulun päivittämiseen vaaditaan vahvistus."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Aikataulun poistamiseen vaaditaan vahvistus."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Virheellinen aikataulutunnus: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Aikataulutunnusta ei löytynyt nykyisistä tiedoista: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Anna vähintään yksi poistettava aikataulutunnus."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Virheelliset aikataulutunnukset: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Aikataulutunnuksia ei löytynyt nykyisistä tiedoista: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Enphase-validointipäätepiste hylkäsi aikataulun: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Aikataulun päivitys on ristiriidassa olemassa olevan akun aikataulun kanssa: {message}"
     }
   },
   "options": {
@@ -161,7 +422,8 @@
           "reauth": "Aloita uudelleentodennus",
           "forget_password": "Unohda tallennettu salasana",
           "type_heatpump": "Lämpöpumppu",
-          "type_ac_battery": "AC-akku"
+          "type_ac_battery": "AC-akku",
+          "battery_schedules_enabled": "Ota akun aikataulutus käyttöön"
         },
         "data_description": {
           "type_envoy": "Sisältää yhdyskäytävän yhteys- ja mittaridiagnostiikan.",
@@ -178,7 +440,8 @@
           "reauth": "Käynnistä kirjautumiskulku päivittääksesi valtuustiedot poistamatta integraatiota.",
           "forget_password": "Poistaa tallennetun salasanan. Automaattista päivitystä ei enää yritetä.",
           "type_heatpump": "Sisältää lämpöpumpun tila-, diagnostiikka- ja kulutusanturit.",
-          "type_ac_battery": "Sisältää AC-akun anturit ja lepotilan ohjaukset, kun ne ovat saatavilla."
+          "type_ac_battery": "Sisältää AC-akun anturit ja lepotilan ohjaukset, kun ne ovat saatavilla.",
+          "battery_schedules_enabled": "Hallitse IQ-akun aikatauluja"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Aloita uudelleentodennus",
           "forget_password": "Unohda tallennettu salasana",
           "type_heatpump": "Lämpöpumppu",
-          "type_ac_battery": "AC-akku"
+          "type_ac_battery": "AC-akku",
+          "battery_schedules_enabled": "Ota akun aikataulutus käyttöön"
         },
         "data_description": {
           "type_envoy": "Sisältää yhdyskäytävän yhteys- ja mittaridiagnostiikan.",
@@ -216,7 +480,8 @@
           "reauth": "Käynnistä kirjautumiskulku päivittääksesi valtuustiedot poistamatta integraatiota.",
           "forget_password": "Poistaa tallennetun salasanan. Automaattista päivitystä ei enää yritetä.",
           "type_heatpump": "Sisältää lämpöpumpun tila-, diagnostiikka- ja kulutusanturit.",
-          "type_ac_battery": "Sisältää AC-akun anturit ja lepotilan ohjaukset, kun ne ovat saatavilla."
+          "type_ac_battery": "Sisältää AC-akun anturit ja lepotilan ohjaukset, kun ne ovat saatavilla.",
+          "battery_schedules_enabled": "Hallitse IQ-akun aikatauluja"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Verkko-vienti",
           "battery_charge": "Akun lataus",
           "battery_discharge": "Akun purku"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "{serial} viimeksi raportoitu"
+      },
+      "battery_cfg_schedules": {
+        "name": "Akun CFG-aikataulut"
+      },
+      "battery_dtg_schedules": {
+        "name": "Akun DTG-aikataulut"
+      },
+      "battery_rbd_schedules": {
+        "name": "Akun RBD-aikataulut"
+      },
+      "battery_schedule_summary": {
+        "name": "Akun aikataulujen yhteenveto"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Akun purkauksen rajoitusraja"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Uuden akun aikataulun raja"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Akun aikataulun raja"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Sunnuntain aikataulu"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Uusi akun aikataulu maanantai"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Uusi akun aikataulu tiistai"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Uusi akun aikataulu keskiviikko"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Uusi akun aikataulu torstai"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Uusi akun aikataulu perjantai"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Uusi akun aikataulu lauantai"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Uusi akun aikataulu sunnuntai"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Akun aikataulu maanantai"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Akun aikataulu tiistai"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Akun aikataulu keskiviikko"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Akun aikataulu torstai"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Akun aikataulu perjantai"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Akun aikataulu lauantai"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Akun aikataulu sunnuntai"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Aikataulu"
+      },
+      "battery_new_schedule_type": {
+        "name": "Akun aikataulun tyyppi"
+      },
+      "battery_schedule_selected": {
+        "name": "Akun aikataulu"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Luo uusi aikataulu"
+      },
+      "battery_schedule_add": {
+        "name": "Lisää akun aikataulu"
+      },
+      "battery_schedule_delete": {
+        "name": "Poista akun aikataulu"
+      },
+      "battery_schedule_refresh": {
+        "name": "Päivitä akun aikataulu"
+      },
+      "battery_schedule_save": {
+        "name": "Tallenna akun aikataulu"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Aikataulun päättymisaika"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Uuden akun aikataulun aloitusaika"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Uuden akun aikataulun päättymisaika"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Akun aikataulun aloitusaika"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Akun aikataulun päättymisaika"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "Sivuston tunnus",
           "description": "Enphase-sivuston tunnus (valinnainen; päätellään kohdelaitteesta)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Pakota päivitys",
+      "description": "Päivitä akun aikataulutiedot heti Enphase-pilvestä.",
+      "sections": {
+        "advanced": {
+          "name": "Lisäasetukset"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Kohteen tunnus",
+          "description": "Valinnainen kohteen tunniste; havaitaan automaattisesti, kun kohteen laite on valittu."
+        },
+        "config_entry_id": {
+          "name": "Asetusmerkinnän tunnus",
+          "description": "Valinnainen asetuskirjauksen tunniste yhdelle Enphase-kohdemerkinnälle."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Lisää akun aikataulu",
+      "description": "Luo akun aikataulu CFG:lle, DTG:lle tai RBD:lle.",
+      "sections": {
+        "advanced": {
+          "name": "Lisäasetukset"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Aikataulun tyyppi",
+          "description": "Akun aikatauluperhe: cfg, dtg tai rbd."
+        },
+        "start_time": {
+          "name": "Alkamisaika",
+          "description": "Aikataulun alkamisaika."
+        },
+        "end_time": {
+          "name": "Päättymisaika",
+          "description": "Aikataulun päättymisaika."
+        },
+        "limit": {
+          "name": "Latausraja",
+          "description": "Akun enimmäisvaraustaso (%)."
+        },
+        "days": {
+          "name": "Päivät",
+          "description": "Aktiivisten viikonpäivien luettelo käyttäen merkintää maanantai=1 ... sunnuntai=7."
+        },
+        "site_id": {
+          "name": "Kohteen tunnus",
+          "description": "Valinnainen kohteen tunniste; havaitaan automaattisesti, kun kohteen laite on valittu."
+        },
+        "config_entry_id": {
+          "name": "Asetusmerkinnän tunnus",
+          "description": "Valinnainen asetuskirjauksen tunniste yhdelle Enphase-kohdemerkinnälle."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Päivitä akun aikataulu",
+      "description": "Päivitä akun aikataulu aikataulutunnuksen perusteella.",
+      "sections": {
+        "advanced": {
+          "name": "Lisäasetukset"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Aikataulun tunnus",
+          "description": "Olemassa olevan Enphase-akun aikataulun tunniste."
+        },
+        "schedule_type": {
+          "name": "Aikataulun tyyppi",
+          "description": "Akun aikatauluperhe: cfg, dtg tai rbd."
+        },
+        "start_time": {
+          "name": "Alkamisaika",
+          "description": "Aikataulun alkamisaika."
+        },
+        "end_time": {
+          "name": "Päättymisaika",
+          "description": "Aikataulun päättymisaika."
+        },
+        "limit": {
+          "name": "Latausraja",
+          "description": "Akun enimmäisvaraustaso (%)."
+        },
+        "days": {
+          "name": "Päivät",
+          "description": "Aktiivisten viikonpäivien luettelo käyttäen merkintää maanantai=1 ... sunnuntai=7."
+        },
+        "confirm": {
+          "name": "Vahvista",
+          "description": "Aseta arvoksi true vahvistaaksesi aikataulun päivityksen."
+        },
+        "site_id": {
+          "name": "Kohteen tunnus",
+          "description": "Valinnainen kohteen tunniste; havaitaan automaattisesti, kun kohteen laite on valittu."
+        },
+        "config_entry_id": {
+          "name": "Asetusmerkinnän tunnus",
+          "description": "Valinnainen asetuskirjauksen tunniste yhdelle Enphase-kohdemerkinnälle."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Poista akun aikataulu",
+      "description": "Poista yksi tai useampi akun aikataulu aikataulutunnuksen perusteella.",
+      "sections": {
+        "advanced": {
+          "name": "Lisäasetukset"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Aikataulun tunnus",
+          "description": "Poistettavan yksittäisen Enphase-akun aikataulun tunniste."
+        },
+        "schedule_ids": {
+          "name": "Aikataulujen tunnukset",
+          "description": "Valinnainen pilkuilla eroteltu tai luettelomuotoinen syöte useille aikataulutunnuksille."
+        },
+        "confirm": {
+          "name": "Vahvista",
+          "description": "Aseta arvoksi true vahvistaaksesi aikataulun poiston."
+        },
+        "site_id": {
+          "name": "Kohteen tunnus",
+          "description": "Valinnainen kohteen tunniste; havaitaan automaattisesti, kun kohteen laite on valittu."
+        },
+        "config_entry_id": {
+          "name": "Asetusmerkinnän tunnus",
+          "description": "Valinnainen asetuskirjauksen tunniste yhdelle Enphase-kohdemerkinnälle."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Validoi akun aikataulu",
+      "description": "Tarkista, onko akun aikataulujen muokkaus käytettävissä valitulle aikatauluperheelle.",
+      "sections": {
+        "advanced": {
+          "name": "Lisäasetukset"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Aikataulun tyyppi",
+          "description": "Akun aikatauluperhe: cfg, dtg tai rbd."
+        },
+        "site_id": {
+          "name": "Kohteen tunnus",
+          "description": "Valinnainen kohteen tunniste; havaitaan automaattisesti, kun kohteen laite on valittu."
+        },
+        "config_entry_id": {
+          "name": "Asetusmerkinnän tunnus",
+          "description": "Valinnainen asetuskirjauksen tunniste yhdelle Enphase-kohdemerkinnälle."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -133,214 +133,214 @@
       "message": "Aikataulu on päällekkäinen olemassa olevan {schedule_label} kanssa. Muokkaa tai poista kyseinen aikataulu ensin käytöstä."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "AC Battery -laitteita ei ole tällä hetkellä saatavilla."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Todennusasetukset eivät ole käytettävissä, kun Enphase-palvelu on poissa käytöstä."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Akun profiilin päivitykset eivät ole sallittuja tälle tilille."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Akun asetusten päivitykset eivät ole sallittuja tälle tilille."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Toinen akun profiilin päivitys on jo käynnissä."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Toinen akun asetusten päivitys on jo käynnissä."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Akun profiilin päivitykset eivät ole käytettävissä."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Akun asetusten päivitykset eivät ole käytettävissä."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Akun päivitykset eivät ole käytettävissä."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Akun päivitykset eivät ole sallittuja tälle tilille."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Akun profiilin päivitystä pyydettiin liian nopeasti. Odota ja yritä uudelleen."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Akun asetusten päivitystä pyydettiin liian nopeasti. Odota ja yritä uudelleen."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Akun kirjoitusoikeutta ei voitu vahvistaa. Päivitä ja yritä uudelleen."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase hylkäsi aikataulun päivityksen (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Aikataulun päivitystä ei voitu todentaa. Todennu uudelleen ja yritä uudestaan."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Aikataulu on ristiriidassa olemassa olevan discharge-to-grid-aikataulun kanssa. Muokkaa tai poista kyseinen aikataulu ensin käytöstä."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Aikataulu on ristiriidassa olemassa olevan restrict-battery-discharge-aikataulun kanssa. Muokkaa tai poista kyseinen aikataulu ensin käytöstä."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Aikataulu on ristiriidassa olemassa olevan charge-from-grid-aikataulun kanssa. Muokkaa tai poista kyseinen aikataulu ensin käytöstä."
     },
     "schedule_update_conflict": {
       "message": "Aikataulun päivitys on ristiriidassa olemassa olevan akun aikataulun kanssa."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Akun profiili ei ole käytettävissä."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase hylkäsi akun profiilin päivityksen (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Akun profiilin päivitystä ei voitu todentaa. Todennu uudelleen ja yritä uudestaan."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Akun asetusten hyötykuorma ei ole käytettävissä."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase hylkäsi akun asetusten päivityksen (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Akun asetusten päivitystä ei voitu todentaa. Todennu uudelleen ja yritä uudestaan."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Full Backup -varaus on kiinteästi 100 %."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Akun varausreservi ei ole käytettävissä."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Savings-profiilin on oltava aktiivinen."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Savings-profiilin asetukset eivät ole käytettävissä."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Valittua akun profiilia ei tueta."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Verkosta lataamisen asetus ei ole käytettävissä."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Enphase ei ottanut verkosta lataamisen kytkintä käyttöön."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Verkosta lataamisen aikataulu ei ole käytettävissä."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Charge-from-grid-aikataulun alku- ja loppuaikojen on oltava eri."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Enphase ei ottanut charge-from-grid-aikataulun kytkintä käyttöön."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Verkosta lataaminen on otettava ensin käyttöön."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Aikataulumuutos odottaa Envoy-synkronointia. Odota."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Charge-from-grid-aikataulun aika on virheellinen."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Aikataulu-API ei ole käytettävissä tässä asiakasversiossa."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Yhtään olemassa olevaa charge-from-grid-aikataulua ei ole käytettävissä."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Luo {schedule_label} IQ Battery -ajastimeen ennen sen käyttöönottoa."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "Enphase ei tällä hetkellä tuo {schedule_label} esiin tälle sivustolle. Odota, että aikataulun synkronointi valmistuu, päivitä ja yritä uudelleen."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Enphase ei ottanut käyttöön {schedule_label}-kytkintä."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "ensisijainen kirjoitus hylättiin"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "{schedule_label}-aikataulun alku- ja loppuaikojen on oltava eri."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Discharge-to-grid-aikataulun aika on virheellinen."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Yhtään olemassa olevaa {schedule_label_lower}-aikataulua ei ole käytettävissä."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "{schedule_label}-aikataulu ei ole käytettävissä."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "{schedule_label}-aikataulun aika on virheellinen."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Nykyinen {schedule_label_lower}-aikataulun aika on virheellinen."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "{schedule_label}-aikataulun rajan on oltava välillä {minimum} ja {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "{schedule_label}-aikataulun rajan on oltava vähintään {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Nykyiset aikatauluajat eivät ole käytettävissä."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Charge-from-grid-aikataulun rajan on oltava välillä {minimum} ja {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Charge-from-grid-aikataulun rajan on oltava vähintään {minimum}%."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Akun sammutustaso ei ole käytettävissä."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Akun sammutustaso on virheellinen."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Akun sammutustason on oltava välillä {minimum} ja {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Storm Alert -poistuminen ei ole käytettävissä."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Storm Alert -poistuminen epäonnistui {count} hälytyksen osalta."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Storm Guard -päivitykset eivät ole sallittuja tälle tilille."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Storm Guard -asetukset eivät ole käytettävissä."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase hylkäsi Storm Guard -päivityksen (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Storm Guard -päivitystä ei voitu todentaa. Todennu uudelleen ja yritä uudestaan."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Valittu järjestelmäprofiili ei ole käytettävissä."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase hylkäsi järjestelmäprofiilin päivityksen (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Järjestelmäprofiilin päivitystä ei voitu todentaa. Todennu uudelleen ja yritä uudestaan."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Järjestelmäprofiilin päivitys epäonnistui."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Järjestelmäprofiilin päivitys epäonnistui verkkovirheen vuoksi. Yritä uudelleen."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Järjestelmäprofiilin päivitys aikakatkaistiin. Yritä uudelleen."
     },
     "scheduler_service_unavailable": {
       "message": "Lataustilan valinta ei ole käytettävissä, kun Enphase-ajastuspalvelu ei ole käytettävissä."
@@ -514,8 +514,8 @@
           "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
           "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
           "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
-          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
-          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
+          "battery_charge": "Määritä kumulatiivinen akun latauksen kokonaismäärä Enphase Energy Site Battery Charge -anturille. Älä valitse päivittäistä energiaa tai reaaliaikaista tehoa.",
+          "battery_discharge": "Määritä kumulatiivinen akun purkauksen kokonaismäärä Enphase Energy Site Battery Discharge -anturille. Älä valitse päivittäistä energiaa tai reaaliaikaista tehoa."
         }
       },
       "migrate_envoy_confirm": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -133,220 +133,220 @@
       "message": "Le planning chevauche le {schedule_label} existant. Ajustez ou désactivez d’abord ce planning."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Aucun appareil de batterie AC n’est actuellement disponible."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Les paramètres d’authentification ne sont pas disponibles tant que le service Enphase est indisponible."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Les mises à jour du profil de batterie ne sont pas autorisées pour ce compte."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Les mises à jour des paramètres de batterie ne sont pas autorisées pour ce compte."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Une autre mise à jour du profil de batterie est déjà en cours."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Une autre mise à jour des paramètres de batterie est déjà en cours."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Les mises à jour du profil de batterie ne sont pas disponibles."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Les mises à jour des paramètres de batterie ne sont pas disponibles."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Les mises à jour de batterie ne sont pas disponibles."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Les mises à jour de batterie ne sont pas autorisées pour ce compte."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "La mise à jour du profil de batterie a été demandée trop rapidement. Veuillez patienter et réessayer."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "La mise à jour des paramètres de batterie a été demandée trop rapidement. Veuillez patienter et réessayer."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "L’accès en écriture à la batterie n’a pas pu être confirmé. Actualisez puis réessayez."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "La mise à jour du planning a été rejetée par Enphase (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "La mise à jour du planning n’a pas pu être authentifiée. Réauthentifiez-vous puis réessayez."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Le planning est en conflit avec le planning existant de décharge vers le réseau. Ajustez ou désactivez d’abord ce planning."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Le planning est en conflit avec le planning existant de restriction de décharge de la batterie. Ajustez ou désactivez d’abord ce planning."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Le planning est en conflit avec le planning existant de charge depuis le réseau. Ajustez ou désactivez d’abord ce planning."
     },
     "schedule_update_conflict": {
       "message": "La mise à jour programmée est en conflit avec une programmation de batterie existante."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Le profil de batterie n’est pas disponible."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "La mise à jour du profil de batterie a été rejetée par Enphase (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "La mise à jour du profil de batterie n’a pas pu être authentifiée. Réauthentifiez-vous puis réessayez."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "La charge utile des paramètres de batterie n’est pas disponible."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "La mise à jour des paramètres de batterie a été rejetée par Enphase (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "La mise à jour des paramètres de batterie n’a pas pu être authentifiée. Réauthentifiez-vous puis réessayez."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "La réserve Sauvegarde complète est fixée à 100 %."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "La réserve de batterie n’est pas disponible."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Le profil Économies doit être actif."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Les paramètres du profil Économies ne sont pas disponibles."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Le profil de batterie sélectionné n’est pas pris en charge."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Le paramètre de charge depuis le réseau n’est pas disponible."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "L’activation ou la désactivation de la charge depuis le réseau n’a pas été appliquée par Enphase."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Le planning de charge depuis le réseau n’est pas disponible."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Les heures de début et de fin du planning de charge depuis le réseau doivent être différentes."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "L’activation ou la désactivation du planning de charge depuis le réseau n’a pas été appliquée par Enphase."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "La charge depuis le réseau doit d’abord être activée."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Une modification de planning est en attente de synchronisation Envoy. Veuillez patienter."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "L’heure du planning de charge depuis le réseau n’est pas valide."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "L’API de planning n’est pas disponible dans cette version du client."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Aucun planning existant de charge depuis le réseau n’est disponible."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Créez un(e) {schedule_label} dans le planificateur IQ Battery avant de l’activer."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} n’est actuellement pas exposé(e) par Enphase pour ce site. Attendez la fin de la synchronisation du planning, puis actualisez et réessayez."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "L’activation ou la désactivation de {schedule_label} n’a pas été appliquée par Enphase."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "écriture principale rejetée"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "Les heures de début et de fin de {schedule_label} doivent être différentes."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "L’heure du planning de décharge vers le réseau n’est pas valide."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Aucun planning existant {schedule_label_lower} n’est disponible."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "Le planning {schedule_label} n’est pas disponible."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "L’heure du planning {schedule_label} n’est pas valide."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "L’heure actuelle du planning {schedule_label_lower} n’est pas valide."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "La limite du planning {schedule_label} doit être comprise entre {minimum} et {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "La limite du planning {schedule_label} doit être d’au moins {minimum} %."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Les horaires actuels du planning ne sont pas disponibles."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "La limite du planning de charge depuis le réseau doit être comprise entre {minimum} et {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "La limite du planning de charge depuis le réseau doit être d’au moins {minimum} %."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Le niveau d’arrêt de la batterie n’est pas disponible."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Le niveau d’arrêt de la batterie n’est pas valide."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Le niveau d’arrêt de la batterie doit être compris entre {minimum} et {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "La désactivation de Storm Alert n’est pas disponible."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "La désactivation de Storm Alert a échoué pour {count} alerte(s)."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Les mises à jour de Storm Guard ne sont pas autorisées pour ce compte."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Les paramètres de Storm Guard ne sont pas disponibles."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "La mise à jour de Storm Guard a été rejetée par Enphase (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "La mise à jour de Storm Guard n’a pas pu être authentifiée. Réauthentifiez-vous puis réessayez."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Le profil système sélectionné n’est pas disponible."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "La mise à jour du profil système a été rejetée par Enphase (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "La mise à jour du profil système n’a pas pu être authentifiée. Réauthentifiez-vous puis réessayez."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "La mise à jour du profil système a échoué."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "La mise à jour du profil système a échoué en raison d’une erreur réseau. Réessayez."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "La mise à jour du profil système a expiré. Réessayez."
     },
     "scheduler_service_unavailable": {
       "message": "La sélection du mode de charge n'est pas disponible lorsque le service de planification Enphase est en panne."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "L’état de charge cible sélectionné de la batterie AC n’est pas disponible."
     },
     "battery_schedule_day_required": {
       "message": "Sélectionnez au moins un jour pour le planning."
@@ -1826,17 +1826,17 @@
       "description": "Actualisez immédiatement les données de planification de la batterie à partir du cloud Enphase.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Options avancées"
         }
       },
       "fields": {
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "ID du site",
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "ID de l’entrée de configuration",
+          "description": "Identifiant facultatif de l’entrée de configuration pour une seule entrée de site Enphase."
         }
       }
     },

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Le planning chevauche le {schedule_label} existant. Ajustez ou désactivez d’abord ce planning."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "La mise à jour programmée est en conflit avec une programmation de batterie existante."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "La sélection du mode de charge n'est pas disponible lorsque le service de planification Enphase est en panne."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Sélectionnez au moins un jour pour le planning."
+    },
+    "battery_schedule_times_different": {
+      "message": "Les heures de début et de fin du planning doivent être différentes."
+    },
+    "battery_schedule_limit_range": {
+      "message": "La limite de planification {schedule_type} doit être comprise entre {minimum} et {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Le planning a été rejeté par le point de terminaison de validation Enphase."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "La modification du programme de batterie n'est pas disponible."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "L'API de planification de la batterie n'est pas disponible."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Confirmation requise pour mettre à jour un planning."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Confirmation requise pour supprimer un planning."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "ID de planning non valide : {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "ID de planning introuvable dans les données actuelles : {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Fournissez au moins un ID de planning à supprimer."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "ID(s) d'horaire non valide(s) : {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "ID(s) de planning introuvable(s) dans les données actuelles : {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Le planning a été rejeté par le point de terminaison de validation Enphase : {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "La mise à jour du planning est en conflit avec un planning de batterie existant : {message}"
     }
   },
   "options": {
@@ -157,11 +418,12 @@
           "api_timeout": "Délai d'expiration API (s)",
           "nominal_voltage": "Tension nominale (V)",
           "session_history_interval": "Intervalle d'historique de session (min)",
-          "schedule_sync_enabled": "Activer la prise en charge du planificateur",
+          "schedule_sync_enabled": "Activer le planificateur de chargeur EV",
           "reauth": "Démarrer la réauthentification",
           "forget_password": "Oublier le mot de passe stocké",
           "type_heatpump": "Pompe à chaleur",
-          "type_ac_battery": "Batterie AC"
+          "type_ac_battery": "Batterie AC",
+          "battery_schedules_enabled": "Activer le planificateur de batterie"
         },
         "data_description": {
           "type_envoy": "Inclut la connectivité de la passerelle et les diagnostics de compteurs.",
@@ -174,11 +436,12 @@
           "api_timeout": "Secondes avant l’expiration des requêtes API.",
           "nominal_voltage": "Tension de secours utilisée pour estimer la puissance du chargeur.",
           "session_history_interval": "Minutes d'attente entre les récupérations de l'historique de session depuis le cloud.",
-          "schedule_sync_enabled": "Gérer la gestion des plannings Enphase",
+          "schedule_sync_enabled": "Gérer les horaires des chargeurs IQ EV",
           "reauth": "Lancer le processus de connexion pour rafraîchir les identifiants sans supprimer l'intégration.",
           "forget_password": "Supprime le mot de passe stocké. Le rafraîchissement automatique ne sera plus tenté.",
           "type_heatpump": "Inclut des capteurs d'état, de diagnostic et de consommation de la pompe à chaleur.",
-          "type_ac_battery": "Inclut les capteurs de batterie AC et les commandes du mode veille lorsqu’ils sont disponibles."
+          "type_ac_battery": "Inclut les capteurs de batterie AC et les commandes du mode veille lorsqu’ils sont disponibles.",
+          "battery_schedules_enabled": "Gérer les programmes de batterie IQ"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Démarrer la réauthentification",
           "forget_password": "Oublier le mot de passe stocké",
           "type_heatpump": "Pompe à chaleur",
-          "type_ac_battery": "Batterie AC"
+          "type_ac_battery": "Batterie AC",
+          "battery_schedules_enabled": "Activer le planificateur de batterie"
         },
         "data_description": {
           "type_envoy": "Inclut la connectivité de la passerelle et les diagnostics de compteurs.",
@@ -216,7 +480,8 @@
           "reauth": "Lancer le processus de connexion pour rafraîchir les identifiants sans supprimer l'intégration.",
           "forget_password": "Supprime le mot de passe stocké. Le rafraîchissement automatique ne sera plus tenté.",
           "type_heatpump": "Inclut des capteurs d'état, de diagnostic et de consommation de la pompe à chaleur.",
-          "type_ac_battery": "Inclut les capteurs de batterie AC et les commandes du mode veille lorsqu’ils sont disponibles."
+          "type_ac_battery": "Inclut les capteurs de batterie AC et les commandes du mode veille lorsqu’ils sont disponibles.",
+          "battery_schedules_enabled": "Gérer les programmes de batterie IQ"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Export réseau",
           "battery_charge": "Charge batterie",
           "battery_discharge": "Décharge batterie"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Dernier relevé de {serial}"
+      },
+      "battery_cfg_schedules": {
+        "name": "Plannings CFG de la batterie"
+      },
+      "battery_dtg_schedules": {
+        "name": "Plannings DTG de la batterie"
+      },
+      "battery_rbd_schedules": {
+        "name": "Plannings RBD de la batterie"
+      },
+      "battery_schedule_summary": {
+        "name": "Résumé des plannings de batterie"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Limite de restriction de décharge de la batterie"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Limite du nouveau planning de batterie"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Limite du planning de batterie"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Programmation du dimanche"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Nouveau planning de batterie lundi"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Nouveau planning de batterie mardi"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Nouveau planning de batterie mercredi"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Nouveau planning de batterie jeudi"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Nouveau planning de batterie vendredi"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Nouveau planning de batterie samedi"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Nouveau planning de batterie dimanche"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Planning de batterie lundi"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Planning de batterie mardi"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Planning de batterie mercredi"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Planning de batterie jeudi"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Planning de batterie vendredi"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Planning de batterie samedi"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Planning de batterie dimanche"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Programmation"
+      },
+      "battery_new_schedule_type": {
+        "name": "Type de planning de batterie"
+      },
+      "battery_schedule_selected": {
+        "name": "Planning de batterie"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Créer une nouvelle programmation"
+      },
+      "battery_schedule_add": {
+        "name": "Ajouter un planning de batterie"
+      },
+      "battery_schedule_delete": {
+        "name": "Supprimer le planning de batterie"
+      },
+      "battery_schedule_refresh": {
+        "name": "Actualiser le planning de batterie"
+      },
+      "battery_schedule_save": {
+        "name": "Enregistrer le planning de batterie"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Heure de fin de la programmation"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Heure de début du nouveau planning de batterie"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Heure de fin du nouveau planning de batterie"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Heure de début du planning de batterie"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Heure de fin du planning de batterie"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "ID du site",
           "description": "ID de site Enphase (facultatif ; résolu à partir de l'appareil cible)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Forcer l'actualisation",
+      "description": "Actualisez immédiatement les données de planification de la batterie à partir du cloud Enphase.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Ajouter un planning de batterie",
+      "description": "Créer un planning de batterie pour CFG, DTG ou RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Options avancées"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Type de planning",
+          "description": "Famille de planning de batterie : cfg, dtg ou rbd."
+        },
+        "start_time": {
+          "name": "Heure de début",
+          "description": "Heure de début du planning."
+        },
+        "end_time": {
+          "name": "Heure de fin",
+          "description": "Heure de fin du planning."
+        },
+        "limit": {
+          "name": "Limite de charge",
+          "description": "État de charge maximal de la batterie (%)."
+        },
+        "days": {
+          "name": "Jours",
+          "description": "Liste des jours actifs de la semaine en utilisant lundi=1 à dimanche=7."
+        },
+        "site_id": {
+          "name": "ID du site",
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
+        },
+        "config_entry_id": {
+          "name": "ID de l’entrée de configuration",
+          "description": "Identifiant facultatif de l’entrée de configuration pour une seule entrée de site Enphase."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Mettre à jour le planning de batterie",
+      "description": "Mettre à jour un planning de batterie par ID de planning.",
+      "sections": {
+        "advanced": {
+          "name": "Options avancées"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "ID du planning",
+          "description": "Identifiant d’un planning de batterie Enphase existant."
+        },
+        "schedule_type": {
+          "name": "Type de planning",
+          "description": "Famille de planning de batterie : cfg, dtg ou rbd."
+        },
+        "start_time": {
+          "name": "Heure de début",
+          "description": "Heure de début du planning."
+        },
+        "end_time": {
+          "name": "Heure de fin",
+          "description": "Heure de fin du planning."
+        },
+        "limit": {
+          "name": "Limite de charge",
+          "description": "État de charge maximal de la batterie (%)."
+        },
+        "days": {
+          "name": "Jours",
+          "description": "Liste des jours actifs de la semaine en utilisant lundi=1 à dimanche=7."
+        },
+        "confirm": {
+          "name": "Confirmer",
+          "description": "Définir sur true pour confirmer la mise à jour du planning."
+        },
+        "site_id": {
+          "name": "ID du site",
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
+        },
+        "config_entry_id": {
+          "name": "ID de l’entrée de configuration",
+          "description": "Identifiant facultatif de l’entrée de configuration pour une seule entrée de site Enphase."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Supprimer le planning de batterie",
+      "description": "Supprimer un ou plusieurs plannings de batterie par ID de planning.",
+      "sections": {
+        "advanced": {
+          "name": "Options avancées"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "ID du planning",
+          "description": "Identifiant d’un planning de batterie Enphase unique à supprimer."
+        },
+        "schedule_ids": {
+          "name": "IDs des plannings",
+          "description": "Entrée facultative, sous forme de liste ou de valeurs séparées par des virgules, pour plusieurs identifiants de planning."
+        },
+        "confirm": {
+          "name": "Confirmer",
+          "description": "Définir sur true pour confirmer la suppression du planning."
+        },
+        "site_id": {
+          "name": "ID du site",
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
+        },
+        "config_entry_id": {
+          "name": "ID de l’entrée de configuration",
+          "description": "Identifiant facultatif de l’entrée de configuration pour une seule entrée de site Enphase."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Valider le planning de batterie",
+      "description": "Vérifier si la modification des plannings de batterie est disponible pour la famille de planning sélectionnée.",
+      "sections": {
+        "advanced": {
+          "name": "Options avancées"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Type de planning",
+          "description": "Famille de planning de batterie : cfg, dtg ou rbd."
+        },
+        "site_id": {
+          "name": "ID du site",
+          "description": "Identifiant de site facultatif ; détecté automatiquement lorsqu’un appareil de site est sélectionné."
+        },
+        "config_entry_id": {
+          "name": "ID de l’entrée de configuration",
+          "description": "Identifiant facultatif de l’entrée de configuration pour une seule entrée de site Enphase."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -133,220 +133,220 @@
       "message": "Az ütemezés átfedésben van a meglévő {schedule_label} elemmel. Először módosítsa vagy tiltsa le azt az ütemezést."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Jelenleg nem érhetők el AC akkumulátoros eszközök."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "A hitelesítési beállítások nem érhetők el, amíg az Enphase szolgáltatás nem működik."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Az akkumulátorprofil frissítése ennél a fióknál nem engedélyezett."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Az akkumulátorbeállítások frissítése ennél a fióknál nem engedélyezett."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Már folyamatban van egy másik akkumulátorprofil-frissítés."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Már folyamatban van egy másik akkumulátorbeállítás-frissítés."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Az akkumulátorprofil frissítése nem érhető el."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Az akkumulátorbeállítások frissítése nem érhető el."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Az akkumulátorfrissítések nem érhetők el."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Az akkumulátorfrissítések ennél a fióknál nem engedélyezettek."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Az akkumulátorprofil frissítését túl gyorsan kérték. Kérjük, várjon, majd próbálja újra."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Az akkumulátorbeállítások frissítését túl gyorsan kérték. Kérjük, várjon, majd próbálja újra."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Az akkumulátor írási hozzáférését nem sikerült megerősíteni. Frissítsen, majd próbálja újra."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Az Enphase elutasította az ütemezés frissítését (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Az ütemezés frissítését nem sikerült hitelesíteni. Hitelesítse újra magát, majd próbálja újra."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Az ütemezés ütközik a meglévő hálózatba táplálási ütemezéssel. Először módosítsa vagy tiltsa le azt az ütemezést."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Az ütemezés ütközik a meglévő akkumulátorkisütés-korlátozó ütemezéssel. Először módosítsa vagy tiltsa le azt az ütemezést."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Az ütemezés ütközik a meglévő hálózatról töltési ütemezéssel. Először módosítsa vagy tiltsa le azt az ütemezést."
     },
     "schedule_update_conflict": {
       "message": "Az ütemezési frissítés ütközik egy meglévő akkumulátorütemezéssel."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Az akkumulátorprofil nem érhető el."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Az Enphase elutasította az akkumulátorprofil frissítését (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Az akkumulátorprofil frissítését nem sikerült hitelesíteni. Hitelesítse újra magát, majd próbálja újra."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Az akkumulátorbeállítások adatterhe nem érhető el."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Az Enphase elutasította az akkumulátorbeállítások frissítését (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Az akkumulátorbeállítások frissítését nem sikerült hitelesíteni. Hitelesítse újra magát, majd próbálja újra."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "A teljes tartalék akkumulátorszint 100%-on rögzített."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Az akkumulátortartalék nem érhető el."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "A Megtakarítások profilnak aktívnak kell lennie."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "A Megtakarítások profil beállításai nem érhetők el."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "A kiválasztott akkumulátorprofil nem támogatott."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "A hálózatról töltés beállítás nem érhető el."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Az Enphase nem alkalmazta a hálózatról töltés kapcsolóállapotát."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "A hálózatról töltési ütemezés nem érhető el."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "A hálózatról töltési ütemezés kezdési és befejezési idejének különböznie kell."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Az Enphase nem alkalmazta a hálózatról töltési ütemezés kapcsolóállapotát."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Először engedélyezni kell a hálózatról töltést."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Egy ütemezésmódosítás Envoy-szinkronizálásra vár. Kérjük, várjon."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "A hálózatról töltési ütemezés ideje érvénytelen."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Az ütemezési API ebben a kliensverzióban nem érhető el."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Nem érhető el meglévő hálózatról töltési ütemezés."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Hozzon létre egy {schedule_label} elemet az IQ Battery ütemezőben, mielőtt engedélyezné."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "A(z) {schedule_label} jelenleg nincs kitéve az Enphase által ehhez a helyszínhez. Várja meg, amíg az ütemezésszinkronizálás befejeződik, majd frissítsen és próbálja újra."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Az Enphase nem alkalmazta a(z) {schedule_label} kapcsolóállapotát."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "elsődleges írás elutasítva"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "A(z) {schedule_label} kezdési és befejezési idejének különböznie kell."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "A hálózatba táplálási ütemezés ideje érvénytelen."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Nem érhető el meglévő {schedule_label_lower} ütemezés."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "A(z) {schedule_label} ütemezés nem érhető el."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "A(z) {schedule_label} ütemezés ideje érvénytelen."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "A jelenlegi {schedule_label_lower} ütemezés ideje érvénytelen."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "A(z) {schedule_label} ütemezési korlátjának {minimum} és {maximum} között kell lennie."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "A(z) {schedule_label} ütemezési korlátjának legalább {minimum}%-nak kell lennie."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "A jelenlegi ütemezési idők nem érhetők el."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "A hálózatról töltési ütemezés korlátjának {minimum} és {maximum} között kell lennie."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "A hálózatról töltési ütemezés korlátjának legalább {minimum}%-nak kell lennie."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Az akkumulátor leállítási szintje nem érhető el."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Az akkumulátor leállítási szintje érvénytelen."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Az akkumulátor leállítási szintjének {minimum} és {maximum} között kell lennie."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "A Storm Alert letiltása nem érhető el."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "A Storm Alert letiltása {count} riasztásnál nem sikerült."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "A Storm Guard frissítése ennél a fióknál nem engedélyezett."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "A Storm Guard beállításai nem érhetők el."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Az Enphase elutasította a Storm Guard frissítését (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "A Storm Guard frissítését nem sikerült hitelesíteni. Hitelesítse újra magát, majd próbálja újra."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "A kiválasztott rendszerprofil nem érhető el."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Az Enphase elutasította a rendszerprofil frissítését (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "A rendszerprofil frissítését nem sikerült hitelesíteni. Hitelesítse újra magát, majd próbálja újra."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "A rendszerprofil frissítése nem sikerült."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "A rendszerprofil frissítése hálózati hiba miatt nem sikerült. Próbálja újra."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "A rendszerprofil frissítése időtúllépés miatt megszakadt. Próbálja újra."
     },
     "scheduler_service_unavailable": {
       "message": "A töltési mód kiválasztása nem érhető el, amíg az Enphase ütemező szolgáltatás nem működik."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "A kiválasztott AC akkumulátor cél töltöttségi szintje nem érhető el."
     },
     "battery_schedule_day_required": {
       "message": "Válasszon legalább egy napot az ütemezéshez."
@@ -1826,17 +1826,17 @@
       "description": "Azonnal frissítse az akkumulátor-ütemezési adatokat az Enphase felhőből.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Speciális beállítások"
         }
       },
       "fields": {
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "Helyszínazonosító",
+          "description": "Nem kötelező helyszínazonosító; a rendszer automatikusan felismeri, ha helyszíneszköz van kiválasztva."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "Konfigurációs bejegyzés azonosítója",
+          "description": "Nem kötelező konfigurációsbejegyzés-azonosító egyetlen Enphase-helyszínbejegyzéshez."
         }
       }
     },

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Az ütemezés átfedésben van a meglévő {schedule_label} elemmel. Először módosítsa vagy tiltsa le azt az ütemezést."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Az ütemezési frissítés ütközik egy meglévő akkumulátorütemezéssel."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "A töltési mód kiválasztása nem érhető el, amíg az Enphase ütemező szolgáltatás nem működik."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Válasszon legalább egy napot az ütemezéshez."
+    },
+    "battery_schedule_times_different": {
+      "message": "Az ütemezés kezdési és befejezési időpontjának eltérőnek kell lennie."
+    },
+    "battery_schedule_limit_range": {
+      "message": "A {schedule_type} ütemezési korlátjának {minimum} és {maximum} között kell lennie."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Az ütemezést az Enphase érvényesítési végpontja elutasította."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Az akkumulátor-ütemezés szerkesztése nem érhető el."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Az akkumulátor ütemezési API nem érhető el."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Az ütemterv frissítéséhez megerősítés szükséges."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Az ütemezés törléséhez megerősítés szükséges."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Érvénytelen ütemezési azonosító: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Az ütemezési azonosító nem található a jelenlegi adatok között: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Adjon meg legalább egy ütemezési azonosítót a törléshez."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Érvénytelen ütemezési azonosító(k): {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Az ütemezési azonosító(k) nem találhatók az aktuális adatokban: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Az ütemezést az Enphase érvényesítési végpontja elutasította: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Az ütemezési frissítés ütközik egy meglévő akkumulátorütemezéssel: {message}"
     }
   },
   "options": {
@@ -157,11 +418,12 @@
           "api_timeout": "API-időtúllépés (s)",
           "nominal_voltage": "Névleges feszültség (V)",
           "session_history_interval": "Munkamenet előzmény intervallum (min)",
-          "schedule_sync_enabled": "Ütemező támogatás engedélyezése",
+          "schedule_sync_enabled": "Az EV Charger Scheduler engedélyezése",
           "reauth": "Újrahitelesítés indítása",
           "forget_password": "Mentett jelszó elfelejtése",
           "type_heatpump": "Hőszivattyú",
-          "type_ac_battery": "AC akkumulátor"
+          "type_ac_battery": "AC akkumulátor",
+          "battery_schedules_enabled": "Az akkumulátor ütemező engedélyezése"
         },
         "data_description": {
           "type_envoy": "Tartalmazza az átjáró-kapcsolat és a mérők diagnosztikáját.",
@@ -174,11 +436,12 @@
           "api_timeout": "Ennyi másodperc után jár le az API-kérések időkorlátja.",
           "nominal_voltage": "Tartalék feszültség a töltő teljesítménybecsléséhez.",
           "session_history_interval": "Várakozási percek a felhő munkamenet-előzmények lekérései között.",
-          "schedule_sync_enabled": "Az Enphase ütemezésének kezelése",
+          "schedule_sync_enabled": "Kezelje az IQ EV töltő ütemezését",
           "reauth": "Indítsa el a bejelentkezési folyamatot a hitelesítő adatok frissítéséhez az integráció eltávolítása nélkül.",
           "forget_password": "Eltávolítja a mentett jelszót. Automatikus frissítés többé nem lesz megkísérelve.",
           "type_heatpump": "A hőszivattyú állapot-, diagnosztikai és fogyasztási érzékelőit tartalmazza.",
-          "type_ac_battery": "AC akkumulátor érzékelőket és alvó mód vezérlőket tartalmaz, ha elérhetők."
+          "type_ac_battery": "AC akkumulátor érzékelőket és alvó mód vezérlőket tartalmaz, ha elérhetők.",
+          "battery_schedules_enabled": "Kezelje az IQ akkumulátor-ütemezéseket"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Újrahitelesítés indítása",
           "forget_password": "Mentett jelszó elfelejtése",
           "type_heatpump": "Hőszivattyú",
-          "type_ac_battery": "AC akkumulátor"
+          "type_ac_battery": "AC akkumulátor",
+          "battery_schedules_enabled": "Az akkumulátor ütemező engedélyezése"
         },
         "data_description": {
           "type_envoy": "Tartalmazza az átjáró-kapcsolat és a mérők diagnosztikáját.",
@@ -216,7 +480,8 @@
           "reauth": "Indítsa el a bejelentkezési folyamatot a hitelesítő adatok frissítéséhez az integráció eltávolítása nélkül.",
           "forget_password": "Eltávolítja a mentett jelszót. Automatikus frissítés többé nem lesz megkísérelve.",
           "type_heatpump": "A hőszivattyú állapot-, diagnosztikai és fogyasztási érzékelőit tartalmazza.",
-          "type_ac_battery": "AC akkumulátor érzékelőket és alvó mód vezérlőket tartalmaz, ha elérhetők."
+          "type_ac_battery": "AC akkumulátor érzékelőket és alvó mód vezérlőket tartalmaz, ha elérhetők.",
+          "battery_schedules_enabled": "Kezelje az IQ akkumulátor-ütemezéseket"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Hálózati export",
           "battery_charge": "Akkumulátor töltés",
           "battery_discharge": "Akkumulátor kisütés"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "{serial} utolsó jelentése"
+      },
+      "battery_cfg_schedules": {
+        "name": "Akkumulátor CFG ütemezések"
+      },
+      "battery_dtg_schedules": {
+        "name": "Akkumulátor DTG ütemezések"
+      },
+      "battery_rbd_schedules": {
+        "name": "Akkumulátor RBD ütemezések"
+      },
+      "battery_schedule_summary": {
+        "name": "Akkumulátor-ütemezési összefoglaló"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Akkumulátorkisütés-korlátozási határ"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Új akkumulátor-ütemezés korlátja"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Akkumulátor ütemezési korlát"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Vasárnapi ütemezés"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Új akkumulátor-ütemezés hétfő"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Új akkumulátor-ütemezés kedd"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Új akkumulátor-ütemezés szerda"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Új akkumulátor-ütemezés csütörtök"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Új akkumulátor-ütemezés péntek"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Új akkumulátor-ütemezés szombat"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Új akkumulátor-ütemezés vasárnap"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Akkumulátor-ütemezés hétfő"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Akkumulátor-ütemezés kedd"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Akkumulátor-ütemezés szerda"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Akkumulátor-ütemezés csütörtök"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Akkumulátor-ütemezés péntek"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Akkumulátor-ütemezés szombat"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Akkumulátor-ütemezés vasárnap"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Ütemezés"
+      },
+      "battery_new_schedule_type": {
+        "name": "Akkumulátor ütemezési típusa"
+      },
+      "battery_schedule_selected": {
+        "name": "Akkumulátor ütemezése"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Új ütemezés létrehozása"
+      },
+      "battery_schedule_add": {
+        "name": "Akkumulátor-ütemezés hozzáadása"
+      },
+      "battery_schedule_delete": {
+        "name": "Akkumulátor ütemezésének törlése"
+      },
+      "battery_schedule_refresh": {
+        "name": "Akkumulátor ütemezésének frissítése"
+      },
+      "battery_schedule_save": {
+        "name": "Akkumulátor-ütemezési mentés"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Ütemezés befejezési ideje"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Új akkumulátor-ütemezés kezdési ideje"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Új akkumulátor-ütemezés befejezési ideje"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Az akkumulátor ütemezésének kezdési ideje"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Az akkumulátor ütemezésének befejezési ideje"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "Helyszín ID",
           "description": "Enphase helyszínazonosító (opcionális; a célkészülékből oldható fel)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Frissítés kényszerítése",
+      "description": "Azonnal frissítse az akkumulátor-ütemezési adatokat az Enphase felhőből.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Akkumulátor-ütemezés hozzáadása",
+      "description": "Akkumulátor-ütemezés létrehozása CFG, DTG vagy RBD típushoz.",
+      "sections": {
+        "advanced": {
+          "name": "Speciális beállítások"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Ütemezés típusa",
+          "description": "Az akkumulátor-ütemezés családja: cfg, dtg vagy rbd."
+        },
+        "start_time": {
+          "name": "Kezdési idő",
+          "description": "Az ütemezés kezdési ideje."
+        },
+        "end_time": {
+          "name": "Befejezési idő",
+          "description": "Az ütemezés befejezési ideje."
+        },
+        "limit": {
+          "name": "Töltési korlát",
+          "description": "Az akkumulátor maximális töltöttségi szintje (%)."
+        },
+        "days": {
+          "name": "Napok",
+          "description": "Az aktív hétköznapok listája, ahol hétfő=1 és vasárnap=7."
+        },
+        "site_id": {
+          "name": "Helyszínazonosító",
+          "description": "Nem kötelező helyszínazonosító; a rendszer automatikusan felismeri, ha helyszíneszköz van kiválasztva."
+        },
+        "config_entry_id": {
+          "name": "Konfigurációs bejegyzés azonosítója",
+          "description": "Nem kötelező konfigurációsbejegyzés-azonosító egyetlen Enphase-helyszínbejegyzéshez."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Akkumulátor-ütemezés frissítése",
+      "description": "Akkumulátor-ütemezés frissítése ütemezésazonosító alapján.",
+      "sections": {
+        "advanced": {
+          "name": "Speciális beállítások"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Ütemezésazonosító",
+          "description": "Meglévő Enphase akkumulátor-ütemezés azonosítója."
+        },
+        "schedule_type": {
+          "name": "Ütemezés típusa",
+          "description": "Az akkumulátor-ütemezés családja: cfg, dtg vagy rbd."
+        },
+        "start_time": {
+          "name": "Kezdési idő",
+          "description": "Az ütemezés kezdési ideje."
+        },
+        "end_time": {
+          "name": "Befejezési idő",
+          "description": "Az ütemezés befejezési ideje."
+        },
+        "limit": {
+          "name": "Töltési korlát",
+          "description": "Az akkumulátor maximális töltöttségi szintje (%)."
+        },
+        "days": {
+          "name": "Napok",
+          "description": "Az aktív hétköznapok listája, ahol hétfő=1 és vasárnap=7."
+        },
+        "confirm": {
+          "name": "Megerősítés",
+          "description": "Állítsa true értékre az ütemezés frissítésének megerősítéséhez."
+        },
+        "site_id": {
+          "name": "Helyszínazonosító",
+          "description": "Nem kötelező helyszínazonosító; a rendszer automatikusan felismeri, ha helyszíneszköz van kiválasztva."
+        },
+        "config_entry_id": {
+          "name": "Konfigurációs bejegyzés azonosítója",
+          "description": "Nem kötelező konfigurációsbejegyzés-azonosító egyetlen Enphase-helyszínbejegyzéshez."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Akkumulátor-ütemezés törlése",
+      "description": "Egy vagy több akkumulátor-ütemezés törlése ütemezésazonosító alapján.",
+      "sections": {
+        "advanced": {
+          "name": "Speciális beállítások"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Ütemezésazonosító",
+          "description": "Törlendő egyetlen Enphase akkumulátor-ütemezés azonosítója."
+        },
+        "schedule_ids": {
+          "name": "Ütemezésazonosítók",
+          "description": "Nem kötelező, vesszővel elválasztott vagy listás bemenet több ütemezésazonosítóhoz."
+        },
+        "confirm": {
+          "name": "Megerősítés",
+          "description": "Állítsa true értékre az ütemezés törlésének megerősítéséhez."
+        },
+        "site_id": {
+          "name": "Helyszínazonosító",
+          "description": "Nem kötelező helyszínazonosító; a rendszer automatikusan felismeri, ha helyszíneszköz van kiválasztva."
+        },
+        "config_entry_id": {
+          "name": "Konfigurációs bejegyzés azonosítója",
+          "description": "Nem kötelező konfigurációsbejegyzés-azonosító egyetlen Enphase-helyszínbejegyzéshez."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Akkumulátor-ütemezés ellenőrzése",
+      "description": "Ellenőrizze, hogy a kiválasztott ütemezéscsaládhoz elérhető-e az akkumulátor-ütemezés szerkesztése.",
+      "sections": {
+        "advanced": {
+          "name": "Speciális beállítások"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Ütemezés típusa",
+          "description": "Az akkumulátor-ütemezés családja: cfg, dtg vagy rbd."
+        },
+        "site_id": {
+          "name": "Helyszínazonosító",
+          "description": "Nem kötelező helyszínazonosító; a rendszer automatikusan felismeri, ha helyszíneszköz van kiválasztva."
+        },
+        "config_entry_id": {
+          "name": "Konfigurációs bejegyzés azonosítója",
+          "description": "Nem kötelező konfigurációsbejegyzés-azonosító egyetlen Enphase-helyszínbejegyzéshez."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "La pianificazione si sovrappone alla {schedule_label} esistente. Regola o disattiva prima quella pianificazione."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "L'aggiornamento della pianificazione è in conflitto con una pianificazione della batteria esistente."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "La selezione della modalità di ricarica non è disponibile mentre il servizio di pianificazione Enphase non è disponibile."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Seleziona almeno un giorno per la pianificazione."
+    },
+    "battery_schedule_times_different": {
+      "message": "L'ora di inizio e di fine della pianificazione devono essere diverse."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Il limite della pianificazione {schedule_type} deve essere compreso tra {minimum} e {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Pianificazione rifiutata dall'endpoint di convalida Enphase."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "La modifica delle pianificazioni della batteria non è disponibile."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "L'API delle pianificazioni della batteria non è disponibile."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "È richiesta una conferma per aggiornare una pianificazione."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "È richiesta una conferma per eliminare una pianificazione."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "ID pianificazione non valido: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "ID pianificazione non trovato nei dati correnti: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Fornisci almeno un ID pianificazione da eliminare."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "ID pianificazione non validi: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "ID pianificazione non trovati nei dati correnti: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Pianificazione rifiutata dall'endpoint di convalida Enphase: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "L'aggiornamento della pianificazione è in conflitto con una pianificazione della batteria esistente: {message}"
     }
   },
   "options": {
@@ -161,7 +422,8 @@
           "reauth": "Avvia riautenticazione",
           "forget_password": "Dimentica password salvata",
           "type_heatpump": "Pompa di calore",
-          "type_ac_battery": "Batteria AC"
+          "type_ac_battery": "Batteria AC",
+          "battery_schedules_enabled": "Attiva pianificatore batteria"
         },
         "data_description": {
           "type_envoy": "Include connettività del gateway e diagnostica dei contatori.",
@@ -178,7 +440,8 @@
           "reauth": "Avvia il flusso di accesso per aggiornare le credenziali senza rimuovere l'integrazione.",
           "forget_password": "Rimuove la password salvata. L'aggiornamento automatico non verrà più tentato.",
           "type_heatpump": "Include sensori di stato, diagnostica e consumo della pompa di calore.",
-          "type_ac_battery": "Include sensori della batteria AC e controlli della modalità sospensione quando disponibili."
+          "type_ac_battery": "Include sensori della batteria AC e controlli della modalità sospensione quando disponibili.",
+          "battery_schedules_enabled": "Gestisci le pianificazioni batteria IQ"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Avvia riautenticazione",
           "forget_password": "Dimentica password salvata",
           "type_heatpump": "Pompa di calore",
-          "type_ac_battery": "Batteria AC"
+          "type_ac_battery": "Batteria AC",
+          "battery_schedules_enabled": "Attiva pianificatore batteria"
         },
         "data_description": {
           "type_envoy": "Include connettività del gateway e diagnostica dei contatori.",
@@ -216,7 +480,8 @@
           "reauth": "Avvia il flusso di accesso per aggiornare le credenziali senza rimuovere l'integrazione.",
           "forget_password": "Rimuove la password salvata. L'aggiornamento automatico non verrà più tentato.",
           "type_heatpump": "Include sensori di stato, diagnostica e consumo della pompa di calore.",
-          "type_ac_battery": "Include sensori della batteria AC e controlli della modalità sospensione quando disponibili."
+          "type_ac_battery": "Include sensori della batteria AC e controlli della modalità sospensione quando disponibili.",
+          "battery_schedules_enabled": "Gestisci le pianificazioni batteria IQ"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Esportazione verso rete",
           "battery_charge": "Carica batteria",
           "battery_discharge": "Scarica batteria"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Ultimo report di {serial}"
+      },
+      "battery_cfg_schedules": {
+        "name": "Pianificazioni CFG batteria"
+      },
+      "battery_dtg_schedules": {
+        "name": "Pianificazioni DTG batteria"
+      },
+      "battery_rbd_schedules": {
+        "name": "Pianificazioni RBD batteria"
+      },
+      "battery_schedule_summary": {
+        "name": "Riepilogo pianificazioni batteria"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Limite di restrizione della scarica della batteria"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Limite nuova pianificazione batteria"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Limite pianificazione batteria"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Pianificazione domenica"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Nuova pianificazione batteria lunedì"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Nuova pianificazione batteria martedì"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Nuova pianificazione batteria mercoledì"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Nuova pianificazione batteria giovedì"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Nuova pianificazione batteria venerdì"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Nuova pianificazione batteria sabato"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Nuova pianificazione batteria domenica"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Pianificazione batteria lunedì"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Pianificazione batteria martedì"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Pianificazione batteria mercoledì"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Pianificazione batteria giovedì"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Pianificazione batteria venerdì"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Pianificazione batteria sabato"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Pianificazione batteria domenica"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Pianificazione"
+      },
+      "battery_new_schedule_type": {
+        "name": "Tipo di pianificazione batteria"
+      },
+      "battery_schedule_selected": {
+        "name": "Pianificazione batteria"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Crea nuova pianificazione"
+      },
+      "battery_schedule_add": {
+        "name": "Aggiungi pianificazione batteria"
+      },
+      "battery_schedule_delete": {
+        "name": "Elimina pianificazione batteria"
+      },
+      "battery_schedule_refresh": {
+        "name": "Aggiorna pianificazione batteria"
+      },
+      "battery_schedule_save": {
+        "name": "Salva pianificazione batteria"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Ora di fine pianificazione"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Ora di inizio nuova pianificazione batteria"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Ora di fine nuova pianificazione batteria"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Ora di inizio pianificazione batteria"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Ora di fine pianificazione batteria"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "ID sito",
           "description": "ID sito Enphase (facoltativo; risolto dal dispositivo di destinazione)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Aggiornamento forzato",
+      "description": "Aggiorna immediatamente i dati delle pianificazioni della batteria dal cloud Enphase.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Aggiungi pianificazione batteria",
+      "description": "Crea una pianificazione della batteria per CFG, DTG o RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Opzioni avanzate"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Tipo di pianificazione",
+          "description": "Famiglia di pianificazioni della batteria: cfg, dtg o rbd."
+        },
+        "start_time": {
+          "name": "Ora di inizio",
+          "description": "Ora di inizio della pianificazione."
+        },
+        "end_time": {
+          "name": "Ora di fine",
+          "description": "Ora di fine della pianificazione."
+        },
+        "limit": {
+          "name": "Limite di carica",
+          "description": "Stato di carica massimo della batteria (%)."
+        },
+        "days": {
+          "name": "Giorni",
+          "description": "Elenco dei giorni della settimana attivi con lunedì=1 fino a domenica=7."
+        },
+        "site_id": {
+          "name": "ID sito",
+          "description": "Identificatore sito facoltativo; rilevato automaticamente quando viene selezionato un dispositivo del sito."
+        },
+        "config_entry_id": {
+          "name": "ID voce di configurazione",
+          "description": "Identificatore facoltativo della voce di configurazione per una singola voce sito Enphase."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Aggiorna pianificazione batteria",
+      "description": "Aggiorna una pianificazione della batteria tramite ID pianificazione.",
+      "sections": {
+        "advanced": {
+          "name": "Opzioni avanzate"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "ID pianificazione",
+          "description": "Identificatore di una pianificazione batteria Enphase esistente."
+        },
+        "schedule_type": {
+          "name": "Tipo di pianificazione",
+          "description": "Famiglia di pianificazioni della batteria: cfg, dtg o rbd."
+        },
+        "start_time": {
+          "name": "Ora di inizio",
+          "description": "Ora di inizio della pianificazione."
+        },
+        "end_time": {
+          "name": "Ora di fine",
+          "description": "Ora di fine della pianificazione."
+        },
+        "limit": {
+          "name": "Limite di carica",
+          "description": "Stato di carica massimo della batteria (%)."
+        },
+        "days": {
+          "name": "Giorni",
+          "description": "Elenco dei giorni della settimana attivi con lunedì=1 fino a domenica=7."
+        },
+        "confirm": {
+          "name": "Conferma",
+          "description": "Imposta su true per confermare l'aggiornamento della pianificazione."
+        },
+        "site_id": {
+          "name": "ID sito",
+          "description": "Identificatore sito facoltativo; rilevato automaticamente quando viene selezionato un dispositivo del sito."
+        },
+        "config_entry_id": {
+          "name": "ID voce di configurazione",
+          "description": "Identificatore facoltativo della voce di configurazione per una singola voce sito Enphase."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Elimina pianificazione batteria",
+      "description": "Elimina una o più pianificazioni della batteria tramite ID pianificazione.",
+      "sections": {
+        "advanced": {
+          "name": "Opzioni avanzate"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "ID pianificazione",
+          "description": "Identificatore di una singola pianificazione batteria Enphase da eliminare."
+        },
+        "schedule_ids": {
+          "name": "ID pianificazioni",
+          "description": "Input facoltativo separato da virgole o in elenco per più identificatori di pianificazione."
+        },
+        "confirm": {
+          "name": "Conferma",
+          "description": "Imposta su true per confermare l'eliminazione della pianificazione."
+        },
+        "site_id": {
+          "name": "ID sito",
+          "description": "Identificatore sito facoltativo; rilevato automaticamente quando viene selezionato un dispositivo del sito."
+        },
+        "config_entry_id": {
+          "name": "ID voce di configurazione",
+          "description": "Identificatore facoltativo della voce di configurazione per una singola voce sito Enphase."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Convalida pianificazione batteria",
+      "description": "Verifica se la modifica delle pianificazioni della batteria è disponibile per la famiglia di pianificazioni selezionata.",
+      "sections": {
+        "advanced": {
+          "name": "Opzioni avanzate"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Tipo di pianificazione",
+          "description": "Famiglia di pianificazioni della batteria: cfg, dtg o rbd."
+        },
+        "site_id": {
+          "name": "ID sito",
+          "description": "Identificatore sito facoltativo; rilevato automaticamente quando viene selezionato un dispositivo del sito."
+        },
+        "config_entry_id": {
+          "name": "ID voce di configurazione",
+          "description": "Identificatore facoltativo della voce di configurazione per una singola voce sito Enphase."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -133,220 +133,220 @@
       "message": "La pianificazione si sovrappone alla {schedule_label} esistente. Regola o disattiva prima quella pianificazione."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Al momento non è disponibile alcun dispositivo batteria AC."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Le impostazioni di autenticazione non sono disponibili mentre il servizio Enphase non è operativo."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Gli aggiornamenti del profilo batteria non sono consentiti per questo account."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Gli aggiornamenti delle impostazioni della batteria non sono consentiti per questo account."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "È già in corso un altro aggiornamento del profilo batteria."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "È già in corso un altro aggiornamento delle impostazioni della batteria."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Gli aggiornamenti del profilo batteria non sono disponibili."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Gli aggiornamenti delle impostazioni della batteria non sono disponibili."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Gli aggiornamenti della batteria non sono disponibili."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Gli aggiornamenti della batteria non sono consentiti per questo account."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "L'aggiornamento del profilo batteria è stato richiesto troppo rapidamente. Attendi e riprova."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "L'aggiornamento delle impostazioni della batteria è stato richiesto troppo rapidamente. Attendi e riprova."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Non è stato possibile confermare l'accesso in scrittura alla batteria. Aggiorna e riprova."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "L'aggiornamento della pianificazione è stato rifiutato da Enphase (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Non è stato possibile autenticare l'aggiornamento della pianificazione. Esegui nuovamente l'autenticazione e riprova."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "La pianificazione è in conflitto con la pianificazione esistente di scarica verso la rete. Regola o disattiva prima quella pianificazione."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "La pianificazione è in conflitto con la pianificazione esistente di limitazione della scarica della batteria. Regola o disattiva prima quella pianificazione."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "La pianificazione è in conflitto con la pianificazione esistente di ricarica dalla rete. Regola o disattiva prima quella pianificazione."
     },
     "schedule_update_conflict": {
       "message": "L'aggiornamento della pianificazione è in conflitto con una pianificazione della batteria esistente."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Il profilo batteria non è disponibile."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "L'aggiornamento del profilo batteria è stato rifiutato da Enphase (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Non è stato possibile autenticare l'aggiornamento del profilo batteria. Esegui nuovamente l'autenticazione e riprova."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Il payload delle impostazioni della batteria non è disponibile."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "L'aggiornamento delle impostazioni della batteria è stato rifiutato da Enphase (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Non è stato possibile autenticare l'aggiornamento delle impostazioni della batteria. Esegui nuovamente l'autenticazione e riprova."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "La riserva Backup completo è fissata al 100%."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "La riserva della batteria non è disponibile."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Il profilo Risparmio deve essere attivo."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Le impostazioni del profilo Risparmio non sono disponibili."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Il profilo batteria selezionato non è supportato."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "L'impostazione di ricarica dalla rete non è disponibile."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Enphase non ha applicato l'attivazione o disattivazione della ricarica dalla rete."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "La pianificazione di ricarica dalla rete non è disponibile."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "L'ora di inizio e di fine della pianificazione di ricarica dalla rete devono essere diverse."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Enphase non ha applicato l'attivazione o disattivazione della pianificazione di ricarica dalla rete."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "La ricarica dalla rete deve essere prima abilitata."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Una modifica alla pianificazione è in attesa della sincronizzazione Envoy. Attendi."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "L'orario della pianificazione di ricarica dalla rete non è valido."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "L'API delle pianificazioni non è disponibile in questa versione del client."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Non è disponibile alcuna pianificazione esistente di ricarica dalla rete."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Crea una {schedule_label} nel pianificatore IQ Battery prima di abilitarla."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} al momento non è esposta da Enphase per questo sito. Attendi il completamento della sincronizzazione delle pianificazioni, poi aggiorna e riprova."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Enphase non ha applicato l'attivazione o disattivazione di {schedule_label}."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "scrittura primaria rifiutata"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "L'ora di inizio e di fine di {schedule_label} devono essere diverse."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "L'orario della pianificazione di scarica verso la rete non è valido."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Non è disponibile alcuna pianificazione esistente {schedule_label_lower}."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "La pianificazione {schedule_label} non è disponibile."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "L'orario della pianificazione {schedule_label} non è valido."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "L'orario attuale della pianificazione {schedule_label_lower} non è valido."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "Il limite della pianificazione {schedule_label} deve essere compreso tra {minimum} e {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "Il limite della pianificazione {schedule_label} deve essere almeno {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Gli orari attuali della pianificazione non sono disponibili."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Il limite della pianificazione di ricarica dalla rete deve essere compreso tra {minimum} e {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Il limite della pianificazione di ricarica dalla rete deve essere almeno {minimum}%."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Il livello di arresto della batteria non è disponibile."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Il livello di arresto della batteria non è valido."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Il livello di arresto della batteria deve essere compreso tra {minimum} e {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "La disattivazione di Storm Alert non è disponibile."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "La disattivazione di Storm Alert non è riuscita per {count} avviso/i."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Gli aggiornamenti di Storm Guard non sono consentiti per questo account."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Le impostazioni di Storm Guard non sono disponibili."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "L'aggiornamento di Storm Guard è stato rifiutato da Enphase (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Non è stato possibile autenticare l'aggiornamento di Storm Guard. Esegui nuovamente l'autenticazione e riprova."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Il profilo di sistema selezionato non è disponibile."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "L'aggiornamento del profilo di sistema è stato rifiutato da Enphase (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Non è stato possibile autenticare l'aggiornamento del profilo di sistema. Esegui nuovamente l'autenticazione e riprova."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "L'aggiornamento del profilo di sistema non è riuscito."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "L'aggiornamento del profilo di sistema non è riuscito a causa di un errore di rete. Riprova."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "L'aggiornamento del profilo di sistema è scaduto. Riprova."
     },
     "scheduler_service_unavailable": {
       "message": "La selezione della modalità di ricarica non è disponibile mentre il servizio di pianificazione Enphase non è disponibile."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "Lo stato di carica target selezionato della batteria AC non è disponibile."
     },
     "battery_schedule_day_required": {
       "message": "Seleziona almeno un giorno per la pianificazione."
@@ -1826,17 +1826,17 @@
       "description": "Aggiorna immediatamente i dati delle pianificazioni della batteria dal cloud Enphase.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Opzioni avanzate"
         }
       },
       "fields": {
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "ID sito",
+          "description": "Identificatore sito facoltativo; rilevato automaticamente quando viene selezionato un dispositivo del sito."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "ID voce di configurazione",
+          "description": "Identificatore facoltativo della voce di configurazione per una singola voce sito Enphase."
         }
       }
     },

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Tvarkaraštis persidengia su esamu {schedule_label}. Pirmiausia pakoreguokite arba išjunkite tą tvarkaraštį."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Tvarkaraščio atnaujinimas konfliktuoja su esamu baterijos tvarkaraščiu."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Įkrovimo režimo pasirinkimas nepasiekiamas, kol Enphase planavimo paslauga neveikia."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Pasirinkite bent vieną tvarkaraščio dieną."
+    },
+    "battery_schedule_times_different": {
+      "message": "Tvarkaraščio pradžios ir pabaigos laikai turi skirtis."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Tvarkaraščio {schedule_type} riba turi būti tarp {minimum} ir {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Enphase tikrinimo galinis taškas atmetė tvarkaraštį."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Baterijos tvarkaraščių redagavimas nepasiekiamas."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Baterijos tvarkaraščių API nepasiekiama."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Norint atnaujinti tvarkaraštį, reikia patvirtinimo."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Norint ištrinti tvarkaraštį, reikia patvirtinimo."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Neteisingas tvarkaraščio ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Tvarkaraščio ID nerastas dabartiniuose duomenyse: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Pateikite bent vieną ištrintiną tvarkaraščio ID."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Neteisingi tvarkaraščių ID: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Tvarkaraščių ID nerasti dabartiniuose duomenyse: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Enphase tikrinimo galinis taškas atmetė tvarkaraštį: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Tvarkaraščio atnaujinimas konfliktuoja su esamu baterijos tvarkaraščiu: {message}"
     }
   },
   "options": {
@@ -161,7 +422,8 @@
           "reauth": "Pradėti perautentifikavimą",
           "forget_password": "Pamiršti išsaugotą slaptažodį",
           "type_heatpump": "Šilumos siurblys",
-          "type_ac_battery": "AC baterija"
+          "type_ac_battery": "AC baterija",
+          "battery_schedules_enabled": "Įjungti baterijos planuoklį"
         },
         "data_description": {
           "type_envoy": "Apima šliuzo ryšio ir skaitiklių diagnostiką.",
@@ -178,7 +440,8 @@
           "reauth": "Paleiskite prisijungimo eigą, kad atnaujintumėte duomenis nepašalindami integracijos.",
           "forget_password": "Pašalina išsaugotą slaptažodį. Automatinis atnaujinimas daugiau nebus bandomas.",
           "type_heatpump": "Apima šilumos siurblio būsenos, diagnostikos ir vartojimo jutiklius.",
-          "type_ac_battery": "Apima AC baterijos jutiklius ir miego režimo valdiklius, kai jie prieinami."
+          "type_ac_battery": "Apima AC baterijos jutiklius ir miego režimo valdiklius, kai jie prieinami.",
+          "battery_schedules_enabled": "Tvarkyti IQ baterijos tvarkaraščius"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Pradėti perautentifikavimą",
           "forget_password": "Pamiršti išsaugotą slaptažodį",
           "type_heatpump": "Šilumos siurblys",
-          "type_ac_battery": "AC baterija"
+          "type_ac_battery": "AC baterija",
+          "battery_schedules_enabled": "Įjungti baterijos planuoklį"
         },
         "data_description": {
           "type_envoy": "Apima šliuzo ryšio ir skaitiklių diagnostiką.",
@@ -216,7 +480,8 @@
           "reauth": "Paleiskite prisijungimo eigą, kad atnaujintumėte duomenis nepašalindami integracijos.",
           "forget_password": "Pašalina išsaugotą slaptažodį. Automatinis atnaujinimas daugiau nebus bandomas.",
           "type_heatpump": "Apima šilumos siurblio būsenos, diagnostikos ir vartojimo jutiklius.",
-          "type_ac_battery": "Apima AC baterijos jutiklius ir miego režimo valdiklius, kai jie prieinami."
+          "type_ac_battery": "Apima AC baterijos jutiklius ir miego režimo valdiklius, kai jie prieinami.",
+          "battery_schedules_enabled": "Tvarkyti IQ baterijos tvarkaraščius"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Eksportas į tinklą",
           "battery_charge": "Baterijos įkrovimas",
           "battery_discharge": "Baterijos iškrovimas"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Paskutinė {serial} ataskaita"
+      },
+      "battery_cfg_schedules": {
+        "name": "Baterijos CFG tvarkaraščiai"
+      },
+      "battery_dtg_schedules": {
+        "name": "Baterijos DTG tvarkaraščiai"
+      },
+      "battery_rbd_schedules": {
+        "name": "Baterijos RBD tvarkaraščiai"
+      },
+      "battery_schedule_summary": {
+        "name": "Baterijos tvarkaraščių santrauka"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Baterijos iškrovimo ribojimo riba"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Naujo baterijos tvarkaraščio riba"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Baterijos tvarkaraščio riba"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Sekmadienio tvarkaraštis"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Naujas baterijos tvarkaraštis pirmadienis"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Naujas baterijos tvarkaraštis antradienis"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Naujas baterijos tvarkaraštis trečiadienis"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Naujas baterijos tvarkaraštis ketvirtadienis"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Naujas baterijos tvarkaraštis penktadienis"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Naujas baterijos tvarkaraštis šeštadienis"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Naujas baterijos tvarkaraštis sekmadienis"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Baterijos tvarkaraštis pirmadienis"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Baterijos tvarkaraštis antradienis"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Baterijos tvarkaraštis trečiadienis"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Baterijos tvarkaraštis ketvirtadienis"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Baterijos tvarkaraštis penktadienis"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Baterijos tvarkaraštis šeštadienis"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Baterijos tvarkaraštis sekmadienis"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Tvarkaraštis"
+      },
+      "battery_new_schedule_type": {
+        "name": "Baterijos tvarkaraščio tipas"
+      },
+      "battery_schedule_selected": {
+        "name": "Baterijos tvarkaraštis"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Sukurti naują tvarkaraštį"
+      },
+      "battery_schedule_add": {
+        "name": "Pridėti baterijos tvarkaraštį"
+      },
+      "battery_schedule_delete": {
+        "name": "Ištrinti baterijos tvarkaraštį"
+      },
+      "battery_schedule_refresh": {
+        "name": "Atnaujinti baterijos tvarkaraštį"
+      },
+      "battery_schedule_save": {
+        "name": "Išsaugoti baterijos tvarkaraštį"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Tvarkaraščio pabaigos laikas"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Naujo baterijos tvarkaraščio pradžios laikas"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Naujo baterijos tvarkaraščio pabaigos laikas"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Baterijos tvarkaraščio pradžios laikas"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Baterijos tvarkaraščio pabaigos laikas"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "Vietos ID",
           "description": "Enphase vietos ID (pasirinktinai; nustatomas iš tikslinio įrenginio)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Priverstinai atnaujinti",
+      "description": "Nedelsdami atnaujinkite baterijos tvarkaraščių duomenis iš Enphase debesies.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Pridėti baterijos tvarkaraštį",
+      "description": "Sukurkite baterijos tvarkaraštį CFG, DTG arba RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Išplėstinės parinktys"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Tvarkaraščio tipas",
+          "description": "Baterijos tvarkaraščio šeima: cfg, dtg arba rbd."
+        },
+        "start_time": {
+          "name": "Pradžios laikas",
+          "description": "Tvarkaraščio pradžios laikas."
+        },
+        "end_time": {
+          "name": "Pabaigos laikas",
+          "description": "Tvarkaraščio pabaigos laikas."
+        },
+        "limit": {
+          "name": "Įkrovimo riba",
+          "description": "Didžiausias baterijos įkrovos lygis (%)."
+        },
+        "days": {
+          "name": "Dienos",
+          "description": "Aktyvių savaitės dienų sąrašas, kur pirmadienis=1, o sekmadienis=7."
+        },
+        "site_id": {
+          "name": "Svetainės ID",
+          "description": "Pasirenkamas svetainės identifikatorius; aptinkamas automatiškai, kai pasirenkamas svetainės įrenginys."
+        },
+        "config_entry_id": {
+          "name": "Konfigūracijos įrašo ID",
+          "description": "Pasirenkamas konfigūracijos įrašo identifikatorius vienam Enphase svetainės įrašui."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Atnaujinti baterijos tvarkaraštį",
+      "description": "Atnaujinkite baterijos tvarkaraštį pagal tvarkaraščio ID.",
+      "sections": {
+        "advanced": {
+          "name": "Išplėstinės parinktys"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Tvarkaraščio ID",
+          "description": "Esamos Enphase baterijos tvarkaraščio identifikatorius."
+        },
+        "schedule_type": {
+          "name": "Tvarkaraščio tipas",
+          "description": "Baterijos tvarkaraščio šeima: cfg, dtg arba rbd."
+        },
+        "start_time": {
+          "name": "Pradžios laikas",
+          "description": "Tvarkaraščio pradžios laikas."
+        },
+        "end_time": {
+          "name": "Pabaigos laikas",
+          "description": "Tvarkaraščio pabaigos laikas."
+        },
+        "limit": {
+          "name": "Įkrovimo riba",
+          "description": "Didžiausias baterijos įkrovos lygis (%)."
+        },
+        "days": {
+          "name": "Dienos",
+          "description": "Aktyvių savaitės dienų sąrašas, kur pirmadienis=1, o sekmadienis=7."
+        },
+        "confirm": {
+          "name": "Patvirtinimas",
+          "description": "Nustatykite į true, kad patvirtintumėte tvarkaraščio atnaujinimą."
+        },
+        "site_id": {
+          "name": "Svetainės ID",
+          "description": "Pasirenkamas svetainės identifikatorius; aptinkamas automatiškai, kai pasirenkamas svetainės įrenginys."
+        },
+        "config_entry_id": {
+          "name": "Konfigūracijos įrašo ID",
+          "description": "Pasirenkamas konfigūracijos įrašo identifikatorius vienam Enphase svetainės įrašui."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Ištrinti baterijos tvarkaraštį",
+      "description": "Ištrinkite vieną ar kelis baterijos tvarkaraščius pagal tvarkaraščio ID.",
+      "sections": {
+        "advanced": {
+          "name": "Išplėstinės parinktys"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Tvarkaraščio ID",
+          "description": "Vieno Enphase baterijos tvarkaraščio identifikatorius, kurį reikia ištrinti."
+        },
+        "schedule_ids": {
+          "name": "Tvarkaraščių ID",
+          "description": "Pasirenkama kableliais atskirta arba sąrašo įvestis keliems tvarkaraščių identifikatoriams."
+        },
+        "confirm": {
+          "name": "Patvirtinimas",
+          "description": "Nustatykite į true, kad patvirtintumėte tvarkaraščio ištrynimą."
+        },
+        "site_id": {
+          "name": "Svetainės ID",
+          "description": "Pasirenkamas svetainės identifikatorius; aptinkamas automatiškai, kai pasirenkamas svetainės įrenginys."
+        },
+        "config_entry_id": {
+          "name": "Konfigūracijos įrašo ID",
+          "description": "Pasirenkamas konfigūracijos įrašo identifikatorius vienam Enphase svetainės įrašui."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Patvirtinti baterijos tvarkaraštį",
+      "description": "Patikrinkite, ar baterijos tvarkaraščių redagavimas yra prieinamas pasirinktai tvarkaraščių šeimai.",
+      "sections": {
+        "advanced": {
+          "name": "Išplėstinės parinktys"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Tvarkaraščio tipas",
+          "description": "Baterijos tvarkaraščio šeima: cfg, dtg arba rbd."
+        },
+        "site_id": {
+          "name": "Svetainės ID",
+          "description": "Pasirenkamas svetainės identifikatorius; aptinkamas automatiškai, kai pasirenkamas svetainės įrenginys."
+        },
+        "config_entry_id": {
+          "name": "Konfigūracijos įrašo ID",
+          "description": "Pasirenkamas konfigūracijos įrašo identifikatorius vienam Enphase svetainės įrašui."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -133,220 +133,220 @@
       "message": "Tvarkaraštis persidengia su esamu {schedule_label}. Pirmiausia pakoreguokite arba išjunkite tą tvarkaraštį."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Šiuo metu nėra pasiekiamų AC baterijos įrenginių."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Autentifikavimo nustatymai nepasiekiami, kol Enphase paslauga neveikia."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Šiai paskyrai akumuliatoriaus profilio atnaujinimai neleidžiami."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Šiai paskyrai akumuliatoriaus nustatymų atnaujinimai neleidžiami."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Jau vykdomas kitas akumuliatoriaus profilio atnaujinimas."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Jau vykdomas kitas akumuliatoriaus nustatymų atnaujinimas."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Akumuliatoriaus profilio atnaujinimai nepasiekiami."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Akumuliatoriaus nustatymų atnaujinimai nepasiekiami."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Akumuliatoriaus atnaujinimai nepasiekiami."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Šiai paskyrai akumuliatoriaus atnaujinimai neleidžiami."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Akumuliatoriaus profilio atnaujinimo užklausa pateikta per greitai. Palaukite ir bandykite dar kartą."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Akumuliatoriaus nustatymų atnaujinimo užklausa pateikta per greitai. Palaukite ir bandykite dar kartą."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Nepavyko patvirtinti rašymo prieigos prie akumuliatoriaus. Atnaujinkite ir bandykite dar kartą."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase atmetė tvarkaraščio atnaujinimą (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Nepavyko autentifikuoti tvarkaraščio atnaujinimo. Iš naujo autentifikuokitės ir bandykite dar kartą."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Tvarkaraštis konfliktuoja su esamu iškrovimo į tinklą tvarkaraščiu. Pirmiausia pakoreguokite arba išjunkite tą tvarkaraštį."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Tvarkaraštis konfliktuoja su esamu baterijos iškrovimo ribojimo tvarkaraščiu. Pirmiausia pakoreguokite arba išjunkite tą tvarkaraštį."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Tvarkaraštis konfliktuoja su esamu įkrovimo iš tinklo tvarkaraščiu. Pirmiausia pakoreguokite arba išjunkite tą tvarkaraštį."
     },
     "schedule_update_conflict": {
       "message": "Tvarkaraščio atnaujinimas konfliktuoja su esamu baterijos tvarkaraščiu."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Akumuliatoriaus profilis nepasiekiamas."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase atmetė akumuliatoriaus profilio atnaujinimą (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Nepavyko autentifikuoti akumuliatoriaus profilio atnaujinimo. Iš naujo autentifikuokitės ir bandykite dar kartą."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Akumuliatoriaus nustatymų apkrova nepasiekiama."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase atmetė akumuliatoriaus nustatymų atnaujinimą (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Nepavyko autentifikuoti akumuliatoriaus nustatymų atnaujinimo. Iš naujo autentifikuokitės ir bandykite dar kartą."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Pilnos atsargos rezervas nustatytas ties 100%."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Akumuliatoriaus rezervas nepasiekiamas."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Taupymo profilis turi būti aktyvus."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Taupymo profilio nustatymai nepasiekiami."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Pasirinktas akumuliatoriaus profilis nepalaikomas."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Įkrovimo iš tinklo nustatymas nepasiekiamas."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Enphase nepritaikė įkrovimo iš tinklo perjungimo."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Įkrovimo iš tinklo tvarkaraštis nepasiekiamas."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Įkrovimo iš tinklo tvarkaraščio pradžios ir pabaigos laikai turi skirtis."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Enphase nepritaikė įkrovimo iš tinklo tvarkaraščio perjungimo."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Pirmiausia turi būti įjungtas įkrovimas iš tinklo."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Laukiama Envoy sinchronizavimo tvarkaraščio pakeitimui. Palaukite."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Įkrovimo iš tinklo tvarkaraščio laikas neteisingas."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Šioje kliento versijoje tvarkaraščio API nepasiekiama."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Nėra pasiekiamo esamo įkrovimo iš tinklo tvarkaraščio."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Prieš įjungdami sukurkite {schedule_label} IQ Battery planuoklyje."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} šiuo metu Enphase nepateikia šiai svetainei. Palaukite, kol bus baigta tvarkaraščio sinchronizacija, tada atnaujinkite ir bandykite dar kartą."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Enphase nepritaikė {schedule_label} perjungimo."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "pagrindinis įrašymas atmestas"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "{schedule_label} pradžios ir pabaigos laikai turi skirtis."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Iškrovimo į tinklą tvarkaraščio laikas neteisingas."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Nėra pasiekiamo esamo {schedule_label_lower} tvarkaraščio."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "{schedule_label} tvarkaraštis nepasiekiamas."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "{schedule_label} tvarkaraščio laikas neteisingas."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Dabartinis {schedule_label_lower} tvarkaraščio laikas neteisingas."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "{schedule_label} tvarkaraščio riba turi būti tarp {minimum} ir {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "{schedule_label} tvarkaraščio riba turi būti bent {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Dabartiniai tvarkaraščio laikai nepasiekiami."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Įkrovimo iš tinklo tvarkaraščio riba turi būti tarp {minimum} ir {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Įkrovimo iš tinklo tvarkaraščio riba turi būti bent {minimum}%."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Akumuliatoriaus išjungimo lygis nepasiekiamas."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Akumuliatoriaus išjungimo lygis neteisingas."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Akumuliatoriaus išjungimo lygis turi būti tarp {minimum} ir {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Storm Alert atsisakymas nepasiekiamas."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Storm Alert atsisakymas nepavyko {count} įspėjimui(-ams)."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Šiai paskyrai Storm Guard atnaujinimai neleidžiami."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Storm Guard nustatymai nepasiekiami."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase atmetė Storm Guard atnaujinimą (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Nepavyko autentifikuoti Storm Guard atnaujinimo. Iš naujo autentifikuokitės ir bandykite dar kartą."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Pasirinktas sistemos profilis nepasiekiamas."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase atmetė sistemos profilio atnaujinimą (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Nepavyko autentifikuoti sistemos profilio atnaujinimo. Iš naujo autentifikuokitės ir bandykite dar kartą."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Sistemos profilio atnaujinimas nepavyko."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Sistemos profilio atnaujinimas nepavyko dėl tinklo klaidos. Bandykite dar kartą."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Baigėsi sistemos profilio atnaujinimo laikas. Bandykite dar kartą."
     },
     "scheduler_service_unavailable": {
       "message": "Įkrovimo režimo pasirinkimas nepasiekiamas, kol Enphase planavimo paslauga neveikia."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "Pasirinktas AC baterijos tikslinis įkrovos lygis nepasiekiamas."
     },
     "battery_schedule_day_required": {
       "message": "Pasirinkite bent vieną tvarkaraščio dieną."
@@ -1826,17 +1826,17 @@
       "description": "Nedelsdami atnaujinkite baterijos tvarkaraščių duomenis iš Enphase debesies.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Išplėstinės parinktys"
         }
       },
       "fields": {
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "Svetainės ID",
+          "description": "Pasirenkamas svetainės identifikatorius; aptinkamas automatiškai, kai pasirenkamas svetainės įrenginys."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "Konfigūracijos įrašo ID",
+          "description": "Pasirenkamas konfigūracijos įrašo identifikatorius vienam Enphase svetainės įrašui."
         }
       }
     },

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Grafiks pārklājas ar esošo {schedule_label}. Vispirms pielāgojiet vai atspējojiet šo grafiku."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Grafika atjauninājums konfliktē ar esošu akumulatora grafiku."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Uzlādes režīma izvēle nav pieejama, kamēr Enphase plānošanas pakalpojums nav pieejams."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Izvēlieties grafikam vismaz vienu dienu."
+    },
+    "battery_schedule_times_different": {
+      "message": "Grafika sākuma un beigu laikam jābūt atšķirīgam."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Grafika {schedule_type} limitam jābūt starp {minimum} un {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Enphase validācijas galapunkts noraidīja grafiku."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Akumulatora grafiku rediģēšana nav pieejama."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Akumulatora grafiku API nav pieejams."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Lai atjauninātu grafiku, ir nepieciešams apstiprinājums."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Lai dzēstu grafiku, ir nepieciešams apstiprinājums."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Nederīgs grafika ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Grafika ID nav atrasts pašreizējos datos: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Norādiet vismaz vienu dzēšamu grafika ID."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Nederīgi grafiku ID: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Grafiku ID nav atrasti pašreizējos datos: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Enphase validācijas galapunkts noraidīja grafiku: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Grafika atjauninājums konfliktē ar esošu akumulatora grafiku: {message}"
     }
   },
   "options": {
@@ -161,7 +422,8 @@
           "reauth": "Sākt atkārtotu autentifikāciju",
           "forget_password": "Aizmirst saglabāto paroli",
           "type_heatpump": "Siltumsūknis",
-          "type_ac_battery": "AC baterija"
+          "type_ac_battery": "AC baterija",
+          "battery_schedules_enabled": "Iespējot akumulatora plānotāju"
         },
         "data_description": {
           "type_envoy": "Ietver vārtejas savienojamības un skaitītāju diagnostiku.",
@@ -178,7 +440,8 @@
           "reauth": "Palaidiet pieteikšanās plūsmu, lai atjaunotu datus, nenoņemot integrāciju.",
           "forget_password": "Noņem saglabāto paroli. Automātiska atjaunošana vairs netiks mēģināta.",
           "type_heatpump": "Ietver siltumsūkņa statusa, diagnostikas un patēriņa sensorus.",
-          "type_ac_battery": "Ietver AC baterijas sensorus un miega režīma vadīklas, kad tās ir pieejamas."
+          "type_ac_battery": "Ietver AC baterijas sensorus un miega režīma vadīklas, kad tās ir pieejamas.",
+          "battery_schedules_enabled": "Pārvaldīt IQ akumulatora grafikus"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Sākt atkārtotu autentifikāciju",
           "forget_password": "Aizmirst saglabāto paroli",
           "type_heatpump": "Siltumsūknis",
-          "type_ac_battery": "AC baterija"
+          "type_ac_battery": "AC baterija",
+          "battery_schedules_enabled": "Iespējot akumulatora plānotāju"
         },
         "data_description": {
           "type_envoy": "Ietver vārtejas savienojamības un skaitītāju diagnostiku.",
@@ -216,7 +480,8 @@
           "reauth": "Palaidiet pieteikšanās plūsmu, lai atjaunotu datus, nenoņemot integrāciju.",
           "forget_password": "Noņem saglabāto paroli. Automātiska atjaunošana vairs netiks mēģināta.",
           "type_heatpump": "Ietver siltumsūkņa statusa, diagnostikas un patēriņa sensorus.",
-          "type_ac_battery": "Ietver AC baterijas sensorus un miega režīma vadīklas, kad tās ir pieejamas."
+          "type_ac_battery": "Ietver AC baterijas sensorus un miega režīma vadīklas, kad tās ir pieejamas.",
+          "battery_schedules_enabled": "Pārvaldīt IQ akumulatora grafikus"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Eksports uz tīklu",
           "battery_charge": "Akumulatora uzlāde",
           "battery_discharge": "Akumulatora izlāde"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Pēdējais {serial} ziņojums"
+      },
+      "battery_cfg_schedules": {
+        "name": "Akumulatora CFG grafiki"
+      },
+      "battery_dtg_schedules": {
+        "name": "Akumulatora DTG grafiki"
+      },
+      "battery_rbd_schedules": {
+        "name": "Akumulatora RBD grafiki"
+      },
+      "battery_schedule_summary": {
+        "name": "Akumulatora grafiku kopsavilkums"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Akumulatora izlādes ierobežošanas limits"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Jauna akumulatora grafika limits"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Akumulatora grafika limits"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Svētdienas grafiks"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Jauns akumulatora grafiks pirmdienai"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Jauns akumulatora grafiks otrdienai"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Jauns akumulatora grafiks trešdienai"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Jauns akumulatora grafiks ceturtdienai"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Jauns akumulatora grafiks piektdienai"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Jauns akumulatora grafiks sestdienai"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Jauns akumulatora grafiks svētdienai"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Akumulatora grafiks pirmdienai"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Akumulatora grafiks otrdienai"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Akumulatora grafiks trešdienai"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Akumulatora grafiks ceturtdienai"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Akumulatora grafiks piektdienai"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Akumulatora grafiks sestdienai"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Akumulatora grafiks svētdienai"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Grafiks"
+      },
+      "battery_new_schedule_type": {
+        "name": "Akumulatora grafika tips"
+      },
+      "battery_schedule_selected": {
+        "name": "Akumulatora grafiks"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Izveidot jaunu grafiku"
+      },
+      "battery_schedule_add": {
+        "name": "Pievienot akumulatora grafiku"
+      },
+      "battery_schedule_delete": {
+        "name": "Dzēst akumulatora grafiku"
+      },
+      "battery_schedule_refresh": {
+        "name": "Atsvaidzināt akumulatora grafiku"
+      },
+      "battery_schedule_save": {
+        "name": "Saglabāt akumulatora grafiku"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Grafika beigu laiks"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Jauna akumulatora grafika sākuma laiks"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Jauna akumulatora grafika beigu laiks"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Akumulatora grafika sākuma laiks"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Akumulatora grafika beigu laiks"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "Vietnes ID",
           "description": "Enphase vietnes ID (neobligāts; noteikts no mērķa ierīces)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Piespiest atsvaidzināšanu",
+      "description": "Nekavējoties atsvaidziniet akumulatora grafiku datus no Enphase mākoņa.",
+      "sections": {
+        "advanced": {
+          "name": "Papildu opcijas"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Vietnes ID",
+          "description": "Neobligāts vietnes identifikators; tiek noteikts automātiski, ja ir izvēlēta vietnes ierīce."
+        },
+        "config_entry_id": {
+          "name": "Konfigurācijas ieraksta ID",
+          "description": "Neobligāts konfigurācijas ieraksta identifikators vienam Enphase vietnes ierakstam."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Pievienot akumulatora grafiku",
+      "description": "Izveidojiet akumulatora grafiku CFG, DTG vai RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Papildu opcijas"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Grafika tips",
+          "description": "Akumulatora grafika saime: cfg, dtg vai rbd."
+        },
+        "start_time": {
+          "name": "Sākuma laiks",
+          "description": "Grafika sākuma laiks."
+        },
+        "end_time": {
+          "name": "Beigu laiks",
+          "description": "Grafika beigu laiks."
+        },
+        "limit": {
+          "name": "Uzlādes limits",
+          "description": "Maksimālais akumulatora uzlādes līmenis (%)."
+        },
+        "days": {
+          "name": "Dienas",
+          "description": "Aktīvo nedēļas dienu saraksts, kur pirmdiena=1 un svētdiena=7."
+        },
+        "site_id": {
+          "name": "Vietnes ID",
+          "description": "Neobligāts vietnes identifikators; tiek noteikts automātiski, ja ir izvēlēta vietnes ierīce."
+        },
+        "config_entry_id": {
+          "name": "Konfigurācijas ieraksta ID",
+          "description": "Neobligāts konfigurācijas ieraksta identifikators vienam Enphase vietnes ierakstam."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Atjaunināt akumulatora grafiku",
+      "description": "Atjauniniet akumulatora grafiku pēc grafika ID.",
+      "sections": {
+        "advanced": {
+          "name": "Papildu opcijas"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Grafika ID",
+          "description": "Esošā Enphase akumulatora grafika identifikators."
+        },
+        "schedule_type": {
+          "name": "Grafika tips",
+          "description": "Akumulatora grafika saime: cfg, dtg vai rbd."
+        },
+        "start_time": {
+          "name": "Sākuma laiks",
+          "description": "Grafika sākuma laiks."
+        },
+        "end_time": {
+          "name": "Beigu laiks",
+          "description": "Grafika beigu laiks."
+        },
+        "limit": {
+          "name": "Uzlādes limits",
+          "description": "Maksimālais akumulatora uzlādes līmenis (%)."
+        },
+        "days": {
+          "name": "Dienas",
+          "description": "Aktīvo nedēļas dienu saraksts, kur pirmdiena=1 un svētdiena=7."
+        },
+        "confirm": {
+          "name": "Apstiprināt",
+          "description": "Iestatiet uz true, lai apstiprinātu grafika atjaunināšanu."
+        },
+        "site_id": {
+          "name": "Vietnes ID",
+          "description": "Neobligāts vietnes identifikators; tiek noteikts automātiski, ja ir izvēlēta vietnes ierīce."
+        },
+        "config_entry_id": {
+          "name": "Konfigurācijas ieraksta ID",
+          "description": "Neobligāts konfigurācijas ieraksta identifikators vienam Enphase vietnes ierakstam."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Dzēst akumulatora grafiku",
+      "description": "Dzēsiet vienu vai vairākus akumulatora grafikus pēc grafika ID.",
+      "sections": {
+        "advanced": {
+          "name": "Papildu opcijas"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Grafika ID",
+          "description": "Viena dzēšama Enphase akumulatora grafika identifikators."
+        },
+        "schedule_ids": {
+          "name": "Grafiku ID",
+          "description": "Neobligāta ar komatiem atdalīta vērtība vai saraksts vairākiem grafiku identifikatoriem."
+        },
+        "confirm": {
+          "name": "Apstiprināt",
+          "description": "Iestatiet uz true, lai apstiprinātu grafika dzēšanu."
+        },
+        "site_id": {
+          "name": "Vietnes ID",
+          "description": "Neobligāts vietnes identifikators; tiek noteikts automātiski, ja ir izvēlēta vietnes ierīce."
+        },
+        "config_entry_id": {
+          "name": "Konfigurācijas ieraksta ID",
+          "description": "Neobligāts konfigurācijas ieraksta identifikators vienam Enphase vietnes ierakstam."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Validēt akumulatora grafiku",
+      "description": "Pārbaudiet, vai akumulatora grafiku rediģēšana ir pieejama izvēlētajai grafiku saimei.",
+      "sections": {
+        "advanced": {
+          "name": "Papildu opcijas"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Grafika tips",
+          "description": "Akumulatora grafika saime: cfg, dtg vai rbd."
+        },
+        "site_id": {
+          "name": "Vietnes ID",
+          "description": "Neobligāts vietnes identifikators; tiek noteikts automātiski, ja ir izvēlēta vietnes ierīce."
+        },
+        "config_entry_id": {
+          "name": "Konfigurācijas ieraksta ID",
+          "description": "Neobligāts konfigurācijas ieraksta identifikators vienam Enphase vietnes ierakstam."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -133,220 +133,220 @@
       "message": "Grafiks pārklājas ar esošo {schedule_label}. Vispirms pielāgojiet vai atspējojiet šo grafiku."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Pašlaik nav pieejama neviena AC Battery ierīce."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Autentifikācijas iestatījumi nav pieejami, kamēr Enphase pakalpojums nedarbojas."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Šim kontam akumulatora profila atjauninājumi nav atļauti."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Šim kontam akumulatora iestatījumu atjauninājumi nav atļauti."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Jau notiek cita akumulatora profila atjaunināšana."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Jau notiek cita akumulatora iestatījumu atjaunināšana."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Akumulatora profila atjauninājumi nav pieejami."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Akumulatora iestatījumu atjauninājumi nav pieejami."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Akumulatora atjauninājumi nav pieejami."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Šim kontam akumulatora atjauninājumi nav atļauti."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Akumulatora profila atjauninājums tika pieprasīts pārāk ātri. Lūdzu, uzgaidiet un mēģiniet vēlreiz."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Akumulatora iestatījumu atjauninājums tika pieprasīts pārāk ātri. Lūdzu, uzgaidiet un mēģiniet vēlreiz."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Nevarēja apstiprināt akumulatora rakstīšanas piekļuvi. Atsvaidziniet un mēģiniet vēlreiz."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase noraidīja grafika atjauninājumu (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Nevarēja autentificēt grafika atjauninājumu. Veiciet atkārtotu autentifikāciju un mēģiniet vēlreiz."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Grafiks konfliktē ar esošo izlādes tīklā grafiku. Vispirms pielāgojiet vai atspējojiet to."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Grafiks konfliktē ar esošo akumulatora izlādes ierobežošanas grafiku. Vispirms pielāgojiet vai atspējojiet to."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Grafiks konfliktē ar esošo uzlādes no tīkla grafiku. Vispirms pielāgojiet vai atspējojiet to."
     },
     "schedule_update_conflict": {
       "message": "Grafika atjauninājums konfliktē ar esošu akumulatora grafiku."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Akumulatora profils nav pieejams."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase noraidīja akumulatora profila atjauninājumu (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Nevarēja autentificēt akumulatora profila atjauninājumu. Veiciet atkārtotu autentifikāciju un mēģiniet vēlreiz."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Akumulatora iestatījumu slodze nav pieejama."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase noraidīja akumulatora iestatījumu atjauninājumu (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Nevarēja autentificēt akumulatora iestatījumu atjauninājumu. Veiciet atkārtotu autentifikāciju un mēģiniet vēlreiz."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Full Backup rezerve ir fiksēta uz 100%."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Akumulatora rezerve nav pieejama."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Savings profilam jābūt aktīvam."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Savings profila iestatījumi nav pieejami."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Izvēlētais akumulatora profils netiek atbalstīts."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Uzlādes no tīkla iestatījums nav pieejams."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Enphase nepiemēroja uzlādes no tīkla slēdzi."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Uzlādes no tīkla grafiks nav pieejams."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Uzlādes no tīkla grafika sākuma un beigu laikam jāatšķiras."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Enphase nepiemēroja uzlādes no tīkla grafika slēdzi."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Vispirms jāiespējo uzlāde no tīkla."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Grafika maiņa gaida Envoy sinhronizāciju. Lūdzu, uzgaidiet."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Uzlādes no tīkla grafika laiks nav derīgs."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Šajā klienta versijā grafiku API nav pieejams."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Nav pieejams neviens esošs uzlādes no tīkla grafiks."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Pirms iespējošanas izveidojiet {schedule_label} IQ Battery plānotājā."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "Enphase pašlaik nepadara {schedule_label} pieejamu šai vietnei. Pagaidiet, līdz grafika sinhronizācija ir pabeigta, pēc tam atsvaidziniet un mēģiniet vēlreiz."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Enphase nepiemēroja {schedule_label} slēdzi."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "primārā rakstīšana noraidīta"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "{schedule_label} sākuma un beigu laikam jāatšķiras."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Izlādes tīklā grafika laiks nav derīgs."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Nav pieejams neviens esošs {schedule_label_lower} grafiks."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "{schedule_label} grafiks nav pieejams."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "{schedule_label} grafika laiks nav derīgs."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Pašreizējais {schedule_label_lower} grafika laiks nav derīgs."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "{schedule_label} grafika limitam jābūt starp {minimum} un {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "{schedule_label} grafika limitam jābūt vismaz {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Pašreizējie grafika laiki nav pieejami."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Uzlādes no tīkla grafika limitam jābūt starp {minimum} un {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Uzlādes no tīkla grafika limitam jābūt vismaz {minimum}%."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Akumulatora izslēgšanās līmenis nav pieejams."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Akumulatora izslēgšanās līmenis nav derīgs."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Akumulatora izslēgšanās līmenim jābūt starp {minimum} un {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Storm Alert atteikšanās nav pieejama."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Storm Alert atteikšanās neizdevās {count} brīdinājumiem."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Šim kontam Storm Guard atjauninājumi nav atļauti."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Storm Guard iestatījumi nav pieejami."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase noraidīja Storm Guard atjauninājumu (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Nevarēja autentificēt Storm Guard atjauninājumu. Veiciet atkārtotu autentifikāciju un mēģiniet vēlreiz."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Izvēlētais sistēmas profils nav pieejams."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Enphase noraidīja sistēmas profila atjauninājumu (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Nevarēja autentificēt sistēmas profila atjauninājumu. Veiciet atkārtotu autentifikāciju un mēģiniet vēlreiz."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Sistēmas profila atjaunināšana neizdevās."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Sistēmas profila atjaunināšana neizdevās tīkla kļūdas dēļ. Mēģiniet vēlreiz."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Sistēmas profila atjaunināšanas laiks beidzās. Mēģiniet vēlreiz."
     },
     "scheduler_service_unavailable": {
       "message": "Uzlādes režīma izvēle nav pieejama, kamēr Enphase plānošanas pakalpojums nav pieejams."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "Izvēlētais AC Battery mērķa uzlādes līmenis nav pieejams."
     },
     "battery_schedule_day_required": {
       "message": "Izvēlieties grafikam vismaz vienu dienu."

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Tidsplanen overlapper den eksisterende {schedule_label}. Juster eller deaktiver den tidsplanen først."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Planoppdateringen er i konflikt med en eksisterende batteriplan."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Valg av lademodus er ikke tilgjengelig mens Enphase-planleggingstjenesten er nede."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Velg minst én dag for planen."
+    },
+    "battery_schedule_times_different": {
+      "message": "Planens start- og sluttid må være forskjellige."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Grensen for planen {schedule_type} må være mellom {minimum} og {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Planen ble avvist av Enphase-valideringsendepunktet."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Redigering av batteriplaner er ikke tilgjengelig."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "API-et for batteriplaner er ikke tilgjengelig."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Bekreftelse kreves for å oppdatere en plan."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Bekreftelse kreves for å slette en plan."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Ugyldig plan-ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Plan-ID ble ikke funnet i gjeldende data: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Oppgi minst én plan-ID som skal slettes."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Ugyldige plan-ID-er: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Plan-ID-er ble ikke funnet i gjeldende data: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Planen ble avvist av Enphase-valideringsendepunktet: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Planoppdateringen er i konflikt med en eksisterende batteriplan: {message}"
     }
   },
   "options": {
@@ -161,7 +422,8 @@
           "reauth": "Start reautentisering",
           "forget_password": "Glem lagret passord",
           "type_heatpump": "Varmepumpe",
-          "type_ac_battery": "AC-batteri"
+          "type_ac_battery": "AC-batteri",
+          "battery_schedules_enabled": "Aktiver batteriplanlegger"
         },
         "data_description": {
           "type_envoy": "Inkluderer gateway-tilkobling og målerdiagnostikk.",
@@ -178,7 +440,8 @@
           "reauth": "Start innloggingsflyten for å oppdatere legitimasjon uten å fjerne integrasjonen.",
           "forget_password": "Fjerner det lagrede passordet. Automatisk oppdatering vil ikke lenger forsøkes.",
           "type_heatpump": "Inkluderer sensorer for varmepumpens status, diagnostikk og forbruk.",
-          "type_ac_battery": "Inkluderer AC-batterisensorer og kontroller for hvilemodus når de er tilgjengelige."
+          "type_ac_battery": "Inkluderer AC-batterisensorer og kontroller for hvilemodus når de er tilgjengelige.",
+          "battery_schedules_enabled": "Administrer IQ-batteriplaner"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Start reautentisering",
           "forget_password": "Glem lagret passord",
           "type_heatpump": "Varmepumpe",
-          "type_ac_battery": "AC-batteri"
+          "type_ac_battery": "AC-batteri",
+          "battery_schedules_enabled": "Aktiver batteriplanlegger"
         },
         "data_description": {
           "type_envoy": "Inkluderer gateway-tilkobling og målerdiagnostikk.",
@@ -216,7 +480,8 @@
           "reauth": "Start innloggingsflyten for å oppdatere legitimasjon uten å fjerne integrasjonen.",
           "forget_password": "Fjerner det lagrede passordet. Automatisk oppdatering vil ikke lenger forsøkes.",
           "type_heatpump": "Inkluderer sensorer for varmepumpens status, diagnostikk og forbruk.",
-          "type_ac_battery": "Inkluderer AC-batterisensorer og kontroller for hvilemodus når de er tilgjengelige."
+          "type_ac_battery": "Inkluderer AC-batterisensorer og kontroller for hvilemodus når de er tilgjengelige.",
+          "battery_schedules_enabled": "Administrer IQ-batteriplaner"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Netteksport",
           "battery_charge": "Batterilading",
           "battery_discharge": "Batteriutlading"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "{serial} sist rapportert"
+      },
+      "battery_cfg_schedules": {
+        "name": "Batteri-CFG-planer"
+      },
+      "battery_dtg_schedules": {
+        "name": "Batteri-DTG-planer"
+      },
+      "battery_rbd_schedules": {
+        "name": "Batteri-RBD-planer"
+      },
+      "battery_schedule_summary": {
+        "name": "Sammendrag av batteriplaner"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Grense for begrensning av batteriutlading"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Grense for ny batteriplan"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Grense for batteriplan"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Tidsplan søndag"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Ny batteriplan mandag"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Ny batteriplan tirsdag"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Ny batteriplan onsdag"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Ny batteriplan torsdag"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Ny batteriplan fredag"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Ny batteriplan lørdag"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Ny batteriplan søndag"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Batteriplan mandag"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Batteriplan tirsdag"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Batteriplan onsdag"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Batteriplan torsdag"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Batteriplan fredag"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Batteriplan lørdag"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Batteriplan søndag"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Tidsplan"
+      },
+      "battery_new_schedule_type": {
+        "name": "Type batteriplan"
+      },
+      "battery_schedule_selected": {
+        "name": "Batteriplan"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Opprett ny tidsplan"
+      },
+      "battery_schedule_add": {
+        "name": "Legg til batteriplan"
+      },
+      "battery_schedule_delete": {
+        "name": "Slett batteriplan"
+      },
+      "battery_schedule_refresh": {
+        "name": "Oppdater batteriplan"
+      },
+      "battery_schedule_save": {
+        "name": "Lagre batteriplan"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Sluttid for tidsplan"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Starttid for ny batteriplan"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Sluttid for ny batteriplan"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Starttid for batteriplan"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Sluttid for batteriplan"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "Anleggs-ID",
           "description": "Enphase-anleggs-ID (valgfri; hentes fra målenheten)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Tving oppdatering",
+      "description": "Oppdater data for batteriplaner fra Enphase-skyen umiddelbart.",
+      "sections": {
+        "advanced": {
+          "name": "Avanserte alternativer"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Anleggs-ID",
+          "description": "Valgfri anleggsidentifikator; oppdages automatisk når en anleggsenhet er valgt."
+        },
+        "config_entry_id": {
+          "name": "Konfigurasjonsoppførings-ID",
+          "description": "Valgfri identifikator for konfigurasjonsoppføring for én Enphase-anleggsoppføring."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Legg til batteriplan",
+      "description": "Opprett en batteriplan for CFG, DTG eller RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Avanserte alternativer"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Plantype",
+          "description": "Batteriplanfamilie: cfg, dtg eller rbd."
+        },
+        "start_time": {
+          "name": "Starttid",
+          "description": "Planens starttid."
+        },
+        "end_time": {
+          "name": "Sluttid",
+          "description": "Planens sluttid."
+        },
+        "limit": {
+          "name": "Ladegrense",
+          "description": "Maksimalt ladenivå for batteriet (%)."
+        },
+        "days": {
+          "name": "Dager",
+          "description": "Liste over aktive ukedager der mandag=1 og søndag=7."
+        },
+        "site_id": {
+          "name": "Anleggs-ID",
+          "description": "Valgfri anleggsidentifikator; oppdages automatisk når en anleggsenhet er valgt."
+        },
+        "config_entry_id": {
+          "name": "Konfigurasjonsoppførings-ID",
+          "description": "Valgfri identifikator for konfigurasjonsoppføring for én Enphase-anleggsoppføring."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Oppdater batteriplan",
+      "description": "Oppdater en batteriplan etter plan-ID.",
+      "sections": {
+        "advanced": {
+          "name": "Avanserte alternativer"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Plan-ID",
+          "description": "Identifikator for eksisterende Enphase-batteriplan."
+        },
+        "schedule_type": {
+          "name": "Plantype",
+          "description": "Batteriplanfamilie: cfg, dtg eller rbd."
+        },
+        "start_time": {
+          "name": "Starttid",
+          "description": "Planens starttid."
+        },
+        "end_time": {
+          "name": "Sluttid",
+          "description": "Planens sluttid."
+        },
+        "limit": {
+          "name": "Ladegrense",
+          "description": "Maksimalt ladenivå for batteriet (%)."
+        },
+        "days": {
+          "name": "Dager",
+          "description": "Liste over aktive ukedager der mandag=1 og søndag=7."
+        },
+        "confirm": {
+          "name": "Bekreft",
+          "description": "Sett til true for å bekrefte planoppdateringen."
+        },
+        "site_id": {
+          "name": "Anleggs-ID",
+          "description": "Valgfri anleggsidentifikator; oppdages automatisk når en anleggsenhet er valgt."
+        },
+        "config_entry_id": {
+          "name": "Konfigurasjonsoppførings-ID",
+          "description": "Valgfri identifikator for konfigurasjonsoppføring for én Enphase-anleggsoppføring."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Slett batteriplan",
+      "description": "Slett én eller flere batteriplaner etter plan-ID.",
+      "sections": {
+        "advanced": {
+          "name": "Avanserte alternativer"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Plan-ID",
+          "description": "Identifikator for én Enphase-batteriplan som skal slettes."
+        },
+        "schedule_ids": {
+          "name": "Plan-ID-er",
+          "description": "Valgfri kommaseparert verdi eller liste for flere planidentifikatorer."
+        },
+        "confirm": {
+          "name": "Bekreft",
+          "description": "Sett til true for å bekrefte planslettingen."
+        },
+        "site_id": {
+          "name": "Anleggs-ID",
+          "description": "Valgfri anleggsidentifikator; oppdages automatisk når en anleggsenhet er valgt."
+        },
+        "config_entry_id": {
+          "name": "Konfigurasjonsoppførings-ID",
+          "description": "Valgfri identifikator for konfigurasjonsoppføring for én Enphase-anleggsoppføring."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Valider batteriplan",
+      "description": "Kontroller om redigering av batteriplaner er tilgjengelig for den valgte planfamilien.",
+      "sections": {
+        "advanced": {
+          "name": "Avanserte alternativer"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Plantype",
+          "description": "Batteriplanfamilie: cfg, dtg eller rbd."
+        },
+        "site_id": {
+          "name": "Anleggs-ID",
+          "description": "Valgfri anleggsidentifikator; oppdages automatisk når en anleggsenhet er valgt."
+        },
+        "config_entry_id": {
+          "name": "Konfigurasjonsoppførings-ID",
+          "description": "Valgfri identifikator for konfigurasjonsoppføring for én Enphase-anleggsoppføring."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -133,220 +133,220 @@
       "message": "Tidsplanen overlapper den eksisterende {schedule_label}. Juster eller deaktiver den tidsplanen først."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Ingen AC Battery-enheter er tilgjengelige for øyeblikket."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Autentiseringsinnstillinger er ikke tilgjengelige mens Enphase-tjenesten er nede."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Oppdateringer av batteriprofil er ikke tillatt for denne kontoen."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Oppdateringer av batteriinnstillinger er ikke tillatt for denne kontoen."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "En annen oppdatering av batteriprofil pågår allerede."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "En annen oppdatering av batteriinnstillinger pågår allerede."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Oppdateringer av batteriprofil er ikke tilgjengelige."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Oppdateringer av batteriinnstillinger er ikke tilgjengelige."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Batterioppdateringer er ikke tilgjengelige."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Batterioppdateringer er ikke tillatt for denne kontoen."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Oppdatering av batteriprofil ble forespurt for raskt. Vent litt og prøv igjen."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Oppdatering av batteriinnstillinger ble forespurt for raskt. Vent litt og prøv igjen."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Skrivetilgang til batteriet kunne ikke bekreftes. Oppdater og prøv igjen."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Planoppdateringen ble avvist av Enphase (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Planoppdateringen kunne ikke autentiseres. Autentiser på nytt og prøv igjen."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Planen er i konflikt med den eksisterende utlading-til-nettet-planen. Juster eller deaktiver den planen først."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Planen er i konflikt med den eksisterende begrens-batteriutlading-planen. Juster eller deaktiver den planen først."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Planen er i konflikt med den eksisterende lading-fra-nettet-planen. Juster eller deaktiver den planen først."
     },
     "schedule_update_conflict": {
       "message": "Planoppdateringen er i konflikt med en eksisterende batteriplan."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Batteriprofil er ikke tilgjengelig."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Oppdatering av batteriprofil ble avvist av Enphase (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Oppdatering av batteriprofil kunne ikke autentiseres. Autentiser på nytt og prøv igjen."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Nyttelasten for batteriinnstillinger er ikke tilgjengelig."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Oppdatering av batteriinnstillinger ble avvist av Enphase (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Oppdatering av batteriinnstillinger kunne ikke autentiseres. Autentiser på nytt og prøv igjen."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Full Backup-reserven er låst til 100%."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Batterireserven er ikke tilgjengelig."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Spareprofilen må være aktiv."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Innstillinger for spareprofil er ikke tilgjengelige."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Valgt batteriprofil støttes ikke."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Innstillingen for lading fra nettet er ikke tilgjengelig."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Bryteren for lading fra nettet ble ikke brukt av Enphase."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Planen for lading fra nettet er ikke tilgjengelig."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Start- og sluttid for planen for lading fra nettet må være forskjellige."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Bryteren for planen for lading fra nettet ble ikke brukt av Enphase."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Lading fra nettet må aktiveres først."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "En planendring venter på Envoy-synkronisering. Vent litt."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Tidspunktet for planen for lading fra nettet er ugyldig."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Plan-API er ikke tilgjengelig i denne klientversjonen."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Ingen eksisterende plan for lading fra nettet er tilgjengelig."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Opprett en {schedule_label} i IQ Battery-planleggeren før du aktiverer den."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} er for øyeblikket ikke eksponert av Enphase for dette anlegget. Vent til plansynkroniseringen er fullført, oppdater deretter og prøv igjen."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Bryteren for {schedule_label} ble ikke brukt av Enphase."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "primærskriving avvist"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "Start- og sluttid for {schedule_label} må være forskjellige."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Tidspunktet for utlading til nettet-planen er ugyldig."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Ingen eksisterende {schedule_label_lower}-plan er tilgjengelig."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "{schedule_label}-planen er ikke tilgjengelig."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "Tidspunktet for {schedule_label}-planen er ugyldig."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Gjeldende tidspunkt for {schedule_label_lower}-planen er ugyldig."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "Grensen for {schedule_label}-planen må være mellom {minimum} og {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "Grensen for {schedule_label}-planen må være minst {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Gjeldende plantider er ikke tilgjengelige."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Grensen for planen for lading fra nettet må være mellom {minimum} og {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Grensen for planen for lading fra nettet må være minst {minimum}%."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Batteriets avstengningsnivå er ikke tilgjengelig."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Batteriets avstengningsnivå er ugyldig."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Batteriets avstengningsnivå må være mellom {minimum} og {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Fravalg av Storm Alert er ikke tilgjengelig."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Fravalg av Storm Alert mislyktes for {count} varsel(er)."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Storm Guard-oppdateringer er ikke tillatt for denne kontoen."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Storm Guard-innstillinger er ikke tilgjengelige."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Storm Guard-oppdateringen ble avvist av Enphase (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Storm Guard-oppdateringen kunne ikke autentiseres. Autentiser på nytt og prøv igjen."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Valgt systemprofil er ikke tilgjengelig."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Oppdatering av systemprofil ble avvist av Enphase (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Oppdatering av systemprofil kunne ikke autentiseres. Autentiser på nytt og prøv igjen."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Oppdatering av systemprofil mislyktes."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Oppdatering av systemprofil mislyktes på grunn av en nettverksfeil. Prøv igjen."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Oppdatering av systemprofil fikk tidsavbrudd. Prøv igjen."
     },
     "scheduler_service_unavailable": {
       "message": "Valg av lademodus er ikke tilgjengelig mens Enphase-planleggingstjenesten er nede."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "Valgt målladenivå for AC Battery er ikke tilgjengelig."
     },
     "battery_schedule_day_required": {
       "message": "Velg minst én dag for planen."

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -133,220 +133,220 @@
       "message": "Het schema overlapt met het bestaande {schedule_label}. Pas dat schema eerst aan of schakel het uit."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Er zijn momenteel geen AC Battery-apparaten beschikbaar."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Authenticatie-instellingen zijn niet beschikbaar zolang de Enphase-service niet beschikbaar is."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Updates van het batterijprofiel zijn niet toegestaan voor dit account."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Updates van batterij-instellingen zijn niet toegestaan voor dit account."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Er wordt al een andere update van het batterijprofiel uitgevoerd."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Er wordt al een andere update van de batterij-instellingen uitgevoerd."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Updates van het batterijprofiel zijn niet beschikbaar."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Updates van batterij-instellingen zijn niet beschikbaar."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Batterij-updates zijn niet beschikbaar."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Batterij-updates zijn niet toegestaan voor dit account."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "De update van het batterijprofiel is te snel opnieuw aangevraagd. Wacht even en probeer het opnieuw."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "De update van de batterij-instellingen is te snel opnieuw aangevraagd. Wacht even en probeer het opnieuw."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Schrijftoegang voor de batterij kon niet worden bevestigd. Vernieuw en probeer het opnieuw."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "De schema-update is afgewezen door Enphase (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "De schema-update kon niet worden geauthenticeerd. Verifieer opnieuw en probeer het opnieuw."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Het schema conflicteert met het bestaande ontladen-naar-het-net-schema. Pas dat schema eerst aan of schakel het uit."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Het schema conflicteert met het bestaande beperk-batterijontlading-schema. Pas dat schema eerst aan of schakel het uit."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Het schema conflicteert met het bestaande laden-vanaf-het-net-schema. Pas dat schema eerst aan of schakel het uit."
     },
     "schedule_update_conflict": {
       "message": "Geplande update conflicteert met een bestaand batterijschema."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Batterijprofiel is niet beschikbaar."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "De update van het batterijprofiel is afgewezen door Enphase (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "De update van het batterijprofiel kon niet worden geauthenticeerd. Verifieer opnieuw en probeer het opnieuw."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "De payload voor batterij-instellingen is niet beschikbaar."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "De update van de batterij-instellingen is afgewezen door Enphase (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "De update van de batterij-instellingen kon niet worden geauthenticeerd. Verifieer opnieuw en probeer het opnieuw."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "De Full Backup-reserve is vastgesteld op 100%."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Batterijreserve is niet beschikbaar."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Spaarprofiel moet actief zijn."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Instellingen voor het spaarprofiel zijn niet beschikbaar."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Het geselecteerde batterijprofiel wordt niet ondersteund."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "De instelling Laden vanaf het net is niet beschikbaar."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "De schakelaar Laden vanaf het net is niet toegepast door Enphase."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Het laden-vanaf-het-net-schema is niet beschikbaar."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "De begin- en eindtijd van het laden-vanaf-het-net-schema moeten verschillend zijn."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "De schakelaar van het laden-vanaf-het-net-schema is niet toegepast door Enphase."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Laden vanaf het net moet eerst worden ingeschakeld."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Een schemawijziging wacht op Envoy-synchronisatie. Even geduld."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "De tijd van het laden-vanaf-het-net-schema is ongeldig."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "De schema-API is niet beschikbaar in deze clientversie."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Er is geen bestaand laden-vanaf-het-net-schema beschikbaar."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Maak eerst een {schedule_label} in de IQ Battery-planner voordat je die inschakelt."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} wordt momenteel niet door Enphase voor deze site beschikbaar gesteld. Wacht tot de schemasynchronisatie is voltooid, vernieuw dan en probeer het opnieuw."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "De schakelaar voor {schedule_label} is niet toegepast door Enphase."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "primaire schrijfactie afgewezen"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "De begin- en eindtijd van {schedule_label} moeten verschillend zijn."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "De tijd van het ontladen-naar-het-net-schema is ongeldig."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Er is geen bestaand {schedule_label_lower}-schema beschikbaar."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "Het schema {schedule_label} is niet beschikbaar."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "De tijd van het schema {schedule_label} is ongeldig."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "De huidige tijd van het {schedule_label_lower}-schema is ongeldig."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "De limiet van het schema {schedule_label} moet tussen {minimum} en {maximum} liggen."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "De limiet van het schema {schedule_label} moet ten minste {minimum}% zijn."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "De huidige schematijden zijn niet beschikbaar."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "De limiet van het laden-vanaf-het-net-schema moet tussen {minimum} en {maximum} liggen."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "De limiet van het laden-vanaf-het-net-schema moet ten minste {minimum}% zijn."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Het uitschakelniveau van de batterij is niet beschikbaar."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Het uitschakelniveau van de batterij is ongeldig."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Het uitschakelniveau van de batterij moet tussen {minimum} en {maximum} liggen."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Afmelden voor Storm Alert is niet beschikbaar."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Afmelden voor Storm Alert is mislukt voor {count} waarschuwing(en)."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Storm Guard-updates zijn niet toegestaan voor dit account."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Storm Guard-instellingen zijn niet beschikbaar."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "De Storm Guard-update is afgewezen door Enphase (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "De Storm Guard-update kon niet worden geauthenticeerd. Verifieer opnieuw en probeer het opnieuw."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Het geselecteerde systeemprofiel is niet beschikbaar."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "De update van het systeemprofiel is afgewezen door Enphase (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "De update van het systeemprofiel kon niet worden geauthenticeerd. Verifieer opnieuw en probeer het opnieuw."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "De update van het systeemprofiel is mislukt."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "De update van het systeemprofiel is mislukt door een netwerkfout. Probeer het opnieuw."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "De update van het systeemprofiel heeft een time-out bereikt. Probeer het opnieuw."
     },
     "scheduler_service_unavailable": {
       "message": "Selectie van de oplaadmodus is niet beschikbaar terwijl de Enphase-plannerservice niet beschikbaar is."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "De geselecteerde doel-laadtoestand voor AC Battery is niet beschikbaar."
     },
     "battery_schedule_day_required": {
       "message": "Selecteer minimaal één dag voor het schema."

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Het schema overlapt met het bestaande {schedule_label}. Pas dat schema eerst aan of schakel het uit."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Geplande update conflicteert met een bestaand batterijschema."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Selectie van de oplaadmodus is niet beschikbaar terwijl de Enphase-plannerservice niet beschikbaar is."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Selecteer minimaal één dag voor het schema."
+    },
+    "battery_schedule_times_different": {
+      "message": "De begin- en eindtijden van het schema moeten verschillend zijn."
+    },
+    "battery_schedule_limit_range": {
+      "message": "De schemalimiet van {schedule_type} moet tussen {minimum} en {maximum} liggen."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Schema afgewezen door het Enphase-validatie-eindpunt."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Bewerken van het batterijschema is niet beschikbaar."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "API voor batterijschema is niet beschikbaar."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Bevestiging vereist om een ​​planning bij te werken."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Bevestiging vereist om een ​​schema te verwijderen."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Ongeldige schema-ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Schema-ID niet gevonden in huidige gegevens: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Geef ten minste één schema-ID op om te verwijderen."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Ongeldige schema-ID('s): {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Schema-ID('s) niet gevonden in huidige gegevens: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Schema afgewezen door het Enphase-validatie-eindpunt: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Schema-update conflicteert met een bestaand batterijschema: {message}"
     }
   },
   "options": {
@@ -157,11 +418,12 @@
           "api_timeout": "API-time-out (s)",
           "nominal_voltage": "Nominale spanning (V)",
           "session_history_interval": "Sessieverleden-interval (min)",
-          "schedule_sync_enabled": "Schakel Scheduler-ondersteuning in",
+          "schedule_sync_enabled": "Schakel EV Charger Scheduler in",
           "reauth": "Herautenticatie starten",
           "forget_password": "Opgeslagen wachtwoord vergeten",
           "type_heatpump": "Warmtepomp",
-          "type_ac_battery": "AC-batterij"
+          "type_ac_battery": "AC-batterij",
+          "battery_schedules_enabled": "Schakel Batterijplanner in"
         },
         "data_description": {
           "type_envoy": "Bevat gateway-connectiviteit en meterdiagnostiek.",
@@ -174,11 +436,12 @@
           "api_timeout": "Seconden voordat API-aanvragen een time-out krijgen.",
           "nominal_voltage": "Fallbackspanning voor het schatten van laadvermogen.",
           "session_history_interval": "Minuten om te wachten tussen het ophalen van cloudsessiegeschiedenis.",
-          "schedule_sync_enabled": "Beheer het planningsbeheer van Enphase",
+          "schedule_sync_enabled": "Beheer IQ EV-opladerschema's",
           "reauth": "Start de login-flow om inloggegevens te vernieuwen zonder de integratie te verwijderen.",
           "forget_password": "Verwijdert het opgeslagen wachtwoord. Automatisch vernieuwen wordt niet langer geprobeerd.",
           "type_heatpump": "Bevat sensoren voor warmtepompstatus, diagnostiek en verbruik.",
-          "type_ac_battery": "Bevat AC-batterijsensoren en slaapmodusbediening wanneer beschikbaar."
+          "type_ac_battery": "Bevat AC-batterijsensoren en slaapmodusbediening wanneer beschikbaar.",
+          "battery_schedules_enabled": "Beheer IQ-batterijschema's"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Herautenticatie starten",
           "forget_password": "Opgeslagen wachtwoord vergeten",
           "type_heatpump": "Warmtepomp",
-          "type_ac_battery": "AC-batterij"
+          "type_ac_battery": "AC-batterij",
+          "battery_schedules_enabled": "Schakel Batterijplanner in"
         },
         "data_description": {
           "type_envoy": "Bevat gateway-connectiviteit en meterdiagnostiek.",
@@ -216,7 +480,8 @@
           "reauth": "Start de login-flow om inloggegevens te vernieuwen zonder de integratie te verwijderen.",
           "forget_password": "Verwijdert het opgeslagen wachtwoord. Automatisch vernieuwen wordt niet langer geprobeerd.",
           "type_heatpump": "Bevat sensoren voor warmtepompstatus, diagnostiek en verbruik.",
-          "type_ac_battery": "Bevat AC-batterijsensoren en slaapmodusbediening wanneer beschikbaar."
+          "type_ac_battery": "Bevat AC-batterijsensoren en slaapmodusbediening wanneer beschikbaar.",
+          "battery_schedules_enabled": "Beheer IQ-batterijschema's"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Netexport",
           "battery_charge": "Batterijlading",
           "battery_discharge": "Batterijontlading"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Laatst gerapporteerd door {serial}"
+      },
+      "battery_cfg_schedules": {
+        "name": "Batterij CFG-schema's"
+      },
+      "battery_dtg_schedules": {
+        "name": "Batterij DTG-schema's"
+      },
+      "battery_rbd_schedules": {
+        "name": "Batterij RBD-schema's"
+      },
+      "battery_schedule_summary": {
+        "name": "Samenvatting van het batterijschema"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Limiet voor beperkte batterijontlading"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Batterij Nieuwe schemalimiet"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Limiet batterijschema"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Schema zondag"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Nieuw batterijschema maandag"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Nieuw batterijschema dinsdag"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Nieuw batterijschema woensdag"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Nieuw batterijschema donderdag"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Nieuw batterijschema vrijdag"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Nieuw batterijschema zaterdag"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Nieuw batterijschema zondag"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Batterijschema maandag"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Batterijschema dinsdag"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Batterijschema woensdag"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Batterijschema donderdag"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Batterijschema vrijdag"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Batterijschema zaterdag"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Batterijschema zondag"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Schema"
+      },
+      "battery_new_schedule_type": {
+        "name": "Type batterijschema"
+      },
+      "battery_schedule_selected": {
+        "name": "Batterijschema"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Nieuw schema maken"
+      },
+      "battery_schedule_add": {
+        "name": "Batterijschema toevoegen"
+      },
+      "battery_schedule_delete": {
+        "name": "Batterijschema verwijderen"
+      },
+      "battery_schedule_refresh": {
+        "name": "Batterijschema vernieuwen"
+      },
+      "battery_schedule_save": {
+        "name": "Batterijschema opslaan"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Eindtijd schema"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Batterij Nieuw schema Starttijd"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Batterij Nieuw schema Eindtijd"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Starttijd batterijschema"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Eindtijd batterijschema"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "Site-ID",
           "description": "Enphase-site-ID (optioneel; afgeleid van het doelapparaat)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Forceer vernieuwen",
+      "description": "Vernieuw de batterijschemagegevens onmiddellijk vanuit de Enphase-cloud.",
+      "sections": {
+        "advanced": {
+          "name": "Geavanceerde opties"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site-ID",
+          "description": "Optionele site-identificatie; wordt automatisch gedetecteerd wanneer een site-apparaat is geselecteerd."
+        },
+        "config_entry_id": {
+          "name": "Configuratie-item-ID",
+          "description": "Optionele identificatie van het configuratie-item voor één Enphase-site-item."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Voeg batterijschema toe",
+      "description": "Maak een batterijschema voor CFG, DTG of RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Geavanceerde opties"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Schematype",
+          "description": "Familie van het batterijschema: cfg, dtg of rbd."
+        },
+        "start_time": {
+          "name": "Starttijd",
+          "description": "Starttijd van het schema."
+        },
+        "end_time": {
+          "name": "Eindtijd",
+          "description": "Eindtijd van het schema."
+        },
+        "limit": {
+          "name": "Laadlimiet",
+          "description": "Maximale laadtoestand van de batterij (%)."
+        },
+        "days": {
+          "name": "Dagen",
+          "description": "Lijst met actieve weekdagen, waarbij maandag=1 en zondag=7."
+        },
+        "site_id": {
+          "name": "Site-ID",
+          "description": "Optionele site-identificatie; wordt automatisch gedetecteerd wanneer een site-apparaat is geselecteerd."
+        },
+        "config_entry_id": {
+          "name": "Configuratie-item-ID",
+          "description": "Optionele identificatie van het configuratie-item voor één Enphase-site-item."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Update het batterijschema",
+      "description": "Update een batterijschema op basis van schema-ID.",
+      "sections": {
+        "advanced": {
+          "name": "Geavanceerde opties"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Schema-ID",
+          "description": "Identificatie van een bestaand Enphase-batterijschema."
+        },
+        "schedule_type": {
+          "name": "Schematype",
+          "description": "Familie van het batterijschema: cfg, dtg of rbd."
+        },
+        "start_time": {
+          "name": "Starttijd",
+          "description": "Starttijd van het schema."
+        },
+        "end_time": {
+          "name": "Eindtijd",
+          "description": "Eindtijd van het schema."
+        },
+        "limit": {
+          "name": "Laadlimiet",
+          "description": "Maximale laadtoestand van de batterij (%)."
+        },
+        "days": {
+          "name": "Dagen",
+          "description": "Lijst met actieve weekdagen, waarbij maandag=1 en zondag=7."
+        },
+        "confirm": {
+          "name": "Bevestigen",
+          "description": "Stel in op true om de schema-update te bevestigen."
+        },
+        "site_id": {
+          "name": "Site-ID",
+          "description": "Optionele site-identificatie; wordt automatisch gedetecteerd wanneer een site-apparaat is geselecteerd."
+        },
+        "config_entry_id": {
+          "name": "Configuratie-item-ID",
+          "description": "Optionele identificatie van het configuratie-item voor één Enphase-site-item."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Batterijschema verwijderen",
+      "description": "Verwijder een of meer batterijschema's op schema-ID.",
+      "sections": {
+        "advanced": {
+          "name": "Geavanceerde opties"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Schema-ID",
+          "description": "Identificatie van één Enphase-batterijschema om te verwijderen."
+        },
+        "schedule_ids": {
+          "name": "Schema-ID's",
+          "description": "Optionele kommagescheiden waarde of lijstinvoer voor meerdere schema-identificaties."
+        },
+        "confirm": {
+          "name": "Bevestigen",
+          "description": "Stel in op true om het verwijderen van het schema te bevestigen."
+        },
+        "site_id": {
+          "name": "Site-ID",
+          "description": "Optionele site-identificatie; wordt automatisch gedetecteerd wanneer een site-apparaat is geselecteerd."
+        },
+        "config_entry_id": {
+          "name": "Configuratie-item-ID",
+          "description": "Optionele identificatie van het configuratie-item voor één Enphase-site-item."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Valideer het batterijschema",
+      "description": "Controleer of het bewerken van het batterijschema beschikbaar is voor de geselecteerde schemafamilie.",
+      "sections": {
+        "advanced": {
+          "name": "Geavanceerde opties"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Schematype",
+          "description": "Familie van het batterijschema: cfg, dtg of rbd."
+        },
+        "site_id": {
+          "name": "Site-ID",
+          "description": "Optionele site-identificatie; wordt automatisch gedetecteerd wanneer een site-apparaat is geselecteerd."
+        },
+        "config_entry_id": {
+          "name": "Configuratie-item-ID",
+          "description": "Optionele identificatie van het configuratie-item voor één Enphase-site-item."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Harmonogram nakłada się z istniejącym {schedule_label}. Najpierw dostosuj lub wyłącz ten harmonogram."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Harmonogram aktualizacji koliduje z istniejącym harmonogramem baterii."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Wybór trybu ładowania jest niedostępny, gdy usługa harmonogramu Enphase jest wyłączona."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Wybierz co najmniej jeden dzień dla harmonogramu."
+    },
+    "battery_schedule_times_different": {
+      "message": "Godziny rozpoczęcia i zakończenia harmonogramu muszą być różne."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Limit harmonogramu {schedule_type} musi mieścić się w przedziale od {minimum} do {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Harmonogram odrzucony przez punkt końcowy walidacji Enphase."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Edycja harmonogramu baterii jest niedostępna."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "Interfejs API harmonogramu baterii jest niedostępny."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Aby zaktualizować harmonogram, wymagane jest potwierdzenie."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Aby usunąć harmonogram, wymagane jest potwierdzenie."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Nieprawidłowy identyfikator harmonogramu: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "W bieżących danych nie znaleziono identyfikatora harmonogramu: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Podaj co najmniej jeden identyfikator harmonogramu do usunięcia."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Nieprawidłowe identyfikatory harmonogramu: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Nie znaleziono identyfikatorów harmonogramu w bieżących danych: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Harmonogram odrzucony przez punkt końcowy walidacji Enphase: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Aktualizacja harmonogramu koliduje z istniejącym harmonogramem baterii: {message}"
     }
   },
   "options": {
@@ -157,11 +418,12 @@
           "api_timeout": "Limit czasu API (s)",
           "nominal_voltage": "Napięcie znamionowe (V)",
           "session_history_interval": "Interwał historii sesji (min)",
-          "schedule_sync_enabled": "Włącz obsługę harmonogramu",
+          "schedule_sync_enabled": "Włącz harmonogram ładowania pojazdów elektrycznych",
           "reauth": "Rozpocznij ponowne uwierzytelnienie",
           "forget_password": "Usuń zapisane hasło",
           "type_heatpump": "Pompa ciepła",
-          "type_ac_battery": "Bateria AC"
+          "type_ac_battery": "Bateria AC",
+          "battery_schedules_enabled": "Włącz harmonogram baterii"
         },
         "data_description": {
           "type_envoy": "Zawiera diagnostykę łączności bramy i liczników.",
@@ -174,11 +436,12 @@
           "api_timeout": "Liczba sekund przed przekroczeniem limitu czasu żądań API.",
           "nominal_voltage": "Napięcie zapasowe do szacowania mocy ładowarki.",
           "session_history_interval": "Minuty oczekiwania między pobieraniem historii sesji z chmury.",
-          "schedule_sync_enabled": "Zarządzaj zarządzaniem harmonogramem Enphase",
+          "schedule_sync_enabled": "Zarządzaj harmonogramami ładowarek IQ EV",
           "reauth": "Uruchom proces logowania, aby odświeżyć dane uwierzytelniające bez usuwania integracji.",
           "forget_password": "Usuwa zapisane hasło. Automatyczne odświeżanie nie będzie już wykonywane.",
           "type_heatpump": "Zawiera czujniki stanu, diagnostyki i zużycia pompy ciepła.",
-          "type_ac_battery": "Obejmuje sensory baterii AC i sterowanie trybem uśpienia, gdy są dostępne."
+          "type_ac_battery": "Obejmuje sensory baterii AC i sterowanie trybem uśpienia, gdy są dostępne.",
+          "battery_schedules_enabled": "Zarządzaj harmonogramami baterii IQ"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Rozpocznij ponowne uwierzytelnienie",
           "forget_password": "Usuń zapisane hasło",
           "type_heatpump": "Pompa ciepła",
-          "type_ac_battery": "Bateria AC"
+          "type_ac_battery": "Bateria AC",
+          "battery_schedules_enabled": "Włącz harmonogram baterii"
         },
         "data_description": {
           "type_envoy": "Zawiera diagnostykę łączności bramy i liczników.",
@@ -216,7 +480,8 @@
           "reauth": "Uruchom proces logowania, aby odświeżyć dane uwierzytelniające bez usuwania integracji.",
           "forget_password": "Usuwa zapisane hasło. Automatyczne odświeżanie nie będzie już wykonywane.",
           "type_heatpump": "Zawiera czujniki stanu, diagnostyki i zużycia pompy ciepła.",
-          "type_ac_battery": "Obejmuje sensory baterii AC i sterowanie trybem uśpienia, gdy są dostępne."
+          "type_ac_battery": "Obejmuje sensory baterii AC i sterowanie trybem uśpienia, gdy są dostępne.",
+          "battery_schedules_enabled": "Zarządzaj harmonogramami baterii IQ"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Eksport do sieci",
           "battery_charge": "Ładowanie baterii",
           "battery_discharge": "Rozładowanie baterii"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Ostatni raport {serial}"
+      },
+      "battery_cfg_schedules": {
+        "name": "Harmonogramy CFG baterii"
+      },
+      "battery_dtg_schedules": {
+        "name": "Harmonogramy DTG akumulatorów"
+      },
+      "battery_rbd_schedules": {
+        "name": "Harmonogramy RBD baterii"
+      },
+      "battery_schedule_summary": {
+        "name": "Podsumowanie harmonogramu baterii"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Limit ograniczenia rozładowania baterii"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Nowy limit harmonogramu baterii"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Limit harmonogramu baterii"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Harmonogram na niedzielę"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Nowy harmonogram baterii na poniedziałek"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Nowy harmonogram baterii na wtorek"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Nowy harmonogram baterii na środę"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Nowy harmonogram baterii na czwartek"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Nowy harmonogram baterii na piątek"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Nowy harmonogram baterii na sobotę"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Nowy harmonogram baterii na niedzielę"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Harmonogram baterii na poniedziałek"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Harmonogram baterii na wtorek"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Harmonogram baterii na środę"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Harmonogram baterii na czwartek"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Harmonogram baterii na piątek"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Harmonogram baterii na sobotę"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Harmonogram baterii na niedzielę"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Harmonogram"
+      },
+      "battery_new_schedule_type": {
+        "name": "Typ harmonogramu baterii"
+      },
+      "battery_schedule_selected": {
+        "name": "Harmonogram baterii"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Utwórz nowy harmonogram"
+      },
+      "battery_schedule_add": {
+        "name": "Harmonogram baterii Dodaj"
+      },
+      "battery_schedule_delete": {
+        "name": "Harmonogram baterii Usuń"
+      },
+      "battery_schedule_refresh": {
+        "name": "Odświeżanie harmonogramu baterii"
+      },
+      "battery_schedule_save": {
+        "name": "Zapis harmonogramu baterii"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Godzina zakończenia harmonogramu"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Bateria Czas rozpoczęcia nowego harmonogramu"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Czas zakończenia nowego harmonogramu baterii"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Czas rozpoczęcia harmonogramu baterii"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Czas zakończenia harmonogramu baterii"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "ID lokalizacji",
           "description": "ID lokalizacji Enphase (opcjonalne; ustalane z urządzenia docelowego)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Wymuś odświeżenie",
+      "description": "Natychmiast odśwież dane harmonogramu baterii z chmury Enphase.",
+      "sections": {
+        "advanced": {
+          "name": "Opcje zaawansowane"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Identyfikator witryny",
+          "description": "Opcjonalny identyfikator witryny; wykrywany automatycznie po wybraniu urządzenia witryny."
+        },
+        "config_entry_id": {
+          "name": "Identyfikator wpisu konfiguracji",
+          "description": "Opcjonalny identyfikator wpisu konfiguracji dla pojedynczego wpisu witryny Enphase."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Dodaj harmonogram baterii",
+      "description": "Utwórz harmonogram baterii dla CFG, DTG lub RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Opcje zaawansowane"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Typ harmonogramu",
+          "description": "Rodzina harmonogramu baterii: cfg, dtg lub rbd."
+        },
+        "start_time": {
+          "name": "Godzina rozpoczęcia",
+          "description": "Godzina rozpoczęcia harmonogramu."
+        },
+        "end_time": {
+          "name": "Godzina zakończenia",
+          "description": "Godzina zakończenia harmonogramu."
+        },
+        "limit": {
+          "name": "Limit ładowania",
+          "description": "Maksymalny poziom naładowania baterii (%)."
+        },
+        "days": {
+          "name": "Dni",
+          "description": "Lista aktywnych dni tygodnia, gdzie poniedziałek=1, a niedziela=7."
+        },
+        "site_id": {
+          "name": "Identyfikator witryny",
+          "description": "Opcjonalny identyfikator witryny; wykrywany automatycznie po wybraniu urządzenia witryny."
+        },
+        "config_entry_id": {
+          "name": "Identyfikator wpisu konfiguracji",
+          "description": "Opcjonalny identyfikator wpisu konfiguracji dla pojedynczego wpisu witryny Enphase."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Zaktualizuj harmonogram baterii",
+      "description": "Zaktualizuj harmonogram baterii według identyfikatora harmonogramu.",
+      "sections": {
+        "advanced": {
+          "name": "Opcje zaawansowane"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Identyfikator harmonogramu",
+          "description": "Identyfikator istniejącego harmonogramu baterii Enphase."
+        },
+        "schedule_type": {
+          "name": "Typ harmonogramu",
+          "description": "Rodzina harmonogramu baterii: cfg, dtg lub rbd."
+        },
+        "start_time": {
+          "name": "Godzina rozpoczęcia",
+          "description": "Godzina rozpoczęcia harmonogramu."
+        },
+        "end_time": {
+          "name": "Godzina zakończenia",
+          "description": "Godzina zakończenia harmonogramu."
+        },
+        "limit": {
+          "name": "Limit ładowania",
+          "description": "Maksymalny poziom naładowania baterii (%)."
+        },
+        "days": {
+          "name": "Dni",
+          "description": "Lista aktywnych dni tygodnia, gdzie poniedziałek=1, a niedziela=7."
+        },
+        "confirm": {
+          "name": "Potwierdź",
+          "description": "Ustaw wartość true, aby potwierdzić aktualizację harmonogramu."
+        },
+        "site_id": {
+          "name": "Identyfikator witryny",
+          "description": "Opcjonalny identyfikator witryny; wykrywany automatycznie po wybraniu urządzenia witryny."
+        },
+        "config_entry_id": {
+          "name": "Identyfikator wpisu konfiguracji",
+          "description": "Opcjonalny identyfikator wpisu konfiguracji dla pojedynczego wpisu witryny Enphase."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Usuń harmonogram baterii",
+      "description": "Usuń jeden lub więcej harmonogramów baterii według identyfikatora harmonogramu.",
+      "sections": {
+        "advanced": {
+          "name": "Opcje zaawansowane"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Identyfikator harmonogramu",
+          "description": "Identyfikator pojedynczego harmonogramu baterii Enphase do usunięcia."
+        },
+        "schedule_ids": {
+          "name": "Identyfikatory harmonogramów",
+          "description": "Opcjonalna wartość rozdzielona przecinkami lub lista dla wielu identyfikatorów harmonogramów."
+        },
+        "confirm": {
+          "name": "Potwierdź",
+          "description": "Ustaw wartość true, aby potwierdzić usunięcie harmonogramu."
+        },
+        "site_id": {
+          "name": "Identyfikator witryny",
+          "description": "Opcjonalny identyfikator witryny; wykrywany automatycznie po wybraniu urządzenia witryny."
+        },
+        "config_entry_id": {
+          "name": "Identyfikator wpisu konfiguracji",
+          "description": "Opcjonalny identyfikator wpisu konfiguracji dla pojedynczego wpisu witryny Enphase."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Sprawdź harmonogram baterii",
+      "description": "Sprawdź, czy dla wybranej rodziny harmonogramów dostępna jest edycja harmonogramu baterii.",
+      "sections": {
+        "advanced": {
+          "name": "Opcje zaawansowane"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Typ harmonogramu",
+          "description": "Rodzina harmonogramu baterii: cfg, dtg lub rbd."
+        },
+        "site_id": {
+          "name": "Identyfikator witryny",
+          "description": "Opcjonalny identyfikator witryny; wykrywany automatycznie po wybraniu urządzenia witryny."
+        },
+        "config_entry_id": {
+          "name": "Identyfikator wpisu konfiguracji",
+          "description": "Opcjonalny identyfikator wpisu konfiguracji dla pojedynczego wpisu witryny Enphase."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -133,220 +133,220 @@
       "message": "Harmonogram nakłada się z istniejącym {schedule_label}. Najpierw dostosuj lub wyłącz ten harmonogram."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Obecnie nie są dostępne żadne urządzenia AC Battery."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Ustawienia uwierzytelniania są niedostępne, gdy usługa Enphase jest niedostępna."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Aktualizacje profilu baterii nie są dozwolone dla tego konta."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Aktualizacje ustawień baterii nie są dozwolone dla tego konta."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Trwa już inna aktualizacja profilu baterii."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Trwa już inna aktualizacja ustawień baterii."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Aktualizacje profilu baterii są niedostępne."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Aktualizacje ustawień baterii są niedostępne."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Aktualizacje baterii są niedostępne."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Aktualizacje baterii nie są dozwolone dla tego konta."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Aktualizacja profilu baterii została zażądana zbyt szybko. Poczekaj i spróbuj ponownie."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Aktualizacja ustawień baterii została zażądana zbyt szybko. Poczekaj i spróbuj ponownie."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Nie udało się potwierdzić dostępu do zapisu baterii. Odśwież i spróbuj ponownie."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Aktualizacja harmonogramu została odrzucona przez Enphase (HTTP 403 Forbidden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Nie udało się uwierzytelnić aktualizacji harmonogramu. Uwierzytelnij się ponownie i spróbuj jeszcze raz."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Harmonogram koliduje z istniejącym harmonogramem oddawania do sieci. Najpierw dostosuj lub wyłącz ten harmonogram."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Harmonogram koliduje z istniejącym harmonogramem ograniczenia rozładowania baterii. Najpierw dostosuj lub wyłącz ten harmonogram."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Harmonogram koliduje z istniejącym harmonogramem ładowania z sieci. Najpierw dostosuj lub wyłącz ten harmonogram."
     },
     "schedule_update_conflict": {
       "message": "Harmonogram aktualizacji koliduje z istniejącym harmonogramem baterii."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Profil baterii jest niedostępny."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Aktualizacja profilu baterii została odrzucona przez Enphase (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Nie udało się uwierzytelnić aktualizacji profilu baterii. Uwierzytelnij się ponownie i spróbuj jeszcze raz."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Ładunek ustawień baterii jest niedostępny."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Aktualizacja ustawień baterii została odrzucona przez Enphase (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Nie udało się uwierzytelnić aktualizacji ustawień baterii. Uwierzytelnij się ponownie i spróbuj jeszcze raz."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Rezerwa Full Backup jest ustawiona na stałe na 100%."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Rezerwa baterii jest niedostępna."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Profil oszczędzania musi być aktywny."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Ustawienia profilu oszczędzania są niedostępne."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Wybrany profil baterii nie jest obsługiwany."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Ustawienie ładowania z sieci jest niedostępne."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Przełącznik ładowania z sieci nie został zastosowany przez Enphase."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Harmonogram ładowania z sieci jest niedostępny."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Godziny rozpoczęcia i zakończenia harmonogramu ładowania z sieci muszą być różne."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Przełącznik harmonogramu ładowania z sieci nie został zastosowany przez Enphase."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Najpierw należy włączyć ładowanie z sieci."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Zmiana harmonogramu oczekuje na synchronizację z Envoy. Poczekaj."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Godzina harmonogramu ładowania z sieci jest nieprawidłowa."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Interfejs API harmonogramów nie jest dostępny w tej wersji klienta."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Nie jest dostępny żaden istniejący harmonogram ładowania z sieci."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Przed włączeniem utwórz {schedule_label} w harmonogramie IQ Battery."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} nie jest obecnie udostępniany przez Enphase dla tej witryny. Poczekaj na zakończenie synchronizacji harmonogramu, a następnie odśwież i spróbuj ponownie."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Przełącznik {schedule_label} nie został zastosowany przez Enphase."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "odrzucono zapis podstawowy"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "Godziny rozpoczęcia i zakończenia dla {schedule_label} muszą być różne."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Godzina harmonogramu oddawania do sieci jest nieprawidłowa."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Nie jest dostępny żaden istniejący harmonogram {schedule_label_lower}."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "Harmonogram {schedule_label} jest niedostępny."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "Godzina harmonogramu {schedule_label} jest nieprawidłowa."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Bieżąca godzina harmonogramu {schedule_label_lower} jest nieprawidłowa."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "Limit harmonogramu {schedule_label} musi mieścić się w przedziale od {minimum} do {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "Limit harmonogramu {schedule_label} musi wynosić co najmniej {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Bieżące godziny harmonogramu nie są dostępne."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Limit harmonogramu ładowania z sieci musi mieścić się w przedziale od {minimum} do {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Limit harmonogramu ładowania z sieci musi wynosić co najmniej {minimum}%."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Poziom wyłączenia baterii jest niedostępny."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Poziom wyłączenia baterii jest nieprawidłowy."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Poziom wyłączenia baterii musi mieścić się w przedziale od {minimum} do {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Rezygnacja ze Storm Alert jest niedostępna."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Rezygnacja ze Storm Alert nie powiodła się dla {count} alertów."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Aktualizacje Storm Guard nie są dozwolone dla tego konta."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Ustawienia Storm Guard są niedostępne."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Aktualizacja Storm Guard została odrzucona przez Enphase (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Nie udało się uwierzytelnić aktualizacji Storm Guard. Uwierzytelnij się ponownie i spróbuj jeszcze raz."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Wybrany profil systemu jest niedostępny."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Aktualizacja profilu systemu została odrzucona przez Enphase (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Nie udało się uwierzytelnić aktualizacji profilu systemu. Uwierzytelnij się ponownie i spróbuj jeszcze raz."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Aktualizacja profilu systemu nie powiodła się."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Aktualizacja profilu systemu nie powiodła się z powodu błędu sieci. Spróbuj ponownie."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Upłynął limit czasu aktualizacji profilu systemu. Spróbuj ponownie."
     },
     "scheduler_service_unavailable": {
       "message": "Wybór trybu ładowania jest niedostępny, gdy usługa harmonogramu Enphase jest wyłączona."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "Wybrany docelowy poziom naładowania AC Battery jest niedostępny."
     },
     "battery_schedule_day_required": {
       "message": "Wybierz co najmniej jeden dzień dla harmonogramu."

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -133,220 +133,220 @@
       "message": "A programação se sobrepõe à {schedule_label} existente. Ajuste ou desative essa programação primeiro."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Nenhum dispositivo de bateria CA está disponível atualmente."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "As configurações de autenticação ficam indisponíveis enquanto o serviço Enphase está inativo."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Atualizações do perfil da bateria não são permitidas para esta conta."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Atualizações das configurações da bateria não são permitidas para esta conta."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "Outra atualização do perfil da bateria já está em andamento."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "Outra atualização das configurações da bateria já está em andamento."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "As atualizações do perfil da bateria não estão disponíveis."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "As atualizações das configurações da bateria não estão disponíveis."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "As atualizações da bateria não estão disponíveis."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Atualizações de bateria não são permitidas para esta conta."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "A atualização do perfil da bateria foi solicitada muito rapidamente. Aguarde e tente novamente."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "A atualização das configurações da bateria foi solicitada muito rapidamente. Aguarde e tente novamente."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "O acesso de gravação da bateria não pôde ser confirmado. Atualize e tente novamente."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "A atualização do cronograma foi rejeitada pela Enphase (HTTP 403 Proibido)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "A atualização do agendamento não pôde ser autenticada. Autentique novamente e tente novamente."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "O cronograma entra em conflito com o cronograma de descarga para a rede existente. Ajuste ou desative essa programação primeiro."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "A programação entra em conflito com a programação existente de descarga restrita da bateria. Ajuste ou desative essa programação primeiro."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "O cronograma entra em conflito com o cronograma existente de cobrança da rede. Ajuste ou desative essa programação primeiro."
     },
     "schedule_update_conflict": {
       "message": "A atualização do agendamento entra em conflito com um agendamento de bateria existente."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "O perfil da bateria não está disponível."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "A atualização do perfil da bateria foi rejeitada pela Enphase (HTTP 403 Forbidden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "A atualização do perfil da bateria não pôde ser autenticada. Autentique novamente e tente novamente."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "A carga útil das configurações da bateria não está disponível."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "A atualização das configurações da bateria foi rejeitada pela Enphase (HTTP 403 Forbidden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "A atualização das configurações da bateria não pôde ser autenticada. Autentique novamente e tente novamente."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "A reserva total de backup é fixada em 100%."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "A reserva da bateria não está disponível."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "O perfil de poupança deve estar ativo."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "As configurações do perfil de poupança não estão disponíveis."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "O perfil de bateria selecionado não é compatível."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "A configuração de cobrança da rede não está disponível."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "A cobrança da alternância de rede não foi aplicada pela Enphase."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "A cobrança da programação da rede não está disponível."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Os horários de início e término da programação de carga da rede devem ser diferentes."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "A alternância de programação de cobrança da rede não foi aplicada pela Enphase."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "A cobrança da rede deve ser habilitada primeiro."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "Uma alteração de agendamento está pendente de sincronização do Envoy. Por favor, aguarde."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "O horário de agendamento de cobrança da rede é inválido."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "API de agendamento não disponível nesta versão do cliente."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Nenhuma programação existente de cobrança da rede está disponível."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Crie um {schedule_label} no agendador IQ Battery antes de habilitá-lo."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} não está atualmente exposto pela Enphase para este site. Aguarde a conclusão da sincronização agendada, atualize e tente novamente."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "A alternância {schedule_label} não foi aplicada pelo Enphase."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "gravação primária rejeitada"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "Os horários de início e término do {schedule_label} devem ser diferentes."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "O horário de descarga para a rede é inválido."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Nenhuma programação {schedule_label_lower} existente está disponível."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "A programação {schedule_label} não está disponível."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "O horário de agendamento do {schedule_label} é inválido."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "O horário de agendamento atual do {schedule_label_lower} é inválido."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "O limite de agendamento do {schedule_label} deve estar entre {minimum} e {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "O limite de programação {schedule_label} deve ser de pelo menos {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Os horários atuais não estão disponíveis."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "O limite de programação de carga da rede deve estar entre {minimum} e {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "O limite de programação de carga da rede deve ser de pelo menos {minimum}%."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "O nível de desligamento da bateria não está disponível."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "O nível de desligamento da bateria é inválido."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "O nível de desligamento da bateria deve estar entre {minimum} e {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "A desativação do Alerta de Tempestade não está disponível."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Falha na desativação do Alerta de Tempestade para alerta(s) {count}."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Atualizações do Storm Guard não são permitidas para esta conta."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "As configurações do Storm Guard não estão disponíveis."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "A atualização do Storm Guard foi rejeitada pela Enphase (HTTP 403 Forbidden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "A atualização do Storm Guard não pôde ser autenticada. Autentique novamente e tente novamente."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "O perfil de sistema selecionado não está disponível."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "A atualização do perfil do sistema foi rejeitada pela Enphase (HTTP 403 Forbidden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "A atualização do perfil do sistema não pôde ser autenticada. Autentique novamente e tente novamente."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Falha na atualização do perfil do sistema."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "A atualização do perfil do sistema falhou devido a um erro de rede. Tente novamente."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "A atualização do perfil do sistema expirou. Tente novamente."
     },
     "scheduler_service_unavailable": {
       "message": "A seleção do modo de carregamento não está disponível enquanto o serviço de agendamento da Enphase estiver indisponível."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "O estado de carga alvo da bateria CA selecionado não está disponível."
     },
     "battery_schedule_day_required": {
       "message": "Selecione pelo menos um dia para o agendamento."
@@ -1402,46 +1402,46 @@
         "name": "Programação de domingo"
       },
       "battery_new_schedule_mon": {
-        "name": "Battery New Schedule Monday"
+        "name": "Nova programação da bateria segunda-feira"
       },
       "battery_new_schedule_tue": {
-        "name": "Battery New Schedule Tuesday"
+        "name": "Nova programação da bateria terça-feira"
       },
       "battery_new_schedule_wed": {
-        "name": "Battery New Schedule Wednesday"
+        "name": "Nova programação da bateria quarta-feira"
       },
       "battery_new_schedule_thu": {
-        "name": "Battery New Schedule Thursday"
+        "name": "Nova programação da bateria quinta-feira"
       },
       "battery_new_schedule_fri": {
-        "name": "Battery New Schedule Friday"
+        "name": "Nova programação da bateria sexta-feira"
       },
       "battery_new_schedule_sat": {
-        "name": "Battery New Schedule Saturday"
+        "name": "Bateria Nova Programação Sábado"
       },
       "battery_new_schedule_sun": {
-        "name": "Battery New Schedule Sunday"
+        "name": "Nova programação da bateria domingo"
       },
       "battery_schedule_edit_mon": {
-        "name": "Battery Schedule Monday"
+        "name": "Programação da bateria segunda-feira"
       },
       "battery_schedule_edit_tue": {
-        "name": "Battery Schedule Tuesday"
+        "name": "Programação da bateria terça-feira"
       },
       "battery_schedule_edit_wed": {
-        "name": "Battery Schedule Wednesday"
+        "name": "Programação da bateria quarta-feira"
       },
       "battery_schedule_edit_thu": {
-        "name": "Battery Schedule Thursday"
+        "name": "Programação da bateria quinta-feira"
       },
       "battery_schedule_edit_fri": {
-        "name": "Battery Schedule Friday"
+        "name": "Programação da bateria sexta-feira"
       },
       "battery_schedule_edit_sat": {
-        "name": "Battery Schedule Saturday"
+        "name": "Programação da bateria sábado"
       },
       "battery_schedule_edit_sun": {
-        "name": "Battery Schedule Sunday"
+        "name": "Programação da bateria domingo"
       }
     },
     "select": {
@@ -1826,17 +1826,17 @@
       "description": "Atualize imediatamente os dados de agendamento da bateria da nuvem Enphase.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Opções avançadas"
         }
       },
       "fields": {
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "ID do site",
+          "description": "Identificador de site opcional; detectado automaticamente quando um dispositivo de site é selecionado."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "ID de entrada de configuração",
+          "description": "Identificador de entrada de configuração opcional para uma única entrada de site Enphase."
         }
       }
     },
@@ -1845,37 +1845,37 @@
       "description": "Crie um agendamento da bateria para CFG, DTG ou RBD.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Opções avançadas"
         }
       },
       "fields": {
         "schedule_type": {
-          "name": "Schedule Type",
-          "description": "Battery schedule family: cfg, dtg, or rbd."
+          "name": "Tipo de agendamento",
+          "description": "Família de programação de bateria: cfg, dtg ou rbd."
         },
         "start_time": {
-          "name": "Start Time",
-          "description": "Schedule start time."
+          "name": "Hora de início",
+          "description": "Agendar horário de início."
         },
         "end_time": {
-          "name": "End Time",
-          "description": "Schedule end time."
+          "name": "Hora de término",
+          "description": "Agende o horário de término."
         },
         "limit": {
-          "name": "Charge Limit",
-          "description": "Maximum battery state of charge (%)."
+          "name": "Limite de cobrança",
+          "description": "Estado máximo de carga da bateria (%)."
         },
         "days": {
-          "name": "Days",
-          "description": "List of active weekdays using Monday=1 through Sunday=7."
+          "name": "Dias",
+          "description": "Lista de dias da semana ativos usando Segunda=1 até Domingo=7."
         },
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "ID do site",
+          "description": "Identificador de site opcional; detectado automaticamente quando um dispositivo de site é selecionado."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "ID de entrada de configuração",
+          "description": "Identificador de entrada de configuração opcional para uma única entrada de site Enphase."
         }
       }
     },
@@ -1884,45 +1884,45 @@
       "description": "Atualize um agendamento da bateria pelo ID do agendamento.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Opções avançadas"
         }
       },
       "fields": {
         "schedule_id": {
-          "name": "Schedule ID",
-          "description": "Existing Enphase battery schedule identifier."
+          "name": "ID do agendamento",
+          "description": "Identificador de programação de bateria Enphase existente."
         },
         "schedule_type": {
-          "name": "Schedule Type",
-          "description": "Battery schedule family: cfg, dtg, or rbd."
+          "name": "Tipo de agendamento",
+          "description": "Família de programação de bateria: cfg, dtg ou rbd."
         },
         "start_time": {
-          "name": "Start Time",
-          "description": "Schedule start time."
+          "name": "Hora de início",
+          "description": "Agendar horário de início."
         },
         "end_time": {
-          "name": "End Time",
-          "description": "Schedule end time."
+          "name": "Hora de término",
+          "description": "Agende o horário de término."
         },
         "limit": {
-          "name": "Charge Limit",
-          "description": "Maximum battery state of charge (%)."
+          "name": "Limite de cobrança",
+          "description": "Estado máximo de carga da bateria (%)."
         },
         "days": {
-          "name": "Days",
-          "description": "List of active weekdays using Monday=1 through Sunday=7."
+          "name": "Dias",
+          "description": "Lista de dias da semana ativos usando Segunda=1 até Domingo=7."
         },
         "confirm": {
-          "name": "Confirm",
-          "description": "Set to true to confirm the schedule update."
+          "name": "Confirmar",
+          "description": "Defina como verdadeiro para confirmar a atualização do agendamento."
         },
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "ID do site",
+          "description": "Identificador de site opcional; detectado automaticamente quando um dispositivo de site é selecionado."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "ID de entrada de configuração",
+          "description": "Identificador de entrada de configuração opcional para uma única entrada de site Enphase."
         }
       }
     },
@@ -1931,29 +1931,29 @@
       "description": "Exclua um ou mais agendamentos da bateria pelo ID do agendamento.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Opções avançadas"
         }
       },
       "fields": {
         "schedule_id": {
-          "name": "Schedule ID",
-          "description": "Single Enphase battery schedule identifier to delete."
+          "name": "ID do agendamento",
+          "description": "Identificador de programação de bateria Enphase único a ser excluído."
         },
         "schedule_ids": {
-          "name": "Schedule IDs",
-          "description": "Optional comma-separated or list input for multiple schedule identifiers."
+          "name": "IDs de agendamento",
+          "description": "Entrada opcional separada por vírgula ou lista para vários identificadores de agendamento."
         },
         "confirm": {
-          "name": "Confirm",
-          "description": "Set to true to confirm the schedule deletion."
+          "name": "Confirmar",
+          "description": "Defina como verdadeiro para confirmar a exclusão do agendamento."
         },
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "ID do site",
+          "description": "Identificador de site opcional; detectado automaticamente quando um dispositivo de site é selecionado."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "ID de entrada de configuração",
+          "description": "Identificador de entrada de configuração opcional para uma única entrada de site Enphase."
         }
       }
     },
@@ -1962,21 +1962,21 @@
       "description": "Verifique se a edição de agendamentos da bateria está disponível para a família de agendamentos selecionada.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Opções avançadas"
         }
       },
       "fields": {
         "schedule_type": {
-          "name": "Schedule Type",
-          "description": "Battery schedule family: cfg, dtg, or rbd."
+          "name": "Tipo de agendamento",
+          "description": "Família de programação de bateria: cfg, dtg ou rbd."
         },
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "ID do site",
+          "description": "Identificador de site opcional; detectado automaticamente quando um dispositivo de site é selecionado."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "ID de entrada de configuração",
+          "description": "Identificador de entrada de configuração opcional para uma única entrada de site Enphase."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "A programação se sobrepõe à {schedule_label} existente. Ajuste ou desative essa programação primeiro."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "A atualização do agendamento entra em conflito com um agendamento de bateria existente."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "A seleção do modo de carregamento não está disponível enquanto o serviço de agendamento da Enphase estiver indisponível."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Selecione pelo menos um dia para o agendamento."
+    },
+    "battery_schedule_times_different": {
+      "message": "Os horários de início e término do agendamento devem ser diferentes."
+    },
+    "battery_schedule_limit_range": {
+      "message": "O limite do agendamento {schedule_type} deve estar entre {minimum} e {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Agendamento rejeitado pelo endpoint de validação da Enphase."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "A edição de agendamentos da bateria não está disponível."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "A API de agendamentos da bateria não está disponível."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "É necessária confirmação para atualizar um agendamento."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "É necessária confirmação para excluir um agendamento."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "ID de agendamento inválido: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "ID de agendamento não encontrado nos dados atuais: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Forneça pelo menos um ID de agendamento para excluir."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "IDs de agendamento inválidos: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "IDs de agendamento não encontrados nos dados atuais: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Agendamento rejeitado pelo endpoint de validação da Enphase: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "A atualização do agendamento entra em conflito com um agendamento de bateria existente: {message}"
     }
   },
   "options": {
@@ -161,7 +422,8 @@
           "reauth": "Iniciar reautenticação",
           "forget_password": "Esquecer senha armazenada",
           "type_heatpump": "Bomba de calor",
-          "type_ac_battery": "Bateria CA"
+          "type_ac_battery": "Bateria CA",
+          "battery_schedules_enabled": "Ativar agendador da bateria"
         },
         "data_description": {
           "type_envoy": "Inclui conectividade do gateway e diagnósticos dos medidores.",
@@ -178,7 +440,8 @@
           "reauth": "Inicia o fluxo de login para renovar credenciais sem remover a integração.",
           "forget_password": "Remove a senha armazenada. A atualização automática não será mais tentada.",
           "type_heatpump": "Inclui sensores de status, diagnóstico e consumo da bomba de calor.",
-          "type_ac_battery": "Inclui sensores da bateria CA e controles do modo de suspensão quando disponíveis."
+          "type_ac_battery": "Inclui sensores da bateria CA e controles do modo de suspensão quando disponíveis.",
+          "battery_schedules_enabled": "Gerenciar agendamentos de bateria IQ"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Iniciar reautenticação",
           "forget_password": "Esquecer senha armazenada",
           "type_heatpump": "Bomba de calor",
-          "type_ac_battery": "Bateria CA"
+          "type_ac_battery": "Bateria CA",
+          "battery_schedules_enabled": "Ativar agendador da bateria"
         },
         "data_description": {
           "type_envoy": "Inclui conectividade do gateway e diagnósticos dos medidores.",
@@ -216,7 +480,8 @@
           "reauth": "Inicia o fluxo de login para renovar credenciais sem remover a integração.",
           "forget_password": "Remove a senha armazenada. A atualização automática não será mais tentada.",
           "type_heatpump": "Inclui sensores de status, diagnóstico e consumo da bomba de calor.",
-          "type_ac_battery": "Inclui sensores da bateria CA e controles do modo de suspensão quando disponíveis."
+          "type_ac_battery": "Inclui sensores da bateria CA e controles do modo de suspensão quando disponíveis.",
+          "battery_schedules_enabled": "Gerenciar agendamentos de bateria IQ"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Exportação para a rede",
           "battery_charge": "Carga da bateria",
           "battery_discharge": "Descarga da bateria"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Último relatório de {serial}"
+      },
+      "battery_cfg_schedules": {
+        "name": "Agendamentos CFG da bateria"
+      },
+      "battery_dtg_schedules": {
+        "name": "Agendamentos DTG da bateria"
+      },
+      "battery_rbd_schedules": {
+        "name": "Agendamentos RBD da bateria"
+      },
+      "battery_schedule_summary": {
+        "name": "Resumo dos agendamentos da bateria"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Limite de restrição de descarga da bateria"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Limite de novo agendamento da bateria"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Limite de agendamento da bateria"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Programação de domingo"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Battery New Schedule Monday"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Battery New Schedule Tuesday"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Battery New Schedule Wednesday"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Battery New Schedule Thursday"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Battery New Schedule Friday"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Battery New Schedule Saturday"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Battery New Schedule Sunday"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Battery Schedule Monday"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Battery Schedule Tuesday"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Battery Schedule Wednesday"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Battery Schedule Thursday"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Battery Schedule Friday"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Battery Schedule Saturday"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Battery Schedule Sunday"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Programação"
+      },
+      "battery_new_schedule_type": {
+        "name": "Tipo de agendamento da bateria"
+      },
+      "battery_schedule_selected": {
+        "name": "Agendamento da bateria"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Criar nova programação"
+      },
+      "battery_schedule_add": {
+        "name": "Adicionar agendamento da bateria"
+      },
+      "battery_schedule_delete": {
+        "name": "Excluir agendamento da bateria"
+      },
+      "battery_schedule_refresh": {
+        "name": "Atualizar agendamento da bateria"
+      },
+      "battery_schedule_save": {
+        "name": "Salvar agendamento da bateria"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Horário de término da programação"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Hora de início do novo agendamento da bateria"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Hora de término do novo agendamento da bateria"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Hora de início do agendamento da bateria"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Hora de término do agendamento da bateria"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "ID do site",
           "description": "ID do site Enphase (opcional; resolvido a partir do dispositivo de destino)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Forçar atualização",
+      "description": "Atualize imediatamente os dados de agendamento da bateria da nuvem Enphase.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Adicionar agendamento da bateria",
+      "description": "Crie um agendamento da bateria para CFG, DTG ou RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Schedule Type",
+          "description": "Battery schedule family: cfg, dtg, or rbd."
+        },
+        "start_time": {
+          "name": "Start Time",
+          "description": "Schedule start time."
+        },
+        "end_time": {
+          "name": "End Time",
+          "description": "Schedule end time."
+        },
+        "limit": {
+          "name": "Charge Limit",
+          "description": "Maximum battery state of charge (%)."
+        },
+        "days": {
+          "name": "Days",
+          "description": "List of active weekdays using Monday=1 through Sunday=7."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Atualizar agendamento da bateria",
+      "description": "Atualize um agendamento da bateria pelo ID do agendamento.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Schedule ID",
+          "description": "Existing Enphase battery schedule identifier."
+        },
+        "schedule_type": {
+          "name": "Schedule Type",
+          "description": "Battery schedule family: cfg, dtg, or rbd."
+        },
+        "start_time": {
+          "name": "Start Time",
+          "description": "Schedule start time."
+        },
+        "end_time": {
+          "name": "End Time",
+          "description": "Schedule end time."
+        },
+        "limit": {
+          "name": "Charge Limit",
+          "description": "Maximum battery state of charge (%)."
+        },
+        "days": {
+          "name": "Days",
+          "description": "List of active weekdays using Monday=1 through Sunday=7."
+        },
+        "confirm": {
+          "name": "Confirm",
+          "description": "Set to true to confirm the schedule update."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Excluir agendamento da bateria",
+      "description": "Exclua um ou mais agendamentos da bateria pelo ID do agendamento.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Schedule ID",
+          "description": "Single Enphase battery schedule identifier to delete."
+        },
+        "schedule_ids": {
+          "name": "Schedule IDs",
+          "description": "Optional comma-separated or list input for multiple schedule identifiers."
+        },
+        "confirm": {
+          "name": "Confirm",
+          "description": "Set to true to confirm the schedule deletion."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Validar agendamento da bateria",
+      "description": "Verifique se a edição de agendamentos da bateria está disponível para a família de agendamentos selecionada.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Schedule Type",
+          "description": "Battery schedule family: cfg, dtg, or rbd."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -133,220 +133,220 @@
       "message": "Programul se suprapune peste {schedule_label} existent. Ajustați sau dezactivați mai întâi acel program."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "În prezent, nu sunt disponibile dispozitive cu baterie AC."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Setările de autentificare nu sunt disponibile în timp ce serviciul Enphase este oprit."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Actualizările profilului bateriei nu sunt permise pentru acest cont."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Actualizările setărilor bateriei nu sunt permise pentru acest cont."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "O altă actualizare a profilului bateriei este deja în curs."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "O altă actualizare a setărilor bateriei este deja în curs."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Actualizările profilului bateriei nu sunt disponibile."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Actualizările setărilor bateriei nu sunt disponibile."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Actualizările bateriei nu sunt disponibile."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Actualizările bateriei nu sunt permise pentru acest cont."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Actualizarea profilului bateriei a fost solicitată prea repede. Vă rugăm să așteptați și să încercați din nou."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Actualizarea setărilor bateriei a fost solicitată prea repede. Vă rugăm să așteptați și să încercați din nou."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Accesul la scriere la baterie nu a putut fi confirmat. Actualizați și încercați din nou."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Actualizarea programului a fost respinsă de Enphase (HTTP 403 interzis)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Actualizarea programului nu a putut fi autentificată. Reautentificați-vă și încercați din nou."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Programul intră în conflict cu programul existent de descărcare în rețea. Ajustați sau dezactivați mai întâi programul respectiv."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Programul intră în conflict cu programul existent de restricție-descărcare a bateriei. Ajustați sau dezactivați mai întâi programul respectiv."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Programul intră în conflict cu programul existent de taxare de la rețea. Ajustați sau dezactivați mai întâi programul respectiv."
     },
     "schedule_update_conflict": {
       "message": "Actualizarea planificării intră în conflict cu o planificare existentă a bateriei."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Profilul bateriei nu este disponibil."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Actualizarea profilului bateriei a fost respinsă de Enphase (HTTP 403 interzis)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Actualizarea profilului bateriei nu a putut fi autentificată. Reautentificați-vă și încercați din nou."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Sarcina utilă a setărilor bateriei nu este disponibilă."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Actualizarea setărilor bateriei a fost respinsă de Enphase (HTTP 403 interzis)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Actualizarea setărilor bateriei nu a putut fi autentificată. Reautentificați-vă și încercați din nou."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Rezerva de rezervă completă este fixată la 100%."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Rezerva bateriei nu este disponibilă."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Profilul de economii trebuie să fie activ."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Setările profilului de economii nu sunt disponibile."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Profilul de baterie selectat nu este acceptat."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Setarea de încărcare din rețea nu este disponibilă."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Încărcarea de la comutatorul de rețea nu a fost aplicată de Enphase."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Încărcarea din programul rețelei nu este disponibilă."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Orele de începere și de încheiere a programului de taxare din rețea trebuie să fie diferite."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Comutarea programului de încărcare de la rețea nu a fost aplicată de Enphase."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Încărcarea de la rețea trebuie mai întâi activată."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "O modificare a programului este în așteptarea sincronizării Envoy. Va rugam asteptati."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Ora de programare a taxării de la rețea este nevalidă."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Schedule API nu este disponibil pentru această versiune client."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Nu este disponibil niciun program existent de taxare de la rețea."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Creați un {schedule_label} în programatorul IQ Battery înainte de a-l activa."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} nu este expus momentan de către Enphase pentru acest site. Așteptați finalizarea sincronizarii programului, apoi reîmprospătați și încercați din nou."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "Comutatorul {schedule_label} nu a fost aplicat de Enphase."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "scrierea primară a fost respinsă"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "Orele de începere și de sfârșit ale {schedule_label} trebuie să fie diferite."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Ora programului de descărcare în rețea este invalidă."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Nu este disponibil niciun program existent {schedule_label_lower}."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "Programul {schedule_label} nu este disponibil."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "Ora de programare {schedule_label} este nevalidă."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Ora actuală de programare {schedule_label_lower} este nevalidă."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "Limita programului {schedule_label} trebuie să fie între {minimum} și {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "Limita programului {schedule_label} trebuie să fie de cel puțin {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Orarul actual al programului nu este disponibil."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Limita programului de taxare din rețea trebuie să fie între {minimum} și {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Limita programului de taxare din rețea trebuie să fie de cel puțin {minimum}%."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Nivelul de oprire a bateriei nu este disponibil."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Nivelul de oprire a bateriei este nevalid."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Nivelul de oprire a bateriei trebuie să fie între {minimum} și {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Renunțarea la Alertă de furtună nu este disponibilă."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Renunțarea la Alertă de furtună a eșuat pentru alertele {count}."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Actualizările Storm Guard nu sunt permise pentru acest cont."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Setările Storm Guard nu sunt disponibile."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Actualizarea Storm Guard a fost respinsă de Enphase (HTTP 403 interzis)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Actualizarea Storm Guard nu a putut fi autentificată. Reautentificați-vă și încercați din nou."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Profilul de sistem selectat nu este disponibil."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Actualizarea profilului de sistem a fost respinsă de Enphase (HTTP 403 interzis)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Actualizarea profilului de sistem nu a putut fi autentificată. Reautentificați-vă și încercați din nou."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Actualizarea profilului de sistem a eșuat."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Actualizarea profilului de sistem a eșuat din cauza unei erori de rețea. Încearcă din nou."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Actualizarea profilului de sistem a expirat. Încearcă din nou."
     },
     "scheduler_service_unavailable": {
       "message": "Selectarea modului de încărcare nu este disponibilă cât timp serviciul de planificare Enphase este indisponibil."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "Starea de încărcare țintă a bateriei AC selectată nu este disponibilă."
     },
     "battery_schedule_day_required": {
       "message": "Selectați cel puțin o zi pentru planificare."
@@ -1826,17 +1826,17 @@
       "description": "Reîmprospătați imediat datele de planificare a bateriei din cloud-ul Enphase.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Opțiuni avansate"
         }
       },
       "fields": {
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "ID-ul site-ului",
+          "description": "Identificator opțional de site; detectat automat atunci când este selectat un dispozitiv de site."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "ID de intrare de configurare",
+          "description": "Identificator opțional de intrare de configurare pentru o singură intrare de site Enphase."
         }
       }
     },

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Programul se suprapune peste {schedule_label} existent. Ajustați sau dezactivați mai întâi acel program."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Actualizarea planificării intră în conflict cu o planificare existentă a bateriei."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Selectarea modului de încărcare nu este disponibilă cât timp serviciul de planificare Enphase este indisponibil."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Selectați cel puțin o zi pentru planificare."
+    },
+    "battery_schedule_times_different": {
+      "message": "Orele de început și de sfârșit ale planificării trebuie să fie diferite."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Limita pentru planificarea {schedule_type} trebuie să fie între {minimum} și {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Planificare respinsă de endpoint-ul de validare Enphase."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Editarea planificărilor bateriei nu este disponibilă."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "API-ul de planificare a bateriei nu este disponibil."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Este necesară confirmarea pentru a actualiza o planificare."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Este necesară confirmarea pentru a șterge o planificare."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "ID de planificare invalid: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "ID-ul planificării nu a fost găsit în datele curente: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Furnizați cel puțin un ID de planificare pentru ștergere."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "ID-uri de planificare invalide: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "ID-urile planificării nu au fost găsite în datele curente: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Planificare respinsă de endpoint-ul de validare Enphase: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Actualizarea planificării intră în conflict cu o planificare existentă a bateriei: {message}"
     }
   },
   "options": {
@@ -161,7 +422,8 @@
           "reauth": "Pornește reautentificarea",
           "forget_password": "Uită parola salvată",
           "type_heatpump": "Pompă de căldură",
-          "type_ac_battery": "Baterie AC"
+          "type_ac_battery": "Baterie AC",
+          "battery_schedules_enabled": "Activați planificatorul bateriei"
         },
         "data_description": {
           "type_envoy": "Include conectivitatea gateway-ului și diagnosticul contoarelor.",
@@ -178,7 +440,8 @@
           "reauth": "Lansați fluxul de autentificare pentru a reîmprospăta credențialele fără a elimina integrarea.",
           "forget_password": "Elimină parola stocată. Reîmprospătarea automată nu va mai fi încercată.",
           "type_heatpump": "Include senzori pentru starea, diagnosticarea și consumul pompei de căldură.",
-          "type_ac_battery": "Include senzori pentru bateria AC și controale pentru modul de repaus atunci când sunt disponibile."
+          "type_ac_battery": "Include senzori pentru bateria AC și controale pentru modul de repaus atunci când sunt disponibile.",
+          "battery_schedules_enabled": "Gestionați programele bateriei IQ"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Pornește reautentificarea",
           "forget_password": "Uită parola salvată",
           "type_heatpump": "Pompă de căldură",
-          "type_ac_battery": "Baterie AC"
+          "type_ac_battery": "Baterie AC",
+          "battery_schedules_enabled": "Activați planificatorul bateriei"
         },
         "data_description": {
           "type_envoy": "Include conectivitatea gateway-ului și diagnosticul contoarelor.",
@@ -216,7 +480,8 @@
           "reauth": "Lansați fluxul de autentificare pentru a reîmprospăta credențialele fără a elimina integrarea.",
           "forget_password": "Elimină parola stocată. Reîmprospătarea automată nu va mai fi încercată.",
           "type_heatpump": "Include senzori pentru starea, diagnosticarea și consumul pompei de căldură.",
-          "type_ac_battery": "Include senzori pentru bateria AC și controale pentru modul de repaus atunci când sunt disponibile."
+          "type_ac_battery": "Include senzori pentru bateria AC și controale pentru modul de repaus atunci când sunt disponibile.",
+          "battery_schedules_enabled": "Gestionați programele bateriei IQ"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Export în rețea",
           "battery_charge": "Încărcare baterie",
           "battery_discharge": "Descărcare baterie"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Ultimul raport pentru {serial}"
+      },
+      "battery_cfg_schedules": {
+        "name": "Planificări CFG baterie"
+      },
+      "battery_dtg_schedules": {
+        "name": "Planificări DTG baterie"
+      },
+      "battery_rbd_schedules": {
+        "name": "Planificări RBD baterie"
+      },
+      "battery_schedule_summary": {
+        "name": "Rezumatul planificărilor bateriei"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Limită de restricționare a descărcării bateriei"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Limită pentru planificare nouă a bateriei"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Limită de planificare a bateriei"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Programare duminică"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Planificare nouă a bateriei luni"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Planificare nouă a bateriei marți"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Planificare nouă a bateriei miercuri"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Planificare nouă a bateriei joi"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Planificare nouă a bateriei vineri"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Planificare nouă a bateriei sâmbătă"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Planificare nouă a bateriei duminică"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Planificare baterie luni"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Planificare baterie marți"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Planificare baterie miercuri"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Planificare baterie joi"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Planificare baterie vineri"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Planificare baterie sâmbătă"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Planificare baterie duminică"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Programare"
+      },
+      "battery_new_schedule_type": {
+        "name": "Tip planificare baterie"
+      },
+      "battery_schedule_selected": {
+        "name": "Planificare baterie"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Creare programare nouă"
+      },
+      "battery_schedule_add": {
+        "name": "Adăugare planificare baterie"
+      },
+      "battery_schedule_delete": {
+        "name": "Ștergere planificare baterie"
+      },
+      "battery_schedule_refresh": {
+        "name": "Reîmprospătare planificare baterie"
+      },
+      "battery_schedule_save": {
+        "name": "Salvare planificare baterie"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Ora de sfârșit a programării"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Ora de începere a noii planificări a bateriei"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Ora de încheiere a noii planificări a bateriei"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Ora de începere a planificării bateriei"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Ora de încheiere a planificării bateriei"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "ID locație",
           "description": "ID locație Enphase (opțional; rezolvat din dispozitivul țintă)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Forțează reîmprospătarea",
+      "description": "Reîmprospătați imediat datele de planificare a bateriei din cloud-ul Enphase.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Adăugați o planificare a bateriei",
+      "description": "Creați o planificare a bateriei pentru CFG, DTG sau RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Opțiuni avansate"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Tip planificare",
+          "description": "Familia planificării bateriei: cfg, dtg sau rbd."
+        },
+        "start_time": {
+          "name": "Ora de începere",
+          "description": "Ora de începere a planificării."
+        },
+        "end_time": {
+          "name": "Ora de încheiere",
+          "description": "Ora de încheiere a planificării."
+        },
+        "limit": {
+          "name": "Limită de încărcare",
+          "description": "Nivelul maxim de încărcare a bateriei (%)."
+        },
+        "days": {
+          "name": "Zile",
+          "description": "Lista zilelor active ale săptămânii folosind luni=1 până la duminică=7."
+        },
+        "site_id": {
+          "name": "ID locație",
+          "description": "Identificator opțional al locației; detectat automat când este selectat un dispozitiv al locației."
+        },
+        "config_entry_id": {
+          "name": "ID intrare de configurare",
+          "description": "Identificator opțional al intrării de configurare pentru o singură intrare de locație Enphase."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Actualizați planificarea bateriei",
+      "description": "Actualizați o planificare a bateriei după ID-ul planificării.",
+      "sections": {
+        "advanced": {
+          "name": "Opțiuni avansate"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "ID planificare",
+          "description": "Identificatorul unei planificări existente de baterie Enphase."
+        },
+        "schedule_type": {
+          "name": "Tip planificare",
+          "description": "Familia planificării bateriei: cfg, dtg sau rbd."
+        },
+        "start_time": {
+          "name": "Ora de începere",
+          "description": "Ora de începere a planificării."
+        },
+        "end_time": {
+          "name": "Ora de încheiere",
+          "description": "Ora de încheiere a planificării."
+        },
+        "limit": {
+          "name": "Limită de încărcare",
+          "description": "Nivelul maxim de încărcare a bateriei (%)."
+        },
+        "days": {
+          "name": "Zile",
+          "description": "Lista zilelor active ale săptămânii folosind luni=1 până la duminică=7."
+        },
+        "confirm": {
+          "name": "Confirmați",
+          "description": "Setați la true pentru a confirma actualizarea planificării."
+        },
+        "site_id": {
+          "name": "ID locație",
+          "description": "Identificator opțional al locației; detectat automat când este selectat un dispozitiv al locației."
+        },
+        "config_entry_id": {
+          "name": "ID intrare de configurare",
+          "description": "Identificator opțional al intrării de configurare pentru o singură intrare de locație Enphase."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Ștergeți planificarea bateriei",
+      "description": "Ștergeți una sau mai multe planificări ale bateriei după ID-ul planificării.",
+      "sections": {
+        "advanced": {
+          "name": "Opțiuni avansate"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "ID planificare",
+          "description": "Identificatorul unei singure planificări de baterie Enphase care va fi ștearsă."
+        },
+        "schedule_ids": {
+          "name": "ID-uri de planificare",
+          "description": "Intrare opțională, separată prin virgule sau ca listă, pentru mai mulți identificatori de planificare."
+        },
+        "confirm": {
+          "name": "Confirmați",
+          "description": "Setați la true pentru a confirma ștergerea planificării."
+        },
+        "site_id": {
+          "name": "ID locație",
+          "description": "Identificator opțional al locației; detectat automat când este selectat un dispozitiv al locației."
+        },
+        "config_entry_id": {
+          "name": "ID intrare de configurare",
+          "description": "Identificator opțional al intrării de configurare pentru o singură intrare de locație Enphase."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Validați planificarea bateriei",
+      "description": "Verificați dacă editarea planificărilor bateriei este disponibilă pentru familia de planificări selectată.",
+      "sections": {
+        "advanced": {
+          "name": "Opțiuni avansate"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Tip planificare",
+          "description": "Familia planificării bateriei: cfg, dtg sau rbd."
+        },
+        "site_id": {
+          "name": "ID locație",
+          "description": "Identificator opțional al locației; detectat automat când este selectat un dispozitiv al locației."
+        },
+        "config_entry_id": {
+          "name": "ID intrare de configurare",
+          "description": "Identificator opțional al intrării de configurare pentru o singură intrare de locație Enphase."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -131,6 +131,267 @@
     },
     "battery_schedule_overlap": {
       "message": "Schemat överlappar det befintliga {schedule_label}. Justera eller inaktivera det schemat först."
+    },
+    "ac_battery_unavailable": {
+      "message": "No AC Battery devices are currently available."
+    },
+    "auth_settings_service_unavailable": {
+      "message": "Authentication settings are unavailable while the Enphase service is down."
+    },
+    "battery_profile_update_not_permitted": {
+      "message": "Battery profile updates are not permitted for this account."
+    },
+    "battery_settings_update_not_permitted": {
+      "message": "Battery settings updates are not permitted for this account."
+    },
+    "battery_profile_update_in_progress": {
+      "message": "Another battery profile update is already in progress."
+    },
+    "battery_settings_update_in_progress": {
+      "message": "Another battery settings update is already in progress."
+    },
+    "battery_profile_updates_unavailable": {
+      "message": "Battery profile updates are unavailable."
+    },
+    "battery_settings_updates_unavailable": {
+      "message": "Battery settings updates are unavailable."
+    },
+    "battery_updates_unavailable": {
+      "message": "Battery updates are unavailable."
+    },
+    "battery_updates_not_permitted": {
+      "message": "Battery updates are not permitted for this account."
+    },
+    "battery_profile_update_debounced": {
+      "message": "Battery profile update requested too quickly. Please wait and try again."
+    },
+    "battery_settings_update_debounced": {
+      "message": "Battery settings update requested too quickly. Please wait and try again."
+    },
+    "battery_write_access_unconfirmed": {
+      "message": "Battery write access could not be confirmed. Refresh and try again."
+    },
+    "schedule_update_forbidden": {
+      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "schedule_update_unauthorized": {
+      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+    },
+    "schedule_conflict_dtg": {
+      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_rbd": {
+      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+    },
+    "schedule_conflict_cfg": {
+      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+    },
+    "schedule_update_conflict": {
+      "message": "Schemauppdateringen konflikterar med ett befintligt batterischema."
+    },
+    "battery_profile_unavailable": {
+      "message": "Battery profile is unavailable."
+    },
+    "battery_profile_update_forbidden": {
+      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_profile_update_unauthorized": {
+      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "battery_settings_payload_unavailable": {
+      "message": "Battery settings payload is unavailable."
+    },
+    "battery_settings_update_forbidden": {
+      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "battery_settings_update_unauthorized": {
+      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+    },
+    "full_backup_reserve_fixed": {
+      "message": "Full Backup reserve is fixed at 100%."
+    },
+    "battery_reserve_unavailable": {
+      "message": "Battery reserve is unavailable."
+    },
+    "savings_profile_required": {
+      "message": "Savings profile must be active."
+    },
+    "savings_profile_settings_unavailable": {
+      "message": "Savings profile settings are unavailable."
+    },
+    "battery_profile_unsupported": {
+      "message": "Selected battery profile is not supported."
+    },
+    "charge_from_grid_unavailable": {
+      "message": "Charge from grid setting is unavailable."
+    },
+    "charge_from_grid_toggle_not_applied": {
+      "message": "Charge from grid toggle was not applied by Enphase."
+    },
+    "charge_from_grid_schedule_unavailable": {
+      "message": "Charge from grid schedule is unavailable."
+    },
+    "charge_from_grid_schedule_times_different": {
+      "message": "Charge-from-grid schedule start and end times must be different."
+    },
+    "charge_from_grid_schedule_toggle_not_applied": {
+      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+    },
+    "charge_from_grid_required": {
+      "message": "Charge from grid must be enabled first."
+    },
+    "schedule_change_pending": {
+      "message": "A schedule change is pending Envoy sync. Please wait."
+    },
+    "charge_from_grid_schedule_time_invalid": {
+      "message": "Charge-from-grid schedule time is invalid."
+    },
+    "schedule_api_unavailable": {
+      "message": "Schedule API not available on this client version."
+    },
+    "charge_from_grid_schedule_missing": {
+      "message": "No existing charge-from-grid schedule is available."
+    },
+    "schedule_toggle_create_before_enable": {
+      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+    },
+    "schedule_not_exposed": {
+      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+    },
+    "schedule_toggle_not_applied": {
+      "message": "{schedule_label} toggle was not applied by Enphase."
+    },
+    "schedule_primary_write_rejected": {
+      "message": "primary write rejected"
+    },
+    "schedule_family_times_different": {
+      "message": "{schedule_label} start and end times must be different."
+    },
+    "discharge_to_grid_schedule_time_invalid": {
+      "message": "Discharge to grid schedule time is invalid."
+    },
+    "schedule_missing": {
+      "message": "No existing {schedule_label_lower} schedule is available."
+    },
+    "schedule_unavailable": {
+      "message": "{schedule_label} schedule is unavailable."
+    },
+    "schedule_time_invalid": {
+      "message": "{schedule_label} schedule time is invalid."
+    },
+    "current_schedule_time_invalid": {
+      "message": "Current {schedule_label_lower} schedule time is invalid."
+    },
+    "schedule_limit_range": {
+      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+    },
+    "schedule_limit_minimum": {
+      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+    },
+    "current_schedule_times_unavailable": {
+      "message": "Current schedule times are not available."
+    },
+    "charge_from_grid_schedule_limit_range": {
+      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+    },
+    "charge_from_grid_schedule_limit_minimum": {
+      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+    },
+    "battery_shutdown_level_unavailable": {
+      "message": "Battery shutdown level is unavailable."
+    },
+    "battery_shutdown_level_invalid": {
+      "message": "Battery shutdown level is invalid."
+    },
+    "battery_shutdown_level_range": {
+      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+    },
+    "storm_alert_opt_out_unavailable": {
+      "message": "Storm Alert opt-out is unavailable."
+    },
+    "storm_alert_opt_out_failed": {
+      "message": "Storm Alert opt-out failed for {count} alert(s)."
+    },
+    "storm_guard_update_not_permitted": {
+      "message": "Storm Guard updates are not permitted for this account."
+    },
+    "storm_guard_settings_unavailable": {
+      "message": "Storm Guard settings are unavailable."
+    },
+    "storm_guard_update_forbidden": {
+      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "storm_guard_update_unauthorized": {
+      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+    },
+    "selected_system_profile_unavailable": {
+      "message": "Selected system profile is not available."
+    },
+    "system_profile_update_forbidden": {
+      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+    },
+    "system_profile_update_unauthorized": {
+      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+    },
+    "system_profile_update_failed": {
+      "message": "System profile update failed."
+    },
+    "system_profile_update_network": {
+      "message": "System profile update failed due to a network error. Try again."
+    },
+    "system_profile_update_timeout": {
+      "message": "System profile update timed out. Try again."
+    },
+    "scheduler_service_unavailable": {
+      "message": "Val av laddningsläge är inte tillgängligt medan Enphases schematjänst är nere."
+    },
+    "selected_ac_battery_target_state_of_charge_unavailable": {
+      "message": "Selected AC Battery target state of charge is not available."
+    },
+    "battery_schedule_day_required": {
+      "message": "Välj minst en dag för schemat."
+    },
+    "battery_schedule_times_different": {
+      "message": "Schemats start- och sluttider måste vara olika."
+    },
+    "battery_schedule_limit_range": {
+      "message": "Gränsen för schemat {schedule_type} måste vara mellan {minimum} och {maximum}."
+    },
+    "battery_schedule_validation_rejected": {
+      "message": "Schemat avvisades av Enphases valideringsendpoint."
+    },
+    "battery_schedule_editing_unavailable": {
+      "message": "Redigering av batterischeman är inte tillgänglig."
+    },
+    "battery_schedule_api_unavailable": {
+      "message": "API:et för batterischeman är inte tillgängligt."
+    },
+    "battery_schedule_update_confirm_required": {
+      "message": "Bekräftelse krävs för att uppdatera ett schema."
+    },
+    "battery_schedule_delete_confirm_required": {
+      "message": "Bekräftelse krävs för att ta bort ett schema."
+    },
+    "battery_schedule_id_invalid": {
+      "message": "Ogiltigt schema-ID: {schedule_id}"
+    },
+    "battery_schedule_id_not_found": {
+      "message": "Schema-ID hittades inte i aktuella data: {schedule_id}"
+    },
+    "battery_schedule_ids_required": {
+      "message": "Ange minst ett schema-ID att ta bort."
+    },
+    "battery_schedule_ids_invalid": {
+      "message": "Ogiltiga schema-ID:n: {schedule_ids}"
+    },
+    "battery_schedule_ids_not_found": {
+      "message": "Schema-ID:n hittades inte i aktuella data: {schedule_ids}"
+    },
+    "battery_schedule_validation_rejected_detail": {
+      "message": "Schemat avvisades av Enphases valideringsendpoint: {message}"
+    },
+    "schedule_update_conflict_detail": {
+      "message": "Schemauppdateringen konflikterar med ett befintligt batterischema: {message}"
     }
   },
   "options": {
@@ -161,7 +422,8 @@
           "reauth": "Starta omautentisering",
           "forget_password": "Glöm lagrat lösenord",
           "type_heatpump": "Värmepump",
-          "type_ac_battery": "AC-batteri"
+          "type_ac_battery": "AC-batteri",
+          "battery_schedules_enabled": "Aktivera batterischemaläggare"
         },
         "data_description": {
           "type_envoy": "Inkluderar gateway-anslutning och mätardiagnostik.",
@@ -178,7 +440,8 @@
           "reauth": "Starta inloggningsflödet för att uppdatera inloggningsuppgifter utan att ta bort integrationen.",
           "forget_password": "Tar bort det lagrade lösenordet. Automatisk uppdatering försöks inte längre.",
           "type_heatpump": "Inkluderar sensorer för värmepumpens status, diagnostik och förbrukning.",
-          "type_ac_battery": "Inkluderar AC-batterisensorer och vilolägeskontroller när de är tillgängliga."
+          "type_ac_battery": "Inkluderar AC-batterisensorer och vilolägeskontroller när de är tillgängliga.",
+          "battery_schedules_enabled": "Hantera IQ-batterischeman"
         }
       },
       "settings": {
@@ -199,7 +462,8 @@
           "reauth": "Starta omautentisering",
           "forget_password": "Glöm lagrat lösenord",
           "type_heatpump": "Värmepump",
-          "type_ac_battery": "AC-batteri"
+          "type_ac_battery": "AC-batteri",
+          "battery_schedules_enabled": "Aktivera batterischemaläggare"
         },
         "data_description": {
           "type_envoy": "Inkluderar gateway-anslutning och mätardiagnostik.",
@@ -216,7 +480,8 @@
           "reauth": "Starta inloggningsflödet för att uppdatera inloggningsuppgifter utan att ta bort integrationen.",
           "forget_password": "Tar bort det lagrade lösenordet. Automatisk uppdatering försöks inte längre.",
           "type_heatpump": "Inkluderar sensorer för värmepumpens status, diagnostik och förbrukning.",
-          "type_ac_battery": "Inkluderar AC-batterisensorer och vilolägeskontroller när de är tillgängliga."
+          "type_ac_battery": "Inkluderar AC-batterisensorer och vilolägeskontroller när de är tillgängliga.",
+          "battery_schedules_enabled": "Hantera IQ-batterischeman"
         }
       },
       "migrate_envoy_source": {
@@ -243,6 +508,14 @@
           "grid_export": "Export till nätet",
           "battery_charge": "Batteriladdning",
           "battery_discharge": "Batteriurladdning"
+        },
+        "data_description": {
+          "solar_production": "Assign a cumulative production total to the Enphase Energy Site Solar Production sensor. Do not choose daily energy or live power.",
+          "consumption": "Assign a cumulative consumption total to the Enphase Energy Site Consumption sensor. Do not choose daily energy or live power.",
+          "grid_import": "Assign a cumulative grid import total to the Enphase Energy Site Grid Import sensor. Do not choose daily energy or live power.",
+          "grid_export": "Assign a cumulative grid export total to the Enphase Energy Site Grid Export sensor. Do not choose daily energy or live power.",
+          "battery_charge": "Assign a cumulative battery charge total to the Enphase Energy Site Battery Charge sensor. Do not choose daily energy or live power.",
+          "battery_discharge": "Assign a cumulative battery discharge total to the Enphase Energy Site Battery Discharge sensor. Do not choose daily energy or live power."
         }
       },
       "migrate_envoy_confirm": {
@@ -1008,6 +1281,18 @@
       },
       "ac_battery_storage_last_reported": {
         "name": "Senast rapporterat för {serial}"
+      },
+      "battery_cfg_schedules": {
+        "name": "Batteri-CFG-scheman"
+      },
+      "battery_dtg_schedules": {
+        "name": "Batteri-DTG-scheman"
+      },
+      "battery_rbd_schedules": {
+        "name": "Batteri-RBD-scheman"
+      },
+      "battery_schedule_summary": {
+        "name": "Sammanfattning av batterischeman"
       }
     },
     "number": {
@@ -1028,6 +1313,12 @@
       },
       "battery_rbd_schedule_limit": {
         "name": "Gräns för begränsning av batteriurladdning"
+      },
+      "battery_new_schedule_limit": {
+        "name": "Gräns för nytt batterischema"
+      },
+      "battery_schedule_edit_limit": {
+        "name": "Gräns för batterischema"
       }
     },
     "binary_sensor": {
@@ -1109,6 +1400,48 @@
       },
       "evse_schedule_edit_sun": {
         "name": "Schema söndag"
+      },
+      "battery_new_schedule_mon": {
+        "name": "Nytt batterischema måndag"
+      },
+      "battery_new_schedule_tue": {
+        "name": "Nytt batterischema tisdag"
+      },
+      "battery_new_schedule_wed": {
+        "name": "Nytt batterischema onsdag"
+      },
+      "battery_new_schedule_thu": {
+        "name": "Nytt batterischema torsdag"
+      },
+      "battery_new_schedule_fri": {
+        "name": "Nytt batterischema fredag"
+      },
+      "battery_new_schedule_sat": {
+        "name": "Nytt batterischema lördag"
+      },
+      "battery_new_schedule_sun": {
+        "name": "Nytt batterischema söndag"
+      },
+      "battery_schedule_edit_mon": {
+        "name": "Batterischema måndag"
+      },
+      "battery_schedule_edit_tue": {
+        "name": "Batterischema tisdag"
+      },
+      "battery_schedule_edit_wed": {
+        "name": "Batterischema onsdag"
+      },
+      "battery_schedule_edit_thu": {
+        "name": "Batterischema torsdag"
+      },
+      "battery_schedule_edit_fri": {
+        "name": "Batterischema fredag"
+      },
+      "battery_schedule_edit_sat": {
+        "name": "Batterischema lördag"
+      },
+      "battery_schedule_edit_sun": {
+        "name": "Batterischema söndag"
       }
     },
     "select": {
@@ -1123,6 +1456,12 @@
       },
       "evse_schedule_selected": {
         "name": "Schema"
+      },
+      "battery_new_schedule_type": {
+        "name": "Typ av batterischema"
+      },
+      "battery_schedule_selected": {
+        "name": "Batterischema"
       }
     },
     "button": {
@@ -1152,6 +1491,18 @@
       },
       "evse_schedule_add": {
         "name": "Skapa nytt schema"
+      },
+      "battery_schedule_add": {
+        "name": "Lägg till batterischema"
+      },
+      "battery_schedule_delete": {
+        "name": "Ta bort batterischema"
+      },
+      "battery_schedule_refresh": {
+        "name": "Uppdatera batterischema"
+      },
+      "battery_schedule_save": {
+        "name": "Spara batterischema"
       }
     },
     "time": {
@@ -1178,6 +1529,18 @@
       },
       "evse_schedule_edit_end_time": {
         "name": "Schemas sluttid"
+      },
+      "battery_new_schedule_start_time": {
+        "name": "Starttid för nytt batterischema"
+      },
+      "battery_new_schedule_end_time": {
+        "name": "Sluttid för nytt batterischema"
+      },
+      "battery_schedule_edit_start_time": {
+        "name": "Starttid för batterischema"
+      },
+      "battery_schedule_edit_end_time": {
+        "name": "Sluttid för batterischema"
       }
     },
     "calendar": {
@@ -1455,6 +1818,165 @@
         "site_id": {
           "name": "Plats-ID",
           "description": "Enphase plats-ID (valfritt; hämtas från målenheten)."
+        }
+      }
+    },
+    "force_refresh": {
+      "name": "Tvinga uppdatering",
+      "description": "Uppdatera data för batterischeman från Enphase-molnet omedelbart.",
+      "sections": {
+        "advanced": {
+          "name": "Advanced options"
+        }
+      },
+      "fields": {
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier; detected automatically when a site device is selected."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "add_schedule": {
+      "name": "Lägg till batterischema",
+      "description": "Skapa ett batterischema för CFG, DTG eller RBD.",
+      "sections": {
+        "advanced": {
+          "name": "Avancerade alternativ"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Schematyp",
+          "description": "Batterischemafamilj: cfg, dtg eller rbd."
+        },
+        "start_time": {
+          "name": "Starttid",
+          "description": "Schemats starttid."
+        },
+        "end_time": {
+          "name": "Sluttid",
+          "description": "Schemats sluttid."
+        },
+        "limit": {
+          "name": "Laddningsgräns",
+          "description": "Batteriets maximala laddningsnivå (%)."
+        },
+        "days": {
+          "name": "Dagar",
+          "description": "Lista över aktiva veckodagar med måndag=1 till söndag=7."
+        },
+        "site_id": {
+          "name": "Plats-ID",
+          "description": "Valfri platsidentifierare; upptäcks automatiskt när en platsenhet väljs."
+        },
+        "config_entry_id": {
+          "name": "Konfigurationspost-ID",
+          "description": "Valfri identifierare för konfigurationsposten för en enskild Enphase-plats."
+        }
+      }
+    },
+    "update_schedule": {
+      "name": "Uppdatera batterischema",
+      "description": "Uppdatera ett batterischema efter schema-ID.",
+      "sections": {
+        "advanced": {
+          "name": "Avancerade alternativ"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Schema-ID",
+          "description": "Identifierare för ett befintligt Enphase-batterischema."
+        },
+        "schedule_type": {
+          "name": "Schematyp",
+          "description": "Batterischemafamilj: cfg, dtg eller rbd."
+        },
+        "start_time": {
+          "name": "Starttid",
+          "description": "Schemats starttid."
+        },
+        "end_time": {
+          "name": "Sluttid",
+          "description": "Schemats sluttid."
+        },
+        "limit": {
+          "name": "Laddningsgräns",
+          "description": "Batteriets maximala laddningsnivå (%)."
+        },
+        "days": {
+          "name": "Dagar",
+          "description": "Lista över aktiva veckodagar med måndag=1 till söndag=7."
+        },
+        "confirm": {
+          "name": "Bekräfta",
+          "description": "Ange true för att bekräfta schemauppdateringen."
+        },
+        "site_id": {
+          "name": "Plats-ID",
+          "description": "Valfri platsidentifierare; upptäcks automatiskt när en platsenhet väljs."
+        },
+        "config_entry_id": {
+          "name": "Konfigurationspost-ID",
+          "description": "Valfri identifierare för konfigurationsposten för en enskild Enphase-plats."
+        }
+      }
+    },
+    "delete_schedule": {
+      "name": "Ta bort batterischema",
+      "description": "Ta bort ett eller flera batterischeman efter schema-ID.",
+      "sections": {
+        "advanced": {
+          "name": "Avancerade alternativ"
+        }
+      },
+      "fields": {
+        "schedule_id": {
+          "name": "Schema-ID",
+          "description": "Identifierare för ett enskilt Enphase-batterischema som ska tas bort."
+        },
+        "schedule_ids": {
+          "name": "Schema-ID:n",
+          "description": "Valfri kommaseparerad inmatning eller lista för flera schemaidentifierare."
+        },
+        "confirm": {
+          "name": "Bekräfta",
+          "description": "Ange true för att bekräfta borttagningen av schemat."
+        },
+        "site_id": {
+          "name": "Plats-ID",
+          "description": "Valfri platsidentifierare; upptäcks automatiskt när en platsenhet väljs."
+        },
+        "config_entry_id": {
+          "name": "Konfigurationspost-ID",
+          "description": "Valfri identifierare för konfigurationsposten för en enskild Enphase-plats."
+        }
+      }
+    },
+    "validate_schedule": {
+      "name": "Validera batterischema",
+      "description": "Kontrollera om redigering av batterischeman är tillgänglig för den valda schemafamiljen.",
+      "sections": {
+        "advanced": {
+          "name": "Avancerade alternativ"
+        }
+      },
+      "fields": {
+        "schedule_type": {
+          "name": "Schematyp",
+          "description": "Batterischemafamilj: cfg, dtg eller rbd."
+        },
+        "site_id": {
+          "name": "Plats-ID",
+          "description": "Valfri platsidentifierare; upptäcks automatiskt när en platsenhet väljs."
+        },
+        "config_entry_id": {
+          "name": "Konfigurationspost-ID",
+          "description": "Valfri identifierare för konfigurationsposten för en enskild Enphase-plats."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -133,220 +133,220 @@
       "message": "Schemat överlappar det befintliga {schedule_label}. Justera eller inaktivera det schemat först."
     },
     "ac_battery_unavailable": {
-      "message": "No AC Battery devices are currently available."
+      "message": "Inga AC-batterienheter är tillgängliga för närvarande."
     },
     "auth_settings_service_unavailable": {
-      "message": "Authentication settings are unavailable while the Enphase service is down."
+      "message": "Autentiseringsinställningar är inte tillgängliga när Enphase-tjänsten är nere."
     },
     "battery_profile_update_not_permitted": {
-      "message": "Battery profile updates are not permitted for this account."
+      "message": "Batteriprofiluppdateringar är inte tillåtna för det här kontot."
     },
     "battery_settings_update_not_permitted": {
-      "message": "Battery settings updates are not permitted for this account."
+      "message": "Uppdateringar av batteriinställningar är inte tillåtna för det här kontot."
     },
     "battery_profile_update_in_progress": {
-      "message": "Another battery profile update is already in progress."
+      "message": "En annan uppdatering av batteriprofilen pågår redan."
     },
     "battery_settings_update_in_progress": {
-      "message": "Another battery settings update is already in progress."
+      "message": "En annan uppdatering av batteriinställningar pågår redan."
     },
     "battery_profile_updates_unavailable": {
-      "message": "Battery profile updates are unavailable."
+      "message": "Batteriprofiluppdateringar är inte tillgängliga."
     },
     "battery_settings_updates_unavailable": {
-      "message": "Battery settings updates are unavailable."
+      "message": "Uppdateringar av batteriinställningar är inte tillgängliga."
     },
     "battery_updates_unavailable": {
-      "message": "Battery updates are unavailable."
+      "message": "Batteriuppdateringar är inte tillgängliga."
     },
     "battery_updates_not_permitted": {
-      "message": "Battery updates are not permitted for this account."
+      "message": "Batteriuppdateringar är inte tillåtna för detta konto."
     },
     "battery_profile_update_debounced": {
-      "message": "Battery profile update requested too quickly. Please wait and try again."
+      "message": "Uppdatering av batteriprofil begärdes för snabbt. Vänta och försök igen."
     },
     "battery_settings_update_debounced": {
-      "message": "Battery settings update requested too quickly. Please wait and try again."
+      "message": "Uppdatering av batteriinställningar begärdes för snabbt. Vänta och försök igen."
     },
     "battery_write_access_unconfirmed": {
-      "message": "Battery write access could not be confirmed. Refresh and try again."
+      "message": "Batteriskrivåtkomst kunde inte bekräftas. Uppdatera och försök igen."
     },
     "schedule_update_forbidden": {
-      "message": "Schedule update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Schemauppdatering avvisades av Enphase (HTTP 403 förbjuden)."
     },
     "schedule_update_unauthorized": {
-      "message": "Schedule update could not be authenticated. Reauthenticate and try again."
+      "message": "Schemauppdatering kunde inte autentiseras. Autentisera igen och försök igen."
     },
     "schedule_conflict_dtg": {
-      "message": "Schedule conflicts with the existing discharge-to-grid schedule. Adjust or disable that schedule first."
+      "message": "Schema står i konflikt med det befintliga schemat för utsläpp till nät. Justera eller inaktivera det schemat först."
     },
     "schedule_conflict_rbd": {
-      "message": "Schedule conflicts with the existing restrict-battery-discharge schedule. Adjust or disable that schedule first."
+      "message": "Schema konflikter med det befintliga schemat för begränsning av batteriurladdning. Justera eller inaktivera det schemat först."
     },
     "schedule_conflict_cfg": {
-      "message": "Schedule conflicts with the existing charge-from-grid schedule. Adjust or disable that schedule first."
+      "message": "Schema konflikter med det befintliga schemat för debitering från nätet. Justera eller inaktivera det schemat först."
     },
     "schedule_update_conflict": {
       "message": "Schemauppdateringen konflikterar med ett befintligt batterischema."
     },
     "battery_profile_unavailable": {
-      "message": "Battery profile is unavailable."
+      "message": "Batteriprofilen är inte tillgänglig."
     },
     "battery_profile_update_forbidden": {
-      "message": "Battery profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Uppdatering av batteriprofilen avvisades av Enphase (HTTP 403 förbjuden)."
     },
     "battery_profile_update_unauthorized": {
-      "message": "Battery profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Uppdatering av batteriprofilen kunde inte autentiseras. Autentisera igen och försök igen."
     },
     "battery_settings_payload_unavailable": {
-      "message": "Battery settings payload is unavailable."
+      "message": "Batteriinställningarnas nyttolast är inte tillgänglig."
     },
     "battery_settings_update_forbidden": {
-      "message": "Battery settings update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Uppdatering av batteriinställningar avvisades av Enphase (HTTP 403 förbjuden)."
     },
     "battery_settings_update_unauthorized": {
-      "message": "Battery settings update could not be authenticated. Reauthenticate and try again."
+      "message": "Uppdatering av batteriinställningar kunde inte autentiseras. Autentisera igen och försök igen."
     },
     "full_backup_reserve_fixed": {
-      "message": "Full Backup reserve is fixed at 100%."
+      "message": "Full reserv för säkerhetskopiering är fixerad till 100 %."
     },
     "battery_reserve_unavailable": {
-      "message": "Battery reserve is unavailable."
+      "message": "Batterireserven är inte tillgänglig."
     },
     "savings_profile_required": {
-      "message": "Savings profile must be active."
+      "message": "Sparprofilen måste vara aktiv."
     },
     "savings_profile_settings_unavailable": {
-      "message": "Savings profile settings are unavailable."
+      "message": "Inställningar för sparprofiler är inte tillgängliga."
     },
     "battery_profile_unsupported": {
-      "message": "Selected battery profile is not supported."
+      "message": "Vald batteriprofil stöds inte."
     },
     "charge_from_grid_unavailable": {
-      "message": "Charge from grid setting is unavailable."
+      "message": "Inställningen för laddning från nät är inte tillgänglig."
     },
     "charge_from_grid_toggle_not_applied": {
-      "message": "Charge from grid toggle was not applied by Enphase."
+      "message": "Charge from grid toggle applicerades inte av Enphase."
     },
     "charge_from_grid_schedule_unavailable": {
-      "message": "Charge from grid schedule is unavailable."
+      "message": "Debitering från nätschema är inte tillgänglig."
     },
     "charge_from_grid_schedule_times_different": {
-      "message": "Charge-from-grid schedule start and end times must be different."
+      "message": "Start- och sluttid för debitering från nätet måste vara olika."
     },
     "charge_from_grid_schedule_toggle_not_applied": {
-      "message": "Charge-from-grid schedule toggle was not applied by Enphase."
+      "message": "Växling mellan schema för laddning från nät tillämpades inte av Enphase."
     },
     "charge_from_grid_required": {
-      "message": "Charge from grid must be enabled first."
+      "message": "Laddning från nätet måste aktiveras först."
     },
     "schedule_change_pending": {
-      "message": "A schedule change is pending Envoy sync. Please wait."
+      "message": "En schemaändring väntar på Envoy-synkronisering. Vänta."
     },
     "charge_from_grid_schedule_time_invalid": {
-      "message": "Charge-from-grid schedule time is invalid."
+      "message": "Schemaläggningstiden för debitering från nätet är ogiltig."
     },
     "schedule_api_unavailable": {
-      "message": "Schedule API not available on this client version."
+      "message": "Schema API är inte tillgängligt på den här klientversionen."
     },
     "charge_from_grid_schedule_missing": {
-      "message": "No existing charge-from-grid schedule is available."
+      "message": "Det finns inget befintligt schema för avgifter från nätet."
     },
     "schedule_toggle_create_before_enable": {
-      "message": "Create a {schedule_label} in the IQ Battery scheduler before enabling it."
+      "message": "Skapa en {schedule_label} i IQ Battery Scheduler innan du aktiverar den."
     },
     "schedule_not_exposed": {
-      "message": "{schedule_label} is not currently exposed by Enphase for this site. Wait for the schedule sync to complete, then refresh and try again."
+      "message": "{schedule_label} är för närvarande inte exponerad av Enphase för denna webbplats. Vänta tills schemasynkroniseringen är klar, uppdatera sedan och försök igen."
     },
     "schedule_toggle_not_applied": {
-      "message": "{schedule_label} toggle was not applied by Enphase."
+      "message": "{schedule_label}-växlingen användes inte av Enphase."
     },
     "schedule_primary_write_rejected": {
-      "message": "primary write rejected"
+      "message": "primär skrivning avvisad"
     },
     "schedule_family_times_different": {
-      "message": "{schedule_label} start and end times must be different."
+      "message": "{schedule_label} start- och sluttid måste vara olika."
     },
     "discharge_to_grid_schedule_time_invalid": {
-      "message": "Discharge to grid schedule time is invalid."
+      "message": "Tid för urladdning till nätet är ogiltig."
     },
     "schedule_missing": {
-      "message": "No existing {schedule_label_lower} schedule is available."
+      "message": "Inget befintligt {schedule_label_lower}-schema är tillgängligt."
     },
     "schedule_unavailable": {
-      "message": "{schedule_label} schedule is unavailable."
+      "message": "{schedule_label}-schemat är inte tillgängligt."
     },
     "schedule_time_invalid": {
-      "message": "{schedule_label} schedule time is invalid."
+      "message": "{schedule_label} schemaläggningstid är ogiltig."
     },
     "current_schedule_time_invalid": {
-      "message": "Current {schedule_label_lower} schedule time is invalid."
+      "message": "Den aktuella {schedule_label_lower}-schematiden är ogiltig."
     },
     "schedule_limit_range": {
-      "message": "{schedule_label} schedule limit must be between {minimum} and {maximum}."
+      "message": "{schedule_label}-schemagränsen måste vara mellan {minimum} och {maximum}."
     },
     "schedule_limit_minimum": {
-      "message": "{schedule_label} schedule limit must be at least {minimum}%."
+      "message": "{schedule_label}-schemagränsen måste vara minst {minimum}%."
     },
     "current_schedule_times_unavailable": {
-      "message": "Current schedule times are not available."
+      "message": "Aktuella schematider är inte tillgängliga."
     },
     "charge_from_grid_schedule_limit_range": {
-      "message": "Charge-from-grid schedule limit must be between {minimum} and {maximum}."
+      "message": "Schemagränsen för avgifter från nätet måste vara mellan {minimum} och {maximum}."
     },
     "charge_from_grid_schedule_limit_minimum": {
-      "message": "Charge-from-grid schedule limit must be at least {minimum}%."
+      "message": "Schemagränsen för avgifter från nätet måste vara minst {minimum} %."
     },
     "battery_shutdown_level_unavailable": {
-      "message": "Battery shutdown level is unavailable."
+      "message": "Batteriavstängningsnivån är inte tillgänglig."
     },
     "battery_shutdown_level_invalid": {
-      "message": "Battery shutdown level is invalid."
+      "message": "Batteriavstängningsnivån är ogiltig."
     },
     "battery_shutdown_level_range": {
-      "message": "Battery shutdown level must be between {minimum} and {maximum}."
+      "message": "Batteriavstängningsnivån måste vara mellan {minimum} och {maximum}."
     },
     "storm_alert_opt_out_unavailable": {
-      "message": "Storm Alert opt-out is unavailable."
+      "message": "Storm Alert-opt-out är inte tillgängligt."
     },
     "storm_alert_opt_out_failed": {
-      "message": "Storm Alert opt-out failed for {count} alert(s)."
+      "message": "Det gick inte att välja bort Storm Alert för {count}-varningar."
     },
     "storm_guard_update_not_permitted": {
-      "message": "Storm Guard updates are not permitted for this account."
+      "message": "Storm Guard-uppdateringar är inte tillåtna för detta konto."
     },
     "storm_guard_settings_unavailable": {
-      "message": "Storm Guard settings are unavailable."
+      "message": "Storm Guard-inställningarna är inte tillgängliga."
     },
     "storm_guard_update_forbidden": {
-      "message": "Storm Guard update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Storm Guard-uppdateringen avvisades av Enphase (HTTP 403 förbjuden)."
     },
     "storm_guard_update_unauthorized": {
-      "message": "Storm Guard update could not be authenticated. Reauthenticate and try again."
+      "message": "Storm Guard-uppdateringen kunde inte autentiseras. Autentisera igen och försök igen."
     },
     "selected_system_profile_unavailable": {
-      "message": "Selected system profile is not available."
+      "message": "Den valda systemprofilen är inte tillgänglig."
     },
     "system_profile_update_forbidden": {
-      "message": "System profile update was rejected by Enphase (HTTP 403 Forbidden)."
+      "message": "Uppdatering av systemprofilen avvisades av Enphase (HTTP 403 förbjuden)."
     },
     "system_profile_update_unauthorized": {
-      "message": "System profile update could not be authenticated. Reauthenticate and try again."
+      "message": "Systemprofiluppdateringen kunde inte autentiseras. Autentisera igen och försök igen."
     },
     "system_profile_update_failed": {
-      "message": "System profile update failed."
+      "message": "Uppdateringen av systemprofilen misslyckades."
     },
     "system_profile_update_network": {
-      "message": "System profile update failed due to a network error. Try again."
+      "message": "Uppdateringen av systemprofilen misslyckades på grund av ett nätverksfel. Försök igen."
     },
     "system_profile_update_timeout": {
-      "message": "System profile update timed out. Try again."
+      "message": "Uppdatering av systemprofilen tog timeout. Försök igen."
     },
     "scheduler_service_unavailable": {
       "message": "Val av laddningsläge är inte tillgängligt medan Enphases schematjänst är nere."
     },
     "selected_ac_battery_target_state_of_charge_unavailable": {
-      "message": "Selected AC Battery target state of charge is not available."
+      "message": "Valt AC-batterimålläge för laddning är inte tillgängligt."
     },
     "battery_schedule_day_required": {
       "message": "Välj minst en dag för schemat."
@@ -1826,17 +1826,17 @@
       "description": "Uppdatera data för batterischeman från Enphase-molnet omedelbart.",
       "sections": {
         "advanced": {
-          "name": "Advanced options"
+          "name": "Avancerade alternativ"
         }
       },
       "fields": {
         "site_id": {
-          "name": "Site ID",
-          "description": "Optional site identifier; detected automatically when a site device is selected."
+          "name": "Webbplats-ID",
+          "description": "Valfri platsidentifierare; detekteras automatiskt när en platsenhet väljs."
         },
         "config_entry_id": {
-          "name": "Config Entry ID",
-          "description": "Optional config entry identifier for a single Enphase site entry."
+          "name": "Konfigurationspost-ID",
+          "description": "Valfri konfigurationspostidentifierare för en enda Enphase-platspost."
         }
       }
     },

--- a/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
+++ b/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
@@ -2070,6 +2070,20 @@ async def test_battery_schedule_services_cover_failure_paths(
             )
         )
 
+    coord.client.validate_battery_schedule = AsyncMock(return_value={"isValid": False})
+    with pytest.raises(
+        ServiceValidationError,
+        match="Schedule rejected by the Enphase validation endpoint.",
+    ):
+        await validate_schedule(
+            SimpleNamespace(
+                data={
+                    "config_entry_id": config_entry.entry_id,
+                    "schedule_type": "cfg",
+                }
+            )
+        )
+
     coord.client.validate_battery_schedule = AsyncMock(
         return_value={"isValid": "true", "message": "string ok"}
     )

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -52,6 +52,53 @@ def _string_paths_under(data: dict, path: str) -> list[str]:
     return _walk(cur, path)
 
 
+def _battery_schedule_string_paths(data: dict) -> list[str]:
+    """Return the full battery-scheduler translation surface from the catalog."""
+
+    paths = [
+        "options.step.init.data.schedule_sync_enabled",
+        "options.step.init.data.battery_schedules_enabled",
+        "options.step.init.data_description.schedule_sync_enabled",
+        "options.step.init.data_description.battery_schedules_enabled",
+        "options.step.settings.data.battery_schedules_enabled",
+        "options.step.settings.data_description.battery_schedules_enabled",
+    ]
+
+    scheduler_entity_prefixes = (
+        "battery_new_schedule_",
+        "battery_schedule_",
+        "battery_cfg_schedules",
+        "battery_dtg_schedules",
+        "battery_rbd_schedules",
+    )
+    for platform, platform_entries in data["entity"].items():
+        if not isinstance(platform_entries, dict):
+            continue
+        for entity_id in platform_entries:
+            if entity_id.startswith(scheduler_entity_prefixes):
+                paths.extend(
+                    _string_paths_under(data, f"entity.{platform}.{entity_id}")
+                )
+
+    for exception_key in data["exceptions"]:
+        if exception_key.startswith("battery_schedule_") or exception_key in {
+            "scheduler_service_unavailable",
+            "schedule_update_conflict_detail",
+        }:
+            paths.extend(_string_paths_under(data, f"exceptions.{exception_key}"))
+
+    for service_key in (
+        "force_refresh",
+        "add_schedule",
+        "update_schedule",
+        "delete_schedule",
+        "validate_schedule",
+    ):
+        paths.extend(_string_paths_under(data, f"services.{service_key}"))
+
+    return sorted(set(paths))
+
+
 def test_battery_profile_strings_localized_for_non_english_locales() -> None:
     """Guard against English fallback regressions for battery profile features."""
 
@@ -252,65 +299,10 @@ def test_battery_schedule_editor_strings_localized_for_non_english_locales() -> 
         / "translations"
     )
     en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
-    paths = [
-        "options.step.init.data.schedule_sync_enabled",
-        "options.step.init.data.battery_schedules_enabled",
-        "options.step.init.data_description.schedule_sync_enabled",
-        "options.step.init.data_description.battery_schedules_enabled",
-        "options.step.settings.data.battery_schedules_enabled",
-        "options.step.settings.data_description.battery_schedules_enabled",
-        "entity.sensor.battery_cfg_schedules.name",
-        "entity.sensor.battery_dtg_schedules.name",
-        "entity.sensor.battery_rbd_schedules.name",
-        "entity.sensor.battery_schedule_summary.name",
-        "entity.number.battery_new_schedule_limit.name",
-        "entity.number.battery_schedule_edit_limit.name",
-        "entity.select.battery_new_schedule_type.name",
-        "entity.select.battery_schedule_selected.name",
-        "entity.button.battery_schedule_refresh.name",
-        "entity.button.battery_schedule_save.name",
-        "entity.button.battery_schedule_delete.name",
-        "entity.button.battery_schedule_add.name",
-        "entity.time.battery_new_schedule_start_time.name",
-        "entity.time.battery_new_schedule_end_time.name",
-        "entity.time.battery_schedule_edit_start_time.name",
-        "entity.time.battery_schedule_edit_end_time.name",
-        "services.force_refresh.name",
-        "services.force_refresh.description",
-        "services.add_schedule.name",
-        "services.add_schedule.description",
-        "services.update_schedule.name",
-        "services.update_schedule.description",
-        "services.delete_schedule.name",
-        "services.delete_schedule.description",
-        "services.validate_schedule.name",
-        "services.validate_schedule.description",
-        "exceptions.scheduler_service_unavailable.message",
-        "exceptions.battery_schedule_day_required.message",
-        "exceptions.battery_schedule_times_different.message",
-        "exceptions.battery_schedule_limit_range.message",
-        "exceptions.battery_schedule_validation_rejected.message",
-        "exceptions.battery_schedule_validation_rejected_detail.message",
-        "exceptions.battery_schedule_editing_unavailable.message",
-        "exceptions.battery_schedule_api_unavailable.message",
-        "exceptions.battery_schedule_update_confirm_required.message",
-        "exceptions.battery_schedule_delete_confirm_required.message",
-        "exceptions.battery_schedule_id_invalid.message",
-        "exceptions.battery_schedule_id_not_found.message",
-        "exceptions.battery_schedule_ids_required.message",
-        "exceptions.battery_schedule_ids_invalid.message",
-        "exceptions.battery_schedule_ids_not_found.message",
-        "exceptions.schedule_update_conflict_detail.message",
-    ]
-    for subtree in (
-        "services.force_refresh",
-        "services.add_schedule",
-        "services.update_schedule",
-        "services.delete_schedule",
-        "services.validate_schedule",
-    ):
-        paths.extend(_string_paths_under(en_data, subtree))
-    paths = sorted(set(paths))
+    paths = _battery_schedule_string_paths(en_data)
+    assert "services.force_refresh.fields.config_entry_id.name" in paths
+    assert "exceptions.scheduler_service_unavailable.message" in paths
+    assert "entity.button.battery_schedule_add.name" in paths
     for locale in translations_dir.glob("*.json"):
         name = locale.name
         data = json.loads(locale.read_text(encoding="utf-8"))

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import json
 import pathlib
 
@@ -220,8 +221,8 @@ def test_battery_cfg_schedule_status_strings_localized_for_non_english_locales()
             ), f"{name} should localize {path} (still matches English)"
 
 
-def test_battery_schedule_editor_strings_exist_for_english_locales() -> None:
-    """Ensure battery schedule parity entities/services are present in English catalogs."""
+def test_battery_schedule_editor_strings_localized_for_non_english_locales() -> None:
+    """Guard battery schedule strings from silently falling back to English."""
 
     translations_dir = (
         pathlib.Path(__file__).resolve().parents[3]
@@ -229,42 +230,103 @@ def test_battery_schedule_editor_strings_exist_for_english_locales() -> None:
         / "enphase_ev"
         / "translations"
     )
+    en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
     paths = [
         "options.step.init.data.schedule_sync_enabled",
         "options.step.init.data.battery_schedules_enabled",
         "options.step.init.data_description.schedule_sync_enabled",
         "options.step.init.data_description.battery_schedules_enabled",
-        "entity.button.battery_schedule_refresh.name",
-        "entity.button.battery_schedule_save.name",
-        "entity.button.battery_schedule_delete.name",
-        "entity.select.battery_schedule_selected.name",
-        "entity.select.battery_new_schedule_type.name",
-        "entity.number.battery_schedule_edit_limit.name",
-        "entity.time.battery_schedule_edit_start_time.name",
-        "entity.time.battery_schedule_edit_end_time.name",
-        "entity.switch.battery_schedule_edit_mon.name",
+        "options.step.settings.data.battery_schedules_enabled",
+        "options.step.settings.data_description.battery_schedules_enabled",
         "entity.sensor.battery_cfg_schedules.name",
         "entity.sensor.battery_dtg_schedules.name",
         "entity.sensor.battery_rbd_schedules.name",
+        "entity.sensor.battery_schedule_summary.name",
+        "entity.number.battery_new_schedule_limit.name",
+        "entity.number.battery_schedule_edit_limit.name",
+        "entity.select.battery_new_schedule_type.name",
+        "entity.select.battery_schedule_selected.name",
+        "entity.button.battery_schedule_refresh.name",
+        "entity.button.battery_schedule_save.name",
+        "entity.button.battery_schedule_delete.name",
+        "entity.button.battery_schedule_add.name",
+        "entity.time.battery_new_schedule_start_time.name",
+        "entity.time.battery_new_schedule_end_time.name",
+        "entity.time.battery_schedule_edit_start_time.name",
+        "entity.time.battery_schedule_edit_end_time.name",
         "services.force_refresh.name",
+        "services.force_refresh.description",
         "services.add_schedule.name",
+        "services.add_schedule.description",
         "services.update_schedule.name",
+        "services.update_schedule.description",
         "services.delete_schedule.name",
+        "services.delete_schedule.description",
         "services.validate_schedule.name",
+        "services.validate_schedule.description",
+        "exceptions.scheduler_service_unavailable.message",
+        "exceptions.battery_schedule_day_required.message",
+        "exceptions.battery_schedule_times_different.message",
+        "exceptions.battery_schedule_limit_range.message",
+        "exceptions.battery_schedule_validation_rejected.message",
+        "exceptions.battery_schedule_validation_rejected_detail.message",
+        "exceptions.battery_schedule_editing_unavailable.message",
+        "exceptions.battery_schedule_api_unavailable.message",
+        "exceptions.battery_schedule_update_confirm_required.message",
+        "exceptions.battery_schedule_delete_confirm_required.message",
+        "exceptions.battery_schedule_id_invalid.message",
+        "exceptions.battery_schedule_id_not_found.message",
+        "exceptions.battery_schedule_ids_required.message",
+        "exceptions.battery_schedule_ids_invalid.message",
+        "exceptions.battery_schedule_ids_not_found.message",
+        "exceptions.schedule_update_conflict_detail.message",
     ]
-    for locale_name in (
-        "en.json",
-        "en-AU.json",
-        "en-CA.json",
-        "en-IE.json",
-        "en-NZ.json",
-        "en-US.json",
-    ):
-        locale = translations_dir / locale_name
+    for locale in translations_dir.glob("*.json"):
+        name = locale.name
         data = json.loads(locale.read_text(encoding="utf-8"))
         for path in paths:
             value = _at_path(data, path)
-            assert value.strip(), f"{locale.name} missing value for {path}"
+            assert value.strip(), f"{name} missing value for {path}"
+            if name != "en.json" and not name.startswith("en-"):
+                assert value != _at_path(
+                    en_data, path
+                ), f"{name} should localize {path} (still matches English)"
+
+
+def test_translated_user_facing_errors_require_translation_keys() -> None:
+    """Guard audited modules from reintroducing raw user-facing error strings."""
+
+    root = (
+        pathlib.Path(__file__).resolve().parents[3] / "custom_components" / "enphase_ev"
+    )
+    audited_files = [
+        "ac_battery_runtime.py",
+        "battery_runtime.py",
+        "select.py",
+        "services.py",
+        "switch.py",
+    ]
+    for relative_path in audited_files:
+        source = (root / relative_path).read_text(encoding="utf-8")
+        tree = ast.parse(source)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Raise) or not isinstance(node.exc, ast.Call):
+                continue
+            func = node.exc.func
+            name = (
+                func.id
+                if isinstance(func, ast.Name)
+                else func.attr if isinstance(func, ast.Attribute) else None
+            )
+            if name not in {"ServiceValidationError", "HomeAssistantError"}:
+                continue
+            has_translation_key = any(
+                keyword.arg == "translation_key" for keyword in node.exc.keywords
+            )
+            assert has_translation_key, (
+                f"{relative_path}:{node.lineno} raises {name} "
+                "without translation_key"
+            )
 
 
 def test_evse_schedule_editor_strings_exist_for_all_locales() -> None:

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -31,6 +31,27 @@ def _at_path(data: dict, path: str) -> str:
     return cur
 
 
+def _string_paths_under(data: dict, path: str) -> list[str]:
+    """Return every string leaf path beneath the given translation subtree."""
+
+    cur = data
+    for part in path.split("."):
+        cur = cur[part]
+
+    def _walk(node: object, prefix: str) -> list[str]:
+        if isinstance(node, dict):
+            paths: list[str] = []
+            for key, value in node.items():
+                child = f"{prefix}.{key}" if prefix else key
+                paths.extend(_walk(value, child))
+            return paths
+        if isinstance(node, str):
+            return [prefix]
+        return []
+
+    return _walk(cur, path)
+
+
 def test_battery_profile_strings_localized_for_non_english_locales() -> None:
     """Guard against English fallback regressions for battery profile features."""
 
@@ -281,6 +302,15 @@ def test_battery_schedule_editor_strings_localized_for_non_english_locales() -> 
         "exceptions.battery_schedule_ids_not_found.message",
         "exceptions.schedule_update_conflict_detail.message",
     ]
+    for subtree in (
+        "services.force_refresh",
+        "services.add_schedule",
+        "services.update_schedule",
+        "services.delete_schedule",
+        "services.validate_schedule",
+    ):
+        paths.extend(_string_paths_under(en_data, subtree))
+    paths = sorted(set(paths))
     for locale in translations_dir.glob("*.json"):
         name = locale.name
         data = json.loads(locale.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

Localize the IQ Battery scheduler UI and runtime validation errors across all shipped locales, and convert the remaining audited battery-schedule validation error paths to translated exceptions. Tighten the translation regression tests so non-English battery-schedule strings cannot silently fall back to English and direct audited user-facing error raises must carry translation metadata.

## Related Issues

- None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/services.py custom_components/enphase_ev/select.py custom_components/enphase_ev/switch.py custom_components/enphase_ev/ac_battery_runtime.py tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_schedule_editor_parity.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/ac_battery_runtime.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/select.py,custom_components/enphase_ev/services.py,custom_components/enphase_ev/switch.py --fail-under=100"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Non-English battery-schedule strings no longer match `en.json` on the guarded translation path set.
- Remaining translation polish is mostly stylistic in a handful of lower-coverage locales; runtime placeholders were preserved exactly.
