### PR TITLE
Apply battery settings after schedule CRUD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Fixed IQ Battery schedule create, save, and delete flows so CFG/DTG/RBD changes now send the follow-up `batterySettings` apply write Enphase requires before the schedule family leaves the cloud-side `pending` state.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -1317,7 +1317,21 @@ class BatteryRuntime:
         if not callable(normalize):
             normalize = getattr(self.coordinator, "_normalize_minutes_of_day", None)
         if callable(normalize):
-            return normalize(value)
+            normalized = normalize(value)
+            if normalized is not None:
+                return normalized
+        if isinstance(value, str):
+            text = value.strip()
+            if ":" in text:
+                hour_text, minute_text, *_rest = text.split(":")
+                try:
+                    hours = int(hour_text)
+                    minutes = int(minute_text)
+                except ValueError:
+                    return None
+                if 0 <= hours < 24 and 0 <= minutes < 60:
+                    return hours * 60 + minutes
+                return None
         if value is None:
             return None
         try:
@@ -1541,7 +1555,9 @@ class BatteryRuntime:
         timezone: str,
         is_enabled: bool | None = None,
         is_deleted: bool | None = None,
+        apply_settings: bool = True,
     ) -> None:
+        normalized_schedule_type = str(schedule_type).lower()
         self._raise_schedule_overlap_validation_error(
             start_time=start_time,
             end_time=end_time,
@@ -1563,6 +1579,237 @@ class BatteryRuntime:
         except aiohttp.ClientResponseError as err:
             self.raise_schedule_update_validation_error(err)
             raise
+        if (
+            apply_settings
+            and normalized_schedule_type in {"cfg", "dtg", "rbd"}
+            and not is_deleted
+        ):
+            await self.async_apply_schedule_family_settings(
+                normalized_schedule_type,
+                start_time=start_time,
+                end_time=end_time,
+                enabled=is_enabled,
+            )
+
+    async def async_create_battery_schedule(
+        self,
+        *,
+        schedule_type: str,
+        start_time: str,
+        end_time: str,
+        limit: int | None,
+        days: list[int],
+        timezone: str,
+        is_enabled: bool | None = None,
+    ) -> None:
+        normalized_schedule_type = str(schedule_type).lower()
+        self._raise_schedule_overlap_validation_error(
+            start_time=start_time,
+            end_time=end_time,
+            days=days,
+        )
+        try:
+            await self.coordinator.client.create_battery_schedule(
+                schedule_type=schedule_type,
+                start_time=start_time,
+                end_time=end_time,
+                limit=limit,
+                days=days,
+                timezone=timezone,
+                is_enabled=is_enabled,
+            )
+        except aiohttp.ClientResponseError as err:
+            self.raise_schedule_update_validation_error(err)
+            raise
+        if normalized_schedule_type in {"cfg", "dtg", "rbd"}:
+            await self.async_apply_schedule_family_settings(
+                normalized_schedule_type,
+                start_time=start_time,
+                end_time=end_time,
+                enabled=is_enabled,
+            )
+
+    async def async_delete_battery_schedule(
+        self,
+        schedule_id: str,
+        *,
+        schedule_type: str = "cfg",
+        start_time: object | None = None,
+        end_time: object | None = None,
+        enabled: bool | None = None,
+    ) -> None:
+        normalized_schedule_type = str(schedule_type).lower()
+        try:
+            await self.coordinator.client.delete_battery_schedule(
+                schedule_id,
+                schedule_type=normalized_schedule_type,
+            )
+        except aiohttp.ClientResponseError as err:
+            self.raise_schedule_update_validation_error(err)
+            raise
+        if normalized_schedule_type in {"cfg", "dtg", "rbd"}:
+            await self.async_apply_schedule_family_settings(
+                normalized_schedule_type,
+                start_time=start_time,
+                end_time=end_time,
+                enabled=enabled,
+            )
+
+    def _schedule_family_effective_enabled(
+        self, schedule_type: str, enabled: bool | None
+    ) -> bool:
+        if enabled is not None:
+            return bool(enabled)
+
+        coord = self.coordinator
+        effective = getattr(coord, "_battery_schedule_effective_enabled", None)
+        if callable(effective):
+            resolved = effective(schedule_type)
+            if resolved is not None:
+                return bool(resolved)
+
+        state = self.battery_state
+        normalized_schedule_type = str(schedule_type).lower()
+        if normalized_schedule_type == "cfg":
+            resolved = getattr(coord, "battery_charge_from_grid_schedule_enabled", None)
+            if resolved is None:
+                resolved = getattr(
+                    state, "_battery_charge_from_grid_schedule_enabled", None
+                )
+            if resolved is None:
+                resolved = getattr(
+                    coord, "battery_cfg_control_force_schedule_opted", None
+                )
+        else:
+            resolved = getattr(
+                state,
+                self._battery_schedule_enabled_attr(normalized_schedule_type),
+                None,
+            )
+            if resolved is None:
+                control = getattr(
+                    coord, f"battery_{normalized_schedule_type}_control", None
+                )
+                if isinstance(control, dict):
+                    resolved = self._coerce_optional_bool(control.get("enabled"))
+        return bool(resolved) if resolved is not None else False
+
+    def _schedule_family_settings_payload(
+        self,
+        schedule_type: str,
+        *,
+        start_minutes: int | None,
+        end_minutes: int | None,
+        enabled: bool,
+    ) -> dict[str, object] | None:
+        normalized_schedule_type = str(schedule_type).lower()
+        coord = self.coordinator
+        if normalized_schedule_type == "cfg":
+            if start_minutes is None or end_minutes is None:
+                return None
+            if start_minutes == end_minutes:
+                self._raise_validation(
+                    "charge_from_grid_schedule_times_different",
+                    message=(
+                        "Charge-from-grid schedule start and end times must be "
+                        "different."
+                    ),
+                )
+            charge_from_grid_enabled = getattr(
+                coord, "battery_charge_from_grid_enabled", None
+            )
+            if charge_from_grid_enabled is None:
+                charge_from_grid_enabled = getattr(
+                    self.battery_state, "_battery_charge_from_grid", None
+                )
+            payload: dict[str, object] = {
+                "chargeFromGrid": (True if enabled else bool(charge_from_grid_enabled)),
+                "chargeFromGridScheduleEnabled": bool(enabled),
+                "chargeBeginTime": start_minutes,
+                "chargeEndTime": end_minutes,
+                "acceptedItcDisclaimer": self.battery_itc_disclaimer_value(),
+            }
+            cfg_control = coord.battery_cfg_control
+            if isinstance(cfg_control, dict):
+                cfg_payload: dict[str, object] = {}
+                field_map = {
+                    "show": "show",
+                    "enabled": "enabled",
+                    "locked": "locked",
+                    "show_day_schedule": "showDaySchedule",
+                    "schedule_supported": "scheduleSupported",
+                    "force_schedule_supported": "forceScheduleSupported",
+                }
+                for source_key, target_key in field_map.items():
+                    value = cfg_control.get(source_key)
+                    if value is not None:
+                        cfg_payload[target_key] = value
+                cfg_payload["forceScheduleOpted"] = bool(enabled)
+                payload["cfgControl"] = cfg_payload
+            return payload
+
+        if normalized_schedule_type not in {"dtg", "rbd"}:
+            return None
+        return {
+            f"{normalized_schedule_type}Control": self._schedule_family_control_payload(
+                normalized_schedule_type,
+                enabled=enabled,
+                current_start=start_minutes,
+                current_end=end_minutes,
+            )
+        }
+
+    async def async_apply_schedule_family_settings(
+        self,
+        schedule_type: str,
+        *,
+        start_time: object | None = None,
+        end_time: object | None = None,
+        enabled: bool | None = None,
+    ) -> None:
+        normalized_schedule_type = str(schedule_type).lower()
+        if normalized_schedule_type not in {"cfg", "dtg", "rbd"}:
+            return
+
+        coord = self.coordinator
+        start_minutes = self._normalize_schedule_minutes(start_time)
+        end_minutes = self._normalize_schedule_minutes(end_time)
+        if start_minutes is None or end_minutes is None:
+            current_start, current_end = self._current_battery_schedule_window_for_type(
+                normalized_schedule_type
+            )
+            if start_minutes is None:
+                start_minutes = current_start
+            if end_minutes is None:
+                end_minutes = current_end
+
+        payload = self._schedule_family_settings_payload(
+            normalized_schedule_type,
+            start_minutes=start_minutes,
+            end_minutes=end_minutes,
+            enabled=self._schedule_family_effective_enabled(
+                normalized_schedule_type, enabled
+            ),
+        )
+        if payload is None:
+            return
+
+        try:
+            await coord.client.set_battery_settings(
+                payload,
+                schedule_type=normalized_schedule_type,
+            )
+        except aiohttp.ClientResponseError as err:
+            if err.status != HTTPStatus.FORBIDDEN:
+                self.raise_schedule_update_validation_error(err)
+                raise
+            await coord.client.set_battery_settings_compat(
+                payload,
+                schedule_type=normalized_schedule_type,
+                include_source=False,
+                merged_payload=True,
+                strip_devices=True,
+            )
 
     async def async_apply_battery_profile(
         self,
@@ -3767,7 +4014,7 @@ class BatteryRuntime:
                     end_time=end_hhmm,
                     days=days,
                 )
-                await coord.client.create_battery_schedule(
+                await self.async_create_battery_schedule(
                     schedule_type="CFG",
                     start_time=start_hhmm,
                     end_time=end_hhmm,
@@ -4233,19 +4480,15 @@ class BatteryRuntime:
             end_time=end_time,
             days=days,
         )
-        try:
-            await coord.client.create_battery_schedule(
-                schedule_type=str(schedule_type).upper(),
-                start_time=start_time,
-                end_time=end_time,
-                limit=create_limit,
-                days=days,
-                timezone=timezone,
-                is_enabled=is_enabled,
-            )
-        except aiohttp.ClientResponseError as err:
-            self.raise_schedule_update_validation_error(err)
-            raise
+        await self.async_create_battery_schedule(
+            schedule_type=str(schedule_type).upper(),
+            start_time=start_time,
+            end_time=end_time,
+            limit=create_limit,
+            days=days,
+            timezone=timezone,
+            is_enabled=is_enabled,
+        )
 
     async def _async_set_schedule_family_enabled(
         self, schedule_type: str, enabled: bool

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -325,6 +325,60 @@ def async_setup_services(
             for schedule in battery_schedule_inventory(coord)
         }
 
+    def _remaining_schedule_for_delete_family(
+        coord: EnphaseCoordinator,
+        schedule_type: str,
+        deleted_schedule_ids: set[str],
+    ) -> object | None:
+        normalized_schedule_type = str(schedule_type).lower()
+        selected_schedule_id = getattr(
+            coord, f"_battery_{normalized_schedule_type}_schedule_id", None
+        )
+        remaining = [
+            schedule
+            for schedule in battery_schedule_inventory(coord)
+            if schedule.schedule_type == normalized_schedule_type
+            and schedule.schedule_id not in deleted_schedule_ids
+        ]
+        if not remaining:
+            return None
+        if selected_schedule_id is not None:
+            for schedule in remaining:
+                if schedule.schedule_id == selected_schedule_id:
+                    return schedule
+        for schedule in remaining:
+            if schedule.enabled is True:
+                return schedule
+        return remaining[0]
+
+    def _apply_schedule_for_update(
+        coord: EnphaseCoordinator,
+        *,
+        schedule_inventory: dict[str, object],
+        schedule_id: str,
+        schedule_type: str,
+        start_time: str,
+        end_time: str,
+        enabled: bool | None,
+    ) -> tuple[str, str, bool | None]:
+        normalized_schedule_type = str(schedule_type).lower()
+        selected_schedule_id = getattr(
+            coord, f"_battery_{normalized_schedule_type}_schedule_id", None
+        )
+        if selected_schedule_id is None or selected_schedule_id == schedule_id:
+            return start_time, end_time, enabled
+        selected_schedule = schedule_inventory.get(str(selected_schedule_id))
+        if (
+            selected_schedule is not None
+            and selected_schedule.schedule_type == normalized_schedule_type
+        ):
+            return (
+                selected_schedule.start_time,
+                selected_schedule.end_time,
+                selected_schedule.enabled,
+            )
+        return start_time, end_time, enabled
+
     def _validate_schedule_overlap(
         coord: EnphaseCoordinator,
         *,
@@ -578,7 +632,7 @@ def async_setup_services(
                 message="Battery schedule API is unavailable.",
             )
         try:
-            await creator(
+            await coord.battery_runtime.async_create_battery_schedule(
                 schedule_type=str(schedule_type).upper(),
                 start_time=start_str,
                 end_time=end_str,
@@ -652,8 +706,19 @@ def async_setup_services(
                 "battery_schedule_api_unavailable",
                 message="Battery schedule API is unavailable.",
             )
+        apply_start_str, apply_end_str, apply_enabled = _apply_schedule_for_update(
+            coord,
+            schedule_inventory=schedule_inventory,
+            schedule_id=schedule_id,
+            schedule_type=schedule_type,
+            start_time=start_str,
+            end_time=end_str,
+            enabled=(
+                existing_schedule.enabled if existing_schedule is not None else None
+            ),
+        )
         try:
-            await updater(
+            await coord.battery_runtime.async_update_battery_schedule(
                 schedule_id,
                 schedule_type=str(schedule_type).upper(),
                 start_time=start_str,
@@ -669,6 +734,13 @@ def async_setup_services(
                     or hass.config.time_zone
                     or "UTC"
                 ),
+                apply_settings=False,
+            )
+            await coord.battery_runtime.async_apply_schedule_family_settings(
+                schedule_type,
+                start_time=apply_start_str,
+                end_time=apply_end_str,
+                enabled=apply_enabled,
             )
         except aiohttp.ClientResponseError as err:
             coord.battery_runtime.raise_schedule_update_validation_error(err)
@@ -731,6 +803,7 @@ def async_setup_services(
             )
         schedule_inventory = _schedule_inventory_by_id(coord)
         requested_schedule_type = call.data.get("schedule_type")
+        deleted_schedule_ids_by_family: dict[str, set[str]] = {}
         for schedule_id in schedule_ids:
             schedule = schedule_inventory.get(schedule_id)
             schedule_type = (
@@ -743,13 +816,35 @@ def async_setup_services(
                 )
             )
             try:
-                await deleter(
-                    schedule_id,
-                    schedule_type=schedule_type,
-                )
+                await deleter(schedule_id, schedule_type=schedule_type)
             except aiohttp.ClientResponseError as err:
                 coord.battery_runtime.raise_schedule_update_validation_error(err)
                 raise
+            deleted_schedule_ids_by_family.setdefault(
+                str(schedule_type).lower(), set()
+            ).add(schedule_id)
+        for schedule_type, deleted_ids in deleted_schedule_ids_by_family.items():
+            remaining_schedule = _remaining_schedule_for_delete_family(
+                coord, schedule_type, deleted_ids
+            )
+            await coord.battery_runtime.async_apply_schedule_family_settings(
+                schedule_type,
+                start_time=(
+                    remaining_schedule.start_time
+                    if remaining_schedule is not None
+                    else None
+                ),
+                end_time=(
+                    remaining_schedule.end_time
+                    if remaining_schedule is not None
+                    else None
+                ),
+                enabled=(
+                    remaining_schedule.enabled
+                    if remaining_schedule is not None
+                    else False
+                ),
+            )
         await coord.async_request_refresh()
 
     async def _svc_validate_schedule(call: ServiceCall) -> dict[str, object]:

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -203,6 +203,16 @@ def test_normalize_schedule_minutes_falls_back_without_coordinator_helpers(
     assert runtime._normalize_schedule_minutes("abc") is None  # noqa: SLF001
     assert runtime._normalize_schedule_minutes(1440) is None  # noqa: SLF001
     assert runtime._normalize_schedule_minutes("75") == 75  # noqa: SLF001
+    assert runtime._normalize_schedule_minutes("01:15") == 75  # noqa: SLF001
+
+
+def test_normalize_schedule_minutes_rejects_bad_hhmm_values(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory().battery_runtime
+
+    assert runtime._normalize_schedule_minutes("aa:15") is None  # noqa: SLF001
+    assert runtime._normalize_schedule_minutes("24:00") is None  # noqa: SLF001
 
 
 def test_schedule_family_helper_defaults_and_cfg_window(coordinator_factory) -> None:
@@ -343,6 +353,10 @@ async def test_rbd_schedule_time_uses_default_window_when_missing(
         schedule_supported=True,
     )
     coord.client.create_battery_schedule = AsyncMock(return_value={})
+    coord.client.set_battery_settings = AsyncMock(return_value={"message": "success"})
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
+    )
     coord.client.battery_schedules = AsyncMock(return_value={})
     coord.async_request_refresh = AsyncMock()
     coord.kick_fast = MagicMock()
@@ -359,7 +373,22 @@ async def test_rbd_schedule_time_uses_default_window_when_missing(
         timezone="UTC",
         is_enabled=None,
     )
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "rbdControl": {
+                "enabled": False,
+                "show": True,
+                "locked": False,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "startTime": 120,
+                "endTime": 960,
+            }
+        },
+        schedule_type="rbd",
+    )
     coord.client.create_battery_schedule.reset_mock()
+    coord.client.set_battery_settings.reset_mock()
     coord = coordinator_factory()
     coord._battery_has_encharge = True  # noqa: SLF001
     coord._battery_user_is_owner = True  # noqa: SLF001
@@ -370,6 +399,10 @@ async def test_rbd_schedule_time_uses_default_window_when_missing(
         schedule_supported=True,
     )
     coord.client.create_battery_schedule = AsyncMock(return_value={})
+    coord.client.set_battery_settings = AsyncMock(return_value={"message": "success"})
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
+    )
     coord.client.battery_schedules = AsyncMock(return_value={})
     coord.async_request_refresh = AsyncMock()
     coord.kick_fast = MagicMock()
@@ -385,6 +418,20 @@ async def test_rbd_schedule_time_uses_default_window_when_missing(
         days=[1, 2, 3, 4, 5, 6, 7],
         timezone="UTC",
         is_enabled=None,
+    )
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "rbdControl": {
+                "enabled": False,
+                "show": True,
+                "locked": False,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "startTime": 60,
+                "endTime": 900,
+            }
+        },
+        schedule_type="rbd",
     )
 
 
@@ -2325,6 +2372,9 @@ def _seed_cfg_schedule(coord):
     coord.client.update_battery_schedule = AsyncMock(return_value={})
     coord.client._bp_xsrf_token = "tok"  # noqa: SLF001
     coord.client.set_battery_settings = AsyncMock(return_value={"message": "success"})
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
+    )
     coord.async_request_refresh = AsyncMock()
     coord.kick_fast = MagicMock()
 
@@ -2358,6 +2408,10 @@ def _seed_schedule_family(coord, schedule_type: str) -> None:
         coord._battery_rbd_schedule_timezone = "Europe/London"  # noqa: SLF001
         coord._battery_rbd_schedule_enabled = True  # noqa: SLF001
     coord.client.update_battery_schedule = AsyncMock(return_value={})
+    coord.client.set_battery_settings = AsyncMock(return_value={"message": "success"})
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
+    )
     coord.async_request_refresh = AsyncMock()
     coord.kick_fast = MagicMock()
 
@@ -2396,6 +2450,10 @@ def _seed_no_schedule_family(coord, schedule_type: str) -> None:
         )
     coord._battery_schedules_payload = {schedule_type: {"details": []}}  # noqa: SLF001
     coord.client.create_battery_schedule = AsyncMock(return_value={})
