### PR TITLE
Add advisory gateway and EV charger firmware updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug fixes
 - Hardened the firmware catalog build workflow so dead regional release-notes routes degrade to global metadata instead of aborting the catalog publish job on a single `404` response.
 - Refreshed the firmware catalog’s authoritative region routing to cover current public Chile and Jamaica sites and to use Swiss locale-specific documentation URLs for German and Italian.
+- Removed advisory IQ Microinverter firmware update entities and catalog crawling now that Enphase does not expose a reliable public microinverter firmware release source comparable to gateway and EV charger firmware.
 
 ### 🔧 Improvements
-- Enabled advisory firmware update entities for IQ Gateway, IQ Microinverters, and IQ EV Chargers, including region-specific release-note links and charger rollout gating from Enphase feature flags.
+- Enabled advisory firmware update entities for IQ Gateway and IQ EV Chargers, including region-specific release-note links and charger rollout gating from Enphase feature flags.
 
 ### 🔄 Other changes
 - None

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,11 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Hardened the firmware catalog build workflow so dead regional release-notes routes degrade to global metadata instead of aborting the catalog publish job on a single `404` response.
+- Refreshed the firmware catalog’s authoritative region routing to cover current public Chile and Jamaica sites and to use Swiss locale-specific documentation URLs for German and Italian.
 
 ### 🔧 Improvements
-- None
+- Enabled advisory firmware update entities for IQ Gateway, IQ Microinverters, and IQ EV Chargers, including region-specific release-note links and charger rollout gating from Enphase feature flags.
 
 ### 🔄 Other changes
 - None

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 - Guided onboarding for site selection and device-category enablement
 - Unified support for EV chargers, gateway, battery, and microinverter entities
 - EV charging controls and session telemetry, including charge-mode aware behavior
-- Advisory firmware update entities for gateway, microinverter, and EV charger devices with locale-aware release-note links
+- Advisory firmware update entities for gateway and EV charger devices with locale-aware release-note links
 - Heat-pump runtime status, connectivity, SG-Ready mode, power, and current-day consumption details sourced from HEMS endpoints
 - Site and battery energy telemetry, including derived grid-import, grid-export, and battery power sensors for Home Assistant Energy Dashboard use
 - Health diagnostics, service-availability tracking, and actionable repair issues

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 - Guided onboarding for site selection and device-category enablement
 - Unified support for EV chargers, gateway, battery, and microinverter entities
 - EV charging controls and session telemetry, including charge-mode aware behavior
+- Advisory firmware update entities for gateway, microinverter, and EV charger devices with locale-aware release-note links
 - Heat-pump runtime status, connectivity, SG-Ready mode, power, and current-day consumption details sourced from HEMS endpoints
 - Site and battery energy telemetry, including derived grid-import, grid-export, and battery power sensors for Home Assistant Energy Dashboard use
 - Health diagnostics, service-availability tracking, and actionable repair issues

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -42,10 +42,6 @@ _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
 
-# Keep firmware catalog/update implementation in-tree, but disable exposing
-# firmware version checks in the integration for now.
-_ENABLE_FIRMWARE_VERSION_CHECKS = False
-
 PLATFORMS: list[str] = [
     "sensor",
     "binary_sensor",
@@ -55,7 +51,7 @@ PLATFORMS: list[str] = [
     "switch",
     "time",
     "calendar",
-    *(["update"] if _ENABLE_FIRMWARE_VERSION_CHECKS else []),
+    "update",
 ]
 
 _LEGACY_GATEWAY_TYPE_KEYS: tuple[str, ...] = ("meter", "enpower")

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -83,7 +83,7 @@ _LEGACY_CLOUD_ENTITY_SUFFIX_ALIASES_BY_DOMAIN: dict[str, tuple[str, ...]] = {
         "cloud_last_error_code",
     ),
 }
-_STARTUP_MIGRATION_VERSION = 3
+_STARTUP_MIGRATION_VERSION = 5
 _STARTUP_MIGRATION_VERSION_KEY = "startup_migration_version"
 
 _TYPE_DEVICE_KEYS_WITH_DIRECT_CHILD_DEVICES: tuple[str, ...] = ("iqevse",)
@@ -928,6 +928,64 @@ def _migrate_legacy_gateway_type_devices(
         )
 
 
+def _migrate_orphaned_update_entities_to_type_devices(
+    hass: HomeAssistant, entry: EnphaseConfigEntry, site_id: object
+) -> None:
+    if er is None:
+        return
+    try:
+        site_id_text = str(site_id).strip()
+    except Exception:  # noqa: BLE001
+        site_id_text = ""
+    if not site_id_text:
+        return
+
+    try:
+        ent_reg = er.async_get(hass)
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug(
+            "Skipping orphaned update-entity migration for site %s: %s",
+            redact_site_id(site_id_text),
+            redact_text(err, site_ids=(site_id_text,)),
+        )
+        return
+
+    entry_id = getattr(entry, "entry_id", None)
+    gateway_unique_id = f"{DOMAIN}_site_{site_id_text}_envoy_firmware"
+    microinverter_unique_id = f"{DOMAIN}_site_{site_id_text}_microinverter_firmware"
+    removed_gateway_orphans = 0
+    removed_microinverter_updates = 0
+
+    for reg_entry in iter_entity_registry_entries(ent_reg):
+        if not is_owned_entity(reg_entry, entry_id, "update"):
+            continue
+        unique_id = getattr(reg_entry, "unique_id", None)
+        if unique_id == gateway_unique_id:
+            if getattr(reg_entry, "device_id", None) is not None:
+                continue
+            entity_id = getattr(reg_entry, "entity_id", None)
+            if not entity_id:
+                continue
+            ent_reg.async_remove(entity_id)
+            removed_gateway_orphans += 1
+            continue
+        if unique_id != microinverter_unique_id:
+            continue
+        entity_id = getattr(reg_entry, "entity_id", None)
+        if not entity_id:
+            continue
+        ent_reg.async_remove(entity_id)
+        removed_microinverter_updates += 1
+
+    if removed_gateway_orphans or removed_microinverter_updates:
+        _LOGGER.debug(
+            "Removed %s orphaned gateway firmware entities and %s deprecated microinverter firmware entities for site %s",
+            removed_gateway_orphans,
+            removed_microinverter_updates,
+            redact_site_id(site_id_text),
+        )
+
+
 def _remove_evse_type_device_and_entities(
     hass: HomeAssistant,
     entry: EnphaseConfigEntry,
@@ -1027,6 +1085,7 @@ def _complete_startup_migrations_if_ready(
         return
     _migrate_cloud_entity_unique_ids(hass, entry, site_id)
     _migrate_legacy_gateway_type_devices(hass, entry, coord, dev_reg, site_id)
+    _migrate_orphaned_update_entities_to_type_devices(hass, entry, site_id)
     _remove_evse_type_device_and_entities(hass, entry, dev_reg, site_id)
     _migrate_cloud_entities_to_cloud_device(hass, entry, coord, dev_reg, site_id)
     runtime_data = getattr(entry, "runtime_data", None)
@@ -1090,6 +1149,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
     dev_reg = dr.async_get(hass)
     _sync_registry_devices(entry, coord, dev_reg, site_id)
     _remove_evse_type_device_and_entities(hass, entry, dev_reg, site_id)
+    _migrate_orphaned_update_entities_to_type_devices(hass, entry, site_id)
     _complete_startup_migrations_if_ready(hass, entry, coord, dev_reg, site_id)
     last_registry_signature = _registry_metadata_signature(coord)
 
@@ -1101,6 +1161,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
             if current_signature != last_registry_signature:
                 _sync_registry_devices(entry, coord, dev_reg, site_id)
                 _remove_evse_type_device_and_entities(hass, entry, dev_reg, site_id)
+                _migrate_orphaned_update_entities_to_type_devices(hass, entry, site_id)
                 last_registry_signature = current_signature
             _complete_startup_migrations_if_ready(hass, entry, coord, dev_reg, site_id)
         except Exception as err:  # noqa: BLE001

--- a/custom_components/enphase_ev/firmware_catalog.py
+++ b/custom_components/enphase_ev/firmware_catalog.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import re
 import time
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
+from urllib.parse import urlencode, urlsplit, urlunsplit
 
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util import dt as dt_util
@@ -18,11 +20,13 @@ from .runtime_helpers import (
 )
 
 _LOGGER = logging.getLogger(__name__)
+_DOC_CENTER_PRODUCT_TYPE = "216"
 
-FIRMWARE_CATALOG_URL = (
+DEFAULT_FIRMWARE_CATALOG_URL = (
     "https://raw.githubusercontent.com/barneyonline/ha-enphase-energy/"
     "firmware-catalog/catalog/v1/runtime_catalog.json"
 )
+FIRMWARE_CATALOG_URL_ENV = "ENPHASE_EV_FIRMWARE_CATALOG_URL"
 FIRMWARE_CATALOG_CACHE_TTL_SECONDS = 12 * 60 * 60
 FIRMWARE_CATALOG_RETRY_BACKOFF_SECONDS = 30 * 60
 FIRMWARE_CATALOG_FETCH_TIMEOUT_SECONDS = 20
@@ -43,13 +47,13 @@ class FirmwareCatalogManager:
         self,
         hass,
         *,
-        url: str = FIRMWARE_CATALOG_URL,
+        url: str | None = None,
         ttl_seconds: int = FIRMWARE_CATALOG_CACHE_TTL_SECONDS,
         retry_backoff_seconds: int = FIRMWARE_CATALOG_RETRY_BACKOFF_SECONDS,
         fetch_timeout_seconds: int = FIRMWARE_CATALOG_FETCH_TIMEOUT_SECONDS,
     ) -> None:
         self._hass = hass
-        self._url = str(url)
+        self._url = str(url or _firmware_catalog_url())
         self._ttl_seconds = max(300, int(ttl_seconds))
         self._retry_backoff_seconds = max(60, int(retry_backoff_seconds))
         self._fetch_timeout_seconds = max(5, int(fetch_timeout_seconds))
@@ -118,6 +122,13 @@ class FirmwareCatalogManager:
             "catalog_generated_at": generated_at,
             "catalog_source_age_seconds": source_age_seconds,
         }
+
+
+def _firmware_catalog_url() -> str:
+    override = os.getenv(FIRMWARE_CATALOG_URL_ENV)
+    if isinstance(override, str) and override.strip():
+        return override.strip()
+    return DEFAULT_FIRMWARE_CATALOG_URL
 
 
 def _validate_catalog(payload: Any) -> dict[str, Any]:
@@ -335,6 +346,8 @@ def select_catalog_entry(
     if entry is None:
         return CatalogSelection(None, normalized_locale, country_code, source_scope)
 
+    entry = _repair_legacy_release_urls(device_payload, entry)
+
     urls_by_locale = entry.get("urls_by_locale")
     locale_used = normalized_locale
     if isinstance(urls_by_locale, dict) and urls_by_locale:
@@ -360,3 +373,86 @@ def select_catalog_entry(
         locale_used = normalize_locale(locale)
 
     return CatalogSelection(entry, locale_used, country_code, source_scope)
+
+
+def _repair_legacy_release_urls(
+    device_payload: dict[str, Any], entry: dict[str, Any]
+) -> dict[str, Any]:
+    urls_by_locale = entry.get("urls_by_locale")
+    if not isinstance(urls_by_locale, dict) or not urls_by_locale:
+        return entry
+
+    if not any(_is_legacy_release_url(value) for value in urls_by_locale.values()):
+        return entry
+
+    topic_id = _as_int(entry.get("document_topic_id")) or _as_int(
+        device_payload.get("document_topic_id")
+    )
+    product_media_name_id = _as_int(entry.get("product_media_name_id")) or _as_int(
+        device_payload.get("product_media_name_id")
+    )
+    product_type = str(
+        entry.get("product_type")
+        or device_payload.get("product_type")
+        or _DOC_CENTER_PRODUCT_TYPE
+    )
+    if topic_id is None or product_media_name_id is None:
+        return entry
+
+    repaired_urls: dict[str, str] = {}
+    for locale_key, raw_url in urls_by_locale.items():
+        locale = normalize_locale(locale_key)
+        if not _is_legacy_release_url(raw_url):
+            repaired_urls[str(locale_key)] = str(raw_url)
+            continue
+        repaired_urls[str(locale_key)] = _build_release_url(
+            raw_url=str(raw_url),
+            locale=locale,
+            product_type=product_type,
+            topic_id=topic_id,
+            product_media_name_id=product_media_name_id,
+        )
+
+    cloned = dict(entry)
+    cloned["urls_by_locale"] = repaired_urls
+    return cloned
+
+
+def _is_legacy_release_url(value: Any) -> bool:
+    if value is None:
+        return False
+    try:
+        text = str(value)
+    except Exception:  # noqa: BLE001
+        return False
+    return "media_id=" in text and "langcode=" in text
+
+
+def _build_release_url(
+    *,
+    raw_url: str,
+    locale: str,
+    product_type: str,
+    topic_id: int,
+    product_media_name_id: int,
+) -> str:
+    split = urlsplit(raw_url)
+    query = urlencode(
+        {
+            "product_type": product_type,
+            "f[0]": f"document:{topic_id}",
+            "f[1]": f"product_media_name:{product_media_name_id}",
+            "search_api_language": locale,
+            "field_alternative_language": locale,
+        }
+    )
+    return urlunsplit((split.scheme, split.netloc, split.path, query, ""))
+
+
+def _as_int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(str(value))
+    except Exception:  # noqa: BLE001
+        return None

--- a/custom_components/enphase_ev/inventory_view.py
+++ b/custom_components/enphase_ev/inventory_view.py
@@ -388,6 +388,12 @@ class InventoryView:
                 return member
         return None
 
+    def _envoy_preferred_member(self) -> dict[str, object] | None:
+        gateway = self._envoy_primary_gateway_member()
+        if gateway is not None:
+            return gateway
+        return self._envoy_system_controller_member()
+
     def _heatpump_primary_member(self) -> dict[str, object] | None:
         return self.heatpump_runtime._heatpump_primary_member()
 
@@ -411,9 +417,7 @@ class InventoryView:
         if not normalized:
             return None
         if normalized == "envoy":
-            member = self._envoy_system_controller_member()
-            if member is None:
-                member = self._envoy_primary_gateway_member()
+            member = self._envoy_preferred_member()
             controller_name = self._type_member_text(
                 member,
                 "name",
@@ -476,10 +480,8 @@ class InventoryView:
             return None
         if normalized == "envoy":
             serial_keys = ("serial_number", "serial", "serialNumber", "device_sn")
-            controller = self._envoy_system_controller_member()
-            if controller is None:
-                controller = self._envoy_primary_gateway_member()
-            return self._type_member_text(controller, *serial_keys)
+            member = self._envoy_preferred_member()
+            return self._type_member_text(member, *serial_keys)
         if normalized == "heatpump":
             primary = self._heatpump_primary_member()
             serial = self._type_member_text(
@@ -525,10 +527,8 @@ class InventoryView:
             "part_number",
         )
         if normalized == "envoy":
-            controller = self._envoy_system_controller_member()
-            if controller is None:
-                controller = self._envoy_primary_gateway_member()
-            model_id = self._type_member_text(controller, *model_id_keys)
+            member = self._envoy_preferred_member()
+            model_id = self._type_member_text(member, *model_id_keys)
         elif normalized == "heatpump":
             primary = self._heatpump_primary_member()
             model_id = self._type_member_text(
@@ -574,10 +574,16 @@ class InventoryView:
             "application_version",
         )
         if normalized == "envoy":
-            controller = self._envoy_system_controller_member()
-            if controller is None:
-                controller = self._envoy_primary_gateway_member()
-            return self._type_member_text(controller, *sw_keys)
+            member = self._envoy_preferred_member()
+            sw_version = self._type_member_text(member, *sw_keys)
+            if sw_version:
+                return sw_version
+            other_member = (
+                self._envoy_system_controller_member()
+                if member is self._envoy_primary_gateway_member()
+                else self._envoy_primary_gateway_member()
+            )
+            return self._type_member_text(other_member, *sw_keys)
         if normalized == "heatpump":
             primary = self._heatpump_primary_member()
             sw_version = self._type_member_text(primary, *sw_keys)
@@ -612,11 +618,9 @@ class InventoryView:
         if not normalized:
             return None
         if normalized == "envoy":
-            controller = self._envoy_system_controller_member()
-            if controller is None:
-                controller = self._envoy_primary_gateway_member()
+            member = self._envoy_preferred_member()
             return self._type_member_text(
-                controller,
+                member,
                 "hw_version",
                 "hardware_version",
                 "hardwareVersion",

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Gateway Firmware"
       },
-      "microinverter_firmware": {
-        "name": "Microinverter Firmware"
-      },
       "charger_firmware": {
         "name": "Firmware"
       }

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Фърмуер на шлюза"
       },
-      "microinverter_firmware": {
-        "name": "Фърмуер на микроинвертора"
-      },
       "charger_firmware": {
         "name": "Фърмуер"
       }

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Firmware brány"
       },
-      "microinverter_firmware": {
-        "name": "Firmware mikroinvertoru"
-      },
       "charger_firmware": {
         "name": "Verze firmwaru"
       }

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Gateway-firmware"
       },
-      "microinverter_firmware": {
-        "name": "Mikroinverter-firmware"
-      },
       "charger_firmware": {
         "name": "Firmwareversion"
       }

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Gateway-Firmware"
       },
