### PR TITLE
Improve EVSE session freshness and sync latency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🔧 Improvements
-- None
+- Reduced EV charger refresh-path latency by fetching scheduler payloads concurrently across chargers during sync refreshes, and made session-history freshness adaptive so active/recently-ended sessions refresh sooner while idle chargers keep background refreshes off the main coordinator hot path.
 
 ### 🔄 Other changes
 - None

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -10,6 +10,7 @@ from dataclasses import dataclass
 from datetime import datetime, time as dt_time, timedelta
 from datetime import timezone as _tz
 from http import HTTPStatus
+from numbers import Real
 from typing import Callable, Iterable
 from zoneinfo import ZoneInfo
 
@@ -934,14 +935,18 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     @property
     def _session_history_cache_ttl(self) -> float | None:
         """Expose the session history TTL for diagnostics/tests."""
-        if hasattr(self, "session_history"):
-            return self.session_history.cache_ttl
-        return getattr(self, "_session_history_cache_ttl_value", None)
+        fallback = self.__dict__.get("_session_history_cache_ttl_value")
+        session_history = self.__dict__.get("session_history")
+        if session_history is None:
+            return fallback
+        return getattr(session_history, "cache_ttl", fallback)
 
     @_session_history_cache_ttl.setter
     def _session_history_cache_ttl(self, value: float | None) -> None:
         self._session_history_cache_ttl_value = value
-        if hasattr(self, "session_history"):
+        if hasattr(self, "session_history") and hasattr(
+            self.session_history, "cache_ttl"
+        ):
             self.session_history.cache_ttl = value
 
     @property
@@ -991,6 +996,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         *,
         max_cache_age: float | None = None,
     ) -> None:
+        if max_cache_age is None:
+            self.evse_runtime.schedule_session_enrichment(serials, day_local)
+            return
         self.evse_runtime.schedule_session_enrichment(
             serials,
             day_local,
@@ -1005,6 +1013,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         in_background: bool,
         max_cache_age: float | None = None,
     ) -> dict[str, list[dict]]:
