### PR TITLE
Fix same-profile battery reserve writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Switched same-profile IQ Battery reserve changes to the BatteryConfig settings compatibility write path so reserve-only updates apply reliably on sites where the profile endpoint returns success without changing the effective reserve.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -1643,6 +1643,82 @@ class BatteryRuntime:
         coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
         await coord.async_request_refresh()
 
+    async def async_apply_battery_reserve_only(
+        self,
+        *,
+        profile: str,
+        reserve: int,
+        require_exact_pending_match: bool = True,
+    ) -> None:
+        coord = self.coordinator
+        state = self.battery_state
+        normalized_profile = self.normalize_battery_profile_key(profile)
+        if not normalized_profile:
+            self._raise_validation(
+                "battery_profile_unavailable",
+                message="Battery profile is unavailable.",
+            )
+        normalized_reserve = self.normalize_battery_reserve_for_profile(
+            normalized_profile, reserve
+        )
+        normalized_sub_type = self.target_operation_mode_sub_type(normalized_profile)
+        payload = {"batteryBackupPercentage": normalized_reserve}
+        async with state._battery_profile_write_lock:
+            state._battery_profile_last_write_mono = time.monotonic()
+            state._battery_settings_last_write_mono = (
+                state._battery_profile_last_write_mono
+            )
+            try:
+                await coord.client.set_battery_settings_compat(
+                    payload,
+                    merged_payload=True,
+                    strip_devices=True,
+                )
+            except aiohttp.ClientResponseError as err:
+                if err.status == HTTPStatus.FORBIDDEN:
+                    owner = coord.battery_user_is_owner
+                    installer = coord.battery_user_is_installer
+                    if owner is False and installer is False:
+                        self._raise_validation(
+                            "battery_profile_update_not_permitted",
+                            message=(
+                                "Battery profile updates are not permitted for this "
+                                "account."
+                            ),
+                        )
+                    self._raise_validation(
+                        "battery_profile_update_forbidden",
+                        message=(
+                            "Battery profile update was rejected by Enphase "
+                            "(HTTP 403 Forbidden)."
+                        ),
+                    )
+                if err.status == HTTPStatus.UNAUTHORIZED:
+                    self._raise_validation(
+                        "battery_profile_update_unauthorized",
+                        message=(
+                            "Battery profile update could not be authenticated. "
+                            "Reauthenticate and try again."
+                        ),
+                    )
+                raise
+        self.parse_battery_settings_payload(
+            payload,
+            clear_missing_schedule_times=False,
+            clear_missing_reserve_bounds=False,
+        )
+        self.remember_battery_reserve(normalized_profile, normalized_reserve)
+        self.set_battery_pending(
+            profile=normalized_profile,
+            reserve=normalized_reserve,
+            sub_type=normalized_sub_type,
+            require_exact_settings=require_exact_pending_match,
+        )
+        state._storm_guard_cache_until = None
+        state._battery_settings_cache_until = None
+        coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
+        await coord.async_request_refresh()
+
     async def async_apply_battery_settings(self, payload: dict[str, object]) -> None:
         coord = self.coordinator
         state = self.battery_state
@@ -3394,11 +3470,9 @@ class BatteryRuntime:
                 message="Battery reserve is unavailable.",
             )
         normalized = self.normalize_battery_reserve_for_profile(profile, reserve)