-      "microinverter_firmware": {
-        "name": "Mikrowechselrichter-Firmware"
-      },
       "charger_firmware": {
         "name": "Firmware-Version"
       }

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Υλικολογισμικό πύλης"
       },
-      "microinverter_firmware": {
-        "name": "Υλικολογισμικό μικρομετατροπέα"
-      },
       "charger_firmware": {
         "name": "Υλικολογισμικό"
       }

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Gateway Firmware"
       },
-      "microinverter_firmware": {
-        "name": "Microinverter Firmware"
-      },
       "charger_firmware": {
         "name": "Firmware"
       }

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Gateway Firmware"
       },
-      "microinverter_firmware": {
-        "name": "Microinverter Firmware"
-      },
       "charger_firmware": {
         "name": "Firmware"
       }

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Gateway Firmware"
       },
-      "microinverter_firmware": {
-        "name": "Microinverter Firmware"
-      },
       "charger_firmware": {
         "name": "Firmware"
       }

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Gateway Firmware"
       },
-      "microinverter_firmware": {
-        "name": "Microinverter Firmware"
-      },
       "charger_firmware": {
         "name": "Firmware"
       }

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Gateway Firmware"
       },
-      "microinverter_firmware": {
-        "name": "Microinverter Firmware"
-      },
       "charger_firmware": {
         "name": "Firmware"
       }

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Gateway Firmware"
       },
-      "microinverter_firmware": {
-        "name": "Microinverter Firmware"
-      },
       "charger_firmware": {
         "name": "Firmware"
       }

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Firmware del gateway"
       },
-      "microinverter_firmware": {
-        "name": "Firmware del microinversor"
-      },
       "charger_firmware": {
         "name": "Versión de firmware"
       }

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Lüüsi püsivara"
       },
-      "microinverter_firmware": {
-        "name": "Mikroinverteri püsivara"
-      },
       "charger_firmware": {
         "name": "Püsivara"
       }

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Yhdyskäytävän laiteohjelmisto"
       },
-      "microinverter_firmware": {
-        "name": "Mikroinvertterin laiteohjelmisto"
-      },
       "charger_firmware": {
         "name": "Laiteohjelmisto"
       }

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Firmware de la passerelle"
       },
-      "microinverter_firmware": {
-        "name": "Firmware du micro-onduleur"
-      },
       "charger_firmware": {
         "name": "Micrologiciel"
       }

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Átjáró firmware"
       },
-      "microinverter_firmware": {
-        "name": "Mikroinverter firmware"
-      },
       "charger_firmware": {
         "name": "Firmware-verzió"
       }

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Firmware del gateway"
       },
-      "microinverter_firmware": {
-        "name": "Firmware del microinverter"
-      },
       "charger_firmware": {
         "name": "Versione firmware"
       }

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Vartų programinė aparatinė įranga"
       },
-      "microinverter_firmware": {
-        "name": "Mikroinverterio programinė aparatinė įranga"
-      },
       "charger_firmware": {
         "name": "Programinė aparatinė įranga"
       }

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Vārtejas programmaparatūra"
       },
-      "microinverter_firmware": {
-        "name": "Mikroinvertora programmaparatūra"
-      },
       "charger_firmware": {
         "name": "Programmaparatūra"
       }

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Gateway-fastvare"
       },
-      "microinverter_firmware": {
-        "name": "Mikroinverter-fastvare"
-      },
       "charger_firmware": {
         "name": "Fastvare"
       }

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Gatewayfirmware"
       },
-      "microinverter_firmware": {
-        "name": "Micro-omvormerfirmware"
-      },
       "charger_firmware": {
         "name": "Firmwareversie"
       }

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Oprogramowanie sprzętowe bramki"
       },
-      "microinverter_firmware": {
-        "name": "Oprogramowanie sprzętowe mikroinwertera"
-      },
       "charger_firmware": {
         "name": "Oprogramowanie sprzętowe"
       }

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Firmware do gateway"
       },
-      "microinverter_firmware": {
-        "name": "Firmware do microinversor"
-      },
       "charger_firmware": {
         "name": "Versão do firmware"
       }

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Firmware gateway"
       },
-      "microinverter_firmware": {
-        "name": "Firmware microinvertor"
-      },
       "charger_firmware": {
         "name": "Versiune firmware"
       }

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -1552,9 +1552,6 @@
       "gateway_firmware": {
         "name": "Gateway-fastvara"
       },
-      "microinverter_firmware": {
-        "name": "Mikroväxelriktarens fastvara"
-      },
       "charger_firmware": {
         "name": "Inbyggd programvara"
       }

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -4,7 +4,12 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from homeassistant.components.update import UpdateEntity, UpdateEntityDescription
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityDescription,
+)
+from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
@@ -55,6 +60,7 @@ async def async_setup_entry(
                 translation_key="gateway_firmware",
                 description=UpdateEntityDescription(
                     key="gateway_firmware",
+                    device_class=UpdateDeviceClass.FIRMWARE,
                     entity_category=EntityCategory.DIAGNOSTIC,
                 ),
                 installed_version_getter=_gateway_installed_version,
@@ -69,6 +75,7 @@ async def async_setup_entry(
                 translation_key="microinverter_firmware",
                 description=UpdateEntityDescription(
                     key="microinverter_firmware",
+                    device_class=UpdateDeviceClass.FIRMWARE,
                     entity_category=EntityCategory.DIAGNOSTIC,
                 ),
                 installed_version_getter=_microinverter_installed_version,
@@ -101,9 +108,11 @@ async def async_setup_entry(
             ChargerFirmwareUpdateEntity(
                 coordinator=coord,
                 manager=evse_manager,
+                catalog_manager=catalog_manager,
                 serial=sn,
                 description=UpdateEntityDescription(
                     key="charger_firmware",
+                    device_class=UpdateDeviceClass.FIRMWARE,
                     entity_category=EntityCategory.DIAGNOSTIC,
                 ),
             )
@@ -244,6 +253,7 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
             self._attr_latest_version = None
             self._attr_release_url = None
             self._attr_release_summary = None
+            _reconcile_skipped_version(self)
             return
 
         raw_latest = _text(entry.get("version"))
@@ -271,6 +281,7 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
 
         self._attr_release_url = release_url
         self._attr_release_summary = _text(entry.get("summary"))
+        _reconcile_skipped_version(self)
 
 
 class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
@@ -282,6 +293,7 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
         *,
         coordinator: EnphaseCoordinator,
         manager: EvseFirmwareDetailsManager,
+        catalog_manager: FirmwareCatalogManager,
         serial: str,
         description: UpdateEntityDescription,
     ) -> None:
@@ -289,6 +301,7 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
         self.entity_description = description
         self._coord = coordinator
         self._manager = manager
+        self._catalog_manager = catalog_manager
         self._serial = str(serial)
         self._refresh_task = None
 
@@ -302,8 +315,14 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
         self._last_successful_upgrade_date: str | None = None
         self._last_updated_at: str | None = None
         self._is_auto_ota: bool | None = None
+        self._firmware_rollout_enabled: bool | None = None
+        self._country_used: str | None = None
+        self._locale_used: str = "en"
+        self._source_scope: str | None = None
+        self._catalog_generated_at: str | None = None
 
         self._refresh_from_details(self._manager.cached_details)
+        self._refresh_from_catalog(self._catalog_manager.cached_catalog)
 
     @property
     def available(self) -> bool:
@@ -318,14 +337,31 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
         return DeviceInfo(identifiers={(DOMAIN, self._serial)})
 
     @property
+    def state(self) -> str | None:
+        state = super().state
+        if state != STATE_ON:
+            return state
+        if self._firmware_rollout_enabled is False:
+            return STATE_OFF
+        return state
+
+    @property
     def extra_state_attributes(self) -> dict[str, Any]:
         status = self._manager.status_snapshot()
+        catalog_status = self._catalog_manager.status_snapshot()
         return {
             "upgrade_status": self._upgrade_status,
             "status_detail": self._status_detail,
             "last_successful_upgrade_date": self._last_successful_upgrade_date,
             "last_updated_at": self._last_updated_at,
             "is_auto_ota": self._is_auto_ota,
+            "firmware_rollout_enabled": self._firmware_rollout_enabled,
+            "country_used": self._country_used,
+            "locale_used": self._locale_used,
+            "catalog_source_scope": self._source_scope,
+            "catalog_generated_at": self._catalog_generated_at,
+            "catalog_last_fetch_utc": catalog_status.get("last_fetch_utc"),
+            "catalog_last_error": catalog_status.get("last_error"),
             "details_last_fetch_utc": status.get("last_fetch_utc"),
             "details_last_success_utc": status.get("last_success_utc"),
             "details_last_error": status.get("last_error"),
@@ -335,11 +371,12 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
-        await self._async_refresh_details()
+        await self._async_refresh_state()
 
     @callback
     def _handle_coordinator_update(self) -> None:
         self._refresh_from_details(self._manager.cached_details)
+        self._refresh_from_catalog(self._catalog_manager.cached_catalog)
         self._schedule_details_refresh()
         super()._handle_coordinator_update()
 
@@ -348,7 +385,7 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
             return
         if self._refresh_task is not None and not self._refresh_task.done():
             return
-        self._refresh_task = self.hass.async_create_task(self._async_refresh_details())
+        self._refresh_task = self.hass.async_create_task(self._async_refresh_state())
 
     async def _async_refresh_details(self) -> None:
         try:
@@ -366,7 +403,29 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
             return
 
         self._refresh_from_details(details)
-        self.async_write_ha_state()
+
+    async def _async_refresh_state(self) -> None:
+        await self._async_refresh_details()
+        await self._async_refresh_catalog()
+        if self.hass is not None and self.entity_id is not None:
+            self.async_write_ha_state()
+
+    async def _async_refresh_catalog(self) -> None:
+        try:
+            catalog = await self._catalog_manager.async_get_catalog()
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Firmware catalog refresh failed for charger %s: %s",
+                redact_identifier(self._serial),
+                redact_text(
+                    err,
+                    site_ids=(self._coord.site_id,),
+                    identifiers=(self._serial,),
+                ),
+            )
+            return
+
+        self._refresh_from_catalog(catalog)
 
     def _refresh_from_details(
         self, details_by_serial: dict[str, dict[str, Any]] | None
@@ -402,6 +461,52 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
         )
         self._last_updated_at = _text(details.get("lastUpdatedAt")) if details else None
         self._is_auto_ota = _as_bool(details.get("isAutoOta")) if details else None
+        self._firmware_rollout_enabled = _evse_firmware_rollout_enabled(
+            self._coord, self._serial
+        )
+        _reconcile_skipped_version(self)
+
+    def _refresh_from_catalog(self, catalog: dict[str, Any] | None) -> None:
+        country, locale = resolve_country_and_locale(self._coord, self.hass)
+        normalized_locale = normalize_locale(locale)
+
+        self._country_used = country
+        self._locale_used = normalized_locale
+
+        selected = select_catalog_entry(
+            catalog,
+            device_type="iqevse",
+            country=country,
+            locale=normalized_locale,
+        )
+        self._source_scope = selected.source_scope
+        self._locale_used = selected.locale_used or normalized_locale
+        self._catalog_generated_at = (
+            str(catalog.get("generated_at"))
+            if isinstance(catalog, dict) and catalog.get("generated_at") is not None
+            else None
+        )
+
+        entry = selected.entry if isinstance(selected.entry, dict) else None
+        if entry is None:
+            self._attr_release_url = None
+            self._attr_release_summary = None
+            return
+
+        urls = entry.get("urls_by_locale")
+        release_url = None
+        if isinstance(urls, dict):
+            chosen_key = (
+                self._locale_used
+                if self._locale_used in urls
+                else (str(next(iter(urls.keys()))) if urls else None)
+            )
+            if chosen_key is not None:
+                release_url = _text(urls.get(chosen_key))
+                self._locale_used = chosen_key
+
+        self._attr_release_url = release_url
+        self._attr_release_summary = _text(entry.get("summary"))
 
 
 def _charger_serials(coord: EnphaseCoordinator) -> list[str]:
@@ -508,3 +613,20 @@ def _as_int(value: Any) -> int | None:
         return int(str(value))
     except Exception:  # noqa: BLE001
         return None
+
+
+def _evse_firmware_rollout_enabled(
+    coord: EnphaseCoordinator, serial: str
+) -> bool | None:
+    feature_flag_enabled = getattr(coord, "evse_feature_flag_enabled", None)
+    if not callable(feature_flag_enabled):
+        return None
+    try:
+        return feature_flag_enabled("iqevse_itk_fw_upgrade_status", serial)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _reconcile_skipped_version(entity: UpdateEntity) -> None:
+    """Force Home Assistant to clear stale skipped firmware versions immediately."""
+    entity.state_attributes

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -29,7 +29,10 @@ from .firmware_catalog import (
 )
 from .log_redaction import redact_identifier, redact_text
 from .parsing_helpers import coerce_optional_text as _text
-from .runtime_helpers import inventory_type_available as _type_available
+from .runtime_helpers import (
+    inventory_type_available as _type_available,
+    inventory_type_device_info as _type_device_info,
+)
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
 
 PARALLEL_UPDATES = 0
@@ -64,21 +67,6 @@ async def async_setup_entry(
                     entity_category=EntityCategory.DIAGNOSTIC,
                 ),
                 installed_version_getter=_gateway_installed_version,
-            )
-        )
-    if _type_available(coord, "microinverter"):
-        entities.append(
-            FirmwareUpdateEntity(
-                coordinator=coord,
-                manager=catalog_manager,
-                device_type="microinverter",
-                translation_key="microinverter_firmware",
-                description=UpdateEntityDescription(
-                    key="microinverter_firmware",
-                    device_class=UpdateDeviceClass.FIRMWARE,
-                    entity_category=EntityCategory.DIAGNOSTIC,
-                ),
-                installed_version_getter=_microinverter_installed_version,
             )
         )
 