+        if max_cache_age is None:
+            return await self.evse_runtime.async_enrich_sessions(
+                serials,
+                day_local,
+                in_background=in_background,
+            )
         return await self.evse_runtime.async_enrich_sessions(
             serials,
             day_local,
@@ -1020,9 +1034,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return EvseRuntime.session_history_day(payload, day_local_default)
 
     def _session_history_soft_ttl(self, payload: dict) -> float:
-        base_ttl = float(
-            self._session_history_cache_ttl or DEFAULT_SESSION_HISTORY_INTERVAL_MIN * 60
-        )
+        cache_ttl = self._session_history_cache_ttl
+        base_ttl = float(cache_ttl or DEFAULT_SESSION_HISTORY_INTERVAL_MIN * 60)
         if payload.get("actual_charging") or payload.get("charging"):
             return min(base_ttl, SESSION_HISTORY_ACTIVE_SOFT_TTL_S)
 
@@ -1040,9 +1053,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return base_ttl
 
     def _session_history_hard_ttl(self, payload: dict) -> float:
-        base_ttl = float(
-            self._session_history_cache_ttl or DEFAULT_SESSION_HISTORY_INTERVAL_MIN * 60
-        )
+        cache_ttl = self._session_history_cache_ttl
+        base_ttl = float(cache_ttl or DEFAULT_SESSION_HISTORY_INTERVAL_MIN * 60)
         soft_ttl = self._session_history_soft_ttl(payload)
         if soft_ttl < base_ttl:
             return base_ttl
@@ -3853,16 +3865,34 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             sessions_cached = view.sessions or []
             cur["energy_today_sessions"] = sessions_cached
             cur["energy_today_sessions_kwh"] = self._sum_session_energy(sessions_cached)
+            view_needs_refresh = bool(getattr(view, "needs_refresh", False))
+            view_blocked = bool(getattr(view, "blocked", False))
             soft_ttl = self._session_history_soft_ttl(cur)
             hard_ttl = self._session_history_hard_ttl(cur)
-            max_cache_age = (
-                soft_ttl
-                if soft_ttl < float(self.session_history.cache_ttl)
+            session_cache_ttl = float(
+                self._session_history_cache_ttl
+                or DEFAULT_SESSION_HISTORY_INTERVAL_MIN * 60
+            )
+            max_cache_age = soft_ttl if soft_ttl < session_cache_ttl else None
+            cache_age_raw = getattr(view, "cache_age", None)
+            cache_age = (
+                float(cache_age_raw)
+                if isinstance(cache_age_raw, Real)
+                and not isinstance(cache_age_raw, bool)
                 else None
             )
-            cache_age = view.cache_age
-            needs_refresh = cache_age is None or cache_age >= soft_ttl
-            if not needs_refresh or view.blocked:
+            needs_refresh = (
+                cache_age >= soft_ttl if cache_age is not None else view_needs_refresh
+            )
+            if not needs_refresh or view_blocked:
+                continue
+            if cache_age is None:
+                if first_refresh:
+                    background_by_day.setdefault((day_key, max_cache_age), []).append(
+                        sn
+                    )
+                    continue
+                immediate_by_day.setdefault((day_key, max_cache_age), []).append(sn)
                 continue
             if first_refresh:
                 background_by_day.setdefault((day_key, max_cache_age), []).append(sn)

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -164,6 +164,10 @@ HEMS_DEVICES_STALE_AFTER_S = 90.0
 # HEMS heat-pump status/power can lag the Enphase app by only a few seconds.
 # Keep these caches short so we do not hold stale or empty telemetry for minutes.
 HEMS_DEVICES_CACHE_TTL = 15.0
+SESSION_HISTORY_ACTIVE_SOFT_TTL_S = 120.0
+SESSION_HISTORY_RECENT_STOP_SOFT_TTL_S = 300.0
+SESSION_HISTORY_IDLE_HARD_TTL_GRACE_S = 300.0
+SESSION_HISTORY_RECENT_STOP_WINDOW_S = 600.0
 SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES: tuple[str, ...] = (
     "envoys",
     "meters",
@@ -984,8 +988,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self,
         serials: Iterable[str],
         day_local: datetime,
+        *,
+        max_cache_age: float | None = None,
     ) -> None:
-        self.evse_runtime.schedule_session_enrichment(serials, day_local)
+        self.evse_runtime.schedule_session_enrichment(
+            serials,
+            day_local,
+            max_cache_age=max_cache_age,
+        )
 
     async def _async_enrich_sessions(
         self,
@@ -993,11 +1003,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         day_local: datetime,
         *,
         in_background: bool,
+        max_cache_age: float | None = None,
     ) -> dict[str, list[dict]]:
         return await self.evse_runtime.async_enrich_sessions(
             serials,
             day_local,
             in_background=in_background,
+            max_cache_age=max_cache_age,
         )
 
     def _sum_session_energy(self, sessions: list[dict]) -> float:
@@ -1007,15 +1019,46 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def _session_history_day(payload: dict, day_local_default: datetime) -> datetime:
         return EvseRuntime.session_history_day(payload, day_local_default)
 
+    def _session_history_soft_ttl(self, payload: dict) -> float:
+        base_ttl = float(
+            self._session_history_cache_ttl or DEFAULT_SESSION_HISTORY_INTERVAL_MIN * 60
+        )
+        if payload.get("actual_charging") or payload.get("charging"):
+            return min(base_ttl, SESSION_HISTORY_ACTIVE_SOFT_TTL_S)
+
+        session_end = helper_coerce_optional_int(payload.get("session_end"))
+        if session_end is not None:
+            try:
+                recent_stop_age = max(0.0, time.time() - float(session_end))
+            except Exception:
+                recent_stop_age = None
+            if (
+                recent_stop_age is not None
+                and recent_stop_age <= SESSION_HISTORY_RECENT_STOP_WINDOW_S
+            ):
+                return min(base_ttl, SESSION_HISTORY_RECENT_STOP_SOFT_TTL_S)
+        return base_ttl
+
+    def _session_history_hard_ttl(self, payload: dict) -> float:
+        base_ttl = float(
+            self._session_history_cache_ttl or DEFAULT_SESSION_HISTORY_INTERVAL_MIN * 60
+        )
+        soft_ttl = self._session_history_soft_ttl(payload)
+        if soft_ttl < base_ttl:
+            return base_ttl
+        return max(base_ttl, soft_ttl + SESSION_HISTORY_IDLE_HARD_TTL_GRACE_S)
+
     async def _async_fetch_sessions_today(
         self,
         sn: str,
         *,
         day_local: datetime | None = None,
+        max_cache_age: float | None = None,
     ) -> list[dict]:
         return await self.evse_runtime.async_fetch_sessions_today(
             sn,
             day_local=day_local,
+            max_cache_age=max_cache_age,
         )
 
     @staticmethod
@@ -3799,8 +3842,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             day_local_default = dt_util.as_local(day_ref)
 
         now_mono = time.monotonic()
-        immediate_by_day: dict[str, list[str]] = {}
-        background_by_day: dict[str, list[str]] = {}
+        immediate_by_day: dict[tuple[str, float | None], list[str]] = {}
+        background_by_day: dict[tuple[str, float | None], list[str]] = {}
         day_locals: dict[str, datetime] = {}
         for sn, cur in out.items():
             history_day = self._session_history_day(cur, day_local_default)
@@ -3810,30 +3853,62 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             sessions_cached = view.sessions or []
             cur["energy_today_sessions"] = sessions_cached
             cur["energy_today_sessions_kwh"] = self._sum_session_energy(sessions_cached)
-            if not view.needs_refresh or view.blocked:
+            soft_ttl = self._session_history_soft_ttl(cur)
+            hard_ttl = self._session_history_hard_ttl(cur)
+            max_cache_age = (
+                soft_ttl
+                if soft_ttl < float(self.session_history.cache_ttl)
+                else None
+            )
+            cache_age = view.cache_age
+            needs_refresh = cache_age is None or cache_age >= soft_ttl
+            if not needs_refresh or view.blocked:
                 continue
-            target = background_by_day if first_refresh else immediate_by_day
-            target.setdefault(day_key, []).append(sn)
+            if first_refresh:
+                background_by_day.setdefault((day_key, max_cache_age), []).append(sn)
+                continue
+            # Refresh active or recently-ended sessions sooner in the background,
+            # but still force an inline catch-up once cached data ages too far.
+            if cache_age is None or cache_age >= hard_ttl:
+                immediate_by_day.setdefault((day_key, max_cache_age), []).append(sn)
+                continue
+            background_by_day.setdefault((day_key, max_cache_age), []).append(sn)
         # Prune after day-keys are known so historical session-day entries in use
         # by current chargers are retained for normal TTL behavior.
         self._prune_runtime_caches(active_serials=out.keys(), keep_day_keys=day_locals)
 
-        for day_key, serials in immediate_by_day.items():
-            updates = await self._async_enrich_sessions(
-                serials,
-                day_locals.get(day_key, day_local_default),
-                in_background=False,
-            )
+        for (day_key, max_cache_age), serials in immediate_by_day.items():
+            if max_cache_age is None:
+                updates = await self._async_enrich_sessions(
+                    serials,
+                    day_locals.get(day_key, day_local_default),
+                    in_background=False,
+                )
+            else:
+                updates = await self._async_enrich_sessions(
+                    serials,
+                    day_locals.get(day_key, day_local_default),
+                    in_background=False,
+                    max_cache_age=max_cache_age,
+                )
             for sn, sessions in updates.items():
                 cur = out.get(sn)
                 if cur is None:
                     continue
                 cur["energy_today_sessions"] = sessions
                 cur["energy_today_sessions_kwh"] = self._sum_session_energy(sessions)
-        for day_key, serials in background_by_day.items():
-            self._schedule_session_enrichment(
-                serials, day_locals.get(day_key, day_local_default)
-            )
+        for (day_key, max_cache_age), serials in background_by_day.items():
+            if max_cache_age is None:
+                self._schedule_session_enrichment(
+                    serials,
+                    day_locals.get(day_key, day_local_default),
+                )
+            else:
+                self._schedule_session_enrichment(
+                    serials,
+                    day_locals.get(day_key, day_local_default),
+                    max_cache_age=max_cache_age,
+                )
         phase_timings["sessions_s"] = round(time.monotonic() - sessions_start, 3)
         self._sync_session_history_issue()
 

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -172,6 +172,12 @@ class EvseRuntime:
     ) -> dict[str, list[dict]]:
         manager = getattr(self.coordinator, "session_history", None)
         if manager is not None:
+            if max_cache_age is None:
+                return await manager.async_enrich(
+                    serials,
+                    day_local,
+                    in_background=in_background,
+                )
             return await manager.async_enrich(
                 serials,
                 day_local,

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -148,10 +148,19 @@ class EvseRuntime:
         self,
         serials: Iterable[str],
         day_local: datetime,
+        *,
+        max_cache_age: float | None = None,
     ) -> None:
         manager = getattr(self.coordinator, "session_history", None)
         if manager is not None:
-            manager.schedule_enrichment(serials, day_local)
+            if max_cache_age is None:
+                manager.schedule_enrichment(serials, day_local)
+                return
+            manager.schedule_enrichment_with_options(
+                serials,
+                day_local=day_local,
+                max_cache_age=max_cache_age,
+            )
 
     async def async_enrich_sessions(
         self,
@@ -159,11 +168,15 @@ class EvseRuntime:
         day_local: datetime,
         *,
         in_background: bool,
+        max_cache_age: float | None = None,
     ) -> dict[str, list[dict]]:
         manager = getattr(self.coordinator, "session_history", None)
         if manager is not None:
             return await manager.async_enrich(
-                serials, day_local, in_background=in_background
+                serials,
+                day_local,
+                in_background=in_background,
+                max_cache_age=max_cache_age,
             )
         return {}
 
@@ -213,6 +226,7 @@ class EvseRuntime:
         sn: str,
         *,
         day_local: datetime | None = None,
+        max_cache_age: float | None = None,
     ) -> list[dict]:
         if not sn:
             return []
