### PR TITLE
Enable password storage by default for reauthentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Fixed IQ Battery schedule create, save, and delete flows so CFG/DTG/RBD changes now send the follow-up `batterySettings` apply write Enphase requires before the schedule family leaves the cloud-side `pending` state.
+- Enabled the "Store password for automatic reauthentication" checkbox by default when the Enphase sign-in form opens during initial setup, reconfigure, and reauthentication flows.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -221,7 +221,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._type_keys_loaded = False
         self._inventory_unknown = False
         self._email: str | None = None
-        self._remember_password = False
+        self._remember_password = True
         self._password: str | None = None
         self._reconfigure_entry: ConfigEntry | None = None
         self._reauth_entry: ConfigEntry | None = None
@@ -974,15 +974,18 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not has_email:
             return self.async_abort(reason="manual_mode_removed")
         self._email = self._reconfigure_entry.data.get(CONF_EMAIL)
-        self._remember_password = bool(
+        stored_remember_password = bool(
             self._reconfigure_entry.data.get(CONF_REMEMBER_PASSWORD)
         )
+        self._remember_password = True
         self._site_only = bool(self._reconfigure_entry.data.get(CONF_SITE_ONLY, False))
         self._include_inverters = bool(
             self._reconfigure_entry.data.get(CONF_INCLUDE_INVERTERS, True)
         )
-        if self._remember_password:
+        if stored_remember_password:
             self._password = self._reconfigure_entry.data.get(CONF_PASSWORD)
+        else:
+            self._password = None
         return await self.async_step_user()
 
     async def async_step_reauth(
@@ -997,15 +1000,18 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         if not has_email:
             return self.async_abort(reason="manual_mode_removed")
         self._email = self._reauth_entry.data.get(CONF_EMAIL)
-        self._remember_password = bool(
+        stored_remember_password = bool(
             self._reauth_entry.data.get(CONF_REMEMBER_PASSWORD)
         )
+        self._remember_password = True
         self._site_only = bool(self._reauth_entry.data.get(CONF_SITE_ONLY, False))
         self._include_inverters = bool(
             self._reauth_entry.data.get(CONF_INCLUDE_INVERTERS, True)
         )
-        if self._remember_password:
+        if stored_remember_password:
             self._password = self._reauth_entry.data.get(CONF_PASSWORD)
+        else:
+            self._password = None
         return await self.async_step_user()
 
     @staticmethod

--- a/tests/components/enphase_ev/test_config_flow_coverage.py
+++ b/tests/components/enphase_ev/test_config_flow_coverage.py
@@ -642,6 +642,23 @@ async def test_site_step_prefills_selected_site(hass) -> None:
 
 
 @pytest.mark.asyncio
+async def test_user_step_remember_password_defaults_enabled(hass) -> None:
+    flow = _make_flow(hass)
+
+    result = await flow.async_step_user()
+
+    assert result["type"] is FlowResultType.FORM
+    schema_keys = list(result["data_schema"].schema.keys())
+    key = next(
+        item
+        for item in schema_keys
+        if isinstance(item, VolOptional) and item.schema == CONF_REMEMBER_PASSWORD
+    )
+    default = key.default() if callable(key.default) else key.default
+    assert default is True
+
+
+@pytest.mark.asyncio
 async def test_site_step_requires_selection(hass) -> None:
     flow = _make_flow(hass)
     flow._sites = {"1001": "Existing"}
@@ -1215,6 +1232,68 @@ async def test_finalize_login_entry_reauth_updates_entry(hass) -> None:
     assert CONF_AUTH_BLOCKED_UNTIL not in entry.data
     assert CONF_AUTH_BLOCK_REASON not in entry.data
     mock_reload.assert_awaited_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_reconfigure_step_remember_password_defaults_enabled(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SITE_ID: "12345",
+            CONF_EMAIL: "user@example.com",
+            CONF_REMEMBER_PASSWORD: False,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = _make_flow(hass)
+    flow.context = {
+        "source": config_entries.SOURCE_RECONFIGURE,
+        "entry_id": entry.entry_id,
+    }
+
+    result = await flow.async_step_reconfigure()
+
+    assert result["type"] is FlowResultType.FORM
+    schema_keys = list(result["data_schema"].schema.keys())
+    key = next(
+        item
+        for item in schema_keys
+        if isinstance(item, VolOptional) and item.schema == CONF_REMEMBER_PASSWORD
+    )
+    default = key.default() if callable(key.default) else key.default
+    assert default is True
+
+
+@pytest.mark.asyncio
+async def test_reauth_step_remember_password_defaults_enabled(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SITE_ID: "12345",
+            CONF_EMAIL: "user@example.com",
+            CONF_REMEMBER_PASSWORD: False,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    flow = _make_flow(hass)
+    flow.context = {
+        "source": config_entries.SOURCE_REAUTH,
+        "entry_id": entry.entry_id,
+    }
+
+    result = await flow.async_step_reauth({})
+
+    assert result["type"] is FlowResultType.FORM
+    schema_keys = list(result["data_schema"].schema.keys())
+    key = next(
+        item
+        for item in schema_keys
+        if isinstance(item, VolOptional) and item.schema == CONF_REMEMBER_PASSWORD
+    )
+    default = key.default() if callable(key.default) else key.default
+    assert default is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Enable the sign-in flow to default `Store password for automatic reauthentication` to enabled during initial setup, reconfigure, and reauthentication so users get the safer default without having to opt in manually each time.

The root cause was that the config flow initialized the remember-password flag to `False`, and reconfigure/reauth inherited the stored setting as the initial checkbox state. That meant the form opened unchecked unless the entry was already storing a password.

Fixes the default form state while still preserving the user’s explicit choice on submit.

## Related Issues

- None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

List the exact commands you ran. Prefer the pinned Docker environment from `devtools/docker/`.

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/config_flow.py tests/components/enphase_ev/test_config_flow_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/config_flow.py tests/components/enphase_ev/test_config_flow_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_config_flow_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/config_flow.py --fail-under=100"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Added regression coverage for the user, reconfigure, and reauth form defaults.
- No translation changes were required because the label text did not change.