@@ -171,10 +159,15 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
         return super().available and _type_available(self._coord, self._device_type)
 
     @property
-    def device_info(self):
-        info = self._coord.inventory_view.type_device_info(self._device_type)
+    def device_info(self) -> DeviceInfo | None:
+        info = _type_device_info(self._coord, self._device_type)
         if info is not None:
             return info
+        if self._device_type == "envoy":
+            return DeviceInfo(
+                identifiers={(DOMAIN, f"type:{self._coord.site_id}:envoy")},
+                manufacturer="Enphase",
+            )
         return None
 
     @property
@@ -555,19 +548,6 @@ def _async_prune_removed_charger_updates(
 
 def _gateway_installed_version(coord: EnphaseCoordinator) -> str | None:
     return _text(coord.inventory_view.type_device_sw_version("envoy"))
-
-
-def _microinverter_installed_version(coord: EnphaseCoordinator) -> str | None:
-    version = _text(coord.inventory_view.type_device_sw_version("microinverter"))
-    if version:
-        return version
-
-    bucket = coord.inventory_view.type_bucket("microinverter")
-    if isinstance(bucket, dict):
-        firmware_summary = _text(bucket.get("firmware_summary"))
-        if firmware_summary:
-            return firmware_summary
-    return None
 
 
 def _charger_installed_version(coord: EnphaseCoordinator, serial: str) -> str | None:

--- a/devtools/docker/docker-compose.yml
+++ b/devtools/docker/docker-compose.yml
@@ -18,6 +18,7 @@ services:
       - "8123:8123"
     environment:
       - TZ=${TZ:-UTC}
+      - ENPHASE_EV_FIRMWARE_CATALOG_URL=http://127.0.0.1:8123/local/catalog/v1/runtime_catalog.json
     dns:
       - ${HA_RUNTIME_DNS_1:-1.1.1.1}
       - ${HA_RUNTIME_DNS_2:-8.8.8.8}

--- a/scripts/firmware_catalog.py
+++ b/scripts/firmware_catalog.py
@@ -27,10 +27,18 @@ BASE_URL = "https://enphase.com"
 ROOT_PATH = "/installers/resources/documentation"
 TARGET_CATEGORY_LABEL = "Apps and software"
 TARGET_CATEGORY_PATH = "/installers/resources/documentation/apps"
+COMMUNICATION_CATEGORY_PATH = "/installers/resources/documentation/communication"
+DEFAULT_PRODUCT_TYPE = "216"
 
-TARGET_PRODUCTS: dict[str, str] = {
-    "envoy": "IQ Gateway software",
-    "microinverter": "IQ Microinverter software",
+TARGET_PRODUCTS: dict[str, dict[str, str]] = {
+    "envoy": {
+        "label": "IQ Gateway software",
+        "docs_path": COMMUNICATION_CATEGORY_PATH,
+    },
+    "iqevse": {
+        "label": "IQ EV Charger software",
+        "docs_path": TARGET_CATEGORY_PATH,
+    },
 }
 
 DEFAULT_TIMEOUT = 30
@@ -1226,16 +1234,23 @@ def pick_latest_release(releases: list[ReleaseCard]) -> ReleaseCard | None:
 def build_release_urls_by_locale(
     *,
     locales: list[str],
-    media_id: str,
-    langcode: str,
     apps_url: str,
+    product_type: str,
+    topic_id: int,
+    product_media_name_id: int,
 ) -> dict[str, str]:
     urls: dict[str, str] = {}
     for locale in locales:
         normalized = _normalize_locale(locale)
         urls[normalized] = _with_query(
             apps_url,
-            {"media_id": media_id, "langcode": langcode or "und"},
+            {
+                "product_type": product_type,
+                "f[0]": f"document:{topic_id}",
+                "f[1]": f"product_media_name:{product_media_name_id}",
+                "search_api_language": normalized,
+                "field_alternative_language": normalized,
+            },
         )
     return urls
 
@@ -1243,18 +1258,20 @@ def build_release_urls_by_locale(
 def card_to_runtime_entry(
     *,
     card: ReleaseCard,
+    product_type: str,
     topic_id: int,
+    product_media_name_id: int,
     locales: list[str],
     apps_url: str,
 ) -> dict[str, Any]:
     media_id = card.media_id or ""
-    langcode = card.langcode or "und"
     urls_by_locale = (
         build_release_urls_by_locale(
             locales=locales,
-            media_id=media_id,
-            langcode=langcode,
             apps_url=apps_url,
+            product_type=product_type,
+            topic_id=topic_id,
+            product_media_name_id=product_media_name_id,
         )
         if media_id
         else {}
@@ -1263,7 +1280,9 @@ def card_to_runtime_entry(
         "version": card.version,
         "release_date": card.release_date,
         "media_id": media_id or None,
+        "product_type": product_type,
         "document_topic_id": topic_id,
+        "product_media_name_id": product_media_name_id,
         "countries_text": card.countries_text,
         "urls_by_locale": urls_by_locale,
         "summary": card.summary,
@@ -1335,14 +1354,23 @@ def fetch_previous_runtime_catalog(
     return payload
 
 
-def _bootstrap_target(target: dict[str, Any], *, timeout: int) -> dict[str, Any]:
+def _bootstrap_target(
+    target: dict[str, Any], *, timeout: int, docs_path: str
+) -> dict[str, Any]:
     root_url = urljoin(str(target["site_url"]), ROOT_PATH.lstrip("/"))
     root_html = fetch_text(root_url, timeout=timeout)
-    docs_path, discovered_product_type = discover_apps_entrypoint(root_html)
+    discovered_product_type = DEFAULT_PRODUCT_TYPE
+    if docs_path == TARGET_CATEGORY_PATH:
+        discovered_docs_path, discovered_product_type = discover_apps_entrypoint(
+            root_html
+        )
+        docs_path = discovered_docs_path
 
     apps_url = urljoin(str(target["site_url"]), docs_path.lstrip("/"))
-    apps_bootstrap_url = _with_query(
-        apps_url, {"product_type": discovered_product_type}
+    apps_bootstrap_url = (
+        _with_query(apps_url, {"product_type": discovered_product_type})
+        if docs_path == TARGET_CATEGORY_PATH
+        else apps_url
     )
     apps_html = fetch_text(apps_bootstrap_url, timeout=timeout)
 
@@ -1358,8 +1386,8 @@ def _bootstrap_target(target: dict[str, Any], *, timeout: int) -> dict[str, Any]
         )
 
     product_ids = {
-        device_key: product_facets.get(product_label)
-        for device_key, product_label in TARGET_PRODUCTS.items()
+        device_key: product_facets.get(product_meta["label"])
+        for device_key, product_meta in TARGET_PRODUCTS.items()
     }
     return {
         "root_url": root_url,
@@ -1422,73 +1450,91 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
     targets_by_key: dict[str, dict[str, Any]] = {
         str(target["key"]): target for target in crawl_targets
     }
-    global_target = targets_by_key.get(global_target_key)
-    if not isinstance(global_target, dict):
+    global_base_target = targets_by_key.get(global_target_key)
+    if not isinstance(global_base_target, dict):
         raise RuntimeError("Global routing target is missing")
-
-    global_target.update(_bootstrap_target(global_target, timeout=timeout))
-    global_target["bootstrap_error"] = None
-
-    for target in crawl_targets:
-        if str(target["key"]) == global_target_key:
-            continue
-        try:
-            target.update(_bootstrap_target(target, timeout=timeout))
-            target["bootstrap_error"] = None
-        except Exception as err:  # noqa: BLE001
-            target.update(
-                {
-                    "root_url": global_target["root_url"],
-                    "docs_path": global_target["docs_path"],
-                    "apps_url": global_target["apps_url"],
-                    "apps_html": global_target["apps_html"],
-                    "apps_bootstrap_url": global_target["apps_bootstrap_url"],
-                    "product_type": global_target["product_type"],
-                    "topic_id": global_target["topic_id"],
-                    "topic_facets": dict(global_target["topic_facets"]),
-                    "product_facets": dict(global_target["product_facets"]),
-                    "product_ids": dict(global_target["product_ids"]),
-                    "bootstrap_error": str(err),
-                }
-            )
-            _LOGGER.warning(
-                "Firmware catalog bootstrap failed for target %s; falling back to global metadata: %s",
-                target.get("key"),
-                err,
-            )
-
-    global_product_ids = {
-        device_key: global_target["product_ids"].get(device_key)
-        for device_key in TARGET_PRODUCTS
-    }
-    for device_key, product_label in TARGET_PRODUCTS.items():
-        if global_product_ids.get(device_key) is None:
-            raise RuntimeError(f"Could not discover product id for '{product_label}'")
-
-    global_topic_id = int(global_target["topic_id"])
-    global_product_type = str(global_target["product_type"])
-    global_root_url = str(global_target["root_url"])
-    global_apps_url = str(global_target["apps_url"])
-    global_topic_facets = dict(global_target["topic_facets"])
-    global_product_facets = dict(global_target["product_facets"])
-    global_apps_html = str(global_target["apps_html"])
-
-    language_options = parse_language_options(global_apps_html, "search_api_language")
-    alt_language_options = parse_language_options(
-        global_apps_html, "field_alternative_language"
-    )
-    locale_options = dict(language_options)
-    locale_options.update(alt_language_options)
-    locale_options.setdefault("en", "United States (EN)")
-    region_mapping = build_region_country_mapping(locale_options)
 
     all_country_codes: set[str] = {
         str(route["country_code"]) for route in routes if route.get("country_code")
     }
     devices_catalog: dict[str, Any] = {}
     crawl_meta: dict[str, Any] = {}
-    for device_key in TARGET_PRODUCTS:
-        global_product_id = int(global_product_ids[device_key])
+    source_devices: dict[str, Any] = {}
+    global_root_url = urljoin(
+        str(global_base_target["site_url"]), ROOT_PATH.lstrip("/")
+    )
+    global_apps_url = ""
+    global_product_type = DEFAULT_PRODUCT_TYPE
+    global_topic_facets: dict[str, Any] = {}
+    global_product_facets: dict[str, Any] = {}
+    language_options: dict[str, str] = {}
+    alt_language_options: dict[str, str] = {}
+
+    for device_key, product_meta in TARGET_PRODUCTS.items():
+        device_targets = [dict(target) for target in crawl_targets]
+        device_targets_by_key: dict[str, dict[str, Any]] = {
+            str(target["key"]): target for target in device_targets
+        }
+        global_target = device_targets_by_key[global_target_key]
+
+        docs_path = str(product_meta["docs_path"])
+        global_target.update(
+            _bootstrap_target(global_target, timeout=timeout, docs_path=docs_path)
+        )
+        global_target["bootstrap_error"] = None
+
+        for target in device_targets:
+            if str(target["key"]) == global_target_key:
+                continue
+            try:
+                target.update(
+                    _bootstrap_target(target, timeout=timeout, docs_path=docs_path)
+                )
+                target["bootstrap_error"] = None
+            except Exception as err:  # noqa: BLE001
+                target.update(
+                    {
+                        "root_url": global_target["root_url"],
+                        "docs_path": global_target["docs_path"],
+                        "apps_url": global_target["apps_url"],
+                        "apps_html": global_target["apps_html"],
+                        "apps_bootstrap_url": global_target["apps_bootstrap_url"],
+                        "product_type": global_target["product_type"],
+                        "topic_id": global_target["topic_id"],
+                        "topic_facets": dict(global_target["topic_facets"]),
+                        "product_facets": dict(global_target["product_facets"]),
+                        "product_ids": dict(global_target["product_ids"]),
+                        "bootstrap_error": str(err),
+                    }
+                )
+                _LOGGER.warning(
+                    "Firmware catalog bootstrap failed for target %s device %s; falling back to global metadata: %s",
+                    target.get("key"),
+                    device_key,
+                    err,
+                )
+
+        global_product_id_raw = global_target["product_ids"].get(device_key)
+        if global_product_id_raw is None:
+            raise RuntimeError(
+                f"Could not discover product id for '{product_meta['label']}'"
+            )
+        global_product_id = int(global_product_id_raw)
+        global_topic_id = int(global_target["topic_id"])
+        global_product_type = str(global_target["product_type"])
+        global_apps_url = str(global_target["apps_url"])
+        global_topic_facets = dict(global_target["topic_facets"])
+        global_product_facets = dict(global_target["product_facets"])
+
+        if not language_options:
+            global_apps_html = str(global_target["apps_html"])
+            language_options = parse_language_options(
+                global_apps_html, "search_api_language"
+            )
+            alt_language_options = parse_language_options(
+                global_apps_html, "field_alternative_language"
+            )
+
         target_entries: dict[str, dict[str, Any] | None] = {}
         target_crawl: dict[str, Any] = {}
         total_count = 0
@@ -1498,7 +1544,7 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
         bootstrap_error_targets: list[str] = []
         crawl_error_targets: list[str] = []
 
-        for target in crawl_targets:
+        for target in device_targets:
             target_product_id = target["product_ids"].get(device_key)
             used_global_product_id = target_product_id is None
             if used_global_product_id:
@@ -1553,7 +1599,9 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
             target_entries[str(target["key"])] = (
                 card_to_runtime_entry(
                     card=latest_card,
+                    product_type=str(target["product_type"]),
                     topic_id=int(target["topic_id"]),
+                    product_media_name_id=product_id,
                     locales=list(target["locales"]),
                     apps_url=str(target["apps_url"]),
                 )
@@ -1623,6 +1671,13 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
             "latest_by_country": latest_by_country,
             "latest_global": latest_global,
         }
+        source_devices[device_key] = {
+            "docs_url": global_apps_url,
+            "docs_path": str(global_target["docs_path"]),
+            "product_type": int(global_product_type),
+            "document_topic_id": global_topic_id,
+            "product_media_name_id": global_product_id,
+        }
         crawl_meta[device_key] = {
             "count": total_count,
             "targets": target_crawl,
@@ -1633,6 +1688,11 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
             "crawl_error_targets": sorted(set(crawl_error_targets)),
         }
 
+    locale_options = dict(language_options)
+    locale_options.update(alt_language_options)
+    locale_options.setdefault("en", "United States (EN)")
+    region_mapping = build_region_country_mapping(locale_options)
+
     runtime_catalog = {
         "schema_version": SCHEMA_VERSION,
         "generated_at": generated_at,
@@ -1641,6 +1701,7 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
             "entrypoint": global_root_url,
             "apps_url": global_apps_url,
             "product_type": int(global_product_type),
+            "devices": source_devices,
             "routing": "authoritative_region_site_routes",
             "target_count": len(crawl_targets),
             "crawl": crawl_meta,
@@ -1664,13 +1725,12 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
             "root": global_root_url,
             "apps": global_apps_url,
             "product_type": int(global_product_type),
+            "devices": source_devices,
             "targets": [
                 {
                     "key": target["key"],
                     "site_url": target["site_url"],
                     "query_locale": target["query_locale"],
-                    "apps": target["apps_url"],
-                    "product_type": int(target["product_type"]),
                 }
                 for target in crawl_targets
             ],
@@ -1691,8 +1751,10 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
             "products": global_product_facets,
             "targets": {
                 key: {
-                    "label": TARGET_PRODUCTS[key],
-                    "product_media_name_id": int(global_product_ids[key]),
+                    "label": TARGET_PRODUCTS[key]["label"],
+                    "product_media_name_id": int(
+                        devices_catalog[key]["product_media_name_id"]
+                    ),
                 }
                 for key in TARGET_PRODUCTS
             },

--- a/scripts/firmware_catalog.py
+++ b/scripts/firmware_catalog.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import argparse
 import html
 import json
+import logging
 import re
 import sys
 from dataclasses import dataclass, field
@@ -19,6 +20,8 @@ from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urljoin, urlparse, urlsplit, urlunsplit
 from urllib.request import Request, urlopen
+
+_LOGGER = logging.getLogger(__name__)
 
 BASE_URL = "https://enphase.com"
 ROOT_PATH = "/installers/resources/documentation"
@@ -160,6 +163,12 @@ REGION_SITE_ROUTE_ROWS: list[dict[str, str | None]] = [
         "site_url": "https://enphase.com/es-lac/",
     },
     {
+        "label": "Chile",
+        "country_code": "CL",
+        "locale": "es-lac",
+        "site_url": "https://enphase.com/es-lac/",
+    },
+    {
         "label": "Costa Rica",
         "country_code": "CR",
         "locale": "es-lac",
@@ -170,6 +179,12 @@ REGION_SITE_ROUTE_ROWS: list[dict[str, str | None]] = [
         "country_code": "DO",
         "locale": "es-do",
         "site_url": "https://enphase.com/es-do/",
+    },
+    {
+        "label": "Jamaica",
+        "country_code": "JM",
+        "locale": "en-lac",
+        "site_url": "https://enphase.com/en-lac/",
     },
     {
         "label": "Mexico",
@@ -403,7 +418,7 @@ REGION_SITE_ROUTE_ROWS: list[dict[str, str | None]] = [
         "label": "Switzerland - Deutsch",
         "country_code": "CH",
         "locale": "de-ch",
-        "site_url": "https://enphase.com/de-de/",
+        "site_url": "https://enphase.com/de-ch/",
     },
     {
         "label": "Switzerland - Francais",
@@ -415,7 +430,7 @@ REGION_SITE_ROUTE_ROWS: list[dict[str, str | None]] = [
         "label": "Switzerland - Italiano",
         "country_code": "CH",
         "locale": "it-ch",
-        "site_url": "https://enphase.com/it-it/",
+        "site_url": "https://enphase.com/it-ch/",
     },
     {
         "label": "Turkiye",
@@ -1320,6 +1335,46 @@ def fetch_previous_runtime_catalog(
     return payload
 
 
+def _bootstrap_target(target: dict[str, Any], *, timeout: int) -> dict[str, Any]:
+    root_url = urljoin(str(target["site_url"]), ROOT_PATH.lstrip("/"))
+    root_html = fetch_text(root_url, timeout=timeout)
+    docs_path, discovered_product_type = discover_apps_entrypoint(root_html)
+
+    apps_url = urljoin(str(target["site_url"]), docs_path.lstrip("/"))
+    apps_bootstrap_url = _with_query(
+        apps_url, {"product_type": discovered_product_type}
+    )
+    apps_html = fetch_text(apps_bootstrap_url, timeout=timeout)
+
+    product_type = (
+        parse_product_type_from_apps_page(apps_html) or discovered_product_type
+    )
+    product_facets = parse_facet_values(apps_html, "product_media_name")
+    topic_facets = parse_facet_values(apps_html, "document")
+    topic_id = _resolve_release_notes_topic_id(topic_facets)
+    if topic_id is None:
+        raise RuntimeError(
+            f"Could not discover release-notes topic id from apps page: {apps_bootstrap_url}"
+        )
+
+    product_ids = {
+        device_key: product_facets.get(product_label)
+        for device_key, product_label in TARGET_PRODUCTS.items()
+    }
+    return {
+        "root_url": root_url,
+        "docs_path": docs_path,
+        "apps_url": apps_url,
+        "apps_html": apps_html,
+        "apps_bootstrap_url": apps_bootstrap_url,
+        "product_type": product_type,
+        "topic_id": int(topic_id),
+        "topic_facets": topic_facets,
+        "product_facets": product_facets,
+        "product_ids": product_ids,
+    }
+
+
 def catalogs_equal_ignoring_generated_at(
     current_catalog: dict[str, Any],
     previous_catalog: dict[str, Any] | None,
@@ -1364,49 +1419,43 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
         str(routes[0]["target_key"]),
     )
 
-    targets_by_key: dict[str, dict[str, Any]] = {}
-    for target in crawl_targets:
-        root_url = urljoin(str(target["site_url"]), ROOT_PATH.lstrip("/"))
-        root_html = fetch_text(root_url, timeout=timeout)
-        docs_path, discovered_product_type = discover_apps_entrypoint(root_html)
-
-        apps_url = urljoin(str(target["site_url"]), docs_path.lstrip("/"))
-        apps_bootstrap_url = _with_query(
-            apps_url, {"product_type": discovered_product_type}
-        )
-        apps_html = fetch_text(apps_bootstrap_url, timeout=timeout)
-
-        product_type = (
-            parse_product_type_from_apps_page(apps_html) or discovered_product_type
-        )
-        product_facets = parse_facet_values(apps_html, "product_media_name")
-        topic_facets = parse_facet_values(apps_html, "document")
-        topic_id = _resolve_release_notes_topic_id(topic_facets)
-        if topic_id is None:
-            raise RuntimeError(
-                f"Could not discover release-notes topic id from apps page: {apps_bootstrap_url}"
-            )
-
-        product_ids = {
-            device_key: product_facets.get(product_label)
-            for device_key, product_label in TARGET_PRODUCTS.items()
-        }
-
-        target["root_url"] = root_url
-        target["docs_path"] = docs_path
-        target["apps_url"] = apps_url
-        target["apps_html"] = apps_html
-        target["apps_bootstrap_url"] = apps_bootstrap_url
-        target["product_type"] = product_type
-        target["topic_id"] = int(topic_id)
-        target["topic_facets"] = topic_facets
-        target["product_facets"] = product_facets
-        target["product_ids"] = product_ids
-        targets_by_key[str(target["key"])] = target
-
+    targets_by_key: dict[str, dict[str, Any]] = {
+        str(target["key"]): target for target in crawl_targets
+    }
     global_target = targets_by_key.get(global_target_key)
     if not isinstance(global_target, dict):
         raise RuntimeError("Global routing target is missing")
+
+    global_target.update(_bootstrap_target(global_target, timeout=timeout))
+    global_target["bootstrap_error"] = None
+
+    for target in crawl_targets:
+        if str(target["key"]) == global_target_key:
+            continue
+        try:
+            target.update(_bootstrap_target(target, timeout=timeout))
+            target["bootstrap_error"] = None
+        except Exception as err:  # noqa: BLE001
+            target.update(
+                {
+                    "root_url": global_target["root_url"],
+                    "docs_path": global_target["docs_path"],
+                    "apps_url": global_target["apps_url"],
+                    "apps_html": global_target["apps_html"],
+                    "apps_bootstrap_url": global_target["apps_bootstrap_url"],
+                    "product_type": global_target["product_type"],
+                    "topic_id": global_target["topic_id"],
+                    "topic_facets": dict(global_target["topic_facets"]),
+                    "product_facets": dict(global_target["product_facets"]),
+                    "product_ids": dict(global_target["product_ids"]),
+                    "bootstrap_error": str(err),
+                }
+            )
+            _LOGGER.warning(
+                "Firmware catalog bootstrap failed for target %s; falling back to global metadata: %s",
+                target.get("key"),
+                err,
+            )
 
     global_product_ids = {
         device_key: global_target["product_ids"].get(device_key)
@@ -1446,6 +1495,8 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
         missing_product_ids: list[str] = []
         fallback_id_targets: list[str] = []
         empty_release_targets: list[str] = []
+        bootstrap_error_targets: list[str] = []
+        crawl_error_targets: list[str] = []
 
         for target in crawl_targets:
             target_product_id = target["product_ids"].get(device_key)
@@ -1460,15 +1511,29 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
             if used_global_product_id and str(target["key"]) != global_target_key:
                 fallback_id_targets.append(str(target["key"]))
 
-            cards, visited_pages = crawl_release_cards(
-                apps_url=str(target["apps_url"]),
-                product_type=str(target["product_type"]),
-                topic_id=int(target["topic_id"]),
-                product_media_name_id=product_id,
-                search_locale=str(target["query_locale"]),
-                timeout=timeout,
-                max_pages=max_pages,
-            )
+            if target.get("bootstrap_error"):
+                bootstrap_error_targets.append(str(target["key"]))
+            try:
+                cards, visited_pages = crawl_release_cards(
+                    apps_url=str(target["apps_url"]),
+                    product_type=str(target["product_type"]),
+                    topic_id=int(target["topic_id"]),
+                    product_media_name_id=product_id,
+                    search_locale=str(target["query_locale"]),
+                    timeout=timeout,
+                    max_pages=max_pages,
+                )
+                crawl_error: str | None = None
+            except Exception as err:  # noqa: BLE001
+                cards, visited_pages = [], []
+                crawl_error = str(err)
+                crawl_error_targets.append(str(target["key"]))
+                _LOGGER.warning(
+                    "Firmware catalog crawl failed for target %s device %s; treating as empty result: %s",
+                    target.get("key"),
+                    device_key,
+                    err,
+                )
             total_count += len(cards)
             target_crawl[str(target["key"])] = {
                 "site_url": target["site_url"],
@@ -1478,6 +1543,8 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
                 "count": len(cards),
                 "product_media_name_id": product_id,
                 "used_global_product_media_name_id": used_global_product_id,
+                "bootstrap_error": target.get("bootstrap_error"),
+                "crawl_error": crawl_error,
             }
             if len(cards) == 0:
                 empty_release_targets.append(str(target["key"]))
@@ -1562,6 +1629,8 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
             "missing_product_media_id_targets": sorted(set(missing_product_ids)),
             "used_global_product_media_id_targets": sorted(set(fallback_id_targets)),
             "empty_release_targets": sorted(set(empty_release_targets)),
+            "bootstrap_error_targets": sorted(set(bootstrap_error_targets)),
+            "crawl_error_targets": sorted(set(crawl_error_targets)),
         }
 
     runtime_catalog = {

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -406,6 +406,47 @@ def test_type_device_envoy_falls_back_to_gateway_member_metadata(
     assert info["sw_version"] == "D8.3.5167"
 
 
+def test_type_device_envoy_prefers_gateway_firmware_over_controller_version(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "envoy": {
+                "type_key": "envoy",
+                "type_label": "Gateway",
+                "count": 2,
+                "devices": [
+                    {
+                        "name": "IQ Gateway",
+                        "serial_number": "GW-123",
+                        "sku_id": "SC-IQG-PCBA-ROW",
+                        "envoy_sw_version": "D8.3.5232",
+                    },
+                    {
+                        "name": "IQ System Controller 3 INT",
+                        "serial_number": "SC-123",
+                        "channel_type": "IQ System Controller",
+                        "sw_version": "522-00003-01-v2.7.7054_rel/31.44",
+                    },
+                ],
+            }
+        },
+        ["envoy"],
+    )
+
+    assert coord.inventory_view.type_device_model("envoy") == "IQ Gateway"
+    assert coord.inventory_view.type_device_serial_number("envoy") == "GW-123"
+    assert coord.inventory_view.type_device_model_id("envoy") == "SC-IQG-PCBA-ROW"
+    assert coord.inventory_view.type_device_sw_version("envoy") == "D8.3.5232"
+    info = coord.inventory_view.type_device_info("envoy")
+    assert info is not None
+    assert info["model"] == "IQ Gateway"
+    assert info["serial_number"] == "GW-123"
+    assert info["model_id"] == "SC-IQG-PCBA-ROW"
+    assert info["sw_version"] == "D8.3.5232"
+
+
 def test_type_device_envoy_does_not_promote_localized_meters_to_gateway(
     hass, monkeypatch
 ) -> None:

--- a/tests/components/enphase_ev/test_firmware_catalog.py
+++ b/tests/components/enphase_ev/test_firmware_catalog.py
@@ -42,7 +42,7 @@ async def test_catalog_manager_caches_and_uses_stale_on_error(monkeypatch) -> No
     payload = {
         "schema_version": 1,
         "generated_at": "2026-03-01T00:00:00Z",
-        "devices": {"envoy": {}, "microinverter": {}},
+        "devices": {"envoy": {}},
     }
     fake_session = _FakeSession(
         [
@@ -120,6 +120,19 @@ async def test_catalog_manager_cold_start_failure_honors_backoff(monkeypatch) ->
     assert manager.status_snapshot()["last_error"] == "email=[redacted]"
 
 
+def test_catalog_manager_uses_env_override(monkeypatch) -> None:
+    monkeypatch.setenv(
+        firmware_catalog.FIRMWARE_CATALOG_URL_ENV,
+        "http://127.0.0.1:8123/local/catalog/v1/runtime_catalog.json",
+    )
+
+    manager = firmware_catalog.FirmwareCatalogManager(SimpleNamespace())
+
+    assert manager.status_snapshot()["url"] == (
+        "http://127.0.0.1:8123/local/catalog/v1/runtime_catalog.json"
+    )
+
+
 @pytest.mark.asyncio
 async def test_catalog_manager_lock_recheck_returns_cached_without_fetch(
     monkeypatch,
@@ -127,7 +140,7 @@ async def test_catalog_manager_lock_recheck_returns_cached_without_fetch(
     payload = {
         "schema_version": 1,
         "generated_at": "2026-03-01T00:00:00Z",
-        "devices": {"envoy": {}, "microinverter": {}},
+        "devices": {"envoy": {}},
     }
     manager = firmware_catalog.FirmwareCatalogManager(SimpleNamespace())
 
@@ -328,6 +341,39 @@ def test_select_catalog_entry_country_and_locale_fallback() -> None:
     assert legacy_selection.source_scope == "country"
     assert legacy_selection.entry and legacy_selection.entry["version"] == "8.2.4401"
 
+    repair_selection = firmware_catalog.select_catalog_entry(
+        {
+            "schema_version": 1,
+            "devices": {
+                "envoy": {
+                    "document_topic_id": 217,
+                    "product_media_name_id": 5002,
+                    "latest_by_country": {
+                        "AU": {
+                            "version": "8.2.4401",
+                            "urls_by_locale": {
+                                "en-au": (
+                                    "https://enphase.com/en-au/installers/resources/"
+                                    "documentation/apps?media_id=22469&langcode=und"
+                                )
+                            },
+                        }
+                    },
+                }
+            },
+        },
+        device_type="envoy",
+        country="AU",
+        locale="en-au",
+    )
+    assert repair_selection.entry is not None
+    assert repair_selection.entry["urls_by_locale"]["en-au"] == (
+        "https://enphase.com/en-au/installers/resources/documentation/apps?"
+        "product_type=216&f%5B0%5D=document%3A217&"
+        "f%5B1%5D=product_media_name%3A5002&"
+        "search_api_language=en-au&field_alternative_language=en-au"
+    )
+
 
 def test_source_age_seconds_handles_future_and_invalid() -> None:
     now = datetime.now(firmware_catalog.dt_util.UTC)
@@ -335,6 +381,40 @@ def test_source_age_seconds_handles_future_and_invalid() -> None:
     assert firmware_catalog._source_age_seconds(future) == 0.0
     assert firmware_catalog._source_age_seconds("not-a-date") is None
     assert firmware_catalog._source_age_seconds(None) is None
+
+
+def test_legacy_release_url_helper_edge_paths() -> None:
+    entry = {
+        "urls_by_locale": {
+            "en-au": "https://example.test/envoy?media_id=123&langcode=und",
+            "fr-fr": "https://example.test/envoy/fr",
+        }
+    }
+    device_payload = {"document_topic_id": None, "product_media_name_id": 5002}
+    assert firmware_catalog._repair_legacy_release_urls(device_payload, entry) is entry
+
+    device_payload = {"document_topic_id": 217, "product_media_name_id": 5002}
+    assert (
+        firmware_catalog._repair_legacy_release_urls(device_payload, entry) is not entry
+    )
+
+    non_legacy_entry = {
+        "document_topic_id": 217,
+        "product_media_name_id": 5002,
+        "urls_by_locale": {"en-au": "https://example.test/envoy/fr"},
+    }
+    assert (
+        firmware_catalog._repair_legacy_release_urls(device_payload, non_legacy_entry)
+        is non_legacy_entry
+    )
+
+    class _BadStr:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    assert firmware_catalog._is_legacy_release_url(None) is False
+    assert firmware_catalog._is_legacy_release_url(_BadStr()) is False
+    assert firmware_catalog._as_int(_BadStr()) is None
 
 
 def test_coordinator_metrics_include_firmware_catalog_status(

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -13,6 +13,7 @@ from homeassistant.helpers import device_registry as dr, entity_registry as er
 
 import custom_components.enphase_ev as enphase_init
 from custom_components.enphase_ev import (
+    PLATFORMS,
     DOMAIN,
     _async_update_listener,
     _complete_startup_migrations_if_ready,
@@ -992,7 +993,7 @@ async def test_async_unload_entry_stops_schedule_sync(
     assert await async_unload_entry(hass, config_entry)
     schedule_sync.async_stop.assert_awaited_once()
     coord.cleanup_runtime_state.assert_called_once()
-    assert unload.await_count == 8
+    assert unload.await_count == len(PLATFORMS)
     assert config_entry.runtime_data is None
 
 
@@ -1026,7 +1027,7 @@ async def test_async_unload_entry_handles_missing_runtime_data(
     monkeypatch.setattr(hass.config_entries, "async_forward_entry_unload", unload)
 
     assert await async_unload_entry(hass, config_entry)
-    assert unload.await_count == 8
+    assert unload.await_count == len(PLATFORMS)
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -27,6 +27,7 @@ from custom_components.enphase_ev import (
     _migrate_cloud_entity_unique_ids,
     _migrate_cloud_entities_to_cloud_device,
     _migrate_legacy_gateway_type_devices,
+    _migrate_orphaned_update_entities_to_type_devices,
     _normalize_selected_type_keys,
     _normalize_evse_model_name,
     _registry_charger_metadata_signature,
@@ -147,9 +148,14 @@ def test_complete_startup_migrations_if_ready_ignores_failing_readiness_check(
 
     migrate_gateway = MagicMock()
     migrate_cloud = MagicMock()
+    migrate_updates = MagicMock()
     monkeypatch.setattr(
         "custom_components.enphase_ev._migrate_legacy_gateway_type_devices",
         migrate_gateway,
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev._migrate_orphaned_update_entities_to_type_devices",
+        migrate_updates,
     )
     monkeypatch.setattr(
         "custom_components.enphase_ev._migrate_cloud_entities_to_cloud_device",
@@ -161,6 +167,7 @@ def test_complete_startup_migrations_if_ready_ignores_failing_readiness_check(
     )
 
     migrate_gateway.assert_not_called()
+    migrate_updates.assert_not_called()
     migrate_cloud.assert_not_called()
     assert "startup_migration_version" not in config_entry.data
 
@@ -189,6 +196,170 @@ def test_iter_device_registry_entries_handles_edge_paths() -> None:
         )
         == []
     )
+
+
+@pytest.mark.asyncio
+async def test_migrate_orphaned_update_entities_to_type_devices_removes_site_updates(
+    hass: HomeAssistant, config_entry
+) -> None:
+    site_id = config_entry.data[CONF_SITE_ID]
+    ent_reg = er.async_get(hass)
+    owned_gateway = ent_reg.async_get_or_create(
+        "update",
+        DOMAIN,
+        f"{DOMAIN}_site_{site_id}_envoy_firmware",
+        config_entry=config_entry,
+        original_name="Gateway Firmware",
+    )
+    owned_micro = ent_reg.async_get_or_create(
+        "update",
+        DOMAIN,
+        f"{DOMAIN}_site_{site_id}_microinverter_firmware",
+        config_entry=config_entry,
+        original_name="Microinverter Firmware",
+    )
+    kept_charger = ent_reg.async_get_or_create(
+        "update",
+        DOMAIN,
+        f"{DOMAIN}_site_{site_id}_iqevse_firmware",
+        config_entry=config_entry,
+        original_name="Charger Firmware",
+    )
+
+    _migrate_orphaned_update_entities_to_type_devices(hass, config_entry, site_id)
+
+    assert ent_reg.async_get(owned_gateway.entity_id) is None
+    assert ent_reg.async_get(owned_micro.entity_id) is None
+    assert ent_reg.async_get(kept_charger.entity_id) is not None
+
+
+def test_migrate_orphaned_update_entities_to_type_devices_handles_edge_paths(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    _migrate_orphaned_update_entities_to_type_devices(hass, config_entry, "   ")
+
+    class _BadSiteId:
+        def __str__(self) -> str:
+            raise RuntimeError("boom")
+
+    _migrate_orphaned_update_entities_to_type_devices(hass, config_entry, _BadSiteId())
+
+    monkeypatch.setattr("custom_components.enphase_ev.er", None)
+    _migrate_orphaned_update_entities_to_type_devices(
+        hass, config_entry, config_entry.data[CONF_SITE_ID]
+    )
+
+    class _BrokenEntityRegistryModule:
+        @staticmethod
+        def async_get(_hass):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr("custom_components.enphase_ev.er", _BrokenEntityRegistryModule)
+    _migrate_orphaned_update_entities_to_type_devices(
+        hass, config_entry, config_entry.data[CONF_SITE_ID]
+    )
+
+    removed: list[str] = []
+    fake_registry = SimpleNamespace(
+        entities={
+            "foreign_owner": SimpleNamespace(
+                entity_id="update.foreign_owner",
+                platform=DOMAIN,
+                domain="update",
+                device_id=None,
+                unique_id=f"{DOMAIN}_site_{config_entry.data[CONF_SITE_ID]}_envoy_firmware",
+                config_entry_id="other-entry",
+            ),
+            "wrong_platform": SimpleNamespace(
+                entity_id="update.wrong_platform",
+                platform="other_platform",
+                domain="update",
+                device_id=None,
+                unique_id=f"{DOMAIN}_site_{config_entry.data[CONF_SITE_ID]}_envoy_firmware",
+                config_entry_id=config_entry.entry_id,
+            ),
+            "wrong_domain": SimpleNamespace(
+                entity_id="sensor.wrong_domain",
+                platform=DOMAIN,
+                domain="sensor",
+                device_id=None,
+                unique_id=f"{DOMAIN}_site_{config_entry.data[CONF_SITE_ID]}_envoy_firmware",
+                config_entry_id=config_entry.entry_id,
+            ),
+            "has_device": SimpleNamespace(
+                entity_id="update.has_device",
+                platform=DOMAIN,
+                domain="update",
+                device_id="device-1",
+                unique_id=f"{DOMAIN}_site_{config_entry.data[CONF_SITE_ID]}_envoy_firmware",
+                config_entry_id=config_entry.entry_id,
+            ),
+            "gateway_missing_entity_id": SimpleNamespace(
+                entity_id=None,
+                platform=DOMAIN,
+                domain="update",
+                device_id=None,
+                unique_id=f"{DOMAIN}_site_{config_entry.data[CONF_SITE_ID]}_envoy_firmware",
+                config_entry_id=config_entry.entry_id,
+            ),
+            "wrong_unique": SimpleNamespace(
+                entity_id="update.wrong_unique",
+                platform=DOMAIN,
+                domain="update",
+                device_id=None,
+                unique_id=f"{DOMAIN}_site_{config_entry.data[CONF_SITE_ID]}_iqevse_firmware",
+                config_entry_id=config_entry.entry_id,
+            ),
+            "missing_entity_id": SimpleNamespace(
+                entity_id=None,
+                platform=DOMAIN,
+                domain="update",
+                device_id=None,
+                unique_id=f"{DOMAIN}_site_{config_entry.data[CONF_SITE_ID]}_microinverter_firmware",
+                config_entry_id=config_entry.entry_id,
+            ),
+            "micro_with_device": SimpleNamespace(
+                entity_id="update.micro_with_device",
+                platform=DOMAIN,
+                domain=None,
+                device_id="device-1",
+                unique_id=f"{DOMAIN}_site_{config_entry.data[CONF_SITE_ID]}_microinverter_firmware",
+                config_entry_id=config_entry.entry_id,
+            ),
+        },
+        async_remove=lambda entity_id: removed.append(entity_id),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.er",
+        SimpleNamespace(async_get=lambda _hass: fake_registry),
+    )
+    _migrate_orphaned_update_entities_to_type_devices(
+        hass, config_entry, config_entry.data[CONF_SITE_ID]
+    )
+    assert removed == ["update.micro_with_device"]
+
+    wrong_platform_registry = SimpleNamespace(
+        entities={
+            "wrong_platform": SimpleNamespace(
+                entity_id="update.wrong_platform",
+                platform="other_platform",
+                domain="update",
+                device_id=None,
+                unique_id=f"{DOMAIN}_site_{config_entry.data[CONF_SITE_ID]}_envoy_firmware",
+                config_entry_id=config_entry.entry_id,
+            )
+        },
+        async_remove=lambda entity_id: removed.append(entity_id),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.er",
+        SimpleNamespace(async_get=lambda _hass: wrong_platform_registry),
+    )
+    removed.clear()
+    _migrate_orphaned_update_entities_to_type_devices(
+        hass, config_entry, config_entry.data[CONF_SITE_ID]
+    )
+    assert removed == []
 
 
 @pytest.mark.asyncio
@@ -496,6 +667,7 @@ async def test_async_setup_entry_records_startup_migration_version(
     dummy_coord = _with_inventory_view(DummyCoordinator())
     migrate_gateway = MagicMock()
     migrate_cloud = MagicMock()
+    migrate_updates = MagicMock()
     monkeypatch.setattr(
         "custom_components.enphase_ev.coordinator.EnphaseCoordinator",
         lambda hass_, entry_data, config_entry=None: dummy_coord,
@@ -503,6 +675,10 @@ async def test_async_setup_entry_records_startup_migration_version(
     monkeypatch.setattr(
         "custom_components.enphase_ev._migrate_legacy_gateway_type_devices",
         migrate_gateway,
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev._migrate_orphaned_update_entities_to_type_devices",
+        migrate_updates,
     )
     monkeypatch.setattr(
         "custom_components.enphase_ev._migrate_cloud_entities_to_cloud_device",
@@ -513,8 +689,9 @@ async def test_async_setup_entry_records_startup_migration_version(
     assert await async_setup_entry(hass, config_entry)
 
     migrate_gateway.assert_called_once()
+    assert migrate_updates.call_count == 2
     migrate_cloud.assert_called_once()
-    assert config_entry.data["startup_migration_version"] == 3
+    assert config_entry.data["startup_migration_version"] == 5
 
 
 @pytest.mark.asyncio
@@ -2016,6 +2193,10 @@ async def test_startup_migration_removes_evse_type_device_and_inventory_entity(
     )
     monkeypatch.setattr(
         "custom_components.enphase_ev._migrate_legacy_gateway_type_devices",
+        Mock(),
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev._migrate_orphaned_update_entities_to_type_devices",
         Mock(),
     )
     monkeypatch.setattr(
@@ -3705,6 +3886,11 @@ async def test_async_setup_entry_registry_sync_listener_only_resyncs_devices_on_
     monkeypatch.setattr(
         "custom_components.enphase_ev._migrate_legacy_gateway_type_devices", migrate
     )
+    migrate_updates = Mock()
+    monkeypatch.setattr(
+        "custom_components.enphase_ev._migrate_orphaned_update_entities_to_type_devices",
+        migrate_updates,
+    )
     migrate_cloud = Mock()
     monkeypatch.setattr(
         "custom_components.enphase_ev._migrate_cloud_entities_to_cloud_device",
@@ -3715,6 +3901,7 @@ async def test_async_setup_entry_registry_sync_listener_only_resyncs_devices_on_
     assert topology_listeners, "expected setup to register a topology listener"
     assert state_listeners, "expected setup to register a state listener"
     assert migrate.call_count == 0
+    assert migrate_updates.call_count == 1
     assert migrate_cloud.call_count == 0
     assert "startup_migration_version" not in config_entry.data
     assert sync_registry_devices.call_count == 1
@@ -3724,8 +3911,9 @@ async def test_async_setup_entry_registry_sync_listener_only_resyncs_devices_on_
 
     assert sync_registry_devices.call_count == 1
     assert migrate.call_count == 1
+    assert migrate_updates.call_count == 2
     assert migrate_cloud.call_count == 1
-    assert config_entry.data["startup_migration_version"] == 3
+    assert config_entry.data["startup_migration_version"] == 5
 
     for listener in state_listeners[:-1]:
         listener()
@@ -3734,6 +3922,7 @@ async def test_async_setup_entry_registry_sync_listener_only_resyncs_devices_on_
     dummy_coord.data[RANDOM_SERIAL]["sw_version"] = "1.2.3"
     state_listeners[-1]()
     assert sync_registry_devices.call_count == 2
+    assert migrate_updates.call_count == 3
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -815,7 +815,6 @@ def test_update_entity_strings_localized_for_non_english_locales() -> None:
     en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
     paths = [
         "entity.update.gateway_firmware.name",
-        "entity.update.microinverter_firmware.name",
         "entity.update.charger_firmware.name",
     ]
     for locale in translations_dir.glob("*.json"):

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -7,7 +7,7 @@ import pytest
 from homeassistant.components.update import UpdateEntityDescription
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 from custom_components.enphase_ev import PLATFORMS
 from custom_components.enphase_ev.const import DOMAIN
@@ -21,6 +21,7 @@ from custom_components.enphase_ev.update import (
     _charger_serials,
     _charger_installed_version,
     _charger_update_unique_id,
+    _evse_firmware_rollout_enabled,
     _gateway_installed_version,
     _microinverter_installed_version,
     _text,
@@ -79,6 +80,9 @@ class DummyCoordinator:
         self._iqevse_version = "25.37.1.13"
         self._listeners = []
         self._available_types = {"envoy", "microinverter", "iqevse"}
+        self._evse_feature_flags = {
+            TEST_EVSE_SERIAL: {"iqevse_itk_fw_upgrade_status": True}
+        }
         self.data = {
             TEST_EVSE_SERIAL: {
                 "firmware_version": "25.37.1.13",
@@ -137,6 +141,11 @@ class DummyCoordinator:
     def iter_serials(self) -> list[str]:
         return list(self.data)
 
+    def evse_feature_flag_enabled(self, key: str, sn: str | None = None) -> bool | None:
+        if sn is None:
+            return None
+        return self._evse_feature_flags.get(sn, {}).get(key)
+
 
 def _catalog_payload() -> dict:
     return {
@@ -191,6 +200,30 @@ def _catalog_payload() -> dict:
                     "urls_by_locale": {"en": "https://example.test/micro/global"},
                 },
             },
+            "iqevse": {
+                "latest_by_locale": {
+                    "fr-fr": {
+                        "version": "25.37.1.14",
+                        "summary": "Charger firmware update",
+                        "urls_by_locale": {"fr-fr": "https://example.test/charger/fr"},
+                    }
+                },
+                "latest_by_country": {
+                    "AU": {
+                        "version": "25.37.1.14",
+                        "summary": "Charger firmware update",
+                        "urls_by_locale": {
+                            "en": "https://example.test/charger/en",
+                            "fr-fr": "https://example.test/charger/fr",
+                        },
+                    }
+                },
+                "latest_global": {
+                    "version": "25.37.1.14",
+                    "summary": "Charger global",
+                    "urls_by_locale": {"en": "https://example.test/charger/global"},
+                },
+            },
         },
     }
 
@@ -211,8 +244,8 @@ def _evse_payload() -> dict[str, dict]:
     }
 
 
-def test_platform_disables_update_by_default() -> None:
-    assert "update" not in PLATFORMS
+def test_platform_enables_update_entities() -> None:
+    assert "update" in PLATFORMS
 
 
 @pytest.mark.asyncio
@@ -369,12 +402,32 @@ async def test_gateway_update_entity_states_and_release_url_selection(hass) -> N
     assert entity.installed_version == "8.2.4300"
     assert entity.latest_version == "8.2.4401"
     assert entity.state == "on"
+    assert entity.supported_features == 0
     assert entity.release_url == "https://example.test/envoy/fr"
     assert entity.device_info["name"] == "envoy device"
 
+    entity.async_write_ha_state = lambda: None
+    await entity.async_skip()
+    assert entity.state == "off"
+    assert entity.state_attributes["skipped_version"] == "8.2.4401"
+    await entity.async_clear_skipped()
+    assert entity.state == "on"
+
+    await entity.async_skip()
     coord._gateway_version = "8.2.4401"
     entity._refresh_from_catalog(manager.cached_catalog)
     assert entity.state == "off"
+    assert entity.state_attributes["skipped_version"] is None
+
+    coord._gateway_version = "8.2.4300"
+    entity._refresh_from_catalog(manager.cached_catalog)
+    await entity.async_skip()
+    payload = _catalog_payload()
+    payload["devices"]["envoy"]["latest_by_country"]["AU"]["version"] = "8.2.4500"
+    payload["devices"]["envoy"]["latest_by_locale"]["fr-fr"]["version"] = "8.2.4500"
+    entity._refresh_from_catalog(payload)
+    assert entity.state == "on"
+    assert entity.state_attributes["skipped_version"] is None
 
     coord._gateway_version = "firmware build unknown"
     entity._refresh_from_catalog(manager.cached_catalog)
@@ -403,6 +456,7 @@ async def test_microinverter_update_entity_uses_normalized_versions(hass) -> Non
     assert entity.installed_version == "04.30.31"
     assert entity.latest_version == "04.30.32"
     assert entity.state == "on"
+    assert entity.supported_features == 0
     assert entity.release_url == "https://example.test/micro/fr"
 
     attrs = entity.extra_state_attributes
@@ -416,20 +470,26 @@ async def test_microinverter_update_entity_uses_normalized_versions(hass) -> Non
 async def test_charger_update_entity_uses_fw_details_payload(hass) -> None:
     coord = DummyCoordinator()
     manager = DummyEvseFirmwareManager(_evse_payload())
+    catalog_manager = DummyCatalogManager(_catalog_payload())
     entity = ChargerFirmwareUpdateEntity(
         coordinator=coord,
         manager=manager,
+        catalog_manager=catalog_manager,
         serial=TEST_EVSE_SERIAL,
         description=UpdateEntityDescription(key="charger_firmware"),
     )
     entity.hass = hass
 
     entity._refresh_from_details(manager.cached_details)
+    entity._refresh_from_catalog(catalog_manager.cached_catalog)
     assert entity.installed_version == "25.37.1.13"
     assert entity.latest_version == "25.37.1.14"
     assert entity.state == "on"
     assert entity.available is True
+    assert entity.supported_features == 0
     assert entity.device_info["identifiers"] == {("enphase_ev", TEST_EVSE_SERIAL)}
+    assert entity.release_url == "https://example.test/charger/fr"
+    assert entity.release_summary == "Charger firmware update"
 
     attrs = entity.extra_state_attributes
     assert attrs["upgrade_status"] == 5
@@ -438,7 +498,33 @@ async def test_charger_update_entity_uses_fw_details_payload(hass) -> None:
     )
     assert attrs["last_updated_at"] == "2025-12-08T15:52:59.806385175Z[UTC]"
     assert attrs["is_auto_ota"] is False
+    assert attrs["firmware_rollout_enabled"] is True
     assert attrs["details_last_error"] is None
+    assert attrs["catalog_source_scope"] == "locale"
+    assert attrs["catalog_generated_at"] == "2026-03-01T00:00:00Z"
+
+    entity.async_write_ha_state = lambda: None
+    await entity.async_skip()
+    assert entity.state == "off"
+    assert entity.state_attributes["skipped_version"] == "25.37.1.14"
+    await entity.async_clear_skipped()
+    assert entity.state == "on"
+
+    await entity.async_skip()
+    manager.cached_details[TEST_EVSE_SERIAL]["currentFwVersion"] = "25.37.1.14"
+    entity._refresh_from_details(manager.cached_details)
+    assert entity.state == "off"
+    assert entity.state_attributes["skipped_version"] is None
+
+    manager.cached_details[TEST_EVSE_SERIAL]["currentFwVersion"] = "25.37.1.13"
+    manager.cached_details[TEST_EVSE_SERIAL]["targetFwVersion"] = "25.37.1.14"
+    entity._refresh_from_details(manager.cached_details)
+    await entity.async_skip()
+    manager.cached_details[TEST_EVSE_SERIAL]["currentFwVersion"] = "25.37.1.13"
+    manager.cached_details[TEST_EVSE_SERIAL]["targetFwVersion"] = "25.37.1.15"
+    entity._refresh_from_details(manager.cached_details)
+    assert entity.state == "on"
+    assert entity.state_attributes["skipped_version"] is None
 
 
 @pytest.mark.asyncio
@@ -455,6 +541,7 @@ async def test_charger_update_entity_falls_back_to_summary_versions(hass) -> Non
     entity = ChargerFirmwareUpdateEntity(
         coordinator=coord,
         manager=manager,
+        catalog_manager=DummyCatalogManager(_catalog_payload()),
         serial=TEST_EVSE_SERIAL,
         description=UpdateEntityDescription(key="charger_firmware"),
     )
@@ -469,6 +556,53 @@ async def test_charger_update_entity_falls_back_to_summary_versions(hass) -> Non
     entity._refresh_from_details(manager.cached_details)
     assert entity.latest_version is None
     assert entity.state is None
+
+
+@pytest.mark.asyncio
+async def test_charger_update_entity_suppresses_notification_when_rollout_disabled(
+    hass,
+) -> None:
+    coord = DummyCoordinator()
+    coord._evse_feature_flags[TEST_EVSE_SERIAL]["iqevse_itk_fw_upgrade_status"] = False
+    manager = DummyEvseFirmwareManager(_evse_payload())
+    entity = ChargerFirmwareUpdateEntity(
+        coordinator=coord,
+        manager=manager,
+        catalog_manager=DummyCatalogManager(_catalog_payload()),
+        serial=TEST_EVSE_SERIAL,
+        description=UpdateEntityDescription(key="charger_firmware"),
+    )
+    entity.hass = hass
+
+    entity._refresh_from_details(manager.cached_details)
+    assert entity.latest_version == "25.37.1.14"
+    assert entity.state == "off"
+    assert entity.extra_state_attributes["firmware_rollout_enabled"] is False
+
+
+@pytest.mark.asyncio
+async def test_charger_update_entity_clears_release_metadata_without_catalog_entry(
+    hass,
+) -> None:
+    coord = DummyCoordinator()
+    manager = DummyEvseFirmwareManager(_evse_payload())
+    entity = ChargerFirmwareUpdateEntity(
+        coordinator=coord,
+        manager=manager,
+        catalog_manager=DummyCatalogManager({"generated_at": "2026-03-01T00:00:00Z"}),
+        serial=TEST_EVSE_SERIAL,
+        description=UpdateEntityDescription(key="charger_firmware"),
+    )
+    entity.hass = hass
+    entity._attr_release_url = "https://example.test/old"
+    entity._attr_release_summary = "Old"
+
+    entity._refresh_from_catalog({"generated_at": "2026-03-01T00:00:00Z"})
+    assert entity.release_url is None
+    assert entity.release_summary is None
+    assert (
+        entity.extra_state_attributes["catalog_generated_at"] == "2026-03-01T00:00:00Z"
+    )
 
 
 @pytest.mark.asyncio
@@ -535,9 +669,11 @@ async def test_entity_refresh_and_scheduler_branches(hass, monkeypatch) -> None:
 async def test_charger_entity_refresh_branches(hass, monkeypatch) -> None:
     coord = DummyCoordinator()
     manager = DummyEvseFirmwareManager(_evse_payload())
+    catalog_manager = DummyCatalogManager(_catalog_payload())
     entity = ChargerFirmwareUpdateEntity(
         coordinator=coord,
         manager=manager,
+        catalog_manager=catalog_manager,
         serial=TEST_EVSE_SERIAL,
         description=UpdateEntityDescription(key="charger_firmware"),
     )
@@ -551,7 +687,8 @@ async def test_charger_entity_refresh_branches(hass, monkeypatch) -> None:
     monkeypatch.setattr(
         CoordinatorEntity, "_handle_coordinator_update", lambda self: None
     )
-    monkeypatch.setattr(entity, "async_write_ha_state", lambda: None)
+    write_state = MagicMock()
+    monkeypatch.setattr(entity, "async_write_ha_state", write_state)
 
     await entity.async_added_to_hass()
 
@@ -568,6 +705,9 @@ async def test_charger_entity_refresh_branches(hass, monkeypatch) -> None:
     entity.hass = None
     entity._schedule_details_refresh()
     entity.hass = hass
+    entity.entity_id = "update.test_charger_firmware"
+    await entity._async_refresh_state()
+    write_state.assert_called()
     entity._handle_coordinator_update()
 
     class _FailingManager(DummyEvseFirmwareManager):
@@ -579,11 +719,28 @@ async def test_charger_entity_refresh_branches(hass, monkeypatch) -> None:
     failing_entity = ChargerFirmwareUpdateEntity(
         coordinator=coord,
         manager=_FailingManager(_evse_payload()),
+        catalog_manager=catalog_manager,
         serial=TEST_EVSE_SERIAL,
         description=UpdateEntityDescription(key="charger_firmware"),
     )
     failing_entity.hass = hass
-    await failing_entity._async_refresh_details()
+    await failing_entity._async_refresh_state()
+
+    class _FailingCatalogManager(DummyCatalogManager):
+        async def async_get_catalog(
+            self, *, force_refresh: bool = False
+        ):  # noqa: ARG002
+            raise RuntimeError("boom")
+
+    failing_catalog_entity = ChargerFirmwareUpdateEntity(
+        coordinator=coord,
+        manager=manager,
+        catalog_manager=_FailingCatalogManager(_catalog_payload()),
+        serial=TEST_EVSE_SERIAL,
+        description=UpdateEntityDescription(key="charger_firmware"),
+    )
+    failing_catalog_entity.hass = hass
+    await failing_catalog_entity._async_refresh_state()
 
 
 @pytest.mark.asyncio
@@ -700,6 +857,24 @@ def test_helper_functions_cover_edge_paths() -> None:
     assert _as_bool("unknown") is None
     assert _as_int("5") == 5
     assert _as_int("bad") is None
+    assert _evse_firmware_rollout_enabled(SimpleNamespace(), "SN1") is None
+    assert (
+        _evse_firmware_rollout_enabled(
+            SimpleNamespace(evse_feature_flag_enabled=lambda key, sn: key == "x"), "SN1"
+        )
+        is False
+    )
+    assert (
+        _evse_firmware_rollout_enabled(
+            SimpleNamespace(
+                evse_feature_flag_enabled=lambda _key, _sn: (_ for _ in ()).throw(
+                    RuntimeError("boom")
+                )
+            ),
+            "SN1",
+        )
+        is None
+    )
     assert _text(None) is None
 
     class _BadStr:

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -23,7 +23,6 @@ from custom_components.enphase_ev.update import (
     _charger_update_unique_id,
     _evse_firmware_rollout_enabled,
     _gateway_installed_version,
-    _microinverter_installed_version,
     _text,
     _type_available,
     async_setup_entry,
@@ -76,7 +75,6 @@ class DummyCoordinator:
         self.battery_country_code = "AU"
         self.battery_locale = "fr-fr"
         self._gateway_version = "8.2.4300"
-        self._micro_version = "v04.30.31"
         self._iqevse_version = "25.37.1.13"
         self._listeners = []
         self._available_types = {"envoy", "microinverter", "iqevse"}
@@ -115,20 +113,12 @@ class DummyCoordinator:
     def type_device_sw_version(self, type_key: str) -> str | None:
         if type_key == "envoy":
             return self._gateway_version
-        if type_key == "microinverter":
-            return self._micro_version
         if type_key == "iqevse":
             return self._iqevse_version
         return None
 
     def type_bucket(self, type_key: str):
-        if type_key != "microinverter":
-            return None
-        return {
-            "firmware_summary": self._micro_version,
-            "count": 1,
-            "devices": [{}],
-        }
+        return None
 
     def type_device_info(self, type_key: str):
         return {
@@ -174,30 +164,6 @@ def _catalog_payload() -> dict:
                     "version": "8.2.4400",
                     "summary": "Gateway global",
                     "urls_by_locale": {"en": "https://example.test/envoy/global"},
-                },
-            },
-            "microinverter": {
-                "latest_by_locale": {
-                    "fr-fr": {
-                        "version": "04.30.32",
-                        "summary": "Micro firmware update",
-                        "urls_by_locale": {"fr-fr": "https://example.test/micro/fr"},
-                    }
-                },
-                "latest_by_country": {
-                    "AU": {
-                        "version": "04.30.32",
-                        "summary": "Micro firmware update",
-                        "urls_by_locale": {
-                            "en": "https://example.test/micro/en",
-                            "fr-fr": "https://example.test/micro/fr",
-                        },
-                    }
-                },
-                "latest_global": {
-                    "version": "04.30.30",
-                    "summary": "Micro global",
-                    "urls_by_locale": {"en": "https://example.test/micro/global"},
                 },
             },
             "iqevse": {
@@ -268,10 +234,9 @@ async def test_async_setup_entry_adds_firmware_update_entities(
 
     await async_setup_entry(hass, config_entry, _capture)
 
-    assert len(added) == 3
+    assert len(added) == 2
     unique_ids = {entity.unique_id for entity in added}
     assert f"enphase_ev_site_{coord.site_id}_envoy_firmware" in unique_ids
-    assert f"enphase_ev_site_{coord.site_id}_microinverter_firmware" in unique_ids
     assert f"enphase_ev_{TEST_EVSE_SERIAL}_charger_firmware" in unique_ids
 
 
@@ -417,6 +382,10 @@ async def test_gateway_update_entity_states_and_release_url_selection(hass) -> N
     coord._gateway_version = "8.2.4401"
     entity._refresh_from_catalog(manager.cached_catalog)
     assert entity.state == "off"
+    assert entity.latest_version == "8.2.4401"
+    assert entity.release_url == "https://example.test/envoy/fr"
+    assert entity.release_summary == "Gateway firmware update"
+    assert entity.state_attributes["release_url"] == "https://example.test/envoy/fr"
     assert entity.state_attributes["skipped_version"] is None
 
     coord._gateway_version = "8.2.4300"
@@ -437,33 +406,29 @@ async def test_gateway_update_entity_states_and_release_url_selection(hass) -> N
     assert entity.available is False
 
 
-@pytest.mark.asyncio
-async def test_microinverter_update_entity_uses_normalized_versions(hass) -> None:
+def test_firmware_update_entities_fall_back_to_type_device_identifiers() -> None:
     coord = DummyCoordinator()
+    coord.inventory_view = SimpleNamespace(
+        has_type_for_entities=coord.has_type_for_entities,
+        has_type=coord.has_type,
+        type_bucket=coord.type_bucket,
+        type_device_info=lambda _type: None,
+        type_device_sw_version=coord.type_device_sw_version,
+    )
     manager = DummyCatalogManager(_catalog_payload())
 
-    entity = FirmwareUpdateEntity(
+    gateway = FirmwareUpdateEntity(
         coordinator=coord,
         manager=manager,
-        device_type="microinverter",
-        translation_key="microinverter_firmware",
-        description=UpdateEntityDescription(key="microinverter_firmware"),
-        installed_version_getter=_microinverter_installed_version,
+        device_type="envoy",
+        translation_key="gateway_firmware",
+        description=UpdateEntityDescription(key="gateway_firmware"),
+        installed_version_getter=_gateway_installed_version,
     )
-    entity.hass = hass
-
-    entity._refresh_from_catalog(manager.cached_catalog)
-    assert entity.installed_version == "04.30.31"
-    assert entity.latest_version == "04.30.32"
-    assert entity.state == "on"
-    assert entity.supported_features == 0
-    assert entity.release_url == "https://example.test/micro/fr"
-
-    attrs = entity.extra_state_attributes
-    assert attrs["country_used"] == "AU"
-    assert attrs["locale_used"] == "fr-fr"
-    assert attrs["catalog_source_scope"] == "locale"
-    assert attrs["catalog_generated_at"] == "2026-03-01T00:00:00Z"
+    assert gateway.device_info == {
+        "identifiers": {(DOMAIN, f"type:{coord.site_id}:envoy")},
+        "manufacturer": "Enphase",
+    }
 
 
 @pytest.mark.asyncio
@@ -514,6 +479,10 @@ async def test_charger_update_entity_uses_fw_details_payload(hass) -> None:
     manager.cached_details[TEST_EVSE_SERIAL]["currentFwVersion"] = "25.37.1.14"
     entity._refresh_from_details(manager.cached_details)
     assert entity.state == "off"
+    assert entity.latest_version == "25.37.1.14"
+    assert entity.release_url == "https://example.test/charger/fr"
+    assert entity.release_summary == "Charger firmware update"
+    assert entity.state_attributes["release_url"] == "https://example.test/charger/fr"
     assert entity.state_attributes["skipped_version"] is None
 
     manager.cached_details[TEST_EVSE_SERIAL]["currentFwVersion"] = "25.37.1.13"
@@ -818,20 +787,8 @@ def test_helper_functions_cover_edge_paths() -> None:
         data={"SN1": {"firmware_version": "1.2.3"}},
         inventory_view=SimpleNamespace(
             type_device_sw_version=lambda _type: None,
-            type_bucket=lambda _type: {"firmware_summary": "v1.2.3"},
+            type_bucket=lambda _type: None,
         ),
-    )
-    assert _microinverter_installed_version(coord) == "v1.2.3"
-    assert (
-        _microinverter_installed_version(
-            SimpleNamespace(
-                inventory_view=SimpleNamespace(
-                    type_device_sw_version=lambda _type: None,
-                    type_bucket=lambda _type: None,
-                )
-            )
-        )
-        is None
     )
     assert _charger_serials(SimpleNamespace()) == []
     assert _charger_installed_version(coord, "SN1") == "1.2.3"
@@ -885,7 +842,7 @@ def test_helper_functions_cover_edge_paths() -> None:
     assert _as_bool(_BadStr()) is None
 
 
-def test_device_info_none_when_coordinator_does_not_supply_info() -> None:
+def test_device_info_falls_back_when_coordinator_does_not_supply_info() -> None:
     coord = DummyCoordinator()
     coord.inventory_view.type_device_info = lambda _type: None
     entity = FirmwareUpdateEntity(
@@ -896,7 +853,20 @@ def test_device_info_none_when_coordinator_does_not_supply_info() -> None:
         description=UpdateEntityDescription(key="gateway_firmware"),
         installed_version_getter=_gateway_installed_version,
     )
-    assert entity.device_info is None
+    assert entity.device_info == {
+        "identifiers": {(DOMAIN, f"type:{coord.site_id}:envoy")},
+        "manufacturer": "Enphase",
+    }
+
+    other = FirmwareUpdateEntity(
+        coordinator=coord,
+        manager=DummyCatalogManager(_catalog_payload()),
+        device_type="other",
+        translation_key="gateway_firmware",
+        description=UpdateEntityDescription(key="gateway_firmware"),
+        installed_version_getter=_gateway_installed_version,
+    )
+    assert other.device_info is None
 
 
 def test_prune_removed_charger_updates_covers_registry_filters() -> None:

--- a/tests/scripts/test_firmware_catalog.py
+++ b/tests/scripts/test_firmware_catalog.py
@@ -926,6 +926,30 @@ def test_route_helper_edge_branches(firmware_catalog_module) -> None:
     )
 
 
+def test_authoritative_region_routes_cover_current_public_sites(
+    firmware_catalog_module,
+) -> None:
+    routes = firmware_catalog_module.build_region_site_routes(
+        firmware_catalog_module.REGION_SITE_ROUTE_ROWS
+    )
+    route_by_country_and_locale = {
+        (route["country_code"], route["locale"]): route for route in routes
+    }
+
+    assert route_by_country_and_locale[("CL", "es-lac")]["site_url"] == (
+        "https://enphase.com/es-lac/"
+    )
+    assert route_by_country_and_locale[("JM", "en-lac")]["site_url"] == (
+        "https://enphase.com/en-lac/"
+    )
+    assert route_by_country_and_locale[("CH", "de-ch")]["site_url"] == (
+        "https://enphase.com/de-ch/"
+    )
+    assert route_by_country_and_locale[("CH", "it-ch")]["site_url"] == (
+        "https://enphase.com/it-ch/"
+    )
+
+
 def test_build_catalog_edge_error_and_degradation_paths(
     firmware_catalog_module,
     monkeypatch,
@@ -950,6 +974,131 @@ def test_build_catalog_edge_error_and_degradation_paths(
     with pytest.raises(RuntimeError, match="Global routing target is missing"):
         firmware_catalog_module.build_catalog(tmp_path, timeout=5, max_pages=1)
 
+    routes = [
+        {
+            "label": "United States",
+            "country_code": "US",
+            "locale": "en",
+            "site_url": "https://global.example/",
+            "query_locale": "en",
+            "target_key": "https://global.example/|en",
+        },
+        {
+            "label": "Australia",
+            "country_code": "AU",
+            "locale": "en-au",
+            "site_url": "https://regional.example/",
+            "query_locale": "en-au",
+            "target_key": "https://regional.example/|en-au",
+        },
+    ]
+    targets = [
+        {
+            "key": "https://global.example/|en",
+            "site_url": "https://global.example/",
+            "query_locale": "en",
+            "locales": ["en"],
+            "countries": ["US"],
+            "labels": ["United States"],
+        },
+        {
+            "key": "https://regional.example/|en-au",
+            "site_url": "https://regional.example/",
+            "query_locale": "en-au",
+            "locales": ["en-au"],
+            "countries": ["AU"],
+            "labels": ["Australia"],
+        },
+    ]
+
+    monkeypatch.setattr(
+        firmware_catalog_module, "build_region_site_routes", lambda _rows: routes
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module, "build_crawl_targets", lambda _routes: targets
+    )
+
+    def _fake_fetch_text(url: str, timeout: int = 30) -> str:  # noqa: ARG001
+        if "regional.example" in url:
+            raise RuntimeError("HTTP Error 404: Not Found")
+        return "GLOBAL"
+
+    monkeypatch.setattr(firmware_catalog_module, "fetch_text", _fake_fetch_text)
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "discover_apps_entrypoint",
+        lambda _html: ("/installers/resources/documentation/apps", "216"),
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "parse_product_type_from_apps_page",
+        lambda _html: "216",
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "parse_facet_values",
+        lambda html, alias: (
+            {"Release notes": 217}
+            if alias == "document"
+            else (
+                {"IQ Gateway software": 5002, "IQ Microinverter software": 7738}
+                if html == "GLOBAL"
+                else {"IQ Gateway software": 5002}
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module, "parse_language_options", lambda _html, _name: {}
+    )
+
+    def _fake_crawl_release_cards(**kwargs):
+        if kwargs["search_locale"] == "en-au":
+            raise RuntimeError("HTTP Error 404: Not Found")
+        return [], ["https://example.test/p0"]
+
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "crawl_release_cards",
+        _fake_crawl_release_cards,
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "fetch_previous_runtime_catalog",
+        lambda timeout=30: None,
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module, "_now_utc_iso", lambda: "2026-03-01T00:00:00Z"
+    )
+
+    firmware_catalog_module.build_catalog(tmp_path, timeout=5, max_pages=1)
+    runtime = json.loads(
+        (tmp_path / "catalog" / "v1" / "runtime_catalog.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert runtime["devices"]["envoy"]["latest_global"] is None
+    assert runtime["devices"]["envoy"]["latest_by_country"] == {}
+    micro_meta = runtime["source"]["crawl"]["microinverter"]
+    envoy_meta = runtime["source"]["crawl"]["envoy"]
+    assert micro_meta["missing_product_media_id_targets"] == []
+    assert micro_meta["used_global_product_media_id_targets"] == []
+    assert envoy_meta["bootstrap_error_targets"] == ["https://regional.example/|en-au"]
+    assert micro_meta["crawl_error_targets"] == ["https://regional.example/|en-au"]
+    assert (
+        envoy_meta["targets"]["https://regional.example/|en-au"]["bootstrap_error"]
+        == "HTTP Error 404: Not Found"
+    )
+    assert (
+        micro_meta["targets"]["https://regional.example/|en-au"]["crawl_error"]
+        == "HTTP Error 404: Not Found"
+    )
+
+
+def test_build_catalog_tracks_missing_regional_product_ids(
+    firmware_catalog_module,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
     routes = [
         {
             "label": "United States",
@@ -1027,7 +1176,7 @@ def test_build_catalog_edge_error_and_degradation_paths(
     monkeypatch.setattr(
         firmware_catalog_module,
         "crawl_release_cards",
-        lambda **kwargs: ([], ["https://example.test/p0"]),
+        lambda **kwargs: ([], [f"https://example.test/{kwargs['search_locale']}"]),
     )
     monkeypatch.setattr(
         firmware_catalog_module,
@@ -1044,8 +1193,6 @@ def test_build_catalog_edge_error_and_degradation_paths(
             encoding="utf-8"
         )
     )
-    assert runtime["devices"]["envoy"]["latest_global"] is None
-    assert runtime["devices"]["envoy"]["latest_by_country"] == {}
     micro_meta = runtime["source"]["crawl"]["microinverter"]
     assert micro_meta["missing_product_media_id_targets"] == [
         "https://regional.example/|en-au"

--- a/tests/scripts/test_firmware_catalog.py
+++ b/tests/scripts/test_firmware_catalog.py
@@ -158,9 +158,10 @@ def test_pick_latest_release_and_urls(firmware_catalog_module) -> None:
 
     urls = firmware_catalog_module.build_release_urls_by_locale(
         locales=["en", "fr-fr", "en-au"],
-        media_id="22469",
-        langcode="und",
         apps_url="https://enphase.com/en-au/installers/resources/documentation/apps",
+        product_type="216",
+        topic_id=217,
+        product_media_name_id=5002,
     )
     assert urls["en"].startswith(
         "https://enphase.com/en-au/installers/resources/documentation/apps?"
@@ -168,7 +169,11 @@ def test_pick_latest_release_and_urls(firmware_catalog_module) -> None:
     assert urls["fr-fr"].startswith(
         "https://enphase.com/en-au/installers/resources/documentation/apps?"
     )
-    assert "media_id=22469" in urls["en-au"]
+    assert "product_type=216" in urls["en-au"]
+    assert "f%5B0%5D=document%3A217" in urls["en-au"]
+    assert "f%5B1%5D=product_media_name%3A5002" in urls["en-au"]
+    assert "search_api_language=en-au" in urls["en-au"]
+    assert "field_alternative_language=en-au" in urls["en-au"]
 
 
 def test_catalogs_equal_ignoring_generated_at(firmware_catalog_module) -> None:
@@ -387,7 +392,9 @@ def test_helper_edge_branches(
 
     entry = firmware_catalog_module.card_to_runtime_entry(
         card=no_date,
+        product_type="216",
         topic_id=217,
+        product_media_name_id=5002,
         locales=["en"],
         apps_url="https://enphase.com/installers/resources/documentation/apps",
     )
@@ -530,14 +537,14 @@ def test_build_catalog_success_and_error_paths(
             countries_text="All countries except Ireland",
         ),
     ]
-    micro_cards = [
+    charger_cards = [
         firmware_catalog_module.ReleaseCard(
-            title="IQ8 Series Microinverters firmware version release notes (2.48.01)",
-            version="2.48.01",
-            release_date="2025-11-20",
-            media_id="33001",
-            langcode="en",
-            summary="Micro release",
+            title="IQ EV Charger software release notes (25.37.1.14)",
+            version="25.37.1.14",
+            release_date="2025-11-22",
+            media_id="33002",
+            langcode="und",
+            summary="Charger release",
             countries_text=None,
         )
     ]
@@ -545,8 +552,8 @@ def test_build_catalog_success_and_error_paths(
     def _fake_crawl_release_cards(**kwargs):
         if kwargs["product_media_name_id"] == 5002:
             return gateway_cards, ["https://example.com/p0", "https://example.com/p1"]
-        if kwargs["product_media_name_id"] == 7738 and kwargs["search_locale"] == "en":
-            return micro_cards, ["https://example.com/p0"]
+        if kwargs["product_media_name_id"] == 6001:
+            return charger_cards, ["https://example.com/p0"]
         return [], ["https://example.com/p0"]
 
     monkeypatch.setattr(
@@ -578,13 +585,32 @@ def test_build_catalog_success_and_error_paths(
         ],
     )
     monkeypatch.setattr(firmware_catalog_module, "fetch_text", _fake_fetch_text)
+    original_parse_facet_values = firmware_catalog_module.parse_facet_values
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "parse_facet_values",
+        lambda html, alias: (
+            {
+                **original_parse_facet_values(html, alias),
+                "IQ EV Charger software": 6001,
+            }
+            if alias == "product_media_name"
+            else original_parse_facet_values(html, alias)
+        ),
+    )
     monkeypatch.setattr(
         firmware_catalog_module, "crawl_release_cards", _fake_crawl_release_cards
     )
-    call_log: list[tuple[int, str]] = []
+    call_log: list[tuple[int, str, str]] = []
 
     def _logged_crawl_release_cards(**kwargs):
-        call_log.append((kwargs["product_media_name_id"], kwargs["search_locale"]))
+        call_log.append(
+            (
+                kwargs["product_media_name_id"],
+                kwargs["search_locale"],
+                kwargs["apps_url"],
+            )
+        )
         return _fake_crawl_release_cards(**kwargs)
 
     monkeypatch.setattr(
@@ -608,7 +634,7 @@ def test_build_catalog_success_and_error_paths(
                         "pages": ["https://example.com/p0", "https://example.com/p1"],
                         "count": 2,
                     },
-                    "microinverter": {"pages": ["https://example.com/p0"], "count": 0},
+                    "iqevse": {"pages": ["https://example.com/p0"], "count": 1},
                 },
             },
             "devices": {
@@ -618,8 +644,8 @@ def test_build_catalog_success_and_error_paths(
                     "latest_by_country": {},
                     "latest_global": None,
                 },
-                "microinverter": {
-                    "product_media_name_id": 7738,
+                "iqevse": {
+                    "product_media_name_id": 6001,
                     "document_topic_id": 217,
                     "latest_by_country": {},
                     "latest_global": None,
@@ -634,6 +660,7 @@ def test_build_catalog_success_and_error_paths(
     runtime_payload = json.loads(runtime_path.read_text(encoding="utf-8"))
     assert runtime_payload["schema_version"] == 1
     assert runtime_payload["devices"]["envoy"]["product_media_name_id"] == 5002
+    assert runtime_payload["devices"]["iqevse"]["product_media_name_id"] == 6001
     assert (
         runtime_payload["devices"]["envoy"]["latest_by_country"]["PR"]["version"]
         == "8.2.4401"
@@ -643,18 +670,23 @@ def test_build_catalog_success_and_error_paths(
         == "8.2.4401"
     )
     assert (
-        runtime_payload["devices"]["microinverter"]["latest_by_country"]["AU"][
-            "version"
-        ]
-        == "2.48.01"
+        runtime_payload["devices"]["iqevse"]["latest_by_country"]["AU"]["version"]
+        == "25.37.1.14"
     )
     envoy_crawl = runtime_payload["source"]["crawl"]["envoy"]
-    micro_crawl = runtime_payload["source"]["crawl"]["microinverter"]
-    assert (5002, "en-au") in call_log
-    assert (7738, "en-au") in call_log
+    charger_crawl = runtime_payload["source"]["crawl"]["iqevse"]
+    assert (
+        5002,
+        "en-au",
+        "https://enphase.com/en-au/installers/resources/documentation/communication",
+    ) in call_log
+    assert (
+        6001,
+        "en-au",
+        "https://enphase.com/en-au/installers/resources/documentation/apps",
+    ) in call_log
     assert envoy_crawl["used_global_product_media_id_targets"] == []
-    assert "https://enphase.com/en-au/|en-au" in micro_crawl["empty_release_targets"]
-    assert "https://enphase.com/|es-pr" in micro_crawl["empty_release_targets"]
+    assert charger_crawl["used_global_product_media_id_targets"] == []
     assert (tmp_path / "sources" / "enphase_doc_center" / "entrypoints.json").exists()
     assert (tmp_path / "data" / "PR" / "catalog.json").exists()
     assert (
@@ -667,7 +699,11 @@ def test_build_catalog_success_and_error_paths(
         lambda _apps_html, alias: (
             {}
             if alias == "document"
-            else {"IQ Gateway software": 5002, "IQ Microinverter software": 7738}
+            else {
+                "IQ Gateway software": 5002,
+                "IQ EV Charger software": 6001,
+                "IQ Microinverter software": 7738,
+            }
         ),
     )
     with pytest.raises(RuntimeError, match="release-notes topic id"):
@@ -677,12 +713,10 @@ def test_build_catalog_success_and_error_paths(
         firmware_catalog_module,
         "parse_facet_values",
         lambda _apps_html, alias: (
-            {"Release notes": 217}
-            if alias == "document"
-            else {"IQ Gateway software": 5002}
+            {"Release notes": 217} if alias == "document" else {}
         ),
     )
-    with pytest.raises(RuntimeError, match="IQ Microinverter software"):
+    with pytest.raises(RuntimeError, match="IQ Gateway software"):
         firmware_catalog_module.build_catalog(tmp_path, timeout=5, max_pages=1)
 
 
@@ -719,6 +753,53 @@ def test_country_entry_prefers_non_global_over_global_fallback(
     )
 
 
+def test_bootstrap_target_discovers_apps_entrypoint_for_apps_docs(
+    firmware_catalog_module,
+    monkeypatch,
+) -> None:
+    target = {
+        "site_url": "https://enphase.com/en-au/",
+        "query_locale": "en-au",
+        "key": "https://enphase.com/en-au/|en-au",
+    }
+
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "fetch_text",
+        lambda url, timeout=30: "ROOT" if url.endswith("/documentation") else "APPS",
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "discover_apps_entrypoint",
+        lambda html: ("/installers/resources/documentation/apps", "216"),
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "parse_product_type_from_apps_page",
+        lambda html: "216",
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "parse_facet_values",
+        lambda html, alias: (
+            {"Release notes": 217}
+            if alias == "document"
+            else {"IQ Gateway software": 5002, "IQ EV Charger software": 6001}
+        ),
+    )
+
+    bootstrap = firmware_catalog_module._bootstrap_target(
+        target,
+        timeout=5,
+        docs_path=firmware_catalog_module.TARGET_CATEGORY_PATH,
+    )
+
+    assert bootstrap["docs_path"] == "/installers/resources/documentation/apps"
+    assert bootstrap["apps_bootstrap_url"].endswith("product_type=216")
+    assert bootstrap["product_ids"]["envoy"] == 5002
+    assert bootstrap["product_ids"]["iqevse"] == 6001
+
+
 def test_locale_fallback_uses_best_country_entry_not_global(
     firmware_catalog_module,
     fixture_dir: Path,
@@ -751,15 +832,6 @@ def test_locale_fallback_uses_best_country_entry_not_global(
         summary="Belgium envoy release",
         countries_text=None,
     )
-    global_micro = firmware_catalog_module.ReleaseCard(
-        title="IQ8 Series Microinverters firmware version release notes (2.48.01)",
-        version="2.48.01",
-        release_date="2025-11-20",
-        media_id="global-micro",
-        langcode="und",
-        summary="Global micro release",
-        countries_text=None,
-    )
 
     def _fake_crawl_release_cards(**kwargs):
         product_media_name_id = kwargs["product_media_name_id"]
@@ -768,8 +840,6 @@ def test_locale_fallback_uses_best_country_entry_not_global(
             return [global_envoy], ["https://example.test/envoy/global"]
         if product_media_name_id == 5002 and search_locale == "nl-be":
             return [be_regional_envoy], ["https://example.test/envoy/nl-be"]
-        if product_media_name_id == 7738 and search_locale == "en":
-            return [global_micro], ["https://example.test/micro/global"]
         return [], [
             f"https://example.test/empty/{product_media_name_id}/{search_locale}"
         ]
@@ -815,6 +885,19 @@ def test_locale_fallback_uses_best_country_entry_not_global(
         ],
     )
     monkeypatch.setattr(firmware_catalog_module, "fetch_text", _fake_fetch_text)
+    original_parse_facet_values = firmware_catalog_module.parse_facet_values
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "parse_facet_values",
+        lambda html, alias: (
+            {
+                **original_parse_facet_values(html, alias),
+                "IQ EV Charger software": 6001,
+            }
+            if alias == "product_media_name"
+            else original_parse_facet_values(html, alias)
+        ),
+    )
     monkeypatch.setattr(
         firmware_catalog_module, "crawl_release_cards", _fake_crawl_release_cards
     )
@@ -1041,9 +1124,12 @@ def test_build_catalog_edge_error_and_degradation_paths(
             {"Release notes": 217}
             if alias == "document"
             else (
-                {"IQ Gateway software": 5002, "IQ Microinverter software": 7738}
+                {
+                    "IQ Gateway software": 5002,
+                    "IQ EV Charger software": 6001,
+                }
                 if html == "GLOBAL"
-                else {"IQ Gateway software": 5002}
+                else {}
             )
         ),
     )
@@ -1078,18 +1164,15 @@ def test_build_catalog_edge_error_and_degradation_paths(
     )
     assert runtime["devices"]["envoy"]["latest_global"] is None
     assert runtime["devices"]["envoy"]["latest_by_country"] == {}
-    micro_meta = runtime["source"]["crawl"]["microinverter"]
     envoy_meta = runtime["source"]["crawl"]["envoy"]
-    assert micro_meta["missing_product_media_id_targets"] == []
-    assert micro_meta["used_global_product_media_id_targets"] == []
     assert envoy_meta["bootstrap_error_targets"] == ["https://regional.example/|en-au"]
-    assert micro_meta["crawl_error_targets"] == ["https://regional.example/|en-au"]
+    assert envoy_meta["crawl_error_targets"] == ["https://regional.example/|en-au"]
     assert (
         envoy_meta["targets"]["https://regional.example/|en-au"]["bootstrap_error"]
         == "HTTP Error 404: Not Found"
     )
     assert (
-        micro_meta["targets"]["https://regional.example/|en-au"]["crawl_error"]
+        envoy_meta["targets"]["https://regional.example/|en-au"]["crawl_error"]
         == "HTTP Error 404: Not Found"
     )
 
@@ -1164,9 +1247,12 @@ def test_build_catalog_tracks_missing_regional_product_ids(
             {"Release notes": 217}
             if alias == "document"
             else (
-                {"IQ Gateway software": 5002, "IQ Microinverter software": 7738}
+                {
+                    "IQ Gateway software": 5002,
+                    "IQ EV Charger software": 6001,
+                }
                 if html == "GLOBAL"
-                else {"IQ Gateway software": 5002}
+                else {}
             )
         ),
     )
@@ -1193,11 +1279,11 @@ def test_build_catalog_tracks_missing_regional_product_ids(
             encoding="utf-8"
         )
     )
-    micro_meta = runtime["source"]["crawl"]["microinverter"]
-    assert micro_meta["missing_product_media_id_targets"] == [
+    envoy_meta = runtime["source"]["crawl"]["envoy"]
+    assert envoy_meta["missing_product_media_id_targets"] == [
         "https://regional.example/|en-au"
     ]
-    assert micro_meta["used_global_product_media_id_targets"] == [
+    assert envoy_meta["used_global_product_media_id_targets"] == [
         "https://regional.example/|en-au"
     ]
 


### PR DESCRIPTION
## Summary

Add advisory firmware update support for IQ Gateway and IQ EV Charger devices, including locale-aware release note links and charger rollout gating.

This PR also hardens the firmware catalog pipeline and runtime link handling, aligns gateway firmware/device metadata with the actual IQ Gateway member, and removes advisory IQ Microinverter firmware support because Enphase does not expose a reliable public firmware release source for it.

## Related Issues

- None

## Type of change

- [x] Bugfix
- [x] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/update.py custom_components/enphase_ev/__init__.py scripts/firmware_catalog.py tests/components/enphase_ev/test_update_module.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_service_translations.py tests/components/enphase_ev/test_firmware_catalog.py tests/scripts/test_firmware_catalog.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/update.py custom_components/enphase_ev/__init__.py scripts/firmware_catalog.py tests/components/enphase_ev/test_update_module.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_service_translations.py tests/components/enphase_ev/test_firmware_catalog.py tests/scripts/test_firmware_catalog.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_update_module.py tests/components/enphase_ev/test_service_translations.py tests/components/enphase_ev/test_firmware_catalog.py tests/scripts/test_firmware_catalog.py -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/update.py,scripts/firmware_catalog.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/scripts/test_firmware_catalog.py tests/components/enphase_ev/test_update_module.py"
python3 -m pre_commit run --all-files
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Firmware updates are advisory only. Home Assistant surfaces version availability and release-note links, but does not initiate installs.
- IQ Gateway metadata and installed firmware selection now prefer the actual gateway member instead of the system controller member.
- IQ Microinverter firmware advisories are removed from the active entity surface and from the generated firmware catalog.
- The local development runtime was used to verify that only the gateway and EV charger firmware update entities remain active after the cleanup path runs.