@@ -235,13 +249,28 @@ class EvseRuntime:
         ttl = (
             self.coordinator._session_history_cache_ttl or MIN_SESSION_HISTORY_CACHE_TTL
         )
+        if max_cache_age is not None:
+            try:
+                ttl = max(MIN_SESSION_HISTORY_CACHE_TTL, min(ttl, float(max_cache_age)))
+            except (TypeError, ValueError):
+                pass
         if cached:
             cached_ts, cached_sessions = cached
             if time.monotonic() - cached_ts < ttl:
                 return cached_sessions
         manager = getattr(self.coordinator, "session_history", None)
         if manager is not None:
-            sessions = await manager._async_fetch_sessions_today(sn, day_local=local_dt)
+            if max_cache_age is None:
+                sessions = await manager._async_fetch_sessions_today(
+                    sn,
+                    day_local=local_dt,
+                )
+            else:
+                sessions = await manager._async_fetch_sessions_today(
+                    sn,
+                    day_local=local_dt,
+                    max_cache_age=max_cache_age,
+                )
         else:
             sessions = []
         self.set_session_history_cache_shim_entry(str(sn), day_key, sessions)

--- a/custom_components/enphase_ev/schedule_sync.py
+++ b/custom_components/enphase_ev/schedule_sync.py
@@ -36,6 +36,7 @@ from .schedule import normalize_slot_payload
 _LOGGER = logging.getLogger(__name__)
 
 SYNC_INTERVAL = timedelta(minutes=5)
+SYNC_REFRESH_CONCURRENCY = 3
 PATCH_REFRESH_DELAY_S = 1.0
 SYNC_CAPTURE_ERRORS = (RuntimeError, TypeError, ValueError, AttributeError)
 
