### PR TITLE
Prepare release 2.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,31 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- Hardened the firmware catalog build workflow so dead regional release-notes routes degrade to global metadata instead of aborting the catalog publish job on a single `404` response.
-- Refreshed the firmware catalog’s authoritative region routing to cover current public Chile and Jamaica sites and to use Swiss locale-specific documentation URLs for German and Italian.
-- Removed advisory IQ Microinverter firmware update entities and catalog crawling now that Enphase does not expose a reliable public microinverter firmware release source comparable to gateway and EV charger firmware.
+- None
+
+### 🔧 Improvements
+- None
+
+### 🔄 Other changes
+- None
+
+## v2.9.0 - 2026-04-23
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Added advisory firmware update entities for IQ Gateway and IQ EV Chargers, including region-specific release-note links and charger rollout gating from Enphase feature flags.
+
+### 🐛 Bug fixes
 - Fixed IQ Battery schedule create, save, and delete flows so CFG/DTG/RBD changes now send the follow-up `batterySettings` apply write Enphase requires before the schedule family leaves the cloud-side `pending` state.
 - Enabled the "Store password for automatic reauthentication" checkbox by default when the Enphase sign-in form opens during initial setup, reconfigure, and reauthentication flows.
 
 ### 🔧 Improvements
-- Enabled advisory firmware update entities for IQ Gateway and IQ EV Chargers, including region-specific release-note links and charger rollout gating from Enphase feature flags.
+- None
 
 ### 🔄 Other changes
-- None
+- Bumped the integration manifest version to `2.9.0`.
 
 ## v2.8.6 - 2026-04-21
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.8.6"
+  "version": "2.9.0"
 }


### PR DESCRIPTION
## Summary

Prepare release `2.9.0` by bumping the integration manifest version and promoting the current unreleased notes into a dated changelog entry. The changelog entry includes all PRs merged since `v2.8.6` and classifies advisory firmware visibility as a new feature rather than a bug fix.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release preparation / versioning.

## Testing

List the exact commands you ran. Prefer the pinned Docker environment from `devtools/docker/`.

```bash
python3 -m json.tool custom_components/enphase_ev/manifest.json
git diff --check
```

Add any extra commands, targeted tests, or manual validation below.

- Verified the `v2.9.0` changelog scope against commits merged after `v2.8.6`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Metadata-only release prep change; no diagnostics or screenshots.