### PR TITLE
Restore reserve-only battery write guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Switched same-profile IQ Battery reserve changes to the BatteryConfig settings compatibility write path so reserve-only updates apply reliably on sites where the profile endpoint returns success without changing the effective reserve.
+- Restored the normal battery write-access refresh, debounce checks, and settings-write lock for same-profile reserve-only updates so the new compatibility write path preserves the existing guard rails.
 
 ### 🔧 Improvements
 - Reduced EV charger refresh-path latency by fetching scheduler payloads concurrently across chargers during sync refreshes, and made session-history freshness adaptive so active/recently-ended sessions refresh sooner while idle chargers keep background refreshes off the main coordinator hot path.

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -1663,45 +1663,48 @@ class BatteryRuntime:
         )
         normalized_sub_type = self.target_operation_mode_sub_type(normalized_profile)
         payload = {"batteryBackupPercentage": normalized_reserve}
+        await self.async_assert_battery_profile_write_allowed()
+        self.assert_battery_settings_write_allowed()
         async with state._battery_profile_write_lock:
-            state._battery_profile_last_write_mono = time.monotonic()
-            state._battery_settings_last_write_mono = (
-                state._battery_profile_last_write_mono
-            )
-            try:
-                await coord.client.set_battery_settings_compat(
-                    payload,
-                    merged_payload=True,
-                    strip_devices=True,
+            async with state._battery_settings_write_lock:
+                state._battery_profile_last_write_mono = time.monotonic()
+                state._battery_settings_last_write_mono = (
+                    state._battery_profile_last_write_mono
                 )
-            except aiohttp.ClientResponseError as err:
-                if err.status == HTTPStatus.FORBIDDEN:
-                    owner = coord.battery_user_is_owner
-                    installer = coord.battery_user_is_installer
-                    if owner is False and installer is False:
+                try:
+                    await coord.client.set_battery_settings_compat(
+                        payload,
+                        merged_payload=True,
+                        strip_devices=True,
+                    )
+                except aiohttp.ClientResponseError as err:
+                    if err.status == HTTPStatus.FORBIDDEN:
+                        owner = coord.battery_user_is_owner
+                        installer = coord.battery_user_is_installer
+                        if owner is False and installer is False:
+                            self._raise_validation(
+                                "battery_profile_update_not_permitted",
+                                message=(
+                                    "Battery profile updates are not permitted for this "
+                                    "account."
+                                ),
+                            )
                         self._raise_validation(
-                            "battery_profile_update_not_permitted",
+                            "battery_profile_update_forbidden",
                             message=(
-                                "Battery profile updates are not permitted for this "
-                                "account."
+                                "Battery profile update was rejected by Enphase "
+                                "(HTTP 403 Forbidden)."
                             ),
                         )
-                    self._raise_validation(
-                        "battery_profile_update_forbidden",
-                        message=(
-                            "Battery profile update was rejected by Enphase "
-                            "(HTTP 403 Forbidden)."
-                        ),
-                    )
-                if err.status == HTTPStatus.UNAUTHORIZED:
-                    self._raise_validation(
-                        "battery_profile_update_unauthorized",
-                        message=(
-                            "Battery profile update could not be authenticated. "
-                            "Reauthenticate and try again."
-                        ),
-                    )
-                raise
+                    if err.status == HTTPStatus.UNAUTHORIZED:
+                        self._raise_validation(
+                            "battery_profile_update_unauthorized",
+                            message=(
+                                "Battery profile update could not be authenticated. "
+                                "Reauthenticate and try again."
+                            ),
+                        )
+                    raise
         self.parse_battery_settings_payload(
             payload,
             clear_missing_schedule_times=False,

--- a/tests/components/enphase_ev/test_coordinator_battery_profile.py
+++ b/tests/components/enphase_ev/test_coordinator_battery_profile.py
@@ -689,6 +689,37 @@ async def test_battery_reserve_write_direct_helper_forbidden_read_only_user(
 
 
 @pytest.mark.asyncio
+async def test_battery_reserve_write_direct_helper_forbidden_after_permission_change(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+
+    async def _forbidden_after_role_change(*_args, **_kwargs):
+        coord._battery_user_is_owner = False  # noqa: SLF001
+        coord._battery_user_is_installer = False  # noqa: SLF001
+        raise aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=403,
+            message="Forbidden",
+        )
+
+    coord.client.set_battery_settings_compat = AsyncMock(
+        side_effect=_forbidden_after_role_change
+    )
+
+    with pytest.raises(ServiceValidationError, match="not permitted"):
+        await coord.battery_runtime.async_apply_battery_reserve_only(
+            profile="self-consumption",
+            reserve=30,
+        )
+
+
+@pytest.mark.asyncio
 async def test_battery_reserve_write_direct_helper_translates_auth_and_reraises(
     coordinator_factory,
 ) -> None:
@@ -718,6 +749,8 @@ async def test_battery_reserve_write_direct_helper_translates_auth_and_reraises(
             message="boom",
         )
     )
+    coord._battery_profile_last_write_mono = time.monotonic() - 10  # noqa: SLF001
+    coord._battery_settings_last_write_mono = time.monotonic() - 10  # noqa: SLF001
 
     with pytest.raises(aiohttp.ClientResponseError) as err:
         await coord.battery_runtime.async_apply_battery_reserve_only(
@@ -726,6 +759,112 @@ async def test_battery_reserve_write_direct_helper_translates_auth_and_reraises(
         )
     assert err.value.status == 500
     assert err.value.message == "boom"
+
+
+@pytest.mark.asyncio
+async def test_battery_reserve_write_direct_helper_refreshes_unknown_write_access(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_backup_percentage = 20  # noqa: SLF001
+    coord._battery_user_is_owner = None  # noqa: SLF001
+    coord._battery_user_is_installer = None  # noqa: SLF001
+    coord.client.battery_site_settings = AsyncMock(
+        return_value={"data": {"userDetails": {"isOwner": True, "isInstaller": False}}}
+    )
+    coord.client.set_battery_settings_compat = AsyncMock(return_value={})
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+
+    await coord.battery_runtime.async_apply_battery_reserve_only(
+        profile="self-consumption",
+        reserve=30,
+    )
+
+    coord.client.battery_site_settings.assert_awaited_once()
+    coord.client.set_battery_settings_compat.assert_awaited_once_with(
+        {"batteryBackupPercentage": 30},
+        merged_payload=True,
+        strip_devices=True,
+    )
+    assert coord.battery_user_is_owner is True
+    assert coord.battery_write_access_confirmed is True
+
+
+@pytest.mark.asyncio
+async def test_battery_reserve_write_direct_helper_rejects_settings_debounce(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord._battery_profile_last_write_mono = time.monotonic() - 10  # noqa: SLF001
+    coord._battery_settings_last_write_mono = time.monotonic()  # noqa: SLF001
+    coord.client.set_battery_settings_compat = AsyncMock(return_value={})
+
+    with pytest.raises(ServiceValidationError, match="too quickly"):
+        await coord.battery_runtime.async_apply_battery_reserve_only(
+            profile="self-consumption",
+            reserve=30,
+        )
+
+    coord.client.set_battery_settings_compat.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_battery_reserve_write_direct_helper_rejects_settings_lock(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord._battery_profile_last_write_mono = time.monotonic() - 10  # noqa: SLF001
+    coord._battery_settings_last_write_mono = time.monotonic() - 10  # noqa: SLF001
+    coord.client.set_battery_settings_compat = AsyncMock(return_value={})
+
+    await coord._battery_settings_write_lock.acquire()  # noqa: SLF001
+    try:
+        with pytest.raises(ServiceValidationError, match="already in progress"):
+            await coord.battery_runtime.async_apply_battery_reserve_only(
+                profile="self-consumption",
+                reserve=30,
+            )
+    finally:
+        coord._battery_settings_write_lock.release()  # noqa: SLF001
+
+    coord.client.set_battery_settings_compat.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_battery_reserve_write_direct_helper_holds_settings_lock_during_write(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord._battery_profile_last_write_mono = time.monotonic() - 10  # noqa: SLF001
+    coord._battery_settings_last_write_mono = time.monotonic() - 10  # noqa: SLF001
+    coord.async_request_refresh = AsyncMock()
+    coord.kick_fast = MagicMock()
+
+    async def _fake_write(*args, **kwargs):
+        assert coord._battery_profile_write_lock.locked()  # noqa: SLF001
+        assert coord._battery_settings_write_lock.locked()  # noqa: SLF001
+        return {}
+
+    coord.client.set_battery_settings_compat = AsyncMock(side_effect=_fake_write)
+
+    await coord.battery_runtime.async_apply_battery_reserve_only(
+        profile="self-consumption",
+        reserve=30,
+    )
+
+    coord.client.set_battery_settings_compat.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -766,6 +905,34 @@ async def test_battery_profile_unauthorized_translates_to_reauth_error(
     )
 
     with pytest.raises(ServiceValidationError, match="Reauthenticate"):
+        await coord._async_apply_battery_profile(  # noqa: SLF001
+            profile="self-consumption",
+            reserve=30,
+        )
+
+
+@pytest.mark.asyncio
+async def test_battery_profile_forbidden_translates_to_http_403_error(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    coord = coordinator_factory()
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord._battery_user_is_owner = True  # noqa: SLF001
+    coord._battery_user_is_installer = False  # noqa: SLF001
+    coord.client.set_battery_profile = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=403,
+            message="Forbidden",
+        )
+    )
+
+    with pytest.raises(ServiceValidationError, match="HTTP 403 Forbidden"):
         await coord._async_apply_battery_profile(  # noqa: SLF001
             profile="self-consumption",
             reserve=30,
@@ -1302,6 +1469,7 @@ async def test_battery_profile_setter_validation_and_fallbacks(
     coord._battery_backup_percentage = 10  # noqa: SLF001
     coord._battery_operation_mode_sub_type = "prioritize-energy"  # noqa: SLF001
     coord._battery_profile_last_write_mono = time.monotonic() - 10  # noqa: SLF001
+    coord._battery_settings_last_write_mono = time.monotonic() - 10  # noqa: SLF001
     coord.client.set_battery_settings_compat.reset_mock()
     await coord.async_set_battery_reserve(5)
     args = coord.client.set_battery_settings_compat.await_args.args


### PR DESCRIPTION
## Summary

Follow up the reserve-only IQ Battery fix from #579 by restoring the existing battery write safeguards on `async_apply_battery_reserve_only()`.

This keeps the BatteryConfig settings compatibility write shape for same-profile reserve changes, but also:
- re-runs battery write-access confirmation when owner/installer status is unknown
- enforces both profile and settings debounce checks
- serializes reserve-only writes with the existing battery-settings lock

## Related Issues

- Related to #460
- Related to #518
- Follow-up to #579

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

Exact commands run:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_coordinator_battery_profile.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_coordinator_battery_profile.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_battery_profile.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py --fail-under=100"
```

Additional manual validation:
- exercised the reserve-only path against the local dev account/config entry in Docker and confirmed the patched flow re-fetched BatteryConfig site settings when owner/installer state was unknown before proceeding with the write path

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The live dev-account validation confirmed the narrow follow-up fix: `async_apply_battery_reserve_only()` now refreshes battery write access when role state is unknown before it attempts the compatibility write.

It did not prove that the broader same-profile reserve update itself is effective on this account. During the live check, the backend still read back the original reserve after the write path returned, with no backend pending flag. That appears to be a separate Enphase / reserve-write behavior issue, so this PR is intentionally scoped to restoring the missing guard rails dropped by #579.