@@ -415,8 +416,21 @@ class ScheduleSync:
                 if serials is not None
                 else self._coordinator.iter_serials()
             )
-            for sn in serial_list:
-                await self._sync_serial(sn)
+            unique_serials = [sn for sn in dict.fromkeys(serial_list) if sn]
+            if unique_serials:
+                semaphore = asyncio.Semaphore(SYNC_REFRESH_CONCURRENCY)
+
+                async def _fetch_one(
+                    sn: str,
+                ) -> tuple[str, dict[str, Any] | None, Exception | None]:
+                    async with semaphore:
+                        return (sn, *await self._async_fetch_serial_sync(sn))
+
+                results = await asyncio.gather(
+                    *(_fetch_one(sn) for sn in unique_serials)
+                )
+                for sn, response, err in results:
+                    self._apply_sync_serial_result(sn, response, err)
             self._last_sync = dt_util.utcnow()
             self._last_status = f"ok:{reason}"
 
@@ -534,10 +548,26 @@ class ScheduleSync:
         return True
 
     async def _sync_serial(self, sn: str) -> None:
+        response, err = await self._async_fetch_serial_sync(sn)
+        self._apply_sync_serial_result(sn, response, err)
+
+    async def _async_fetch_serial_sync(
+        self, sn: str
+    ) -> tuple[dict[str, Any] | None, Exception | None]:
         try:
-            response = await self._coordinator.client.get_schedules(sn)
+            return await self._coordinator.client.get_schedules(sn), None
+        except Exception as err:  # noqa: BLE001
+            return None, err
+
+    def _apply_sync_serial_result(
+        self,
+        sn: str,
+        response: dict[str, Any] | None,
+        err: Exception | None,
+    ) -> None:
+        if err is None:
             self._mark_scheduler_available()
-        except SchedulerUnavailable as err:
+        elif isinstance(err, SchedulerUnavailable):
             self._last_error = redact_text(
                 err,
                 site_ids=(getattr(self._coordinator, "site_id", None),),
@@ -546,7 +576,7 @@ class ScheduleSync:
             self._last_status = "scheduler_unavailable"
             self._note_scheduler_unavailable(err)
             return
-        except Exception as err:  # noqa: BLE001
+        else:
             self._last_error = redact_text(
                 err,
                 site_ids=(getattr(self._coordinator, "site_id", None),),

--- a/custom_components/enphase_ev/session_history.py
+++ b/custom_components/enphase_ev/session_history.py
@@ -219,6 +219,16 @@ class SessionHistoryManager:
 
     def schedule_enrichment(self, serials: Iterable[str], day_local: datetime) -> None:
         """Launch a background enrichment task for the provided serials."""
+        self.schedule_enrichment_with_options(serials, day_local=day_local)
+
+    def schedule_enrichment_with_options(
+        self,
+        serials: Iterable[str],
+        *,
+        day_local: datetime,
+        max_cache_age: float | None = None,
+    ) -> None:
+        """Launch a background enrichment task for the provided serials."""
         candidates = [sn for sn in dict.fromkeys(serials) if sn]
         pending = [sn for sn in candidates if sn not in self._refresh_in_progress]
         if not pending:
@@ -228,7 +238,9 @@ class SessionHistoryManager:
         async def _run() -> None:
             try:
                 updates = await self._async_enrich_sessions(
-                    pending, day_local=day_local
+                    pending,
+                    day_local=day_local,
+                    max_cache_age=max_cache_age,
                 )
                 if updates:
                     self._apply_updates(updates)
@@ -249,9 +261,14 @@ class SessionHistoryManager:
         day_local: datetime,
         *,
         in_background: bool,
+        max_cache_age: float | None = None,
     ) -> dict[str, list[dict]]:
         """Fetch session history for the provided serials."""
-        updates = await self._async_enrich_sessions(serials, day_local=day_local)
+        updates = await self._async_enrich_sessions(
+            serials,
+            day_local=day_local,
+            max_cache_age=max_cache_age,
+        )
         if in_background and updates:
             self._apply_updates(updates)
         return updates
@@ -261,6 +278,7 @@ class SessionHistoryManager:
         serials: Iterable[str],
         *,
         day_local: datetime,
+        max_cache_age: float | None = None,
     ) -> dict[str, list[dict]]:
         serial_list = [sn for sn in dict.fromkeys(serials) if sn]
         if not serial_list:
@@ -270,9 +288,17 @@ class SessionHistoryManager:
         async def _refresh(sn: str) -> tuple[str, list[dict] | None]:
             async with semaphore:
                 try:
-                    sessions = await self._async_fetch_sessions_today(
-                        sn, day_local=day_local
-                    )
+                    if max_cache_age is None:
+                        sessions = await self._async_fetch_sessions_today(
+                            sn,
+                            day_local=day_local,
+                        )
+                    else:
+                        sessions = await self._async_fetch_sessions_today(
+                            sn,
+                            day_local=day_local,
+                            max_cache_age=max_cache_age,
+                        )
                 except asyncio.CancelledError as err:
                     self._logger.debug(
                         "Session history enrichment cancelled for %s: %s", sn, err
@@ -351,6 +377,7 @@ class SessionHistoryManager:
         sn: str,
         *,
         day_local: datetime | None = None,
+        max_cache_age: float | None = None,
     ) -> list[dict]:
         """Return session history for the provided day, caching results."""
         if self._fetch_override is not None:
@@ -374,7 +401,16 @@ class SessionHistoryManager:
             active_serials.add(sn)
         self.prune(active_serials=active_serials, keep_day_keys={day_key})
         cached = self._cache.get(cache_key)
-        if cached and (now_mono - cached[0] < self._cache_ttl):
+        refresh_after = self._cache_ttl
+        if max_cache_age is not None:
+            try:
+                refresh_after = max(
+                    MIN_SESSION_HISTORY_CACHE_TTL,
+                    min(self._cache_ttl, float(max_cache_age)),
+                )
+            except (TypeError, ValueError):
+                refresh_after = self._cache_ttl
+        if cached and (now_mono - cached[0] < refresh_after):
             return cached[1]
         if self._service_backoff_active():
             return cached[1] if cached else []

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -900,6 +900,35 @@ async def test_async_enrich_sessions_invokes_history(coordinator_factory):
 
 
 @pytest.mark.asyncio
+async def test_async_enrich_sessions_invokes_history_with_max_cache_age(
+    coordinator_factory,
+):
+    coord = coordinator_factory()
+    serials = [SERIAL_ONE]
+    fake_history = SimpleNamespace(
+        async_enrich=AsyncMock(return_value={"123": []}),
+        cache_ttl=MIN_SESSION_HISTORY_CACHE_TTL,
+    )
+    coord.session_history = fake_history
+
+    day = datetime(2025, 5, 1, tzinfo=timezone.utc)
+    result = await coord._async_enrich_sessions(
+        serials,
+        day,
+        in_background=True,
+        max_cache_age=120.0,
+    )
+
+    assert result == {"123": []}
+    fake_history.async_enrich.assert_awaited_once_with(
+        serials,
+        day,
+        in_background=True,
+        max_cache_age=120.0,
+    )
+
+
+@pytest.mark.asyncio
 async def test_async_fetch_sessions_today_handles_timezone_error(
     monkeypatch, coordinator_factory
 ):

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2595,6 +2595,171 @@ async def test_first_refresh_defers_session_history(hass, monkeypatch, config_en
 
 
 @pytest.mark.asyncio
+async def test_steady_state_refresh_defers_stale_session_history_when_cached(
+    hass, monkeypatch
+) -> None:
+    await hass.config.async_set_time_zone("UTC")
+    coord = _make_coordinator(hass, monkeypatch)
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord.data = {RANDOM_SERIAL: {"display_name": "Garage EV"}}
+
+    now_local = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: now_local)
+
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                    "charging": False,
+                }
+            ]
+        }
+    )
+    coord.client.summary_v2 = AsyncMock(
+        return_value=[{"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"}]
+    )
+    coord.client.charge_mode = AsyncMock(return_value=None)
+
+    day_key = now_local.strftime("%Y-%m-%d")
+    cached_sessions = [{"session_id": "cached", "energy_kwh": 1.25}]
+    coord.session_history._cache[(RANDOM_SERIAL, day_key)] = (  # noqa: SLF001
+        time.monotonic() - coord.session_history.cache_ttl - 1,
+        cached_sessions,
+    )
+    coord._async_enrich_sessions = AsyncMock(return_value={})  # type: ignore[assignment]  # noqa: SLF001
+    coord._schedule_session_enrichment = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+
+    data = await coord._async_update_data()
+
+    assert data[RANDOM_SERIAL]["energy_today_sessions"] == cached_sessions
+    assert data[RANDOM_SERIAL]["energy_today_sessions_kwh"] == pytest.approx(1.25)
+    coord._async_enrich_sessions.assert_not_awaited()  # type: ignore[attr-defined]
+    coord._schedule_session_enrichment.assert_called_once()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_active_session_history_refreshes_early_in_background(
+    hass, monkeypatch
+) -> None:
+    await hass.config.async_set_time_zone("UTC")
+    coord = _make_coordinator(hass, monkeypatch)
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord.data = {RANDOM_SERIAL: {"display_name": "Garage EV"}}
+
+    now_local = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: now_local)
+
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                    "charging": True,
+                    "pluggedIn": True,
+                }
+            ]
+        }
+    )
+    coord.client.summary_v2 = AsyncMock(
+        return_value=[{"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"}]
+    )
+    coord.client.charge_mode = AsyncMock(return_value=None)
+
+    day_key = now_local.strftime("%Y-%m-%d")
+    cached_sessions = [{"session_id": "cached", "energy_kwh": 1.25}]
+    coord.session_history._cache[(RANDOM_SERIAL, day_key)] = (  # noqa: SLF001
+        time.monotonic() - 180,
+        cached_sessions,
+    )
+    coord._async_enrich_sessions = AsyncMock(return_value={})  # type: ignore[assignment]  # noqa: SLF001
+    coord._schedule_session_enrichment = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+
+    data = await coord._async_update_data()
+
+    assert data[RANDOM_SERIAL]["energy_today_sessions"] == cached_sessions
+    coord._async_enrich_sessions.assert_not_awaited()  # type: ignore[attr-defined]
+    coord._schedule_session_enrichment.assert_called_once()  # type: ignore[attr-defined]
+    assert (
+        coord._schedule_session_enrichment.call_args.kwargs["max_cache_age"] == 120.0
+    )  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_active_session_history_hard_ttl_refreshes_inline(
+    hass, monkeypatch
+) -> None:
+    await hass.config.async_set_time_zone("UTC")
+    coord = _make_coordinator(hass, monkeypatch)
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord.data = {RANDOM_SERIAL: {"display_name": "Garage EV"}}
+
+    now_local = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: now_local)
+
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                    "charging": True,
+                    "pluggedIn": True,
+                }
+            ]
+        }
+    )
+    coord.client.summary_v2 = AsyncMock(
+        return_value=[{"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"}]
+    )
+    coord.client.charge_mode = AsyncMock(return_value=None)
+
+    day_key = now_local.strftime("%Y-%m-%d")
+    coord.session_history._cache[(RANDOM_SERIAL, day_key)] = (  # noqa: SLF001
+        time.monotonic() - coord.session_history.cache_ttl - 5,
+        [{"session_id": "stale", "energy_kwh": 1.0}],
+    )
+    coord._async_enrich_sessions = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value={RANDOM_SERIAL: [{"session_id": "fresh", "energy_kwh": 2.5}]}
+    )
+    coord._schedule_session_enrichment = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+
+    data = await coord._async_update_data()
+
+    assert data[RANDOM_SERIAL]["energy_today_sessions"] == [
+        {"session_id": "fresh", "energy_kwh": 2.5}
+    ]
+    assert data[RANDOM_SERIAL]["energy_today_sessions_kwh"] == pytest.approx(2.5)
+    coord._async_enrich_sessions.assert_awaited_once()  # type: ignore[attr-defined]
+    assert coord._async_enrich_sessions.await_args.kwargs["max_cache_age"] == 120.0  # type: ignore[attr-defined]
+    coord._schedule_session_enrichment.assert_not_called()  # type: ignore[attr-defined]
+
+
+def test_session_history_adaptive_ttl_helpers(hass, monkeypatch) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    monkeypatch.setattr(time, "time", lambda: 1_000.0)
+
+    assert coord._session_history_soft_ttl({"charging": True}) == 120.0  # noqa: SLF001
+    assert coord._session_history_hard_ttl({"charging": True}) == 600.0  # noqa: SLF001
+    assert (
+        coord._session_history_soft_ttl({"charging": False, "session_end": 950})
+        == 300.0
+    )  # noqa: SLF001
+    assert coord._session_history_hard_ttl({"charging": False}) == 900.0  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_first_refresh_soft_fails_optional_evse_status_endpoint(
     hass, monkeypatch
 ) -> None:

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2694,6 +2694,56 @@ async def test_active_session_history_refreshes_early_in_background(
 
 
 @pytest.mark.asyncio
+async def test_first_refresh_with_cached_active_session_defers_in_background(
+    hass, monkeypatch
+) -> None:
+    await hass.config.async_set_time_zone("UTC")
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.data = {RANDOM_SERIAL: {"display_name": "Garage EV"}}
+
+    now_local = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: now_local)
+
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                    "charging": True,
+                    "pluggedIn": True,
+                }
+            ]
+        }
+    )
+    coord.client.summary_v2 = AsyncMock(
+        return_value=[{"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"}]
+    )
+    coord.client.charge_mode = AsyncMock(return_value=None)
+
+    day_key = now_local.strftime("%Y-%m-%d")
+    cached_sessions = [{"session_id": "cached", "energy_kwh": 1.25}]
+    coord.session_history._cache[(RANDOM_SERIAL, day_key)] = (  # noqa: SLF001
+        time.monotonic() - 180,
+        cached_sessions,
+    )
+    coord._async_enrich_sessions = AsyncMock(return_value={})  # type: ignore[assignment]  # noqa: SLF001
+    coord._schedule_session_enrichment = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+
+    data = await coord._async_update_data()
+
+    assert data[RANDOM_SERIAL]["energy_today_sessions"] == cached_sessions
+    coord._async_enrich_sessions.assert_not_awaited()  # type: ignore[attr-defined]
+    coord._schedule_session_enrichment.assert_called_once()  # type: ignore[attr-defined]
+    assert (
+        coord._schedule_session_enrichment.call_args.kwargs["max_cache_age"] == 120.0
+    )  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
 async def test_active_session_history_hard_ttl_refreshes_inline(
     hass, monkeypatch
 ) -> None:
@@ -2747,14 +2797,32 @@ async def test_active_session_history_hard_ttl_refreshes_inline(
 
 
 def test_session_history_adaptive_ttl_helpers(hass, monkeypatch) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+
     coord = _make_coordinator(hass, monkeypatch)
     monkeypatch.setattr(time, "time", lambda: 1_000.0)
+    original_coerce_optional_int = coord_mod.helper_coerce_optional_int
+
+    class _BadAge:
+        def __float__(self) -> float:
+            raise ValueError("boom")
+
+    def _coerce_optional_int(value):
+        if value == "bad":
+            return _BadAge()
+        return original_coerce_optional_int(value)
+
+    monkeypatch.setattr(coord_mod, "helper_coerce_optional_int", _coerce_optional_int)
 
     assert coord._session_history_soft_ttl({"charging": True}) == 120.0  # noqa: SLF001
     assert coord._session_history_hard_ttl({"charging": True}) == 600.0  # noqa: SLF001
     assert (
         coord._session_history_soft_ttl({"charging": False, "session_end": 950})
         == 300.0
+    )  # noqa: SLF001
+    assert (
+        coord._session_history_soft_ttl({"charging": False, "session_end": "bad"})
+        == 600.0
     )  # noqa: SLF001
     assert coord._session_history_hard_ttl({"charging": False}) == 900.0  # noqa: SLF001
 

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -211,6 +211,81 @@ async def test_evse_runtime_resolvers_use_runtime_methods(
 
 
 @pytest.mark.asyncio
+async def test_evse_runtime_session_history_helpers_pass_max_cache_age(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    runtime = coord.evse_runtime
+    manager = SimpleNamespace(
+        async_enrich=AsyncMock(return_value={"EV1": [{"energy_kwh": 1.0}]}),
+        _async_fetch_sessions_today=AsyncMock(return_value=[{"energy_kwh": 1.0}]),
+        schedule_enrichment=MagicMock(),
+        schedule_enrichment_with_options=MagicMock(),
+    )
+    coord.session_history = manager
+    day = datetime(2025, 1, 1, tzinfo=UTC)
+
+    runtime.schedule_session_enrichment(["EV1"], day, max_cache_age=120.0)
+    result = await runtime.async_enrich_sessions(
+        ["EV1"],
+        day,
+        in_background=True,
+        max_cache_age=120.0,
+    )
+    sessions = await runtime.async_fetch_sessions_today(
+        "EV1",
+        day_local=day,
+        max_cache_age=120.0,
+    )
+
+    manager.schedule_enrichment_with_options.assert_called_once_with(
+        ["EV1"],
+        day_local=day,
+        max_cache_age=120.0,
+    )
+    manager.async_enrich.assert_awaited_once_with(
+        ["EV1"],
+        day,
+        in_background=True,
+        max_cache_age=120.0,
+    )
+    manager._async_fetch_sessions_today.assert_awaited_once_with(
+        "EV1",
+        day_local=day,
+        max_cache_age=120.0,
+    )
+    assert result == {"EV1": [{"energy_kwh": 1.0}]}
+    assert sessions == [{"energy_kwh": 1.0}]
+
+
+@pytest.mark.asyncio
+async def test_evse_runtime_async_fetch_sessions_today_ignores_invalid_max_cache_age(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    runtime = coord.evse_runtime
+    manager = SimpleNamespace(
+        _async_fetch_sessions_today=AsyncMock(return_value=[{"energy_kwh": 2.0}]),
+        cache_ttl=600,
+    )
+    coord.session_history = manager
+    day = datetime(2025, 1, 2, tzinfo=UTC)
+
+    sessions = await runtime.async_fetch_sessions_today(
+        "EV1",
+        day_local=day,
+        max_cache_age="bad",
+    )
+
+    manager._async_fetch_sessions_today.assert_awaited_once_with(
+        "EV1",
+        day_local=day,
+        max_cache_age="bad",
+    )
+    assert sessions == [{"energy_kwh": 2.0}]
+
+
+@pytest.mark.asyncio
 async def test_evse_runtime_run_lookup_tasks_handles_empty_input(
     coordinator_factory,
 ) -> None:

--- a/tests/components/enphase_ev/test_helper_modules.py
+++ b/tests/components/enphase_ev/test_helper_modules.py
@@ -995,6 +995,37 @@ async def test_session_history_max_cache_age_forces_early_refresh(hass, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_session_history_invalid_max_cache_age_falls_back_to_default_ttl(
+    hass, monkeypatch
+):
+    """Invalid max_cache_age values should preserve the default cache TTL."""
+    await hass.config.async_set_time_zone("UTC")
+    now = datetime(2025, 10, 16, tzinfo=timezone.utc)
+    client = _DummySessionClient()
+    manager = SessionHistoryManager(
+        hass,
+        lambda: client,
+        cache_ttl=600,
+        data_supplier=lambda: {"EV-01": {"sn": "EV-01"}},
+        publish_callback=lambda _: None,
+    )
+    monkeypatch.setattr(sh_mod.dt_util, "now", lambda: now)
+    monkeypatch.setattr(sh_mod.dt_util, "as_local", lambda value: value)
+
+    day_key = now.strftime("%Y-%m-%d")
+    manager._cache[("EV-01", day_key)] = (time.monotonic() - 180, ["cached"])
+
+    sessions = await manager._async_fetch_sessions_today(
+        "EV-01",
+        day_local=now,
+        max_cache_age="bad",
+    )
+
+    assert sessions == ["cached"]
+    assert client.calls == []
+
+
+@pytest.mark.asyncio
 async def test_session_history_async_enrich_handles_failures(hass, monkeypatch) -> None:
     """Ensure async_enrich collects updates even when some refreshes fail."""
     await hass.config.async_set_time_zone("UTC")

--- a/tests/components/enphase_ev/test_helper_modules.py
+++ b/tests/components/enphase_ev/test_helper_modules.py
@@ -967,6 +967,34 @@ async def test_session_history_schedule_enrichment_runs(hass) -> None:
 
 
 @pytest.mark.asyncio
+async def test_session_history_max_cache_age_forces_early_refresh(hass, monkeypatch):
+    """max_cache_age should bypass the default TTL when the caller wants fresher data."""
+    await hass.config.async_set_time_zone("UTC")
+    now = datetime(2025, 10, 16, tzinfo=timezone.utc)
+    client = _DummySessionClient()
+    manager = SessionHistoryManager(
+        hass,
+        lambda: client,
+        cache_ttl=600,
+        data_supplier=lambda: {"EV-01": {"sn": "EV-01"}},
+        publish_callback=lambda _: None,
+    )
+    monkeypatch.setattr(sh_mod.dt_util, "now", lambda: now)
+    monkeypatch.setattr(sh_mod.dt_util, "as_local", lambda value: value)
+
+    day_key = now.strftime("%Y-%m-%d")
+    manager._cache[("EV-01", day_key)] = (time.monotonic() - 180, ["cached"])
+    sessions = await manager._async_fetch_sessions_today(
+        "EV-01",
+        day_local=now,
+        max_cache_age=120,
+    )
+
+    assert len(sessions) == 2
+    assert len(client.calls) == 1
+
+
+@pytest.mark.asyncio
 async def test_session_history_async_enrich_handles_failures(hass, monkeypatch) -> None:
     """Ensure async_enrich collects updates even when some refreshes fail."""
     await hass.config.async_set_time_zone("UTC")

--- a/tests/components/enphase_ev/test_schedule_sync.py
+++ b/tests/components/enphase_ev/test_schedule_sync.py
@@ -567,6 +567,53 @@ async def test_schedule_sync_listener_notified_on_refresh(hass) -> None:
 
 
 @pytest.mark.asyncio
+async def test_schedule_sync_refresh_fetches_serials_concurrently(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"site_id": RANDOM_SITE_ID},
+        options={OPT_SCHEDULE_SYNC_ENABLED: True},
+    )
+    client = SimpleNamespace()
+    client._bearer = lambda: "token"
+    release = asyncio.Event()
+    both_started = asyncio.Event()
+    started: list[str] = []
+
+    async def _get_schedules(sn: str):
+        started.append(sn)
+        if len(started) == 2:
+            both_started.set()
+        await release.wait()
+        return {
+            "meta": {"serverTimeStamp": f"{sn}-ts"},
+            "config": {},
+            "slots": [_slot(f"{sn}:slot-1")],
+        }
+
+    client.get_schedules = AsyncMock(side_effect=_get_schedules)
+    coord = DummyCoordinator(
+        hass,
+        client,
+        entry,
+        data={
+            RANDOM_SERIAL: {"display_name": "Garage Charger"},
+            "SECONDARY": {"display_name": "Driveway Charger"},
+        },
+    )
+    coord.iter_serials = lambda: [RANDOM_SERIAL, "SECONDARY"]  # type: ignore[assignment]
+    sync = ScheduleSync(hass, coord, entry)
+
+    refresh_task = asyncio.create_task(sync.async_refresh(reason="manual"))
+    await asyncio.wait_for(both_started.wait(), timeout=1)
+    release.set()
+    await refresh_task
+
+    assert set(started) == {RANDOM_SERIAL, "SECONDARY"}
+    assert set(sync._slot_cache) == {RANDOM_SERIAL, "SECONDARY"}
+    assert sync._last_status == "ok:manual"
+
+
+@pytest.mark.asyncio
 async def test_schedule_sync_removes_helper_when_slot_removed(hass) -> None:
     slot_id = f"{RANDOM_SITE_ID}:{RANDOM_SERIAL}:slot-3"
     payload = {


### PR DESCRIPTION
## Summary

Improve EV charger scheduler and session-history refresh behavior to reduce coordinator latency without letting active session data drift too far stale.

- fetch EV charger scheduler payloads concurrently during schedule sync refreshes
- make session-history freshness adaptive so active and recently-ended sessions refresh sooner
- keep idle session-history refreshes off the main coordinator hot path until they reach a hard age ceiling
- add regression coverage for the adaptive session-history and concurrent schedule-sync paths

## Related Issues

- None

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

List the exact commands you ran. Prefer the pinned Docker environment from `devtools/docker/`.

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/session_history.py custom_components/enphase_ev/schedule_sync.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_helper_modules.py tests/components/enphase_ev/test_schedule_sync.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/session_history.py custom_components/enphase_ev/schedule_sync.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_helper_modules.py tests/components/enphase_ev/test_schedule_sync.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_schedule_sync.py tests/components/enphase_ev/test_coordinator_behavior.py -k 'schedule_sync or session_history or first_refresh or steady_state_refresh_defers_stale_session_history_when_cached'"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_helper_modules.py -k 'session_history and (adaptive or active_session_history or steady_state_refresh_defers_stale_session_history_when_cached or max_cache_age)'"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_helper_modules.py tests/components/enphase_ev/test_session_history_additional.py tests/components/enphase_ev/test_coordinator_behavior.py -k 'session_history or first_refresh'"
```

Add any extra commands, targeted tests, or manual validation below.

- Targeted Docker checks only; full repository test suite, `pre-commit`, quality-scale validation, and coverage report were not run.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Adaptive session-history policy:
  - active chargers: soft TTL 120s, hard TTL 600s
  - recently-stopped chargers: soft TTL 300s for 10 minutes after `session_end`
  - idle chargers: soft TTL remains the configured cache TTL, with a 300s hard-TTL grace window before inline refresh