-        sub_type = self.target_operation_mode_sub_type(profile)
-        await self.async_apply_battery_profile(
+        await self.async_apply_battery_reserve_only(
             profile=profile,
             reserve=normalized,
-            sub_type=sub_type,
         )
 
     async def async_set_savings_use_battery_after_peak(self, enabled: bool) -> None:

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -450,16 +450,18 @@ async def test_battery_profile_write_blocked_for_read_only_user(
     coord._battery_show_charge_from_grid = True  # noqa: SLF001
     coord._battery_user_is_owner = False  # noqa: SLF001
     coord._battery_user_is_installer = False  # noqa: SLF001
-    coord.client.set_battery_profile = AsyncMock(return_value={"message": "success"})
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
+    )
 
     assert coord.battery_reserve_editable is False
     with pytest.raises(ServiceValidationError, match="not permitted"):
         await coord.async_set_battery_reserve(30)
-    coord.client.set_battery_profile.assert_not_awaited()
+    coord.client.set_battery_settings_compat.assert_not_awaited()
 
 
 @pytest.mark.asyncio
-async def test_battery_profile_write_refreshes_permission_when_role_unknown(
+async def test_battery_reserve_write_succeeds_when_role_unknown(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -468,19 +470,19 @@ async def test_battery_profile_write_refreshes_permission_when_role_unknown(
     coord._battery_show_charge_from_grid = True  # noqa: SLF001
     coord._battery_user_is_owner = None  # noqa: SLF001
     coord._battery_user_is_installer = None  # noqa: SLF001
-    coord.client.battery_site_settings = AsyncMock(
-        side_effect=lambda: {
-            "data": {"userDetails": {"isOwner": True, "isInstaller": False}}
-        }
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
     )
-    coord.client.set_battery_profile = AsyncMock(return_value={"message": "success"})
     coord.async_request_refresh = AsyncMock()
     coord.kick_fast = MagicMock()
 
     await coord.async_set_battery_reserve(30)
 
-    coord.client.battery_site_settings.assert_awaited_once()
-    coord.client.set_battery_profile.assert_awaited_once()
+    coord.client.set_battery_settings_compat.assert_awaited_once_with(
+        {"batteryBackupPercentage": 30},
+        merged_payload=True,
+        strip_devices=True,
+    )
 
 
 @pytest.mark.asyncio
@@ -493,7 +495,7 @@ async def test_battery_profile_forbidden_translates_to_validation_error(
     coord._battery_profile = "self-consumption"  # noqa: SLF001
     coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
     coord._battery_show_charge_from_grid = True  # noqa: SLF001
-    coord.client.set_battery_profile = AsyncMock(
+    coord.client.set_battery_settings_compat = AsyncMock(
         side_effect=aiohttp.ClientResponseError(
             request_info=None,
             history=(),
@@ -569,7 +571,7 @@ async def test_battery_profile_forbidden_after_permission_change_returns_permiss
 
 
 @pytest.mark.asyncio
-async def test_battery_profile_write_calls_client_set_battery_profile(
+async def test_battery_reserve_write_calls_client_set_battery_settings_compat(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -583,22 +585,16 @@ async def test_battery_profile_write_calls_client_set_battery_profile(
     ]
     coord.async_request_refresh = AsyncMock()
     coord.kick_fast = MagicMock()
-    coord.client.set_battery_profile = AsyncMock(return_value={"message": "success"})
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
+    )
 
     await coord.async_set_battery_reserve(30)
 
-    coord.client.set_battery_profile.assert_awaited_once_with(
-        profile="self-consumption",
-        battery_backup_percentage=30,
-        operation_mode_sub_type=None,
-        devices=[
-            {
-                "uuid": "evse-1",
-                "deviceType": "iqEvse",
-                "enable": False,
-                "chargeMode": "MANUAL",
-            }
-        ],
+    coord.client.set_battery_settings_compat.assert_awaited_once_with(
+        {"batteryBackupPercentage": 30},
+        merged_payload=True,
+        strip_devices=True,
     )
 
 
@@ -614,7 +610,7 @@ async def test_battery_profile_write_forbidden_translates_from_client_call(
     coord._battery_show_charge_from_grid = True  # noqa: SLF001
     coord._battery_user_is_owner = True  # noqa: SLF001
     coord._battery_user_is_installer = False  # noqa: SLF001
-    coord.client.set_battery_profile = AsyncMock(
+    coord.client.set_battery_settings_compat = AsyncMock(
         side_effect=aiohttp.ClientResponseError(
             request_info=None,
             history=(),
@@ -639,7 +635,7 @@ async def test_battery_profile_write_read_only_user_translates_permission_error(
     coord._battery_show_charge_from_grid = True  # noqa: SLF001
     coord._battery_user_is_owner = False  # noqa: SLF001
     coord._battery_user_is_installer = False  # noqa: SLF001
-    coord.client.set_battery_profile = AsyncMock(
+    coord.client.set_battery_settings_compat = AsyncMock(
         side_effect=aiohttp.ClientResponseError(
             request_info=None,
             history=(),
@@ -650,6 +646,86 @@ async def test_battery_profile_write_read_only_user_translates_permission_error(
 
     with pytest.raises(ServiceValidationError, match="not permitted"):
         await coord.async_set_battery_reserve(30)
+
+
+@pytest.mark.asyncio
+async def test_battery_reserve_write_direct_helper_rejects_missing_profile(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+
+    with pytest.raises(ServiceValidationError, match="Battery profile is unavailable"):
+        await coord.battery_runtime.async_apply_battery_reserve_only(
+            profile="",
+            reserve=30,
+        )
+
+
+@pytest.mark.asyncio
+async def test_battery_reserve_write_direct_helper_forbidden_read_only_user(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_user_is_owner = False  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.client.set_battery_settings_compat = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=403,
+            message="Forbidden",
+        )
+    )
+
+    with pytest.raises(ServiceValidationError, match="not permitted"):
+        await coord.battery_runtime.async_apply_battery_reserve_only(
+            profile="self-consumption",
+            reserve=30,
+        )
+
+
+@pytest.mark.asyncio
+async def test_battery_reserve_write_direct_helper_translates_auth_and_reraises(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord.client.set_battery_settings_compat = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=401,
+            message="Unauthorized",
+        )
+    )
+
+    with pytest.raises(ServiceValidationError, match="Reauthenticate"):
+        await coord.battery_runtime.async_apply_battery_reserve_only(
+            profile="self-consumption",
+            reserve=30,
+        )
+
+    coord.client.set_battery_settings_compat = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=500,
+            message="boom",
+        )
+    )
+
+    with pytest.raises(aiohttp.ClientResponseError) as err:
+        await coord.battery_runtime.async_apply_battery_reserve_only(
+            profile="self-consumption",
+            reserve=30,
+        )
+    assert err.value.status == 500
+    assert err.value.message == "boom"
 
 
 @pytest.mark.asyncio
@@ -1182,6 +1258,7 @@ async def test_battery_profile_setter_validation_and_fallbacks(
 
     coord = coordinator_factory()
     coord.client.set_battery_profile = AsyncMock(return_value={"message": "success"})
+    coord.client.set_battery_settings_compat = AsyncMock(return_value={})
     coord.client.battery_site_settings = AsyncMock(return_value={"data": {}})
     coord.async_request_refresh = AsyncMock()
     coord.kick_fast = MagicMock()
@@ -1210,9 +1287,11 @@ async def test_battery_profile_setter_validation_and_fallbacks(
     coord._battery_backup_percentage = 25  # noqa: SLF001
     coord._battery_operation_mode_sub_type = "prioritize-energy"  # noqa: SLF001
     await coord.async_set_battery_reserve(5)
-    kwargs = coord.client.set_battery_profile.await_args.kwargs
-    assert kwargs["battery_backup_percentage"] == 5
-    assert kwargs["operation_mode_sub_type"] == "prioritize-energy"
+    args = coord.client.set_battery_settings_compat.await_args.args
+    kwargs = coord.client.set_battery_settings_compat.await_args.kwargs
+    assert args[0] == {"batteryBackupPercentage": 5}
+    assert kwargs == {"merged_payload": True, "strip_devices": True}
+    assert coord._battery_pending_sub_type == "prioritize-energy"  # noqa: SLF001
 
     coord._clear_battery_pending()  # noqa: SLF001
     coord._battery_profile = "self-consumption"  # noqa: SLF001
@@ -1223,11 +1302,13 @@ async def test_battery_profile_setter_validation_and_fallbacks(
     coord._battery_backup_percentage = 10  # noqa: SLF001
     coord._battery_operation_mode_sub_type = "prioritize-energy"  # noqa: SLF001
     coord._battery_profile_last_write_mono = time.monotonic() - 10  # noqa: SLF001
-    coord.client.set_battery_profile.reset_mock()
+    coord.client.set_battery_settings_compat.reset_mock()
     await coord.async_set_battery_reserve(5)
-    kwargs = coord.client.set_battery_profile.await_args.kwargs
-    assert kwargs["battery_backup_percentage"] == 5
-    assert kwargs["operation_mode_sub_type"] == "prioritize-energy"
+    args = coord.client.set_battery_settings_compat.await_args.args
+    kwargs = coord.client.set_battery_settings_compat.await_args.kwargs
+    assert args[0] == {"batteryBackupPercentage": 5}
+    assert kwargs == {"merged_payload": True, "strip_devices": True}
+    assert coord._battery_pending_sub_type == "prioritize-energy"  # noqa: SLF001
 
     coord._clear_battery_pending()  # noqa: SLF001
     coord._battery_profile = "cost_savings"  # noqa: SLF001


### PR DESCRIPTION
## Summary

Fixes same-profile IQ Battery reserve updates on sites where the profile write path returns success without changing the effective reserve. Reserve-only writes now use the BatteryConfig settings compatibility path with a merged payload and stripped `devices`, which matches the live Enphase request shape that applied correctly during local account verification. Fixes #518.

## Related Issues

- #518

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_coordinator_battery_profile.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev/test_coordinator_battery_profile.py tests/components/enphase_ev/test_battery_runtime_settings.py -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py"
```

Extra manual validation:
- Verified against a live Enphase site in the local dev environment that `Self-Consumption / 20% -> 45% -> 20%` reserve-only writes now converge correctly.
- Restored the site to `Self-Consumption / 20%` after validation.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Live investigation showed that same-profile reserve changes could return success through `set_battery_profile(...)` while leaving the effective reserve unchanged.
- The compatible `batterySettings` merged payload succeeded only when `devices` was stripped, which is the request shape this change now uses for reserve-only updates.