+    coord.client.set_battery_settings = AsyncMock(return_value={"message": "success"})
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
+    )
     coord.async_request_refresh = AsyncMock()
     coord.kick_fast = MagicMock()
 
@@ -2476,6 +2534,12 @@ async def test_cfg_schedule_time_update_uses_in_place_put(
     # delete+create should NOT be used.
     coord.client.delete_battery_schedule.assert_not_awaited()
     coord.client.create_battery_schedule.assert_not_awaited()
+    coord.client.set_battery_settings.assert_awaited_once()
+    payload = coord.client.set_battery_settings.await_args.args[0]
+    assert payload["chargeFromGrid"] is True
+    assert payload["chargeFromGridScheduleEnabled"] is False
+    assert payload["chargeBeginTime"] == 1380
+    assert payload["chargeEndTime"] == 360
 
 
 @pytest.mark.asyncio
@@ -2841,6 +2905,7 @@ async def test_atomic_cfg_schedule_update_updates_state_on_success(
     assert coord._battery_charge_end_time == 360  # noqa: SLF001
     assert coord._battery_cfg_schedule_limit == 95  # noqa: SLF001
     assert coord._battery_settings_cache_until is None  # noqa: SLF001
+    coord.client.set_battery_settings.assert_awaited_once()
     coord.async_request_refresh.assert_awaited_once()
     coord.kick_fast.assert_called_once()
 
@@ -2920,6 +2985,19 @@ async def test_dtg_schedule_time_update_omits_enabled_flag(
     assert call.kwargs["start_time"] == "17:30"
     assert call.kwargs["end_time"] == "23:00"
     assert call.kwargs["is_enabled"] is None
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "dtgControl": {
+                "enabled": True,
+                "show": True,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "startTime": 1050,
+                "endTime": 1380,
+            }
+        },
+        schedule_type="dtg",
+    )
     assert coord._battery_dtg_begin_time == 1050  # noqa: SLF001
 
 
@@ -2954,7 +3032,292 @@ async def test_rbd_schedule_limit_update_uses_in_place_put(
     assert call.kwargs["limit"] == 80
     assert call.kwargs["timezone"] == "Europe/London"
     assert call.kwargs["is_enabled"] is None
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "rbdControl": {
+                "enabled": True,
+                "show": True,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "startTime": 60,
+                "endTime": 960,
+            }
+        },
+        schedule_type="rbd",
+    )
     assert coord._battery_rbd_schedule_limit == 80  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_rbd_schedule_update_uses_compat_apply_after_forbidden_primary_write(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_schedule_family(coord, "rbd")
+    coord.client.set_battery_settings = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=403,
+            message="Forbidden",
+        )
+    )
+
+    await coord.battery_runtime.async_update_battery_schedule(
+        "sched-rbd",
+        schedule_type="RBD",
+        start_time="01:15",
+        end_time="16:15",
+        limit=100,
+        days=[1, 2, 3, 4, 5, 6, 7],
+        timezone="Europe/London",
+    )
+
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "rbdControl": {
+                "enabled": True,
+                "show": True,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "startTime": 75,
+                "endTime": 975,
+            }
+        },
+        schedule_type="rbd",
+    )
+    coord.client.set_battery_settings_compat.assert_awaited_once_with(
+        {
+            "rbdControl": {
+                "enabled": True,
+                "show": True,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "startTime": 75,
+                "endTime": 975,
+            }
+        },
+        schedule_type="rbd",
+        include_source=False,
+        merged_payload=True,
+        strip_devices=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cfg_schedule_update_uses_compat_apply_after_forbidden_primary_write(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_cfg_schedule(coord)
+    coord.client.set_battery_settings = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=403,
+            message="Forbidden",
+        )
+    )
+
+    await coord.battery_runtime.async_update_battery_schedule(
+        "sched-1",
+        schedule_type="CFG",
+        start_time="23:00",
+        end_time="06:00",
+        limit=95,
+        days=[1, 2, 3, 4, 5, 6, 7],
+        timezone="Europe/Lisbon",
+    )
+
+    coord.client.set_battery_settings.assert_awaited_once()
+    payload = coord.client.set_battery_settings.await_args.args[0]
+    assert payload["chargeFromGrid"] is True
+    assert payload["chargeFromGridScheduleEnabled"] is False
+    assert payload["chargeBeginTime"] == 1380
+    assert payload["chargeEndTime"] == 360
+    coord.client.set_battery_settings_compat.assert_awaited_once_with(
+        payload,
+        schedule_type="cfg",
+        include_source=False,
+        merged_payload=True,
+        strip_devices=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_schedule_family_applies_disabled_family_settings(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_schedule_family(coord, "dtg")
+    coord.client.delete_battery_schedule = AsyncMock(return_value={})
+
+    await coord.battery_runtime.async_delete_battery_schedule(
+        "sched-dtg",
+        schedule_type="dtg",
+        enabled=False,
+    )
+
+    coord.client.delete_battery_schedule.assert_awaited_once_with(
+        "sched-dtg",
+        schedule_type="dtg",
+    )
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "dtgControl": {
+                "enabled": False,
+                "show": True,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "startTime": 1080,
+                "endTime": 1380,
+            }
+        },
+        schedule_type="dtg",
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_schedule_family_translates_client_error(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_schedule_family(coord, "dtg")
+    coord.client.delete_battery_schedule = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=403,
+            message="Forbidden",
+        )
+    )
+
+    with pytest.raises(ServiceValidationError, match="403 Forbidden"):
+        await coord.battery_runtime.async_delete_battery_schedule(
+            "sched-dtg",
+            schedule_type="dtg",
+        )
+
+
+@pytest.mark.asyncio
+async def test_delete_schedule_family_reraises_client_error_when_helper_does_not(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    _seed_schedule_family(coord, "dtg")
+    err = aiohttp.ClientResponseError(
+        request_info=None,
+        history=(),
+        status=500,
+        message="boom",
+    )
+    coord.client.delete_battery_schedule = AsyncMock(side_effect=err)
+    coord.battery_runtime.raise_schedule_update_validation_error = (
+        MagicMock()
+    )  # noqa: SLF001
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await coord.battery_runtime.async_delete_battery_schedule(
+            "sched-dtg",
+            schedule_type="dtg",
+        )
+
+
+def test_schedule_family_settings_payload_cfg_guard_paths(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_charge_from_grid = True  # noqa: SLF001
+    coord._battery_cfg_control = BatteryControlCapability(
+        show=True,
+        enabled=True,
+        locked=False,
+        show_day_schedule=True,
+        schedule_supported=True,
+        force_schedule_supported=True,
+    )
+    runtime = coord.battery_runtime
+
+    assert (
+        runtime._schedule_family_settings_payload(  # noqa: SLF001
+            "cfg",
+            start_minutes=None,
+            end_minutes=120,
+            enabled=False,
+        )
+        is None
+    )
+    with pytest.raises(ServiceValidationError, match="must be different"):
+        runtime._schedule_family_settings_payload(  # noqa: SLF001
+            "cfg",
+            start_minutes=120,
+            end_minutes=120,
+            enabled=False,
+        )
+
+    payload = runtime._schedule_family_settings_payload(  # noqa: SLF001
+        "cfg",
+        start_minutes=120,
+        end_minutes=180,
+        enabled=False,
+    )
+    assert payload["chargeFromGrid"] is True
+    assert payload["cfgControl"] == {
+        "show": True,
+        "enabled": True,
+        "locked": False,
+        "showDaySchedule": True,
+        "scheduleSupported": True,
+        "forceScheduleSupported": True,
+        "forceScheduleOpted": False,
+    }
+    assert (
+        runtime._schedule_family_settings_payload(  # noqa: SLF001
+            "unknown",
+            start_minutes=120,
+            end_minutes=180,
+            enabled=False,
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_apply_schedule_family_settings_handles_noop_and_non_forbidden_error(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.battery_runtime
+    coord.client.set_battery_settings = AsyncMock(return_value={})
+
+    await runtime.async_apply_schedule_family_settings("unknown")
+    coord.client.set_battery_settings.assert_not_awaited()
+
+    runtime._schedule_family_settings_payload = MagicMock(  # noqa: SLF001
+        return_value=None
+    )
+    await runtime.async_apply_schedule_family_settings("cfg", enabled=False)
+    coord.client.set_battery_settings.assert_not_awaited()
+
+    coord = coordinator_factory()
+    runtime = coord.battery_runtime
+    runtime.raise_schedule_update_validation_error = MagicMock()  # noqa: SLF001
+    coord.client.set_battery_settings = AsyncMock(
+        side_effect=aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=500,
+            message="boom",
+        )
+    )
+    with pytest.raises(aiohttp.ClientResponseError):
+        await runtime.async_apply_schedule_family_settings(
+            "cfg",
+            start_time="02:00",
+            end_time="05:00",
+            enabled=False,
+        )
+    runtime.raise_schedule_update_validation_error.assert_called_once()  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -4044,6 +4407,20 @@ async def test_rbd_schedule_time_create_omits_limit_when_unknown(
     assert call.kwargs["end_time"] == "15:00"
     assert call.kwargs["limit"] is None
     assert call.kwargs["is_enabled"] is False
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "rbdControl": {
+                "enabled": False,
+                "show": True,
+                "locked": False,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "startTime": 60,
+                "endTime": 900,
+            }
+        },
+        schedule_type="rbd",
+    )
 
 
 async def test_async_update_data_site_only_ignores_battery_schedule_refresh_errors(
@@ -4162,6 +4539,9 @@ def _seed_no_cfg_schedule(coord):
     coord._battery_schedules_payload = {"cfg": {"details": []}}  # noqa: SLF001
     coord.client.create_battery_schedule = AsyncMock(return_value={})
     coord.client.set_battery_settings = AsyncMock(return_value={"message": "success"})
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
+    )
     coord.async_request_refresh = AsyncMock()
     coord.kick_fast = MagicMock()
 
@@ -4187,8 +4567,12 @@ async def test_cfg_schedule_creates_when_none_exists(
         timezone="UTC",
         is_enabled=False,
     )
-    # Legacy set_battery_settings should NOT have been called.
-    coord.client.set_battery_settings.assert_not_awaited()
+    coord.client.set_battery_settings.assert_awaited_once()
+    payload = coord.client.set_battery_settings.await_args.args[0]
+    assert payload["chargeFromGrid"] is True
+    assert payload["chargeFromGridScheduleEnabled"] is False
+    assert payload["chargeBeginTime"] == 1320
+    assert payload["chargeEndTime"] == 480
     coord.async_request_refresh.assert_awaited_once()
 
 

--- a/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
+++ b/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
@@ -82,6 +82,10 @@ def _prepare_battery_schedule_coord(coord) -> dict[str, object]:
     coord.client.update_battery_schedule = AsyncMock(return_value={"status": "ok"})
     coord.client.delete_battery_schedule = AsyncMock(return_value={"status": "ok"})
     coord.client.validate_battery_schedule = AsyncMock(return_value={"valid": True})
+    coord.client.set_battery_settings = AsyncMock(return_value={"message": "success"})
+    coord.client.set_battery_settings_compat = AsyncMock(
+        return_value={"message": "success"}
+    )
     coord.async_request_refresh = AsyncMock()
     coord._battery_schedules_payload = payload  # noqa: SLF001
     coord.parse_battery_schedules_payload(payload)
@@ -1583,6 +1587,8 @@ async def test_battery_schedule_services_support_crud_and_validation(
         limit=91,
         days=[1, 5],
         timezone="Australia/Melbourne",
+        is_enabled=None,
+        is_deleted=None,
     )
     assert coord.client.delete_battery_schedule.await_count == 2
     assert coord.client.delete_battery_schedule.await_args_list[0].kwargs == {
@@ -1590,6 +1596,30 @@ async def test_battery_schedule_services_support_crud_and_validation(
     }
     assert coord.client.delete_battery_schedule.await_args_list[1].kwargs == {
         "schedule_type": "dtg"
+    }
+    assert coord.client.set_battery_settings.await_count == 4
+    create_payload = coord.client.set_battery_settings.await_args_list[0].args[0]
+    assert create_payload["chargeFromGrid"] is True
+    assert create_payload["chargeFromGridScheduleEnabled"] is True
+    assert create_payload["chargeBeginTime"] == 300
+    assert create_payload["chargeEndTime"] == 420
+    update_payload = coord.client.set_battery_settings.await_args_list[1].args[0]
+    assert update_payload["chargeFromGrid"] is True
+    assert update_payload["chargeFromGridScheduleEnabled"] is True
+    assert update_payload["chargeBeginTime"] == 360
+    assert update_payload["chargeEndTime"] == 480
+    delete_cfg_payload = coord.client.set_battery_settings.await_args_list[2].args[0]
+    assert delete_cfg_payload["chargeFromGridScheduleEnabled"] is False
+    assert delete_cfg_payload["chargeBeginTime"] == 60
+    assert delete_cfg_payload["chargeEndTime"] == 210
+    delete_dtg_payload = coord.client.set_battery_settings.await_args_list[3].args[0]
+    assert delete_dtg_payload == {
+        "dtgControl": {
+            "enabled": False,
+            "scheduleSupported": True,
+            "startTime": 1080,
+            "endTime": 1260,
+        }
     }
     assert result == {"valid": True}
 
@@ -1682,6 +1712,382 @@ async def test_battery_schedule_services_update_uses_inventory_schedule_family(
         limit=41,
         days=[2, 4],
         timezone="UTC",
+        is_enabled=None,
+        is_deleted=None,
+    )
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "dtgControl": {
+                "enabled": False,
+                "scheduleSupported": True,
+                "startTime": 1140,
+                "endTime": 1320,
+            }
+        },
+        schedule_type="dtg",
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_schedule_services_delete_uses_enabled_remaining_schedule(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.services import async_setup_services
+
+    coord = coordinator_factory()
+    payload = _prepare_battery_schedule_coord(coord)
+    payload["dtg"] = {
+        "scheduleStatus": "active",
+        "details": [
+            {
+                "scheduleId": "def456",
+                "startTime": "18:00",
+                "endTime": "21:00",
+                "limit": 40,
+                "days": [2, 4],
+                "timezone": "UTC",
+                "isEnabled": False,
+            },
+            {
+                "scheduleId": "ghi789",
+                "startTime": "21:30",
+                "endTime": "23:00",
+                "limit": 40,
+                "days": [2, 4],
+                "timezone": "UTC",
+                "isEnabled": True,
+            },
+        ],
+    }
+    coord._battery_schedules_payload = payload  # noqa: SLF001
+    coord.parse_battery_schedules_payload(payload)
+    coord._battery_dtg_schedule_id = None  # noqa: SLF001
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    registered: dict[tuple[str, str], dict[str, object]] = {}
+
+    def fake_register(self, domain, service, handler, schema=None, **kwargs):
+        registered[(domain, service)] = {"handler": handler}
+
+    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    async_setup_services(hass)
+
+    delete_schedule = registered[(DOMAIN, "delete_schedule")]["handler"]
+
+    await delete_schedule(
+        SimpleNamespace(
+            data={
+                "config_entry_id": config_entry.entry_id,
+                "schedule_id": "def456",
+                "confirm": True,
+            }
+        )
+    )
+
+    coord.client.delete_battery_schedule.assert_awaited_once_with(
+        "def456",
+        schedule_type="dtg",
+    )
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "dtgControl": {
+                "enabled": True,
+                "scheduleSupported": True,
+                "startTime": 1290,
+                "endTime": 1380,
+            }
+        },
+        schedule_type="dtg",
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_schedule_services_delete_prefers_selected_remaining_schedule(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.services import async_setup_services
+
+    coord = coordinator_factory()
+    payload = _prepare_battery_schedule_coord(coord)
+    coord._battery_dtg_control = (
+        coord.battery_runtime._parse_battery_control_capability(  # noqa: SLF001
+            {
+                "show": True,
+                "enabled": False,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+            }
+        )
+    )
+    payload["dtg"] = {
+        "scheduleStatus": "active",
+        "details": [
+            {
+                "scheduleId": "def456",
+                "startTime": "18:00",
+                "endTime": "21:00",
+                "limit": 40,
+                "days": [2, 4],
+                "timezone": "UTC",
+                "isEnabled": False,
+            },
+            {
+                "scheduleId": "ghi789",
+                "startTime": "21:30",
+                "endTime": "23:00",
+                "limit": 40,
+                "days": [2, 4],
+                "timezone": "UTC",
+                "isEnabled": True,
+            },
+            {
+                "scheduleId": "jkl012",
+                "startTime": "23:15",
+                "endTime": "23:45",
+                "limit": 40,
+                "days": [2, 4],
+                "timezone": "UTC",
+                "isEnabled": False,
+            },
+        ],
+    }
+    coord._battery_schedules_payload = payload  # noqa: SLF001
+    coord.parse_battery_schedules_payload(payload)
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    registered: dict[tuple[str, str], dict[str, object]] = {}
+
+    def fake_register(self, domain, service, handler, schema=None, **kwargs):
+        registered[(domain, service)] = {"handler": handler}
+
+    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    async_setup_services(hass)
+
+    delete_schedule = registered[(DOMAIN, "delete_schedule")]["handler"]
+
+    await delete_schedule(
+        SimpleNamespace(
+            data={
+                "config_entry_id": config_entry.entry_id,
+                "schedule_id": "jkl012",
+                "confirm": True,
+            }
+        )
+    )
+
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "dtgControl": {
+                "enabled": False,
+                "show": True,
+                "showDaySchedule": True,
+                "scheduleSupported": True,
+                "startTime": 1080,
+                "endTime": 1260,
+            }
+        },
+        schedule_type="dtg",
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_schedule_services_delete_falls_back_to_first_remaining_schedule(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.services import async_setup_services
+
+    coord = coordinator_factory()
+    payload = _prepare_battery_schedule_coord(coord)
+    payload["dtg"] = {
+        "scheduleStatus": "active",
+        "details": [
+            {
+                "scheduleId": "def456",
+                "startTime": "18:00",
+                "endTime": "21:00",
+                "limit": 40,
+                "days": [2, 4],
+                "timezone": "UTC",
+                "isEnabled": False,
+            },
+            {
+                "scheduleId": "ghi789",
+                "startTime": "21:30",
+                "endTime": "23:00",
+                "limit": 40,
+                "days": [2, 4],
+                "timezone": "UTC",
+                "isEnabled": False,
+            },
+        ],
+    }
+    coord._battery_schedules_payload = payload  # noqa: SLF001
+    coord.parse_battery_schedules_payload(payload)
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    registered: dict[tuple[str, str], dict[str, object]] = {}
+
+    def fake_register(self, domain, service, handler, schema=None, **kwargs):
+        registered[(domain, service)] = {"handler": handler}
+
+    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    async_setup_services(hass)
+
+    delete_schedule = registered[(DOMAIN, "delete_schedule")]["handler"]
+
+    await delete_schedule(
+        SimpleNamespace(
+            data={
+                "config_entry_id": config_entry.entry_id,
+                "schedule_id": "def456",
+                "confirm": True,
+            }
+        )
+    )
+
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "dtgControl": {
+                "enabled": False,
+                "scheduleSupported": True,
+                "startTime": 1290,
+                "endTime": 1380,
+            }
+        },
+        schedule_type="dtg",
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_schedule_services_update_preserves_selected_family_window(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.services import async_setup_services
+
+    coord = coordinator_factory()
+    payload = _prepare_battery_schedule_coord(coord)
+    payload["dtg"] = {
+        "scheduleStatus": "active",
+        "details": [
+            {
+                "scheduleId": "def456",
+                "startTime": "18:00",
+                "endTime": "21:00",
+                "limit": 40,
+                "days": [2, 4],
+                "timezone": "UTC",
+                "isEnabled": False,
+            },
+            {
+                "scheduleId": "ghi789",
+                "startTime": "21:30",
+                "endTime": "23:00",
+                "limit": 40,
+                "days": [2, 4],
+                "timezone": "UTC",
+                "isEnabled": True,
+            },
+        ],
+    }
+    coord._battery_schedules_payload = payload  # noqa: SLF001
+    coord.parse_battery_schedules_payload(payload)
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    registered: dict[tuple[str, str], dict[str, object]] = {}
+
+    def fake_register(self, domain, service, handler, schema=None, **kwargs):
+        registered[(domain, service)] = {"handler": handler}
+
+    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    async_setup_services(hass)
+
+    update_schedule = registered[(DOMAIN, "update_schedule")]["handler"]
+
+    await update_schedule(
+        SimpleNamespace(
+            data={
+                "config_entry_id": config_entry.entry_id,
+                "schedule_id": "def456",
+                "schedule_type": "dtg",
+                "start_time": dt_time(17, 0),
+                "end_time": dt_time(17, 30),
+                "limit": 41,
+                "days": [2, 4],
+                "confirm": True,
+            }
+        )
+    )
+
+    coord.client.update_battery_schedule.assert_awaited_once_with(
+        "def456",
+        schedule_type="DTG",
+        start_time="17:00",
+        end_time="17:30",
+        limit=41,
+        days=[2, 4],
+        timezone="UTC",
+        is_enabled=None,
+        is_deleted=None,
+    )
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "dtgControl": {
+                "enabled": True,
+                "scheduleSupported": True,
+                "startTime": 1290,
+                "endTime": 1380,
+            }
+        },
+        schedule_type="dtg",
+    )
+
+
+@pytest.mark.asyncio
+async def test_battery_schedule_services_update_falls_back_when_selected_schedule_missing(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev.services import async_setup_services
+
+    coord = coordinator_factory()
+    _prepare_battery_schedule_coord(coord)
+    coord._battery_dtg_schedule_id = "missing-id"  # noqa: SLF001
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    registered: dict[tuple[str, str], dict[str, object]] = {}
+
+    def fake_register(self, domain, service, handler, schema=None, **kwargs):
+        registered[(domain, service)] = {"handler": handler}
+
+    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    async_setup_services(hass)
+
+    update_schedule = registered[(DOMAIN, "update_schedule")]["handler"]
+
+    await update_schedule(
+        SimpleNamespace(
+            data={
+                "config_entry_id": config_entry.entry_id,
+                "schedule_id": "def456",
+                "schedule_type": "dtg",
+                "start_time": dt_time(19, 0),
+                "end_time": dt_time(22, 0),
+                "limit": 41,
+                "days": [2, 4],
+                "confirm": True,
+            }
+        )
+    )
+
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "dtgControl": {
+                "enabled": False,
+                "scheduleSupported": True,
+                "startTime": 1140,
+                "endTime": 1320,
+            }
+        },
+        schedule_type="dtg",
     )
 
 
@@ -1769,6 +2175,8 @@ async def test_battery_schedule_services_reject_local_overlaps_before_client_cal
         limit=90,
         days=[1, 3, 5],
         timezone="Australia/Melbourne",
+        is_enabled=None,
+        is_deleted=None,
     )
 
 


### PR DESCRIPTION
## Summary

Apply the follow-up `batterySettings` write after IQ Battery schedule create, update, and delete operations so CFG/DTG/RBD changes leave the Enphase cloud-side schedule family in `active` without requiring a manual Apply click.

## Related Issues

- Discussion: https://github.com/barneyonline/ha-enphase-energy/discussions/583

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/services.py --fail-under=100"
```

Additional validation:
- Re-tested the patched schedule create/update/delete flow against the Docker dev environment using the configured live account on site and confirmed CFG/RBD/DTG all returned to `active` without a manual Enphase Cloud Apply click.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The service layer now preserves the coordinator-selected schedule row when deciding which schedule window to push back through `batterySettings` after update/delete operations on multi-schedule families.
