### PR TITLE
Optimize refresh follow-up scheduling and cleanup

### DIFF
--- a/custom_components/enphase_ev/ac_battery_runtime.py
+++ b/custom_components/enphase_ev/ac_battery_runtime.py
@@ -477,6 +477,37 @@ class AcBatteryRuntime:
         state._ac_battery_devices_cache_until = now + 300.0
         coord._note_endpoint_family_success(family, success_ttl_s=300.0)
 
+    def ac_battery_devices_refresh_due(self, *, force: bool = False) -> bool:
+        """Return True when AC Battery inventory should be refreshed."""
+
+        coord = self.coordinator
+        state = self.battery_state
+        has_cached_state = bool(
+            getattr(state, "_ac_battery_data", None)
+            or getattr(state, "_ac_battery_order", None)
+            or getattr(state, "_ac_battery_aggregate_status", None) is not None
+            or getattr(state, "_ac_battery_aggregate_status_details", None)
+            or getattr(state, "_ac_battery_sleep_state", None) is not None
+            or getattr(state, "_ac_battery_devices_payload", None) is not None
+            or getattr(state, "_ac_battery_devices_html_payload", None) is not None
+            or getattr(state, "_ac_battery_telemetry_payloads", None) is not None
+            or getattr(state, "_ac_battery_events_payloads", None) is not None
+            or getattr(state, "_ac_battery_power_w", None) is not None
+        )
+        if not coord.inventory_view.has_type_for_entities("ac_battery"):
+            return has_cached_state
+        if not force and state._ac_battery_devices_cache_until:
+            now = time.monotonic()
+            if now < state._ac_battery_devices_cache_until:
+                return False
+        family = "ac_battery_devices"
+        fetcher = getattr(coord.client, "ac_battery_devices_page", None)
+        if not callable(fetcher):
+            return has_cached_state
+        if coord._endpoint_family_should_run(family, force=force):
+            return True
+        return has_cached_state and not coord._endpoint_family_can_use_stale(family)
+
     async def async_refresh_ac_battery_telemetry(self, *, force: bool = False) -> None:
         coord = self.coordinator
         state = self.battery_state

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -723,6 +723,148 @@ class BatteryRuntime:
             return float(default_ttl)
         return min(float(default_ttl), current_interval)
 
+    def battery_status_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        state = self.battery_state
+        now = time.monotonic()
+        if not force and state._battery_status_cache_until:
+            if now < state._battery_status_cache_until:
+                return False
+        fetcher = getattr(coord.client, "battery_status", None)
+        if not callable(fetcher):
+            return False
+        return coord._endpoint_family_should_run("battery_status", force=force)
+
+    def battery_backup_history_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        state = self.battery_state
+        now = time.monotonic()
+        if not force and state._battery_backup_history_cache_until:
+            if now < state._battery_backup_history_cache_until:
+                return False
+        fetcher = getattr(coord.client, "battery_backup_history", None)
+        if not callable(fetcher):
+            return False
+        return coord._endpoint_family_should_run("battery_backup_history", force=force)
+
+    def battery_settings_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        state = self.battery_state
+        pending_profile = getattr(state, "_battery_pending_profile", None)
+        now = time.monotonic()
+        if not force and not pending_profile and state._battery_settings_cache_until:
+            if now < state._battery_settings_cache_until:
+                return False
+        fetcher = getattr(coord.client, "battery_settings_details", None)
+        if not callable(fetcher):
+            return False
+        return coord._endpoint_family_should_run(
+            "battery_settings",
+            force=force or bool(pending_profile),
+        )
+
+    def battery_schedules_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        fetcher = getattr(coord.client, "battery_schedules", None)
+        if not callable(fetcher):
+            return False
+        return coord._endpoint_family_should_run("battery_schedules", force=force)
+
+    def battery_site_settings_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        state = self.battery_state
+        now = time.monotonic()
+        if not force and state._battery_site_settings_cache_until:
+            if now < state._battery_site_settings_cache_until:
+                return False
+        fetcher = getattr(coord.client, "battery_site_settings", None)
+        if not callable(fetcher):
+            return False
+        return coord._endpoint_family_should_run("battery_site_settings", force=force)
+
+    def grid_control_check_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        state = self.battery_state
+        now = time.monotonic()
+        if not force and state._grid_control_check_cache_until:
+            if now < state._grid_control_check_cache_until:
+                return False
+        state_present = any(
+            getattr(state, attr, None) is not None
+            for attr in (
+                "_grid_control_supported",
+                "_grid_control_disable",
+                "_grid_control_active_download",
+                "_grid_control_sunlight_backup_system_check",
+                "_grid_control_grid_outage_check",
+                "_grid_control_user_initiated_toggle",
+            )
+        )
+        fetcher = getattr(coord.client, "grid_control_check", None)
+        if not callable(fetcher):
+            return state_present
+        family = "grid_control_check"
+        if coord._endpoint_family_should_run(family, force=force):
+            return True
+        return (
+            state_present
+            and coord._endpoint_family_state(family).cooldown_active
+            and not coord._endpoint_family_can_use_stale(family)
+        )
+
+    def dry_contact_settings_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        state = self.battery_state
+        now = time.monotonic()
+        if not force and state._dry_contact_settings_cache_until:
+            if now < state._dry_contact_settings_cache_until:
+                return False
+        state_present = (
+            getattr(state, "_dry_contact_settings_supported", None) is not None
+        )
+        fetcher = getattr(coord.client, "dry_contacts_settings", None)
+        if not callable(fetcher):
+            return state_present
+        family = "dry_contact_settings"
+        if coord._endpoint_family_should_run(family, force=force):
+            return True
+        return (
+            state_present
+            and coord._endpoint_family_state(family).cooldown_active
+            and not coord._endpoint_family_can_use_stale(family)
+        )
+
+    def storm_guard_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        state = self.battery_state
+        pending_profile = getattr(state, "_battery_pending_profile", None)
+        now = time.monotonic()
+        if not force and not pending_profile and state._storm_guard_cache_until:
+            if now < state._storm_guard_cache_until:
+                return False
+        fetcher = getattr(coord.client, "storm_guard_profile", None)
+        if not callable(fetcher):
+            return False
+        return coord._endpoint_family_should_run(
+            "storm_guard",
+            force=force or bool(pending_profile),
+        )
+
+    def storm_alert_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        state = self.battery_state
+        now = time.monotonic()
+        if not force and state._storm_alert_cache_until:
+            if now < state._storm_alert_cache_until:
+                return False
+        fetcher = getattr(coord.client, "storm_guard_alert", None)
+        if not callable(fetcher):
+            return False
+        return coord._endpoint_family_should_run("storm_alert", force=force)
+
+    def ac_battery_devices_refresh_due(self, *, force: bool = False) -> bool:
+        return self._ac_battery_runtime.ac_battery_devices_refresh_due(force=force)
+
     def _battery_control_state_settling(self) -> bool:
         coord = self.coordinator
         state = self.battery_state

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -135,10 +135,10 @@ from .session_history import (
 from .summary import SummaryStore
 from . import system_dashboard_helpers as sd_helpers
 from .refresh_plan import (
-    FOLLOWUP_PLAN,
-    HEATPUMP_FOLLOWUP_PLAN,
-    SITE_ONLY_FOLLOWUP_PLAN,
-    post_session_followup_plan,
+    build_followup_plan,
+    build_heatpump_followup_plan,
+    build_post_session_followup_plan,
+    build_site_only_followup_plan,
 )
 from .refresh_runner import RefreshRunner
 from .service_validation import raise_translated_service_validation
@@ -2144,6 +2144,86 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def payload_health_diagnostics(self) -> dict[str, object]:
         return self.diagnostics.payload_health_diagnostics()
 
+    async def _async_run_timed_refresh_lookup(
+        self,
+        phase_timings: dict[str, float],
+        timing_key: str,
+        callback: Callable[[], object],
+    ) -> object:
+        started = time.monotonic()
+        result = callback()
+        if inspect.isawaitable(result):
+            result = await result
+        phase_timings[timing_key] = round(time.monotonic() - started, 3)
+        return result
+
+    async def _async_resolve_post_status_evse_enrichments(
+        self,
+        phase_timings: dict[str, float],
+        *,
+        records: list[tuple[str, dict]],
+        charge_mode_candidates: list[str],
+        first_refresh: bool,
+    ) -> tuple[
+        dict[str, str | None],
+        dict[str, tuple[bool | None, bool]],
+        dict[str, tuple[bool | None, bool | None, bool, bool]],
+        dict[str, dict[str, object]],
+    ]:
+        if first_refresh:
+            return {}, {}, {}, {}
+        tasks: dict[str, asyncio.Task[object]] = {}
+        unique_candidates = list(dict.fromkeys(charge_mode_candidates))
+        serials = [sn for sn, _obj in records]
+        if unique_candidates:
+            tasks["charge_modes"] = asyncio.create_task(
+                self._async_run_timed_refresh_lookup(
+                    phase_timings,
+                    "charge_mode_s",
+                    lambda: self.evse_runtime.async_resolve_charge_modes(
+                        unique_candidates
+                    ),
+                )
+            )
+        if serials:
+            tasks["green_settings"] = asyncio.create_task(
+                self._async_run_timed_refresh_lookup(
+                    phase_timings,
+                    "green_settings_s",
+                    lambda: self._async_resolve_green_battery_settings(serials),
+                )
+            )
+            tasks["auth_settings"] = asyncio.create_task(
+                self._async_run_timed_refresh_lookup(
+                    phase_timings,
+                    "auth_settings_s",
+                    lambda: self._async_resolve_auth_settings(serials),
+                )
+            )
+            tasks["charger_config"] = asyncio.create_task(
+                self._async_run_timed_refresh_lookup(
+                    phase_timings,
+                    "charger_config_s",
+                    lambda: self._async_resolve_charger_config(
+                        serials,
+                        keys=(
+                            DEFAULT_CHARGE_LEVEL_SETTING,
+                            PHASE_SWITCH_CONFIG_SETTING,
+                        ),
+                    ),
+                )
+            )
+        if not tasks:
+            return {}, {}, {}, {}
+        results = await asyncio.gather(*tasks.values())
+        resolved = dict(zip(tasks.keys(), results, strict=False))
+        return (
+            resolved.get("charge_modes", {}),
+            resolved.get("green_settings", {}),
+            resolved.get("auth_settings", {}),
+            resolved.get("charger_config", {}),
+        )
+
     async def _async_update_data(self) -> dict:
         t0 = time.monotonic()
         refresh_started_utc = dt_util.utcnow()
@@ -2182,10 +2262,15 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 time.monotonic() - site_energy_start, 3
             )
             if not first_refresh:
-                await self.refresh_runner.async_run_refresh_plan(
-                    phase_timings,
-                    plan=SITE_ONLY_FOLLOWUP_PLAN,
+                followup_plan = build_site_only_followup_plan(
+                    self,
+                    force_full=self.endpoint_manual_bypass_active(),
                 )
+                if followup_plan.stages:
+                    await self.refresh_runner.async_run_refresh_plan(
+                        phase_timings,
+                        plan=followup_plan,
+                    )
             if not self._auth_refresh_suspended_active():
                 self._clear_auth_refresh_rejection_state()
             self._prune_runtime_caches(active_serials=(), keep_day_keys=())
@@ -2582,10 +2667,15 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._last_error = self.last_failure_description
 
         if not first_refresh:
-            await self.refresh_runner.async_run_refresh_plan(
-                phase_timings,
-                plan=FOLLOWUP_PLAN,
+            followup_plan = build_followup_plan(
+                self,
+                force_full=self.endpoint_manual_bypass_active(),
             )
+            if followup_plan.stages:
+                await self.refresh_runner.async_run_refresh_plan(
+                    phase_timings,
+                    plan=followup_plan,
+                )
         if not self._auth_refresh_suspended_active():
             self._clear_auth_refresh_rejection_state()
 
@@ -2605,7 +2695,6 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             if not self._has_embedded_charge_mode(obj):
                 charge_mode_candidates.append(sn)
 
-        charge_modes: dict[str, str | None] = {}
         if (
             not first_refresh
             and not charge_mode_candidates
@@ -2617,41 +2706,17 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 await self._get_charge_mode(records[0][0])
             except Exception:
                 pass
-        if not first_refresh and charge_mode_candidates:
-            unique_candidates = list(dict.fromkeys(charge_mode_candidates))
-            charge_start = time.monotonic()
-            if unique_candidates:
-                charge_modes = await self.evse_runtime.async_resolve_charge_modes(
-                    unique_candidates
-                )
-            phase_timings["charge_mode_s"] = round(time.monotonic() - charge_start, 3)
-
-        green_settings: dict[str, tuple[bool | None, bool]] = {}
-        if not first_refresh and records:
-            green_start = time.monotonic()
-            green_settings = await self._async_resolve_green_battery_settings(
-                [sn for sn, _obj in records]
-            )
-            phase_timings["green_settings_s"] = round(time.monotonic() - green_start, 3)
-
-        auth_settings: dict[str, tuple[bool | None, bool | None, bool, bool]] = {}
-        if not first_refresh and records:
-            auth_serials = [sn for sn, _obj in records]
-            auth_start = time.monotonic()
-            if auth_serials:
-                auth_settings = await self._async_resolve_auth_settings(auth_serials)
-            phase_timings["auth_settings_s"] = round(time.monotonic() - auth_start, 3)
-
-        charger_config: dict[str, dict[str, object]] = {}
-        if not first_refresh and records:
-            config_start = time.monotonic()
-            charger_config = await self._async_resolve_charger_config(
-                [sn for sn, _obj in records],
-                keys=(DEFAULT_CHARGE_LEVEL_SETTING, PHASE_SWITCH_CONFIG_SETTING),
-            )
-            phase_timings["charger_config_s"] = round(
-                time.monotonic() - config_start, 3
-            )
+        (
+            charge_modes,
+            green_settings,
+            auth_settings,
+            charger_config,
+        ) = await self._async_resolve_post_status_evse_enrichments(
+            phase_timings,
+            records=records,
+            charge_mode_candidates=charge_mode_candidates,
+            first_refresh=first_refresh,
+        )
 
         def _as_bool(v):
             if isinstance(v, bool):
@@ -3943,10 +4008,16 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._sync_session_history_issue()
 
         if not first_refresh:
-            await self.refresh_runner.async_run_refresh_plan(
-                phase_timings,
-                plan=post_session_followup_plan(day_local_default),
+            post_session_plan = build_post_session_followup_plan(
+                self,
+                day_local_default,
+                force_full=self.endpoint_manual_bypass_active(),
             )
+            if post_session_plan.stages:
+                await self.refresh_runner.async_run_refresh_plan(
+                    phase_timings,
+                    plan=post_session_plan,
+                )
             try:
                 self.evse_timeseries.merge_charger_payloads(
                     out, day_local=day_local_default
@@ -3956,10 +4027,15 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self.discovery_snapshot.sync_site_energy_discovery_state()
             self._sync_site_energy_issue()
             self._sync_battery_profile_pending_issue()
-            await self.refresh_runner.async_run_refresh_plan(
-                phase_timings,
-                plan=HEATPUMP_FOLLOWUP_PLAN,
+            heatpump_plan = build_heatpump_followup_plan(
+                self,
+                force_full=self.endpoint_manual_bypass_active(),
             )
+            if heatpump_plan.stages:
+                await self.refresh_runner.async_run_refresh_plan(
+                    phase_timings,
+                    plan=heatpump_plan,
+                )
 
         # Dynamic poll rate: fast while any charging, within a fast window, or streaming
         if self.config_entry is not None:

--- a/custom_components/enphase_ev/current_power_runtime.py
+++ b/custom_components/enphase_ev/current_power_runtime.py
@@ -43,6 +43,27 @@ class CurrentPowerRuntime:
 
         CurrentPowerSample().apply_to(self.coordinator)
 
+    def _cached_state_present(self) -> bool:
+        coord = self.coordinator
+        return any(
+            getattr(coord, attr, None) is not None
+            for attr in (
+                "_current_power_consumption_w",
+                "_current_power_consumption_sample_utc",
+                "_current_power_consumption_reported_units",
+                "_current_power_consumption_reported_precision",
+                "_current_power_consumption_source",
+            )
+        )
+
+    def refresh_due(self) -> bool:
+        """Return True when current-power data can be refreshed."""
+
+        fetcher = getattr(self.coordinator.client, "latest_power", None)
+        if callable(fetcher):
+            return True
+        return self._cached_state_present()
+
     async def async_refresh(self) -> None:
         """Refresh cached current power consumption from ``client.latest_power``."""
 

--- a/custom_components/enphase_ev/energy.py
+++ b/custom_components/enphase_ev/energy.py
@@ -108,6 +108,27 @@ class EnergyManager:
         """Drop the cached site energy payload."""
         self._site_energy_cache_ts = None
 
+    def site_energy_refresh_due(self, *, force: bool = False) -> bool:
+        """Return True when the site-energy cache should be refreshed."""
+
+        if not hasattr(self, "_site_energy_cache_ts"):
+            self._site_energy_cache_ts = None
+        if not hasattr(self, "_site_energy_cache_ttl"):
+            self._site_energy_cache_ttl = SITE_ENERGY_CACHE_TTL
+        force_refresh = force or self._site_energy_force_refresh
+        if self._service_backoff_active():
+            return False
+        now_mono = time.monotonic()
+        if (
+            not force_refresh
+            and self._site_energy_cache_ts is not None
+            and (now_mono - self._site_energy_cache_ts) < self._site_energy_cache_ttl
+        ):
+            return False
+        client = self._client_provider()
+        fetcher = getattr(client, "lifetime_energy", None)
+        return callable(fetcher)
+
     @property
     def service_available(self) -> bool:
         """Return True when site energy service is available."""

--- a/custom_components/enphase_ev/evse_feature_flags_runtime.py
+++ b/custom_components/enphase_ev/evse_feature_flags_runtime.py
@@ -83,6 +83,27 @@ class EvseFeatureFlagsRuntime:
             EvseFeatureFlagsSnapshot.from_coordinator(self.coordinator)
         )
 
+    def _cached_state_present(self) -> bool:
+        coord = self.coordinator
+        return bool(
+            getattr(coord, "_evse_feature_flags_payload", None) is not None
+            or getattr(coord, "_evse_site_feature_flags", None)
+            or getattr(coord, "_evse_feature_flags_by_serial", None)
+        )
+
+    def refresh_due(self, *, force: bool = False) -> bool:
+        """Return True when feature flags should refresh or cached state should clear."""
+
+        coord = self.coordinator
+        now = time.monotonic()
+        if not force and coord._evse_feature_flags_cache_until:
+            if now < coord._evse_feature_flags_cache_until:
+                return False
+        fetcher = getattr(coord.client, "evse_feature_flags", None)
+        if not callable(fetcher):
+            return self._cached_state_present()
+        return True
+
     def feature_flag(self, key: str, sn: str | None = None) -> object | None:
         """Return a parsed EVSE feature flag for the site or charger."""
 

--- a/custom_components/enphase_ev/evse_timeseries.py
+++ b/custom_components/enphase_ev/evse_timeseries.py
@@ -243,6 +243,36 @@ class EVSETimeseriesManager:
         except Exception:
             return False
 
+    def refresh_due(
+        self,
+        *,
+        day_local: datetime | None = None,
+        force: bool = False,
+    ) -> bool:
+        """Return True when EVSE timeseries data should be refreshed."""
+
+        if day_local is None:
+            day_local = dt_util.as_local(dt_util.now())
+        day_key = self._day_key(day_local)
+        client = self._client_provider()
+        refresh_lifetime = (force or not self._lifetime_cache_fresh()) and (
+            force or not self.lifetime_backoff_active
+        )
+        refresh_daily = (force or not self._daily_cache_fresh(day_key)) and (
+            force or not self.daily_backoff_active
+        )
+        if not (refresh_lifetime or refresh_daily):
+            return False
+        if refresh_lifetime and not callable(
+            getattr(client, "evse_timeseries_lifetime_energy", None)
+        ):
+            refresh_lifetime = False
+        if refresh_daily and not callable(
+            getattr(client, "evse_timeseries_daily_energy", None)
+        ):
+            refresh_daily = False
+        return refresh_lifetime or refresh_daily
+
     async def async_refresh(
         self,
         *,

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -235,6 +235,17 @@ class HeatpumpRuntime:
         self._heatpump_power_last_error = error
         return False
 
+    def _heatpump_cleanup_due(self, *attrs: str) -> bool:
+        for attr in attrs:
+            value = getattr(self, attr, None)
+            if isinstance(value, bool):
+                if value:
+                    return True
+                continue
+            if value is not None:
+                return True
+        return False
+
     @staticmethod
     async def _async_call_refreshable_fetcher(
         fetcher, *, force: bool = False
@@ -586,6 +597,34 @@ class HeatpumpRuntime:
         self, *, force: bool = False
     ) -> None:
         await self._async_refresh_heatpump_runtime_state(force=force)
+
+    def heatpump_runtime_state_refresh_due(self, *, force: bool = False) -> bool:
+        now = time.monotonic()
+        if not self.has_type("heatpump"):
+            return self._heatpump_cleanup_due(
+                "_heatpump_known_present",
+                "_heatpump_runtime_state",
+                "_heatpump_runtime_state_cache_until",
+                "_heatpump_runtime_state_backoff_until",
+                "_heatpump_runtime_state_last_error",
+                "_heatpump_runtime_state_last_success_mono",
+                "_heatpump_runtime_state_last_success_utc",
+                "_heatpump_runtime_state_using_stale",
+            )
+        if (
+            not force
+            and self._heatpump_runtime_state_cache_until is not None
+            and now < self._heatpump_runtime_state_cache_until
+        ):
+            return False
+        if (
+            not force
+            and self._heatpump_runtime_state_backoff_until is not None
+            and now < self._heatpump_runtime_state_backoff_until
+        ):
+            return False
+        fetcher = getattr(self.client, "hems_heatpump_state", None)
+        return callable(fetcher)
 
     def _heatpump_daily_window(self) -> tuple[str, str, str, tuple[str, str]] | None:
         tz_name = self._site_timezone_name()
@@ -1245,6 +1284,46 @@ class HeatpumpRuntime:
         self, *, force: bool = False
     ) -> None:
         await self._async_refresh_heatpump_daily_consumption(force=force)
+
+    def heatpump_daily_consumption_refresh_due(self, *, force: bool = False) -> bool:
+        now = time.monotonic()
+        if not self.has_type("heatpump"):
+            return self._heatpump_cleanup_due(
+                "_heatpump_known_present",
+                "_heatpump_daily_consumption",
+                "_heatpump_daily_consumption_previous",
+                "_heatpump_daily_consumption_cache_until",
+                "_heatpump_daily_consumption_backoff_until",
+                "_heatpump_daily_consumption_last_error",
+                "_heatpump_daily_consumption_cache_key",
+                "_heatpump_daily_consumption_last_success_mono",
+                "_heatpump_daily_consumption_last_success_utc",
+                "_heatpump_daily_consumption_using_stale",
+                "_heatpump_daily_split_last_error",
+                "_heatpump_daily_split_last_success_mono",
+                "_heatpump_daily_split_last_success_utc",
+                "_heatpump_daily_split_using_stale",
+            )
+        window = self._heatpump_daily_window()
+        if window is None:
+            return False
+        _start_at, _end_at, _tz_name, marker = window
+        if (
+            not force
+            and self._heatpump_daily_consumption_cache_until is not None
+            and self._heatpump_daily_consumption_cache_key == marker
+            and now < self._heatpump_daily_consumption_cache_until
+        ):
+            return False
+        if (
+            not force
+            and self._heatpump_daily_consumption_backoff_until is not None
+            and self._heatpump_daily_consumption_cache_key == marker
+            and now < self._heatpump_daily_consumption_backoff_until
+        ):
+            return False
+        fetcher = getattr(self.client, "pv_system_today", None)
+        return callable(fetcher)
 
     def _heatpump_power_candidate_device_uids(self) -> list[str | None]:
         candidates: list[str | None] = []
@@ -1957,6 +2036,34 @@ class HeatpumpRuntime:
 
     async def async_refresh_heatpump_power(self, *, force: bool = False) -> None:
         await self._async_refresh_heatpump_power(force=force)
+
+    def heatpump_power_refresh_due(self, *, force: bool = False) -> bool:
+        now = time.monotonic()
+        if not self.has_type("heatpump"):
+            return self._heatpump_cleanup_due(
+                "_heatpump_known_present",
+                "_heatpump_power_w",
+                "_heatpump_power_sample_utc",
+                "_heatpump_power_start_utc",
+                "_heatpump_power_device_uid",
+                "_heatpump_power_source",
+                "_heatpump_power_snapshot",
+                "_heatpump_power_cache_until",
+                "_heatpump_power_backoff_until",
+                "_heatpump_power_last_error",
+                "_heatpump_power_last_success_mono",
+                "_heatpump_power_last_success_utc",
+                "_heatpump_power_using_stale",
+                "_heatpump_power_selection_marker",
+            )
+        if not force and self._heatpump_power_cache_until is not None:
+            if now < self._heatpump_power_cache_until:
+                return False
+        if not force and self._heatpump_power_backoff_until is not None:
+            if now < self._heatpump_power_backoff_until:
+                return False
+        fetcher = getattr(self.client, "pv_system_today", None)
+        return callable(fetcher)
 
     @staticmethod
     def _hems_event_entries(payload: object) -> list[dict[str, object]]:

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -1780,6 +1780,17 @@ class InventoryRuntime:
         )
         coord._note_endpoint_family_success(family)
 
+    def devices_inventory_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        now = time.monotonic()
+        if not coord._endpoint_family_should_run("inventory_topology", force=force):
+            return False
+        if not force and self._devices_inventory_cache_until:
+            if now < self._devices_inventory_cache_until:
+                return False
+        fetcher = getattr(self.client, "devices_inventory", None)
+        return callable(fetcher)
+
     async def _async_refresh_hems_devices(self, *, force: bool = False) -> None:
         now = time.monotonic()
         if not force and self._hems_devices_cache_until:
@@ -1922,6 +1933,14 @@ class InventoryRuntime:
             "HEMS discovery summary",
             self._debug_hems_inventory_summary(),
         )
+
+    def hems_devices_refresh_due(self, *, force: bool = False) -> bool:
+        now = time.monotonic()
+        if not force and self._hems_devices_cache_until:
+            if now < self._hems_devices_cache_until:
+                return False
+        fetcher = getattr(self.client, "hems_devices", None)
+        return callable(fetcher)
 
     def _system_dashboard_detail_records(
         self,
@@ -2746,6 +2765,64 @@ class InventoryRuntime:
         )
         self._merge_microinverter_type_bucket()
         self._merge_heatpump_type_bucket()
+
+    def inverters_refresh_due(self, *, force: bool = False) -> bool:
+        coord = self.coordinator
+        now = time.monotonic()
+        if not self.include_inverters:
+            return False
+        fetch_inventory = getattr(self.client, "inverters_inventory", None)
+        fetch_status = getattr(self.client, "inverter_status", None)
+        if not callable(fetch_inventory) or not callable(fetch_status):
+            return False
+        inventory_cache_until = getattr(self, "_inverters_inventory_cache_until", None)
+        inventory_due = True
+        if isinstance(inventory_cache_until, (int, float)) and now < float(
+            inventory_cache_until
+        ):
+            inventory_due = False
+        else:
+            inventory_due = coord._endpoint_family_should_run(
+                "inverter_inventory", force=force
+            )
+        status_cache_until = getattr(self, "_inverter_status_cache_until", None)
+        status_due = False
+        if isinstance(status_cache_until, (int, float)) and now < float(
+            status_cache_until
+        ):
+            status_due = False
+        else:
+            status_due = coord._endpoint_family_should_run(
+                "inverter_status", force=force
+            )
+        start_date = self._inverter_start_date()
+        production_due = False
+        if start_date is not None:
+            end_date = self._site_local_current_date()
+            current_key = (start_date, end_date)
+            cached_payload = getattr(self, "_inverter_production_payload", None)
+            cached_matches = (
+                getattr(self, "_inverter_production_cache_key", None) == current_key
+                and isinstance(cached_payload, dict)
+                and bool(cached_payload)
+            )
+            production_cache_until = getattr(
+                self,
+                "_inverter_production_cache_until",
+                None,
+            )
+            if not (
+                cached_matches
+                and isinstance(production_cache_until, (int, float))
+                and now < float(production_cache_until)
+            ):
+                production_fetcher = getattr(self.client, "inverter_production", None)
+                production_due = callable(
+                    production_fetcher
+                ) and coord._endpoint_family_should_run(
+                    "inverter_production", force=force
+                )
+        return inventory_due or status_due or production_due
 
     def iter_inverter_serials(self) -> list[str]:
         """Return currently active inverter serials in a stable order."""

--- a/custom_components/enphase_ev/refresh_plan.py
+++ b/custom_components/enphase_ev/refresh_plan.py
@@ -405,3 +405,322 @@ def post_session_followup_stage(day_local_default: object) -> RefreshStage:
 
 def post_session_followup_plan(day_local_default: object) -> RefreshPlan:
     return RefreshPlan(stages=(post_session_followup_stage(day_local_default),))
+
+
+def _plan_from_stages(*stages: RefreshStage | None) -> RefreshPlan:
+    filtered = tuple(
+        stage
+        for stage in stages
+        if stage is not None and (stage.parallel_tasks or stage.ordered_tasks)
+    )
+    return RefreshPlan(stages=filtered)
+
+
+def _refresh_due(
+    target: object,
+    predicate_name: str,
+    *,
+    fallback_due: Callable[[], bool] | None = None,
+    **kwargs: object,
+) -> bool:
+    predicate = getattr(target, predicate_name, None)
+    if callable(predicate):
+        return bool(predicate(**kwargs))
+    if fallback_due is None:
+        return False
+    return bool(fallback_due())
+
+
+def _heatpump_power_covers_dependency_refreshes(runtime: object) -> bool:
+    has_type = getattr(runtime, "has_type", None)
+    if callable(has_type):
+        try:
+            if not bool(has_type("heatpump")):
+                return False
+        except Exception:
+            return False
+    client = getattr(runtime, "client", None)
+    if getattr(client, "hems_site_supported", None) is not True:
+        return False
+    return True
+
+
+def build_heatpump_followup_plan(
+    owner: object, *, force_full: bool = False
+) -> RefreshPlan:
+    if force_full:
+        return HEATPUMP_FOLLOWUP_PLAN
+    runtime = getattr(owner, "heatpump_runtime")
+    ordered: list[RefreshTask] = []
+    power_due = runtime.heatpump_power_refresh_due()
+    runtime_due = runtime.heatpump_runtime_state_refresh_due()
+    daily_due = runtime.heatpump_daily_consumption_refresh_due()
+    if power_due and _heatpump_power_covers_dependency_refreshes(runtime):
+        ordered.append(
+            method_task(
+                "heatpump_power_s",
+                "heat pump power",
+                "_async_refresh_heatpump_power",
+            )
+        )
+    else:
+        if runtime_due:
+            ordered.append(
+                method_task(
+                    "heatpump_runtime_s",
+                    "heat pump runtime",
+                    "_async_refresh_heatpump_runtime_state",
+                )
+            )
+        if daily_due:
+            ordered.append(
+                method_task(
+                    "heatpump_daily_s",
+                    "heat pump daily-consumption",
+                    "_async_refresh_heatpump_daily_consumption",
+                )
+            )
+        if power_due:
+            ordered.append(
+                method_task(
+                    "heatpump_power_s",
+                    "heat pump power",
+                    "_async_refresh_heatpump_power",
+                )
+            )
+    return _plan_from_stages(RefreshStage(ordered_tasks=tuple(ordered)))
+
+
+def build_followup_plan(owner: object, *, force_full: bool = False) -> RefreshPlan:
+    if force_full:
+        return FOLLOWUP_PLAN
+    battery = getattr(owner, "battery_runtime")
+    inventory = getattr(owner, "inventory_runtime")
+    current_power = getattr(owner, "current_power_runtime")
+    evse_feature_flags = getattr(owner, "evse_feature_flags_runtime")
+    parallel: list[RefreshTask] = []
+    ordered: list[RefreshTask] = []
+    if battery.battery_site_settings_refresh_due():
+        parallel.append(
+            method_task(
+                "battery_site_settings_s",
+                "battery site settings",
+                "_async_refresh_battery_site_settings",
+            )
+        )
+    if battery.battery_backup_history_refresh_due():
+        parallel.append(
+            method_task(
+                "battery_backup_history_s",
+                "battery backup history",
+                "_async_refresh_battery_backup_history",
+            )
+        )
+    if battery.battery_settings_refresh_due():
+        parallel.append(
+            method_task(
+                "battery_settings_s",
+                "battery settings",
+                "_async_refresh_battery_settings",
+            )
+        )
+    if battery.battery_schedules_refresh_due():
+        parallel.append(
+            method_task(
+                "battery_schedules_s",
+                "battery schedules",
+                "_async_refresh_battery_schedules",
+            )
+        )
+    if battery.storm_guard_refresh_due():
+        parallel.append(
+            method_task(
+                "storm_guard_s",
+                "storm guard",
+                "_async_refresh_storm_guard_profile",
+            )
+        )
+    if battery.storm_alert_refresh_due():
+        parallel.append(
+            method_task(
+                "storm_alert_s",
+                "storm alert",
+                "_async_refresh_storm_alert",
+            )
+        )
+    if battery.grid_control_check_refresh_due():
+        parallel.append(
+            object_method_task(
+                "grid_control_check_s",
+                "grid control",
+                "battery_runtime",
+                "async_refresh_grid_control_check",
+            )
+        )
+    if battery.dry_contact_settings_refresh_due():
+        parallel.append(
+            method_task(
+                "dry_contact_settings_s",
+                "dry contact settings",
+                "_async_refresh_dry_contact_settings",
+            )
+        )
+    if current_power.refresh_due():
+        parallel.append(
+            method_task(
+                "current_power_s",
+                "current power consumption",
+                "_async_refresh_current_power_consumption",
+            )
+        )
+    if evse_feature_flags.refresh_due():
+        parallel.append(
+            method_task(
+                "evse_feature_flags_s",
+                "EVSE feature flags",
+                "_async_refresh_evse_feature_flags",
+            )
+        )
+    if battery.battery_status_refresh_due():
+        ordered.append(
+            object_method_task(
+                "battery_status_s",
+                "battery status",
+                "battery_runtime",
+                "async_refresh_battery_status",
+            )
+        )
+    if battery.ac_battery_devices_refresh_due():
+        ordered.append(
+            object_method_task(
+                "ac_battery_devices_s",
+                "AC Battery devices",
+                "battery_runtime",
+                "async_refresh_ac_battery_devices",
+            )
+        )
+    if inventory.devices_inventory_refresh_due():
+        ordered.append(
+            object_method_task(
+                "devices_inventory_s",
+                "device inventory",
+                "inventory_runtime",
+                "_async_refresh_devices_inventory",
+            )
+        )
+    if inventory.hems_devices_refresh_due():
+        ordered.append(
+            object_method_task(
+                "hems_devices_s",
+                "HEMS inventory",
+                "inventory_runtime",
+                "_async_refresh_hems_devices",
+            )
+        )
+    return _plan_from_stages(
+        RefreshStage(
+            defer_topology=True,
+            parallel_tasks=tuple(parallel),
+            ordered_tasks=tuple(ordered),
+        )
+    )
+
+
+def build_site_only_followup_plan(
+    owner: object, *, force_full: bool = False
+) -> RefreshPlan:
+    if force_full:
+        return SITE_ONLY_FOLLOWUP_PLAN
+    normal = build_followup_plan(owner, force_full=False)
+    stages: tuple[RefreshStage, ...] = normal.stages
+    inventory = getattr(owner, "inventory_runtime")
+    if inventory.inverters_refresh_due():
+        if stages:
+            base_stage = stages[0]
+            stages = (
+                RefreshStage(
+                    defer_topology=base_stage.defer_topology,
+                    stage_key=base_stage.stage_key,
+                    parallel_tasks=base_stage.parallel_tasks,
+                    ordered_tasks=base_stage.ordered_tasks
+                    + (
+                        method_task(
+                            "inverters_s",
+                            "inverters",
+                            "_async_refresh_inverters",
+                        ),
+                    ),
+                ),
+            )
+        else:
+            stages = (
+                RefreshStage(
+                    defer_topology=True,
+                    ordered_tasks=(
+                        method_task(
+                            "inverters_s",
+                            "inverters",
+                            "_async_refresh_inverters",
+                        ),
+                    ),
+                ),
+            )
+    heatpump = build_heatpump_followup_plan(owner, force_full=False)
+    return _plan_from_stages(*(stages + heatpump.stages))
+
+
+def build_post_session_followup_plan(
+    owner: object,
+    day_local_default: object,
+    *,
+    force_full: bool = False,
+) -> RefreshPlan:
+    if force_full:
+        return post_session_followup_plan(day_local_default)
+    parallel: list[RefreshTask] = []
+    evse_timeseries = getattr(owner, "evse_timeseries")
+    if _refresh_due(
+        evse_timeseries,
+        "refresh_due",
+        day_local=day_local_default,
+        fallback_due=lambda: callable(getattr(evse_timeseries, "async_refresh", None)),
+    ):
+        parallel.append(
+            callback_task(
+                "evse_timeseries_s",
+                "EVSE timeseries",
+                lambda inner_owner: inner_owner.evse_timeseries.async_refresh(
+                    day_local=day_local_default
+                ),
+            )
+        )
+    energy = getattr(owner, "energy")
+    if _refresh_due(
+        energy,
+        "site_energy_refresh_due",
+        fallback_due=lambda: callable(
+            getattr(energy, "_async_refresh_site_energy", None)
+        ),
+    ):
+        parallel.append(
+            callback_task(
+                "site_energy_s",
+                "site energy",
+                lambda inner_owner: inner_owner.energy._async_refresh_site_energy(),
+            )
+        )
+    inventory = getattr(owner, "inventory_runtime")
+    if _refresh_due(
+        inventory,
+        "inverters_refresh_due",
+        fallback_due=lambda: callable(getattr(owner, "_async_refresh_inverters", None)),
+    ):
+        parallel.append(
+            method_task("inverters_s", "inverters", "_async_refresh_inverters")
+        )
+    return _plan_from_stages(
+        RefreshStage(
+            defer_topology=True,
+            parallel_tasks=tuple(parallel),
+        )
+    )

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -2034,6 +2034,66 @@ async def test_battery_runtime_grid_control_refresh_keeps_recent_state_during_co
     assert coord._grid_control_active_download is False  # noqa: SLF001
 
 
+def test_battery_runtime_grid_control_refresh_due_requests_state_invalidation(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    grid_health = coord._endpoint_family_state("grid_control_check")  # noqa: SLF001
+    grid_health.next_retry_mono = time.monotonic() + 300
+    grid_health.cooldown_active = True
+    grid_health.last_success_mono = time.monotonic() - 500
+    coord._grid_control_check_cache_until = None  # noqa: SLF001
+    coord._grid_control_supported = True  # noqa: SLF001
+    coord.client.grid_control_check = AsyncMock(side_effect=AssertionError("unused"))
+
+    assert coord.battery_runtime.grid_control_check_refresh_due() is True
+
+
+def test_battery_runtime_dry_contact_refresh_due_requests_state_invalidation(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    dry_health = coord._endpoint_family_state("dry_contact_settings")  # noqa: SLF001
+    dry_health.next_retry_mono = time.monotonic() + 300
+    dry_health.cooldown_active = True
+    dry_health.last_success_mono = time.monotonic() - 2_000
+    coord._dry_contact_settings_cache_until = None  # noqa: SLF001
+    coord._dry_contact_settings_supported = True  # noqa: SLF001
+    coord.client.dry_contacts_settings = AsyncMock(side_effect=AssertionError("unused"))
+
+    assert coord.battery_runtime.dry_contact_settings_refresh_due() is True
+
+
+@pytest.mark.asyncio
+async def test_battery_runtime_ac_battery_refresh_due_requests_cleanup(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._selected_type_keys = {"ac_battery"}  # noqa: SLF001
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._battery_has_acb = True  # noqa: SLF001
+    coord._ac_battery_data = {  # noqa: SLF001
+        "BAT-AC-1": {"serial_number": "BAT-AC-1", "battery_id": "67890"}
+    }
+    coord._ac_battery_order = ["BAT-AC-1"]  # noqa: SLF001
+    coord._ac_battery_devices_payload = {
+        "records": [{"serial_number": "BAT-AC-1"}]
+    }  # noqa: SLF001
+    health = coord._endpoint_family_state("ac_battery_devices")  # noqa: SLF001
+    health.next_retry_mono = time.monotonic() + 300
+    health.cooldown_active = True
+    coord._endpoint_family_can_use_stale = lambda *_args, **_kwargs: False  # type: ignore[method-assign]  # noqa: SLF001
+    coord.client.ac_battery_devices_page = AsyncMock(
+        side_effect=AssertionError("unused")
+    )
+
+    assert coord.battery_runtime.ac_battery_devices_refresh_due() is True
+    await coord.battery_runtime.async_refresh_ac_battery_devices()
+
+    coord.client.ac_battery_devices_page.assert_not_called()
+    assert coord.iter_ac_battery_serials() == []
+
+
 @pytest.mark.asyncio
 async def test_battery_runtime_async_set_grid_connection_uses_runtime_grid_mode() -> (
     None

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -2064,6 +2064,25 @@ def test_battery_runtime_dry_contact_refresh_due_requests_state_invalidation(
     assert coord.battery_runtime.dry_contact_settings_refresh_due() is True
 
 
+def test_battery_runtime_due_predicates_cover_cached_and_missing_fetcher_paths(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    future = time.monotonic() + 300
+
+    coord._battery_settings_cache_until = future  # noqa: SLF001
+    assert coord.battery_runtime.battery_settings_refresh_due() is False
+
+    coord._ac_battery_devices_cache_until = future  # noqa: SLF001
+    coord._selected_type_keys = {"ac_battery"}  # noqa: SLF001
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._battery_has_acb = True  # noqa: SLF001
+    coord.client.ac_battery_devices_page = AsyncMock(
+        side_effect=AssertionError("unused")
+    )
+    assert coord.battery_runtime.ac_battery_devices_refresh_due() is False
+
+
 @pytest.mark.asyncio
 async def test_battery_runtime_ac_battery_refresh_due_requests_cleanup(
     coordinator_factory,
@@ -2092,6 +2111,80 @@ async def test_battery_runtime_ac_battery_refresh_due_requests_cleanup(
 
     coord.client.ac_battery_devices_page.assert_not_called()
     assert coord.iter_ac_battery_serials() == []
+
+
+@pytest.mark.asyncio
+async def test_battery_runtime_optional_refreshes_handle_early_return_paths(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    coord.client.battery_status = None
+    await coord.battery_runtime.async_refresh_battery_status()
+
+    coord.client.battery_backup_history = None
+    await coord.battery_runtime.async_refresh_battery_backup_history()
+
+    coord._endpoint_family_should_run = (  # type: ignore[method-assign]  # noqa: SLF001
+        lambda family, force=False: family != "battery_settings"
+    )
+    coord.client.battery_settings_details = AsyncMock(
+        side_effect=AssertionError("unused")
+    )
+    await coord.battery_runtime.async_refresh_battery_settings()
+    coord.client.battery_settings_details.assert_not_awaited()
+
+    coord._endpoint_family_should_run = lambda *args, **kwargs: True  # type: ignore[method-assign]  # noqa: SLF001
+    coord.client.battery_settings_details = None
+    await coord.battery_runtime.async_refresh_battery_settings()
+
+    coord._endpoint_family_should_run = (  # type: ignore[method-assign]  # noqa: SLF001
+        lambda family, force=False: family != "battery_schedules"
+    )
+    coord.client.battery_schedules = AsyncMock(side_effect=AssertionError("unused"))
+    await coord.battery_runtime.async_refresh_battery_schedules()
+    coord.client.battery_schedules.assert_not_awaited()
+
+    coord._endpoint_family_should_run = lambda *args, **kwargs: True  # type: ignore[method-assign]  # noqa: SLF001
+    coord.client.battery_schedules = None
+    await coord.battery_runtime.async_refresh_battery_schedules()
+
+    coord.client.battery_site_settings = None
+    await coord.battery_runtime.async_refresh_battery_site_settings()
+
+    coord._grid_control_supported = True  # noqa: SLF001
+    coord._grid_control_disable = False  # noqa: SLF001
+    coord._grid_control_active_download = True  # noqa: SLF001
+    coord._grid_control_sunlight_backup_system_check = True  # noqa: SLF001
+    coord._grid_control_grid_outage_check = True  # noqa: SLF001
+    coord._grid_control_user_initiated_toggle = True  # noqa: SLF001
+    coord.client.grid_control_check = None
+    await coord.battery_runtime.async_refresh_grid_control_check()
+    assert coord._grid_control_supported is None  # noqa: SLF001
+    assert coord._grid_control_disable is None  # noqa: SLF001
+    assert coord._grid_control_active_download is None  # noqa: SLF001
+    assert coord._grid_control_sunlight_backup_system_check is None  # noqa: SLF001
+    assert coord._grid_control_grid_outage_check is None  # noqa: SLF001
+    assert coord._grid_control_user_initiated_toggle is None  # noqa: SLF001
+
+    coord._dry_contact_settings_supported = True  # noqa: SLF001
+    coord.client.dry_contacts_settings = None
+    await coord.battery_runtime.async_refresh_dry_contact_settings()
+    assert coord._dry_contact_settings_supported is None  # noqa: SLF001
+
+    coord.client.storm_guard_profile = None
+    await coord.battery_runtime.async_refresh_storm_guard_profile()
+
+    coord._endpoint_family_should_run = (  # type: ignore[method-assign]  # noqa: SLF001
+        lambda family, force=False: family != "storm_alert"
+    )
+    coord.client.storm_guard_alert = AsyncMock(side_effect=AssertionError("unused"))
+    await coord.battery_runtime.async_refresh_storm_alert()
+    coord.client.storm_guard_alert.assert_not_awaited()
+
+    coord._endpoint_family_should_run = lambda *args, **kwargs: True  # type: ignore[method-assign]  # noqa: SLF001
+    coord.client.storm_guard_alert = None
+    await coord.battery_runtime.async_refresh_storm_alert()
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -798,15 +798,14 @@ async def test_async_update_data_site_only_refreshes_hems_before_heatpump_power(
     coord._async_refresh_heatpump_power = AsyncMock(  # noqa: SLF001
         side_effect=lambda: order.append("heatpump_power")
     )
+    coord.heatpump_runtime.heatpump_runtime_state_refresh_due = lambda: True  # type: ignore[method-assign]
+    coord.heatpump_runtime.heatpump_daily_consumption_refresh_due = lambda: True  # type: ignore[method-assign]
+    coord.heatpump_runtime.heatpump_power_refresh_due = lambda: True  # type: ignore[method-assign]
+    coord.heatpump_runtime.has_type = lambda _key: True  # type: ignore[method-assign]
+    coord.client._hems_site_supported = True  # noqa: SLF001
 
     assert await coord._async_update_data() == {}  # noqa: SLF001
-    assert order == [
-        "devices",
-        "hems",
-        "heatpump_runtime",
-        "heatpump_daily",
-        "heatpump_power",
-    ]
+    assert order == ["devices", "hems", "heatpump_power"]
 
 
 @pytest.mark.asyncio
@@ -851,6 +850,9 @@ async def test_async_update_data_site_only_ignores_runtime_and_daily_refresh_err
     coord._async_refresh_heatpump_power = AsyncMock(  # noqa: SLF001
         side_effect=lambda: order.append("heatpump_power")
     )
+    coord.heatpump_runtime.heatpump_runtime_state_refresh_due = lambda: True  # type: ignore[method-assign]
+    coord.heatpump_runtime.heatpump_daily_consumption_refresh_due = lambda: True  # type: ignore[method-assign]
+    coord.heatpump_runtime.heatpump_power_refresh_due = lambda: True  # type: ignore[method-assign]
 
     assert await coord._async_update_data() == {}  # noqa: SLF001
     assert order == ["devices", "hems", "heatpump_power"]
@@ -902,7 +904,7 @@ async def test_async_update_data_continues_when_heatpump_refresh_raises(
 
 
 @pytest.mark.asyncio
-async def test_async_update_data_continues_when_runtime_and_daily_refresh_raise(
+async def test_async_update_data_prefers_heatpump_power_when_all_heatpump_refreshes_are_due(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory()
@@ -946,11 +948,16 @@ async def test_async_update_data_continues_when_runtime_and_daily_refresh_raise(
         side_effect=RuntimeError("daily")
     )
     coord._async_refresh_heatpump_power = AsyncMock(return_value=None)  # noqa: SLF001
+    coord.heatpump_runtime.heatpump_runtime_state_refresh_due = lambda: True  # type: ignore[method-assign]
+    coord.heatpump_runtime.heatpump_daily_consumption_refresh_due = lambda: True  # type: ignore[method-assign]
+    coord.heatpump_runtime.heatpump_power_refresh_due = lambda: True  # type: ignore[method-assign]
+    coord.heatpump_runtime.has_type = lambda _key: True  # type: ignore[method-assign]
+    coord.client._hems_site_supported = True  # noqa: SLF001
 
     result = await coord._async_update_data()  # noqa: SLF001
     assert RANDOM_SERIAL in result
-    coord._async_refresh_heatpump_runtime_state.assert_awaited_once_with()  # noqa: SLF001
-    coord._async_refresh_heatpump_daily_consumption.assert_awaited_once_with()  # noqa: SLF001
+    coord._async_refresh_heatpump_runtime_state.assert_not_awaited()  # noqa: SLF001
+    coord._async_refresh_heatpump_daily_consumption.assert_not_awaited()  # noqa: SLF001
     coord._async_refresh_heatpump_power.assert_awaited_once_with()  # noqa: SLF001
 
 
@@ -5279,6 +5286,7 @@ async def test_update_data_site_only_ignores_optional_refresh_failures(
     coord._async_refresh_heatpump_power = AsyncMock(  # noqa: SLF001
         side_effect=RuntimeError("heatpump")
     )
+    coord.heatpump_runtime.heatpump_power_refresh_due = lambda: True  # type: ignore[method-assign]
 
     await coord._async_update_data()  # noqa: SLF001
 
@@ -5407,6 +5415,7 @@ async def test_update_data_normal_ignores_optional_refresh_failures(
     )  # noqa: SLF001
     coord.evse_runtime.async_resolve_auth_settings = AsyncMock(return_value={})  # type: ignore[method-assign]  # noqa: SLF001
     coord._sync_battery_profile_pending_issue = MagicMock()  # noqa: SLF001
+    coord.heatpump_runtime.heatpump_power_refresh_due = lambda: True  # type: ignore[method-assign]
 
     await coord._async_update_data()  # noqa: SLF001
 
@@ -5561,6 +5570,11 @@ async def test_update_data_site_only_orders_topology_mutations_deterministically
     coord._async_refresh_heatpump_power = AsyncMock(
         side_effect=_record_heatpump_power
     )  # noqa: SLF001
+    coord.heatpump_runtime.heatpump_runtime_state_refresh_due = lambda: True  # type: ignore[method-assign]
+    coord.heatpump_runtime.heatpump_daily_consumption_refresh_due = lambda: True  # type: ignore[method-assign]
+    coord.heatpump_runtime.heatpump_power_refresh_due = lambda: True  # type: ignore[method-assign]
+    coord.heatpump_runtime.has_type = lambda _key: True  # type: ignore[method-assign]
+    coord.client._hems_site_supported = True  # noqa: SLF001
 
     await coord._async_update_data()  # noqa: SLF001
 
@@ -5569,8 +5583,6 @@ async def test_update_data_site_only_orders_topology_mutations_deterministically
         "devices_inventory",
         "hems_devices",
         "inverters",
-        "heatpump_runtime",
-        "heatpump_daily",
         "heatpump_power",
     ]
 

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -10,8 +11,14 @@ from homeassistant.exceptions import ConfigEntryAuthFailed
 from custom_components.enphase_ev.refresh_plan import (
     FOLLOWUP_STAGE,
     FOLLOWUP_PLAN,
+    HEATPUMP_FOLLOWUP_PLAN,
+    SITE_ONLY_FOLLOWUP_PLAN,
     bind_refresh_stage,
     bind_refresh_plan,
+    build_followup_plan,
+    build_heatpump_followup_plan,
+    build_post_session_followup_plan,
+    build_site_only_followup_plan,
     post_session_followup_plan,
     warmup_plan,
 )
@@ -272,17 +279,45 @@ class _RefreshOwner:
         self.evse_timeseries.async_refresh.side_effect = (
             lambda *, day_local: self._record(f"evse_timeseries:{day_local}")
         )
+        self.evse_timeseries.refresh_due = MagicMock(return_value=True)
         self.energy = MagicMock()
         self.energy._async_refresh_site_energy.side_effect = lambda: self._record(
             "site_energy"
         )
+        self.energy.site_energy_refresh_due = MagicMock(return_value=True)
+        self.evse_feature_flags_runtime = SimpleNamespace(
+            refresh_due=lambda: True,
+        )
         self.battery_runtime = SimpleNamespace(
             async_refresh_grid_control_check=self._async_refresh_grid_control_check,
             async_refresh_battery_status=self._async_refresh_battery_status,
+            battery_site_settings_refresh_due=lambda: True,
+            battery_backup_history_refresh_due=lambda: True,
+            battery_settings_refresh_due=lambda: True,
+            battery_schedules_refresh_due=lambda: True,
+            storm_guard_refresh_due=lambda: True,
+            storm_alert_refresh_due=lambda: True,
+            grid_control_check_refresh_due=lambda: True,
+            dry_contact_settings_refresh_due=lambda: True,
+            battery_status_refresh_due=lambda: True,
+            ac_battery_devices_refresh_due=lambda: True,
         )
         self.inventory_runtime = SimpleNamespace(
             _async_refresh_devices_inventory=self._async_refresh_devices_inventory,
             _async_refresh_hems_devices=self._async_refresh_hems_devices,
+            devices_inventory_refresh_due=lambda: True,
+            hems_devices_refresh_due=lambda: True,
+            inverters_refresh_due=lambda: True,
+        )
+        self.current_power_runtime = SimpleNamespace(
+            refresh_due=lambda: True,
+        )
+        self.heatpump_runtime = SimpleNamespace(
+            heatpump_runtime_state_refresh_due=lambda: True,
+            heatpump_daily_consumption_refresh_due=lambda: True,
+            heatpump_power_refresh_due=lambda: True,
+            has_type=lambda key: key == "heatpump",
+            client=SimpleNamespace(hems_site_supported=True),
         )
         self.refresh_runner = SimpleNamespace(
             async_refresh_site_energy_for_warmup=self.async_refresh_site_energy_for_warmup,
@@ -330,6 +365,10 @@ class _RefreshOwner:
     def _async_refresh_current_power_consumption(self) -> str:
         self.calls.append("current_power")
         return "current-power"
+
+    def _async_refresh_evse_feature_flags(self) -> str:
+        self.calls.append("evse_feature_flags")
+        return "evse-feature-flags"
 
     def _async_refresh_battery_status(self) -> str:
         self.calls.append("battery_status")
@@ -443,6 +482,178 @@ def test_refresh_plans_bind_dynamic_followup_and_warmup_calls() -> None:
     assert bound_post.stages[0].parallel_calls[2][2]() == "inverters"
 
 
+def test_dynamic_followup_plan_skips_up_to_date_tasks() -> None:
+    owner = _RefreshOwner()
+    owner.battery_runtime.battery_site_settings_refresh_due = lambda: False
+    owner.battery_runtime.battery_backup_history_refresh_due = lambda: False
+    owner.battery_runtime.battery_settings_refresh_due = lambda: False
+    owner.battery_runtime.battery_schedules_refresh_due = lambda: False
+    owner.battery_runtime.storm_guard_refresh_due = lambda: False
+    owner.battery_runtime.storm_alert_refresh_due = lambda: False
+    owner.battery_runtime.grid_control_check_refresh_due = lambda: False
+    owner.battery_runtime.dry_contact_settings_refresh_due = lambda: False
+    owner.battery_runtime.battery_status_refresh_due = lambda: False
+    owner.battery_runtime.ac_battery_devices_refresh_due = lambda: False
+    owner.inventory_runtime.devices_inventory_refresh_due = lambda: False
+    owner.inventory_runtime.hems_devices_refresh_due = lambda: False
+    owner.current_power_runtime.refresh_due = lambda: False
+    owner.evse_feature_flags_runtime.refresh_due = lambda: False
+
+    assert build_followup_plan(owner).stages == ()
+
+
+def test_dynamic_followup_plan_selects_due_subset() -> None:
+    owner = _RefreshOwner()
+    owner.battery_runtime.battery_backup_history_refresh_due = lambda: False
+    owner.battery_runtime.battery_settings_refresh_due = lambda: False
+    owner.battery_runtime.battery_schedules_refresh_due = lambda: False
+    owner.battery_runtime.storm_guard_refresh_due = lambda: False
+    owner.battery_runtime.storm_alert_refresh_due = lambda: False
+    owner.battery_runtime.grid_control_check_refresh_due = lambda: False
+    owner.battery_runtime.dry_contact_settings_refresh_due = lambda: False
+    owner.battery_runtime.ac_battery_devices_refresh_due = lambda: False
+    owner.inventory_runtime.devices_inventory_refresh_due = lambda: False
+    owner.current_power_runtime.refresh_due = lambda: False
+    owner.evse_feature_flags_runtime.refresh_due = lambda: False
+
+    plan = build_followup_plan(owner)
+
+    assert len(plan.stages) == 1
+    stage = plan.stages[0]
+    assert [task.timing_key for task in stage.parallel_tasks] == [
+        "battery_site_settings_s",
+    ]
+    assert [task.timing_key for task in stage.ordered_tasks] == [
+        "battery_status_s",
+        "hems_devices_s",
+    ]
+
+
+def test_dynamic_site_only_followup_plan_keeps_due_inverters() -> None:
+    owner = _RefreshOwner()
+    owner.inventory_runtime.inverters_refresh_due = lambda: True
+    owner.heatpump_runtime.heatpump_power_refresh_due = lambda: False
+    owner.heatpump_runtime.heatpump_runtime_state_refresh_due = lambda: False
+    owner.heatpump_runtime.heatpump_daily_consumption_refresh_due = lambda: False
+
+    plan = build_site_only_followup_plan(owner)
+
+    assert len(plan.stages) == 1
+    assert [task.timing_key for task in plan.stages[0].ordered_tasks][
+        -1
+    ] == "inverters_s"
+
+
+def test_dynamic_followup_plan_includes_due_evse_feature_flags() -> None:
+    owner = _RefreshOwner()
+    owner.battery_runtime.battery_site_settings_refresh_due = lambda: False
+    owner.battery_runtime.battery_backup_history_refresh_due = lambda: False
+    owner.battery_runtime.battery_settings_refresh_due = lambda: False
+    owner.battery_runtime.battery_schedules_refresh_due = lambda: False
+    owner.battery_runtime.storm_guard_refresh_due = lambda: False
+    owner.battery_runtime.storm_alert_refresh_due = lambda: False
+    owner.battery_runtime.grid_control_check_refresh_due = lambda: False
+    owner.battery_runtime.dry_contact_settings_refresh_due = lambda: False
+    owner.battery_runtime.battery_status_refresh_due = lambda: False
+    owner.battery_runtime.ac_battery_devices_refresh_due = lambda: False
+    owner.inventory_runtime.devices_inventory_refresh_due = lambda: False
+    owner.inventory_runtime.hems_devices_refresh_due = lambda: False
+    owner.current_power_runtime.refresh_due = lambda: False
+
+    plan = build_followup_plan(owner)
+
+    assert len(plan.stages) == 1
+    assert [task.timing_key for task in plan.stages[0].parallel_tasks] == [
+        "evse_feature_flags_s",
+    ]
+
+
+def test_dynamic_plan_builders_force_full_plans() -> None:
+    owner = _RefreshOwner()
+
+    assert build_followup_plan(owner, force_full=True) == FOLLOWUP_PLAN
+    assert (
+        build_site_only_followup_plan(owner, force_full=True) == SITE_ONLY_FOLLOWUP_PLAN
+    )
+    assert (
+        build_heatpump_followup_plan(owner, force_full=True) == HEATPUMP_FOLLOWUP_PLAN
+    )
+    built = build_post_session_followup_plan(owner, "today", force_full=True)
+    static = post_session_followup_plan("today")
+    assert len(built.stages) == len(static.stages) == 1
+    assert built.stages[0].defer_topology is static.stages[0].defer_topology is True
+    assert [task.timing_key for task in built.stages[0].parallel_tasks] == [
+        task.timing_key for task in static.stages[0].parallel_tasks
+    ]
+
+
+def test_dynamic_heatpump_followup_prefers_power() -> None:
+    owner = _RefreshOwner()
+
+    plan = build_heatpump_followup_plan(owner)
+
+    assert len(plan.stages) == 1
+    assert [task.timing_key for task in plan.stages[0].ordered_tasks] == [
+        "heatpump_power_s",
+    ]
+
+
+def test_dynamic_heatpump_followup_uses_runtime_and_daily_when_power_not_due() -> None:
+    owner = _RefreshOwner()
+    owner.heatpump_runtime.heatpump_power_refresh_due = lambda: False
+
+    plan = build_heatpump_followup_plan(owner)
+
+    assert len(plan.stages) == 1
+    assert [task.timing_key for task in plan.stages[0].ordered_tasks] == [
+        "heatpump_runtime_s",
+        "heatpump_daily_s",
+    ]
+
+
+def test_dynamic_heatpump_followup_includes_cleanup_when_power_cannot_cover_deps() -> (
+    None
+):
+    owner = _RefreshOwner()
+    owner.heatpump_runtime.has_type = lambda _key: False
+
+    plan = build_heatpump_followup_plan(owner)
+
+    assert len(plan.stages) == 1
+    assert [task.timing_key for task in plan.stages[0].ordered_tasks] == [
+        "heatpump_runtime_s",
+        "heatpump_daily_s",
+        "heatpump_power_s",
+    ]
+
+
+def test_dynamic_heatpump_followup_includes_cleanup_when_hems_support_unknown() -> None:
+    owner = _RefreshOwner()
+    owner.heatpump_runtime.client.hems_site_supported = None
+
+    plan = build_heatpump_followup_plan(owner)
+
+    assert len(plan.stages) == 1
+    assert [task.timing_key for task in plan.stages[0].ordered_tasks] == [
+        "heatpump_runtime_s",
+        "heatpump_daily_s",
+        "heatpump_power_s",
+    ]
+
+
+def test_dynamic_post_session_followup_only_includes_due_tasks() -> None:
+    owner = _RefreshOwner()
+    owner.energy.site_energy_refresh_due = MagicMock(return_value=False)
+    owner.inventory_runtime.inverters_refresh_due = lambda: False
+
+    plan = build_post_session_followup_plan(owner, "today")
+
+    assert len(plan.stages) == 1
+    assert [task.timing_key for task in plan.stages[0].parallel_tasks] == [
+        "evse_timeseries_s",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_coordinator_refresh_plan_runner_executes_each_stage(
     coordinator_factory,
@@ -550,6 +761,113 @@ async def test_refresh_runner_login_wall_raises_auth_failed_with_block_message(
 
     with pytest.raises(ConfigEntryAuthFailed, match="blocked"):
         await coord.refresh_runner.async_run_refresh_call("k", "label", _raise)
+
+
+@pytest.mark.asyncio
+async def test_post_status_evse_enrichments_run_concurrently(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    phase_timings: dict[str, float] = {}
+    release = asyncio.Event()
+    started: list[str] = []
+    all_started = asyncio.Event()
+
+    async def _gate(name: str, result):
+        started.append(name)
+        if len(started) == 4:
+            all_started.set()
+        await release.wait()
+        return result
+
+    async def _charge_modes(_serials):
+        return await _gate("charge_modes", {"SERIAL-1": "SMART_CHARGING"})
+
+    async def _green_settings(_serials):
+        return await _gate("green_settings", {"SERIAL-1": (True, True)})
+
+    async def _auth_settings(_serials):
+        return await _gate("auth_settings", {"SERIAL-1": (True, False, True, True)})
+
+    async def _charger_config(_serials, *, keys):
+        assert keys
+        return await _gate("charger_config", {"SERIAL-1": {"foo": "bar"}})
+
+    coord.evse_runtime.async_resolve_charge_modes = AsyncMock(side_effect=_charge_modes)
+    coord._async_resolve_green_battery_settings = AsyncMock(  # noqa: SLF001
+        side_effect=_green_settings
+    )
+    coord._async_resolve_auth_settings = AsyncMock(  # noqa: SLF001
+        side_effect=_auth_settings
+    )
+    coord._async_resolve_charger_config = AsyncMock(  # noqa: SLF001
+        side_effect=_charger_config
+    )
+
+    task = asyncio.create_task(
+        coord._async_resolve_post_status_evse_enrichments(
+            phase_timings,
+            records=[("SERIAL-1", {"sn": "SERIAL-1"})],
+            charge_mode_candidates=["SERIAL-1"],
+            first_refresh=False,
+        )
+    )
+
+    await asyncio.wait_for(all_started.wait(), timeout=1)
+    assert started == [
+        "charge_modes",
+        "green_settings",
+        "auth_settings",
+        "charger_config",
+    ]
+    release.set()
+    result = await asyncio.wait_for(task, timeout=1)
+
+    assert result == (
+        {"SERIAL-1": "SMART_CHARGING"},
+        {"SERIAL-1": (True, True)},
+        {"SERIAL-1": (True, False, True, True)},
+        {"SERIAL-1": {"foo": "bar"}},
+    )
+    assert "charge_mode_s" in phase_timings
+    assert "green_settings_s" in phase_timings
+    assert "auth_settings_s" in phase_timings
+    assert "charger_config_s" in phase_timings
+
+
+@pytest.mark.asyncio
+async def test_update_data_raises_when_parallel_evse_lookup_fails(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord.refresh_runner.async_run_refresh_plan = AsyncMock()  # type: ignore[method-assign]
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": "SERIAL-1",
+                    "name": "Garage EV",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                    "charging": False,
+                }
+            ],
+            "ts": 1_700_000_000,
+        }
+    )
+    coord.evse_runtime.async_resolve_charge_modes = AsyncMock(
+        return_value={"SERIAL-1": "IMMEDIATE"}
+    )
+    coord.evse_runtime.async_resolve_green_battery_settings = AsyncMock(return_value={})
+    coord.evse_runtime.async_resolve_auth_settings = AsyncMock(
+        side_effect=RuntimeError("boom")
+    )
+    coord.evse_runtime.async_resolve_charger_config = AsyncMock(return_value={})
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await coord._async_update_data()
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -13,6 +13,7 @@ from custom_components.enphase_ev.refresh_plan import (
     FOLLOWUP_PLAN,
     HEATPUMP_FOLLOWUP_PLAN,
     SITE_ONLY_FOLLOWUP_PLAN,
+    _refresh_due,
     bind_refresh_stage,
     bind_refresh_plan,
     build_followup_plan,
@@ -502,6 +503,10 @@ def test_dynamic_followup_plan_skips_up_to_date_tasks() -> None:
     assert build_followup_plan(owner).stages == ()
 
 
+def test_refresh_due_returns_false_without_predicate_or_fallback() -> None:
+    assert _refresh_due(object(), "missing_predicate") is False
+
+
 def test_dynamic_followup_plan_selects_due_subset() -> None:
     owner = _RefreshOwner()
     owner.battery_runtime.battery_backup_history_refresh_due = lambda: False
@@ -542,6 +547,37 @@ def test_dynamic_site_only_followup_plan_keeps_due_inverters() -> None:
     assert [task.timing_key for task in plan.stages[0].ordered_tasks][
         -1
     ] == "inverters_s"
+
+
+def test_dynamic_site_only_followup_plan_creates_inverter_stage_without_base_followup() -> (
+    None
+):
+    owner = _RefreshOwner()
+    owner.battery_runtime.battery_site_settings_refresh_due = lambda: False
+    owner.battery_runtime.battery_backup_history_refresh_due = lambda: False
+    owner.battery_runtime.battery_settings_refresh_due = lambda: False
+    owner.battery_runtime.battery_schedules_refresh_due = lambda: False
+    owner.battery_runtime.storm_guard_refresh_due = lambda: False
+    owner.battery_runtime.storm_alert_refresh_due = lambda: False
+    owner.battery_runtime.grid_control_check_refresh_due = lambda: False
+    owner.battery_runtime.dry_contact_settings_refresh_due = lambda: False
+    owner.battery_runtime.battery_status_refresh_due = lambda: False
+    owner.battery_runtime.ac_battery_devices_refresh_due = lambda: False
+    owner.inventory_runtime.devices_inventory_refresh_due = lambda: False
+    owner.inventory_runtime.hems_devices_refresh_due = lambda: False
+    owner.current_power_runtime.refresh_due = lambda: False
+    owner.evse_feature_flags_runtime.refresh_due = lambda: False
+    owner.inventory_runtime.inverters_refresh_due = lambda: True
+    owner.heatpump_runtime.heatpump_runtime_state_refresh_due = lambda: False
+    owner.heatpump_runtime.heatpump_daily_consumption_refresh_due = lambda: False
+    owner.heatpump_runtime.heatpump_power_refresh_due = lambda: False
+
+    plan = build_site_only_followup_plan(owner)
+
+    assert len(plan.stages) == 1
+    assert [task.timing_key for task in plan.stages[0].ordered_tasks] == [
+        "inverters_s",
+    ]
 
 
 def test_dynamic_followup_plan_includes_due_evse_feature_flags() -> None:
@@ -630,6 +666,24 @@ def test_dynamic_heatpump_followup_includes_cleanup_when_power_cannot_cover_deps
 def test_dynamic_heatpump_followup_includes_cleanup_when_hems_support_unknown() -> None:
     owner = _RefreshOwner()
     owner.heatpump_runtime.client.hems_site_supported = None
+
+    plan = build_heatpump_followup_plan(owner)
+
+    assert len(plan.stages) == 1
+    assert [task.timing_key for task in plan.stages[0].ordered_tasks] == [
+        "heatpump_runtime_s",
+        "heatpump_daily_s",
+        "heatpump_power_s",
+    ]
+
+
+def test_dynamic_heatpump_followup_includes_cleanup_when_has_type_raises() -> None:
+    owner = _RefreshOwner()
+
+    def _boom(_key: str) -> bool:
+        raise RuntimeError("bad has_type")
+
+    owner.heatpump_runtime.has_type = _boom
 
     plan = build_heatpump_followup_plan(owner)
 

--- a/tests/components/enphase_ev/test_current_power_runtime.py
+++ b/tests/components/enphase_ev/test_current_power_runtime.py
@@ -38,6 +38,16 @@ async def test_async_refresh_no_fetcher(coordinator_factory) -> None:
     assert coord._current_power_consumption_w is None
 
 
+def test_refresh_due_requests_cleanup_when_fetcher_missing_with_cached_state(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client = SimpleNamespace()
+    coord._current_power_consumption_w = 100.0
+
+    assert coord.current_power_runtime.refresh_due() is True
+
+
 @pytest.mark.asyncio
 async def test_async_refresh_fetcher_raises(coordinator_factory) -> None:
     coord = coordinator_factory()

--- a/tests/components/enphase_ev/test_evse_feature_flags_runtime.py
+++ b/tests/components/enphase_ev/test_evse_feature_flags_runtime.py
@@ -173,6 +173,26 @@ async def test_async_refresh_success(coordinator_factory, monkeypatch) -> None:
     assert coord.evse_feature_flags_runtime.feature_flag("site_flag") is True
 
 
+def test_refresh_due_uses_fetch_when_cache_expired(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord._evse_feature_flags_cache_until = None  # noqa: SLF001
+    coord.client = SimpleNamespace(evse_feature_flags=AsyncMock())
+
+    assert coord.evse_feature_flags_runtime.refresh_due() is True
+
+
+def test_refresh_due_requests_cleanup_when_fetcher_missing_with_cached_state(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._evse_feature_flags_cache_until = None  # noqa: SLF001
+    coord._evse_feature_flags_payload = {"meta": {}}  # noqa: SLF001
+    coord._evse_site_feature_flags = {"site_flag": True}  # noqa: SLF001
+    coord.client = SimpleNamespace()
+
+    assert coord.evse_feature_flags_runtime.refresh_due() is True
+
+
 def test_feature_flag_empty_key(coordinator_factory) -> None:
     coord = coordinator_factory()
     assert coord.evse_feature_flags_runtime.feature_flag("  ") is None

--- a/tests/components/enphase_ev/test_evse_timeseries.py
+++ b/tests/components/enphase_ev/test_evse_timeseries.py
@@ -176,6 +176,28 @@ async def test_evse_timeseries_endpoint_backoff_is_independent(hass) -> None:
     assert manager.service_available is True
 
 
+def test_evse_timeseries_refresh_due_defaults_day_and_skips_when_caches_are_fresh(
+    hass, monkeypatch
+) -> None:
+    client = SimpleNamespace(
+        evse_timeseries_daily_energy=AsyncMock(),
+        evse_timeseries_lifetime_energy=AsyncMock(),
+    )
+    manager = EVSETimeseriesManager(hass, lambda: client)
+    day_local = datetime(2026, 3, 11, 12, 0, 0, tzinfo=timezone.utc)
+    day_key = manager._day_key(day_local)  # noqa: SLF001
+    manager._daily_cache[day_key] = (
+        95.0,
+        {"EV-1": {"energy_kwh": 1.0}},
+    )  # noqa: SLF001
+    manager._lifetime_cache = (95.0, {"EV-1": {"energy_kwh": 2.0}})  # noqa: SLF001
+    monkeypatch.setattr(ts_mod.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(ts_mod.dt_util, "now", lambda: day_local)
+    monkeypatch.setattr(ts_mod.dt_util, "as_local", lambda value: value)
+
+    assert manager.refresh_due(day_local=None) is False
+
+
 def _request_info() -> aiohttp.RequestInfo:
     return aiohttp.RequestInfo(
         url=aiohttp.client.URL("https://example.com/evse"),

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -2274,6 +2274,118 @@ def test_heatpump_runtime_refresh_due_skips_when_type_missing_and_no_state(
     assert (
         runtime._site_today_heatpump_total_wh({"stats": ["bad"]}) is None
     )  # noqa: SLF001
+
+
+def test_heatpump_cleanup_due_treats_true_bool_as_cleanup_needed(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_known_present = True  # noqa: SLF001
+
+    assert (
+        runtime._heatpump_cleanup_due("_heatpump_known_present") is True
+    )  # noqa: SLF001
+
+
+def test_heatpump_runtime_state_refresh_due_covers_cache_backoff_and_fetcher(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.heatpump_runtime
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {"heatpump": {"type_key": "heatpump", "count": 1, "devices": [{}]}},
+        ["heatpump"],
+    )
+    monkeypatch.setattr(heatpump_runtime_mod.time, "monotonic", lambda: 100.0)
+
+    runtime._heatpump_runtime_state_cache_until = 150.0  # noqa: SLF001
+    assert runtime.heatpump_runtime_state_refresh_due() is False
+
+    runtime._heatpump_runtime_state_cache_until = None  # noqa: SLF001
+    runtime._heatpump_runtime_state_backoff_until = 150.0  # noqa: SLF001
+    assert runtime.heatpump_runtime_state_refresh_due() is False
+
+    runtime._heatpump_runtime_state_backoff_until = None  # noqa: SLF001
+    coord.client.hems_heatpump_state = None
+    assert runtime.heatpump_runtime_state_refresh_due() is False
+
+    coord.client.hems_heatpump_state = AsyncMock(return_value={})
+    assert runtime.heatpump_runtime_state_refresh_due() is True
+
+
+def test_heatpump_daily_consumption_refresh_due_covers_window_cache_backoff_and_fetcher(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.heatpump_runtime
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {"heatpump": {"type_key": "heatpump", "count": 1, "devices": [{}]}},
+        ["heatpump"],
+    )
+    monkeypatch.setattr(heatpump_runtime_mod.time, "monotonic", lambda: 100.0)
+    monkeypatch.setattr(
+        runtime,
+        "_heatpump_daily_window",
+        lambda: ("start", "end", "UTC", ("2026-04-23", "UTC")),
+    )
+
+    runtime._heatpump_daily_consumption_cache_until = 150.0  # noqa: SLF001
+    runtime._heatpump_daily_consumption_cache_key = (
+        "2026-04-23",
+        "UTC",
+    )  # noqa: SLF001
+    assert runtime.heatpump_daily_consumption_refresh_due() is False
+
+    runtime._heatpump_daily_consumption_cache_until = None  # noqa: SLF001
+    runtime._heatpump_daily_consumption_backoff_until = 150.0  # noqa: SLF001
+    assert runtime.heatpump_daily_consumption_refresh_due() is False
+
+    runtime._heatpump_daily_consumption_backoff_until = None  # noqa: SLF001
+    coord.client.pv_system_today = None
+    assert runtime.heatpump_daily_consumption_refresh_due() is False
+
+    coord.client.pv_system_today = AsyncMock(return_value={})
+    assert runtime.heatpump_daily_consumption_refresh_due() is True
+
+
+def test_heatpump_daily_consumption_refresh_due_returns_false_without_window(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.heatpump_runtime
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {"heatpump": {"type_key": "heatpump", "count": 1, "devices": [{}]}},
+        ["heatpump"],
+    )
+    monkeypatch.setattr(runtime, "_heatpump_daily_window", lambda: None)
+
+    assert runtime.heatpump_daily_consumption_refresh_due() is False
+
+
+def test_heatpump_power_refresh_due_covers_cache_backoff_and_fetcher(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.heatpump_runtime
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {"heatpump": {"type_key": "heatpump", "count": 1, "devices": [{}]}},
+        ["heatpump"],
+    )
+    monkeypatch.setattr(heatpump_runtime_mod.time, "monotonic", lambda: 100.0)
+
+    runtime._heatpump_power_cache_until = 150.0  # noqa: SLF001
+    assert runtime.heatpump_power_refresh_due() is False
+
+    runtime._heatpump_power_cache_until = None  # noqa: SLF001
+    runtime._heatpump_power_backoff_until = 150.0  # noqa: SLF001
+    assert runtime.heatpump_power_refresh_due() is False
+
+    runtime._heatpump_power_backoff_until = None  # noqa: SLF001
+    coord.client.pv_system_today = None
+    assert runtime.heatpump_power_refresh_due() is False
+
+    coord.client.pv_system_today = AsyncMock(return_value={})
+    assert runtime.heatpump_power_refresh_due() is True
     assert (
         runtime._site_today_heatpump_total_wh({"stats": [{"other": 1}]}) is None
     )  # noqa: SLF001

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -2203,6 +2203,34 @@ def test_heatpump_runtime_additional_helper_edge_cases(
         runtime._heatpump_daily_split_available({"daily_grid_wh": 0.0})  # noqa: SLF001
         is True
     )
+
+
+def test_heatpump_runtime_refresh_due_requests_cleanup_when_type_missing(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.heatpump_runtime
+
+    coord.inventory_runtime._set_type_device_buckets({}, [])  # noqa: SLF001
+    coord._heatpump_runtime_state = {"source": "cached"}  # noqa: SLF001
+    coord._heatpump_daily_consumption = {"daily_energy_wh": 12.0}  # noqa: SLF001
+    coord._heatpump_power_w = 500.5  # noqa: SLF001
+
+    assert runtime.heatpump_runtime_state_refresh_due() is True
+    assert runtime.heatpump_daily_consumption_refresh_due() is True
+    assert runtime.heatpump_power_refresh_due() is True
+
+
+def test_heatpump_runtime_refresh_due_skips_when_type_missing_and_no_state(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.heatpump_runtime
+
+    assert runtime.has_type("heatpump") is False
+    assert runtime.heatpump_runtime_state_refresh_due() is False
+    assert runtime.heatpump_daily_consumption_refresh_due() is False
+    assert runtime.heatpump_power_refresh_due() is False
     target = {"split_source": "keep"}
     assert (
         runtime._heatpump_copy_daily_split_fields(

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -907,6 +907,37 @@ async def test_inventory_runtime_devices_and_hems_refresh_cache_paths(
     assert runtime._hems_devices_using_stale is False  # noqa: SLF001
 
 
+@pytest.mark.asyncio
+async def test_inventory_runtime_devices_inventory_early_return_paths(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+
+    coord._endpoint_family_should_run = (  # type: ignore[method-assign]  # noqa: SLF001
+        lambda family, force=False: False if family == "inventory_topology" else True
+    )
+    coord.client.devices_inventory = AsyncMock(side_effect=AssertionError("unused"))
+    await runtime._async_refresh_devices_inventory()
+    coord.client.devices_inventory.assert_not_awaited()
+
+    coord._endpoint_family_should_run = lambda *args, **kwargs: True  # type: ignore[method-assign]  # noqa: SLF001
+    coord.client.devices_inventory = None
+    await runtime._async_refresh_devices_inventory()
+
+
+def test_inventory_runtime_devices_inventory_refresh_due_respects_cache(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    runtime._devices_inventory_cache_until = 150.0  # noqa: SLF001
+    coord.client.devices_inventory = AsyncMock(side_effect=AssertionError("unused"))
+    monkeypatch.setattr(inventory_runtime_mod.time, "monotonic", lambda: 100.0)
+
+    assert runtime.devices_inventory_refresh_due() is False
+
+
 def test_inventory_runtime_inverter_helper_paths(coordinator_factory) -> None:
     runtime = coordinator_factory().inventory_runtime
 
@@ -1092,6 +1123,46 @@ async def test_inventory_runtime_refresh_inverters_paths(coordinator_factory) ->
     await runtime._async_refresh_inverters()  # noqa: SLF001
     assert coord.iter_inverter_serials() == []
     assert coord.inventory_view.type_bucket("microinverter") is None
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_inverters_early_return_paths(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+
+    coord.client.inverters_inventory = None
+    coord.client.inverter_status = AsyncMock(side_effect=AssertionError("unused"))
+    await runtime._async_refresh_inverters()  # noqa: SLF001
+
+    coord.client.inverters_inventory = AsyncMock(return_value={})
+    coord.client.inverter_status = None
+    await runtime._async_refresh_inverters()  # noqa: SLF001
+
+
+def test_inventory_runtime_inverters_refresh_due_covers_include_flag_and_production_due(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    monkeypatch.setattr(inventory_runtime_mod.time, "monotonic", lambda: 100.0)
+
+    coord.include_inverters = False
+    assert runtime.inverters_refresh_due() is False
+
+    coord.include_inverters = True
+    coord.client.inverters_inventory = AsyncMock(return_value={})
+    coord.client.inverter_status = AsyncMock(return_value={})
+    coord.client.inverter_production = AsyncMock(return_value={})
+    runtime._inverters_inventory_cache_until = 150.0  # noqa: SLF001
+    runtime._inverter_status_cache_until = 150.0  # noqa: SLF001
+    runtime._inverter_production_cache_key = None  # noqa: SLF001
+    runtime._inverter_production_payload = None  # noqa: SLF001
+    runtime._inverter_production_cache_until = None  # noqa: SLF001
+    coord.energy._site_energy_meta = {"start_date": "2026-01-01"}  # noqa: SLF001
+
+    assert runtime.inverters_refresh_due() is True
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -10,8 +10,13 @@ from unittest.mock import AsyncMock
 import pytest
 from homeassistant.const import UnitOfPower
 
+from custom_components.enphase_ev import energy as energy_mod
 from custom_components.enphase_ev.api import SiteEnergyUnavailable
-from custom_components.enphase_ev.energy import LifetimeGuardState, SiteEnergyFlow
+from custom_components.enphase_ev.energy import (
+    SITE_ENERGY_CACHE_TTL,
+    LifetimeGuardState,
+    SiteEnergyFlow,
+)
 from custom_components.enphase_ev.sensor import (
     EnphaseBatteryPowerSensor,
     EnphaseGridPowerSensor,
@@ -66,6 +71,35 @@ def test_site_energy_aggregation_with_fallbacks(coordinator_factory) -> None:
     assert isinstance(meta["last_report_date"], datetime)
     assert meta["update_pending"] is False
     assert meta["interval_minutes"] == pytest.approx(60.0)
+
+
+def test_site_energy_refresh_due_initializes_attrs_and_respects_backoff(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    manager = coord.energy
+    del manager._site_energy_cache_ts
+    del manager._site_energy_cache_ttl
+    manager._service_backoff_until = 150.0  # noqa: SLF001
+    monkeypatch.setattr(energy_mod.time, "monotonic", lambda: 100.0)
+
+    assert manager.site_energy_refresh_due() is False
+    assert manager._site_energy_cache_ts is None  # noqa: SLF001
+    assert manager._site_energy_cache_ttl == SITE_ENERGY_CACHE_TTL  # noqa: SLF001
+
+
+def test_site_energy_refresh_due_skips_when_cache_is_fresh(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    manager = coord.energy
+    manager._site_energy_cache_ts = 95.0  # noqa: SLF001
+    manager._site_energy_cache_ttl = 10.0  # noqa: SLF001
+    manager._service_backoff_until = None  # noqa: SLF001
+    coord.client.lifetime_energy = AsyncMock(return_value={})
+    monkeypatch.setattr(energy_mod.time, "monotonic", lambda: 100.0)
+
+    assert manager.site_energy_refresh_due() is False
 
 
 def test_site_energy_aggregation_includes_additional_device_channels(


### PR DESCRIPTION
## Summary

Optimize the coordinator refresh path by parallelizing post-status EVSE enrichment lookups and replacing unconditional follow-up plans with dynamic builders that only schedule refreshes when data is actually due.

This also fixes the stale-state regressions introduced by the dynamic planners so cleanup and stale-marking still run when feature support, topology, or endpoint availability changes.

## Related Issues

- Internal refresh-path optimization and follow-up cleanup regressions.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/refresh_plan.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_heatpump_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_heatpump_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/ac_battery_runtime.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/current_power_runtime.py custom_components/enphase_ev/energy.py custom_components/enphase_ev/evse_feature_flags_runtime.py custom_components/enphase_ev/evse_timeseries.py custom_components/enphase_ev/heatpump_runtime.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/refresh_plan.py tests/components/enphase_ev/test_battery_runtime.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_current_power_runtime.py tests/components/enphase_ev/test_evse_feature_flags_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/ac_battery_runtime.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/current_power_runtime.py,custom_components/enphase_ev/energy.py,custom_components/enphase_ev/evse_feature_flags_runtime.py,custom_components/enphase_ev/evse_timeseries.py,custom_components/enphase_ev/heatpump_runtime.py,custom_components/enphase_ev/inventory_runtime.py,custom_components/enphase_ev/refresh_plan.py --fail-under=100"
```

Notes:
- `pytest -q tests/components/enphase_ev` passed with `2833 passed`.
- The touched-module coverage command is currently failing at `99%` overall because several touched runtime files remain below 100% targeted coverage.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Dynamic follow-up planners now preserve cleanup behavior for EVSE feature flags, AC battery devices, battery support flags, current power, and heat-pump runtime/daily/power state.
- Heat-pump power-only follow-up is used only when dependency refreshes are guaranteed to run.
