### PR TITLE
Handle unavailable session history cache states

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -3895,6 +3895,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             if not needs_refresh or view_blocked:
                 continue
             if not view_has_valid_cache:
+                # Failed/no-cache lookups should retry on the session-history cadence,
+                # not on every fast coordinator poll.
                 if cache_age is not None and cache_age < session_cache_ttl:
                     continue
                 if first_refresh:

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1926,6 +1926,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             ),
             "cache_ttl_seconds": session_manager.cache_ttl,
             "cache_keys": session_manager.cache_key_count,
+            "cache_state_counts": getattr(
+                session_manager,
+                "cache_state_counts",
+                lambda: None,
+            )(),
             "interval_minutes": getattr(self, "_session_history_interval_min", None),
             "in_progress": session_manager.in_progress,
         }
@@ -3867,6 +3872,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             cur["energy_today_sessions_kwh"] = self._sum_session_energy(sessions_cached)
             view_needs_refresh = bool(getattr(view, "needs_refresh", False))
             view_blocked = bool(getattr(view, "blocked", False))
+            view_has_valid_cache = bool(getattr(view, "has_valid_cache", False))
             soft_ttl = self._session_history_soft_ttl(cur)
             hard_ttl = self._session_history_hard_ttl(cur)
             session_cache_ttl = float(
@@ -3882,9 +3888,21 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 else None
             )
             needs_refresh = (
-                cache_age >= soft_ttl if cache_age is not None else view_needs_refresh
+                cache_age >= soft_ttl
+                if view_has_valid_cache and cache_age is not None
+                else view_needs_refresh
             )
             if not needs_refresh or view_blocked:
+                continue
+            if not view_has_valid_cache:
+                if cache_age is not None and cache_age < session_cache_ttl:
+                    continue
+                if first_refresh:
+                    background_by_day.setdefault((day_key, max_cache_age), []).append(
+                        sn
+                    )
+                    continue
+                immediate_by_day.setdefault((day_key, max_cache_age), []).append(sn)
                 continue
             if cache_age is None:
                 if first_refresh:

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -997,6 +997,13 @@ class CoordinatorDiagnostics:
                         None,
                     )
                 ),
+                "cache_state_counts": _signature_copy(
+                    getattr(
+                        session_history,
+                        "cache_state_counts",
+                        lambda: None,
+                    )()
+                ),
             }
         evse_timeseries = getattr(coord, "evse_timeseries", None)
         if evse_timeseries is not None:
@@ -1051,7 +1058,41 @@ class CoordinatorDiagnostics:
         if manager is None:
             return
         available = getattr(manager, "service_available", True)
-        if available:
+        has_current_day_unavailable = False
+        if available and hasattr(manager, "get_cache_view"):
+            data = getattr(coord, "data", None)
+            if isinstance(data, dict) and data:
+                try:
+                    day_ref = dt_util.now()
+                except Exception:
+                    day_ref = datetime.now()
+                try:
+                    day_local_default = dt_util.as_local(day_ref)
+                except Exception:
+                    if day_ref.tzinfo is None:
+                        day_ref = day_ref.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+                    day_local_default = day_ref
+                for sn, payload in data.items():
+                    if not isinstance(payload, dict):
+                        continue
+                    try:
+                        history_day = coord._session_history_day(
+                            payload, day_local_default
+                        )
+                    except Exception:
+                        history_day = day_local_default
+                    try:
+                        view = manager.get_cache_view(
+                            sn, history_day.strftime("%Y-%m-%d")
+                        )
+                    except Exception:
+                        continue
+                    if bool(getattr(view, "has_valid_cache", False)):
+                        continue
+                    if getattr(view, "state", None) == "unavailable":
+                        has_current_day_unavailable = True
+                        break
+        if available and not has_current_day_unavailable:
             self._clear_reported_issue(
                 "_session_history_issue_reported",
                 ISSUE_SESSION_HISTORY_UNAVAILABLE,

--- a/custom_components/enphase_ev/session_history.py
+++ b/custom_components/enphase_ev/session_history.py
@@ -33,6 +33,25 @@ class SessionCacheView:
     cache_age: float | None
     needs_refresh: bool
     blocked: bool
+    state: str
+    has_valid_cache: bool
+    last_error: str | None
+
+
+SESSION_CACHE_STATE_VALID = "valid"
+SESSION_CACHE_STATE_STALE_REUSED = "stale_reused"
+SESSION_CACHE_STATE_UNAVAILABLE = "unavailable"
+
+
+@dataclass(slots=True)
+class SessionCacheEntry:
+    """Structured cache entry for a serial/day session-history result."""
+
+    cached_at_mono: float | None
+    sessions: list[dict]
+    state: str
+    last_error: str | None
+    has_valid_cache: bool
 
 
 class SessionHistoryManager:
@@ -59,7 +78,9 @@ class SessionHistoryManager:
         )
         self._concurrency = max(1, int(concurrency))
         self._cache_day_retention = max(1, int(cache_day_retention))
-        self._cache: dict[tuple[str, str], tuple[float, list[dict]]] = {}
+        self._cache: dict[
+            tuple[str, str], SessionCacheEntry | tuple[float, list[dict]]
+        ] = {}
         self._block_until: dict[str, float] = {}
         self._refresh_in_progress: set[str] = set()
         self._criteria_checked_mono: float | None = None
@@ -101,6 +122,20 @@ class SessionHistoryManager:
     def cache_key_count(self) -> int:
         """Return the number of cached serial/day entries."""
         return len(self._cache)
+
+    def cache_state_counts(self) -> dict[str, int]:
+        """Return counts of cache entries by tri-state."""
+        counts = {
+            SESSION_CACHE_STATE_VALID: 0,
+            SESSION_CACHE_STATE_STALE_REUSED: 0,
+            SESSION_CACHE_STATE_UNAVAILABLE: 0,
+        }
+        for cache_key in list(self._cache):
+            entry = self._get_cache_entry(cache_key)
+            if entry is None:
+                continue
+            counts[entry.state] = counts.get(entry.state, 0) + 1
+        return counts
 
     @property
     def in_progress(self) -> int:
@@ -187,6 +222,83 @@ class SessionHistoryManager:
         except Exception:
             return None
 
+    @staticmethod
+    def _entry_error_text(err: Exception | str | None) -> str | None:
+        if err is None:
+            return None
+        reason = redact_text(err)
+        if reason:
+            return reason
+        if isinstance(err, str):
+            cleaned = err.strip()
+            return cleaned or None
+        return err.__class__.__name__
+
+    def _coerce_cache_entry(
+        self,
+        value: SessionCacheEntry | tuple[float, list[dict]] | None,
+    ) -> SessionCacheEntry | None:
+        if isinstance(value, SessionCacheEntry):
+            return value
+        if isinstance(value, tuple) and len(value) == 2 and isinstance(value[1], list):
+            cached_at_mono = value[0]
+            if not isinstance(cached_at_mono, (int, float)):
+                cached_at_mono = None
+            return SessionCacheEntry(
+                cached_at_mono=(
+                    float(cached_at_mono) if cached_at_mono is not None else None
+                ),
+                sessions=value[1],
+                state=SESSION_CACHE_STATE_VALID,
+                last_error=None,
+                has_valid_cache=True,
+            )
+        return None
+
+    def _get_cache_entry(self, cache_key: tuple[str, str]) -> SessionCacheEntry | None:
+        cached = self._coerce_cache_entry(self._cache.get(cache_key))
+        if cached is not None:
+            self._cache[cache_key] = cached
+        return cached
+
+    def _set_unavailable_entry(
+        self,
+        serial: str,
+        day_key: str,
+        now_mono: float,
+        err: Exception | str | None,
+    ) -> None:
+        self._set_cache_entry(
+            serial,
+            day_key,
+            SessionCacheEntry(
+                cached_at_mono=now_mono,
+                sessions=[],
+                state=SESSION_CACHE_STATE_UNAVAILABLE,
+                last_error=self._entry_error_text(err),
+                has_valid_cache=False,
+            ),
+        )
+
+    def _set_stale_reused_entry(
+        self,
+        serial: str,
+        day_key: str,
+        cached: SessionCacheEntry,
+        err: Exception | str | None,
+    ) -> None:
+        self._set_cache_entry(
+            serial,
+            day_key,
+            SessionCacheEntry(
+                cached_at_mono=cached.cached_at_mono,
+                sessions=list(cached.sessions),
+                state=SESSION_CACHE_STATE_STALE_REUSED,
+                last_error=self._entry_error_text(err),
+                has_valid_cache=True,
+            ),
+        )
+
     def get_cache_view(
         self,
         serial: str,
@@ -196,14 +308,15 @@ class SessionHistoryManager:
         """Return the cache state for a serial/day pair."""
         now = now_mono or time.monotonic()
         cache_key = (serial, day_key)
-        cached = self._cache.get(cache_key)
+        cached = self._get_cache_entry(cache_key)
         sessions: list[dict] = []
         cache_age: float | None = None
         if cached:
-            cached_ts, cached_sessions = cached
-            cache_age = now - cached_ts
-            sessions = cached_sessions
-        needs_refresh = cached is None or (
+            cached_ts = cached.cached_at_mono
+            cache_age = None if cached_ts is None else now - cached_ts
+            sessions = cached.sessions if cached.has_valid_cache else []
+        has_valid_cache = bool(cached and cached.has_valid_cache)
+        needs_refresh = not has_valid_cache or (
             cache_age is not None and cache_age >= self._cache_ttl
         )
         block_until = self._block_until.get(serial)
@@ -215,6 +328,11 @@ class SessionHistoryManager:
             cache_age=cache_age,
             needs_refresh=needs_refresh,
             blocked=blocked,
+            state=(
+                cached.state if cached is not None else SESSION_CACHE_STATE_UNAVAILABLE
+            ),
+            has_valid_cache=has_valid_cache,
+            last_error=cached.last_error if cached is not None else None,
         )
 
     def schedule_enrichment(self, serials: Iterable[str], day_local: datetime) -> None:
@@ -400,7 +518,7 @@ class SessionHistoryManager:
         if active_serials is not None:
             active_serials.add(sn)
         self.prune(active_serials=active_serials, keep_day_keys={day_key})
-        cached = self._cache.get(cache_key)
+        cached = self._get_cache_entry(cache_key)
         refresh_after = self._cache_ttl
         if max_cache_age is not None:
             try:
@@ -410,13 +528,18 @@ class SessionHistoryManager:
                 )
             except (TypeError, ValueError):
                 refresh_after = self._cache_ttl
-        if cached and (now_mono - cached[0] < refresh_after):
-            return cached[1]
+        if (
+            cached is not None
+            and cached.has_valid_cache
+            and cached.cached_at_mono is not None
+            and (now_mono - cached.cached_at_mono) < refresh_after
+        ):
+            return cached.sessions
         if self._service_backoff_active():
-            return cached[1] if cached else []
+            return cached.sessions if cached and cached.has_valid_cache else []
         block_until = self._block_until.get(sn)
         if block_until and now_mono < block_until:
-            return cached[1] if cached else []
+            return cached.sessions if cached and cached.has_valid_cache else []
 
         api_day = local_dt.strftime("%d-%m-%Y")
         client = self._client_getter()
@@ -433,17 +556,18 @@ class SessionHistoryManager:
                 self._logger.debug(
                     "Session history criteria unavailable for %s: %s", sn, err
                 )
-                if cached:
+                if cached and cached.has_valid_cache:
                     self._note_service_unavailable(err, using_stale=True)
-                    return cached[1]
+                    self._set_stale_reused_entry(sn, day_key, cached, err)
+                    return cached.sessions
                 self._note_service_unavailable(err)
-                self._set_cache_entry(sn, day_key, now_mono, [])
+                self._set_unavailable_entry(sn, day_key, now_mono, err)
                 return []
             except Unauthorized as err:
                 self._logger.debug(
                     "Session history criteria unauthorized for %s: %s", sn, err
                 )
-                self._set_cache_entry(sn, day_key, now_mono, [])
+                self._set_unavailable_entry(sn, day_key, now_mono, err)
                 return []
             except aiohttp.ClientResponseError as err:
                 self._logger.debug(
@@ -454,16 +578,17 @@ class SessionHistoryManager:
                 )
                 if err.status in (500, 502, 503, 504, 550):
                     self._block_until[sn] = now_mono + self._failure_backoff
-                self._set_cache_entry(sn, day_key, now_mono, [])
+                self._set_unavailable_entry(sn, day_key, now_mono, err)
                 return []
             except Exception as err:  # noqa: BLE001
                 self._logger.debug(
                     "Session history criteria failed for %s: %s", sn, err
                 )
-                if cached:
+                if cached and cached.has_valid_cache:
                     self._note_service_unavailable(err, using_stale=True)
-                    return cached[1]
-                self._set_cache_entry(sn, day_key, now_mono, [])
+                    self._set_stale_reused_entry(sn, day_key, cached, err)
+                    return cached.sessions
+                self._set_unavailable_entry(sn, day_key, now_mono, err)
                 return []
 
         async def _fetch_page(offset: int, limit: int) -> tuple[list[dict], bool]:
@@ -501,11 +626,12 @@ class SessionHistoryManager:
                 api_day,
                 err,
             )
-            if cached:
+            if cached and cached.has_valid_cache:
                 self._note_service_unavailable(err, using_stale=True)
-                return cached[1]
+                self._set_stale_reused_entry(sn, day_key, cached, err)
+                return cached.sessions
             self._note_service_unavailable(err)
-            self._set_cache_entry(sn, day_key, now_mono, [])
+            self._set_unavailable_entry(sn, day_key, now_mono, err)
             return []
         except Unauthorized as err:
             self._logger.debug(
@@ -514,7 +640,7 @@ class SessionHistoryManager:
                 api_day,
                 err,
             )
-            self._set_cache_entry(sn, day_key, now_mono, [])
+            self._set_unavailable_entry(sn, day_key, now_mono, err)
             return []
         except aiohttp.ClientResponseError as err:
             self._logger.debug(
@@ -526,22 +652,33 @@ class SessionHistoryManager:
             )
             if err.status in (500, 502, 503, 504, 550):
                 self._block_until[sn] = now_mono + self._failure_backoff
-            self._set_cache_entry(sn, day_key, now_mono, [])
+            self._set_unavailable_entry(sn, day_key, now_mono, err)
             return []
         except Exception as err:  # noqa: BLE001
             self._logger.debug(
                 "Session history fetch failed for %s on %s: %s", sn, api_day, err
             )
-            if cached:
+            if cached and cached.has_valid_cache:
                 self._note_service_unavailable(err, using_stale=True)
-                return cached[1]
-            self._set_cache_entry(sn, day_key, now_mono, [])
+                self._set_stale_reused_entry(sn, day_key, cached, err)
+                return cached.sessions
+            self._set_unavailable_entry(sn, day_key, now_mono, err)
             return []
 
         sessions = self._normalise_sessions_for_day(local_dt=local_dt, results=results)
         self._mark_service_available()
         self._block_until.pop(sn, None)
-        self._set_cache_entry(sn, day_key, now_mono, sessions)
+        self._set_cache_entry(
+            sn,
+            day_key,
+            SessionCacheEntry(
+                cached_at_mono=now_mono,
+                sessions=list(sessions),
+                state=SESSION_CACHE_STATE_VALID,
+                last_error=None,
+                has_valid_cache=True,
+            ),
+        )
         return sessions
 
     @staticmethod
@@ -589,10 +726,9 @@ class SessionHistoryManager:
         self,
         serial: str,
         day_key: str,
-        now_mono: float,
-        sessions: list[dict],
+        entry: SessionCacheEntry,
     ) -> None:
-        self._cache[(serial, day_key)] = (now_mono, sessions)
+        self._cache[(serial, day_key)] = entry
         active_serials = self._active_serials_from_data_supplier()
         if active_serials is not None:
             active_serials.add(serial)

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -24,6 +24,7 @@ from http import HTTPStatus
 
 from custom_components.enphase_ev import auth_refresh_runtime as arr_mod
 from custom_components.enphase_ev import coordinator as coord_mod
+from custom_components.enphase_ev import coordinator_diagnostics as coord_diag_mod
 from custom_components.enphase_ev.coordinator import (
     EnphaseCoordinator,
     ChargeModeStartPreferences,
@@ -247,6 +248,7 @@ def test_coordinator_public_diagnostics_helpers(coordinator_factory) -> None:
         "last_payload_signature": None,
         "cache_ttl_seconds": 300,
         "cache_keys": 2,
+        "cache_state_counts": None,
         "interval_minutes": 15,
         "in_progress": 1,
     }
@@ -775,6 +777,77 @@ def test_sync_session_history_issue_creates_and_clears(
     assert any(
         issue[1] == ISSUE_SESSION_HISTORY_UNAVAILABLE
         for issue in mock_issue_registry.deleted
+    )
+
+
+def test_sync_session_history_issue_uses_current_day_unavailable_view(
+    coordinator_factory, mock_issue_registry
+) -> None:
+    coord = coordinator_factory()
+    coord.data = {SERIAL_ONE: {"display_name": "Garage EV"}}
+    coord._session_history_day = lambda payload, default: default  # type: ignore[method-assign]  # noqa: SLF001
+    coord.session_history = SimpleNamespace(
+        service_available=True,
+        get_cache_view=lambda *_args, **_kwargs: SimpleNamespace(
+            has_valid_cache=False,
+            state="unavailable",
+        ),
+    )
+
+    coord._sync_session_history_issue()  # noqa: SLF001
+
+    assert coord._session_history_issue_reported is True  # noqa: SLF001
+    assert any(
+        issue[1] == ISSUE_SESSION_HISTORY_UNAVAILABLE
+        for issue in mock_issue_registry.created
+    )
+
+    coord.session_history.get_cache_view = lambda *_args, **_kwargs: SimpleNamespace(
+        has_valid_cache=True,
+        state="valid",
+    )
+    coord._sync_session_history_issue()  # noqa: SLF001
+
+    assert coord._session_history_issue_reported is False  # noqa: SLF001
+    assert any(
+        issue[1] == ISSUE_SESSION_HISTORY_UNAVAILABLE
+        for issue in mock_issue_registry.deleted
+    )
+
+
+def test_sync_session_history_issue_handles_fallback_day_resolution(
+    coordinator_factory, mock_issue_registry, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    coord.data = {
+        "bad": "skip-me",
+        SERIAL_ONE: {"display_name": "Garage EV"},
+    }
+    coord._session_history_day = MagicMock(side_effect=RuntimeError("boom"))  # type: ignore[assignment]  # noqa: SLF001
+    coord.session_history = SimpleNamespace(
+        service_available=True,
+        get_cache_view=lambda serial, _day_key: SimpleNamespace(
+            has_valid_cache=serial == "bad",
+            state="unavailable",
+        ),
+    )
+    monkeypatch.setattr(
+        coord_diag_mod.dt_util,
+        "now",
+        lambda: datetime(2025, 10, 16, 12, 0, 0),
+    )
+    monkeypatch.setattr(
+        coord_diag_mod.dt_util,
+        "as_local",
+        lambda _value: (_ for _ in ()).throw(ValueError("boom")),
+    )
+
+    coord._sync_session_history_issue()  # noqa: SLF001
+
+    assert coord._session_history_issue_reported is True  # noqa: SLF001
+    assert any(
+        issue[1] == ISSUE_SESSION_HISTORY_UNAVAILABLE
+        for issue in mock_issue_registry.created
     )
 
 

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -35,6 +35,11 @@ from custom_components.enphase_ev.evse_runtime import (
     FAST_TOGGLE_POLL_HOLD_S,
     ChargeModeResolution,
 )
+from custom_components.enphase_ev.session_history import (
+    SESSION_CACHE_STATE_UNAVAILABLE,
+    SessionCacheEntry,
+    SessionCacheView,
+)
 from custom_components.enphase_ev.voltage import resolve_nominal_voltage_for_hass
 
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL, RANDOM_SITE_ID
@@ -2835,6 +2840,225 @@ async def test_active_session_history_hard_ttl_refreshes_inline(
     coord._async_enrich_sessions.assert_awaited_once()  # type: ignore[attr-defined]
     assert coord._async_enrich_sessions.await_args.kwargs["max_cache_age"] == 120.0  # type: ignore[attr-defined]
     coord._schedule_session_enrichment.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_recent_unavailable_session_history_without_valid_cache_defers_retry(
+    hass, monkeypatch
+) -> None:
+    await hass.config.async_set_time_zone("UTC")
+    coord = _make_coordinator(hass, monkeypatch)
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord.data = {RANDOM_SERIAL: {"display_name": "Garage EV"}}
+
+    now_local = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: now_local)
+
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                    "charging": True,
+                    "pluggedIn": True,
+                }
+            ]
+        }
+    )
+    coord.client.summary_v2 = AsyncMock(
+        return_value=[{"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"}]
+    )
+    coord.client.charge_mode = AsyncMock(return_value=None)
+
+    day_key = now_local.strftime("%Y-%m-%d")
+    coord.session_history._cache[(RANDOM_SERIAL, day_key)] = (
+        SessionCacheEntry(  # noqa: SLF001
+            cached_at_mono=time.monotonic(),
+            sessions=[],
+            state=SESSION_CACHE_STATE_UNAVAILABLE,
+            last_error="down",
+            has_valid_cache=False,
+        )
+    )
+    coord._async_enrich_sessions = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value={RANDOM_SERIAL: [{"session_id": "fresh", "energy_kwh": 2.5}]}
+    )
+    coord._schedule_session_enrichment = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+
+    data = await coord._async_update_data()
+
+    assert data[RANDOM_SERIAL]["energy_today_sessions"] == []
+    coord._async_enrich_sessions.assert_not_awaited()  # type: ignore[attr-defined]
+    coord._schedule_session_enrichment.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_aged_unavailable_session_history_without_valid_cache_refreshes_inline(
+    hass, monkeypatch
+) -> None:
+    await hass.config.async_set_time_zone("UTC")
+    coord = _make_coordinator(hass, monkeypatch)
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord.data = {RANDOM_SERIAL: {"display_name": "Garage EV"}}
+
+    now_local = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: now_local)
+
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                    "charging": True,
+                    "pluggedIn": True,
+                }
+            ]
+        }
+    )
+    coord.client.summary_v2 = AsyncMock(
+        return_value=[{"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"}]
+    )
+    coord.client.charge_mode = AsyncMock(return_value=None)
+
+    day_key = now_local.strftime("%Y-%m-%d")
+    coord.session_history._cache[(RANDOM_SERIAL, day_key)] = (
+        SessionCacheEntry(  # noqa: SLF001
+            cached_at_mono=time.monotonic()
+            - coord._session_history_cache_ttl
+            - 1,  # noqa: SLF001
+            sessions=[],
+            state=SESSION_CACHE_STATE_UNAVAILABLE,
+            last_error="down",
+            has_valid_cache=False,
+        )
+    )
+    coord._async_enrich_sessions = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value={RANDOM_SERIAL: [{"session_id": "fresh", "energy_kwh": 2.5}]}
+    )
+    coord._schedule_session_enrichment = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+
+    data = await coord._async_update_data()
+
+    assert data[RANDOM_SERIAL]["energy_today_sessions"] == [
+        {"session_id": "fresh", "energy_kwh": 2.5}
+    ]
+    coord._async_enrich_sessions.assert_awaited_once()  # type: ignore[attr-defined]
+    coord._schedule_session_enrichment.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_missing_session_cache_age_refreshes_inline_after_startup(
+    hass, monkeypatch
+) -> None:
+    await hass.config.async_set_time_zone("UTC")
+    coord = _make_coordinator(hass, monkeypatch)
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord.data = {RANDOM_SERIAL: {"display_name": "Garage EV"}}
+
+    now_local = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: now_local)
+
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                    "charging": False,
+                }
+            ]
+        }
+    )
+    coord.client.summary_v2 = AsyncMock(
+        return_value=[{"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"}]
+    )
+    coord.client.charge_mode = AsyncMock(return_value=None)
+    coord.session_history.get_cache_view = MagicMock(  # type: ignore[assignment]
+        return_value=SessionCacheView(
+            sessions=[{"session_id": "cached", "energy_kwh": 1.0}],
+            cache_age=None,
+            needs_refresh=True,
+            blocked=False,
+            state="valid",
+            has_valid_cache=True,
+            last_error=None,
+        )
+    )
+    coord._async_enrich_sessions = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value={RANDOM_SERIAL: [{"session_id": "fresh", "energy_kwh": 2.5}]}
+    )
+    coord._schedule_session_enrichment = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+
+    data = await coord._async_update_data()
+
+    assert data[RANDOM_SERIAL]["energy_today_sessions"] == [
+        {"session_id": "fresh", "energy_kwh": 2.5}
+    ]
+    coord._async_enrich_sessions.assert_awaited_once()  # type: ignore[attr-defined]
+    coord._schedule_session_enrichment.assert_not_called()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_first_refresh_missing_session_cache_age_defers_in_background(
+    hass, monkeypatch
+) -> None:
+    await hass.config.async_set_time_zone("UTC")
+    coord = _make_coordinator(hass, monkeypatch)
+    coord.data = {RANDOM_SERIAL: {"display_name": "Garage EV"}}
+
+    now_local = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: now_local)
+
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                    "charging": False,
+                }
+            ]
+        }
+    )
+    coord.client.summary_v2 = AsyncMock(
+        return_value=[{"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"}]
+    )
+    coord.client.charge_mode = AsyncMock(return_value=None)
+    coord.session_history.get_cache_view = MagicMock(  # type: ignore[assignment]
+        return_value=SessionCacheView(
+            sessions=[{"session_id": "cached", "energy_kwh": 1.0}],
+            cache_age=None,
+            needs_refresh=True,
+            blocked=False,
+            state="valid",
+            has_valid_cache=True,
+            last_error=None,
+        )
+    )
+    coord._async_enrich_sessions = AsyncMock(return_value={})  # type: ignore[assignment]  # noqa: SLF001
+    coord._schedule_session_enrichment = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+
+    data = await coord._async_update_data()
+
+    assert data[RANDOM_SERIAL]["energy_today_sessions"] == [
+        {"session_id": "cached", "energy_kwh": 1.0}
+    ]
+    coord._async_enrich_sessions.assert_not_awaited()  # type: ignore[attr-defined]
+    coord._schedule_session_enrichment.assert_called_once()  # type: ignore[attr-defined]
 
 
 def test_session_history_adaptive_ttl_helpers(hass, monkeypatch) -> None:

--- a/tests/components/enphase_ev/test_helper_modules.py
+++ b/tests/components/enphase_ev/test_helper_modules.py
@@ -24,6 +24,10 @@ from custom_components.enphase_ev.api import (
 from custom_components.enphase_ev.evse_timeseries import EVSETimeseriesManager
 from custom_components.enphase_ev.session_history import (
     MIN_SESSION_HISTORY_CACHE_TTL,
+    SESSION_CACHE_STATE_STALE_REUSED,
+    SESSION_CACHE_STATE_UNAVAILABLE,
+    SESSION_CACHE_STATE_VALID,
+    SessionCacheEntry,
     SessionCacheView,
     SessionHistoryManager,
 )
@@ -770,6 +774,40 @@ async def test_session_history_fetch_calls_filter_criteria(hass) -> None:
 
 
 @pytest.mark.asyncio
+async def test_session_history_valid_empty_results_cache_as_valid(hass) -> None:
+    await hass.config.async_set_time_zone("UTC")
+
+    class _EmptyClient:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def session_history(self, *_args, **_kwargs) -> dict:
+            self.calls += 1
+            return {"data": {"result": [], "hasMore": False}}
+
+    client = _EmptyClient()
+    manager = SessionHistoryManager(
+        hass,
+        lambda: client,
+        cache_ttl=600,
+        data_supplier=lambda: {},
+        publish_callback=lambda _: None,
+    )
+    day = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+
+    first = await manager._async_fetch_sessions_today("EV-EMPTY", day_local=day)
+    second = await manager._async_fetch_sessions_today("EV-EMPTY", day_local=day)
+    entry = manager._cache[("EV-EMPTY", "2025-10-16")]
+
+    assert first == []
+    assert second == []
+    assert client.calls == 1
+    assert entry.state == SESSION_CACHE_STATE_VALID
+    assert entry.has_valid_cache is True
+    assert entry.sessions == []
+
+
+@pytest.mark.asyncio
 async def test_session_history_fetch_shares_filter_criteria_across_serials(
     hass,
 ) -> None:
@@ -883,6 +921,9 @@ def test_session_history_cache_view_states(hass) -> None:
     fresh = manager.get_cache_view("EV-01", "2025-10-16", now_mono=time.monotonic())
     assert isinstance(fresh, SessionCacheView)
     assert fresh.needs_refresh is False
+    assert fresh.state == SESSION_CACHE_STATE_VALID
+    assert fresh.has_valid_cache is True
+    assert fresh.last_error is None
 
     # Force expiration and block
     manager._cache[cache_key] = (time.monotonic() - 120, [{"session_id": "old"}])
@@ -890,6 +931,70 @@ def test_session_history_cache_view_states(hass) -> None:
     blocked = manager.get_cache_view("EV-01", "2025-10-16")
     assert blocked.needs_refresh is True
     assert blocked.blocked is True
+    assert blocked.state == SESSION_CACHE_STATE_VALID
+    assert blocked.has_valid_cache is True
+
+
+def test_session_history_cache_view_marks_unavailable_without_valid_cache(hass) -> None:
+    manager = SessionHistoryManager(
+        hass,
+        lambda: None,
+        cache_ttl=10,
+        data_supplier=lambda: {},
+        publish_callback=lambda _: None,
+    )
+    manager._cache[("EV-01", "2025-10-16")] = SessionCacheEntry(
+        cached_at_mono=time.monotonic(),
+        sessions=[],
+        state=SESSION_CACHE_STATE_UNAVAILABLE,
+        last_error="down",
+        has_valid_cache=False,
+    )
+
+    view = manager.get_cache_view("EV-01", "2025-10-16")
+
+    assert view.sessions == []
+    assert view.needs_refresh is True
+    assert view.state == SESSION_CACHE_STATE_UNAVAILABLE
+    assert view.has_valid_cache is False
+    assert view.last_error == "down"
+
+
+def test_session_history_cache_state_counts_handles_legacy_and_invalid_entries(
+    hass,
+) -> None:
+    manager = SessionHistoryManager(
+        hass,
+        lambda: None,
+        cache_ttl=10,
+        data_supplier=lambda: {},
+        publish_callback=lambda _: None,
+    )
+    manager._cache[("EV-VALID", "2025-10-16")] = ("bad-ts", [{"session_id": "cached"}])
+    manager._cache[("EV-STALE", "2025-10-16")] = SessionCacheEntry(
+        cached_at_mono=time.monotonic(),
+        sessions=[{"session_id": "stale"}],
+        state=SESSION_CACHE_STATE_STALE_REUSED,
+        last_error="down",
+        has_valid_cache=True,
+    )
+    manager._cache[("EV-BAD", "2025-10-16")] = "invalid"
+
+    counts = manager.cache_state_counts()
+
+    assert counts == {
+        SESSION_CACHE_STATE_VALID: 1,
+        SESSION_CACHE_STATE_STALE_REUSED: 1,
+        SESSION_CACHE_STATE_UNAVAILABLE: 0,
+    }
+    coerced = manager._cache[("EV-VALID", "2025-10-16")]  # noqa: SLF001
+    assert isinstance(coerced, SessionCacheEntry)
+    assert coerced.cached_at_mono is None
+
+
+def test_session_history_entry_error_text_handles_empty_values() -> None:
+    assert SessionHistoryManager._entry_error_text(None) is None  # noqa: SLF001
+    assert SessionHistoryManager._entry_error_text("   ") is None  # noqa: SLF001
 
 
 def _make_request_info() -> RequestInfo:
@@ -916,9 +1021,14 @@ async def test_session_history_async_fetch_handles_errors(hass) -> None:
             data_supplier=lambda: {},
             publish_callback=lambda _: None,
         )
-        return await manager._async_fetch_sessions_today("EV-ERR", day_local=day)
+        sessions = await manager._async_fetch_sessions_today("EV-ERR", day_local=day)
+        return manager, sessions
 
-    assert await _invoke(Unauthorized("bad")) == []
+    manager, sessions = await _invoke(Unauthorized("bad"))
+    assert sessions == []
+    entry = manager._cache[("EV-ERR", day.strftime("%Y-%m-%d"))]
+    assert entry.state == SESSION_CACHE_STATE_UNAVAILABLE
+    assert entry.has_valid_cache is False
 
     response_error = aiohttp.ClientResponseError(
         _make_request_info(),
@@ -926,7 +1036,11 @@ async def test_session_history_async_fetch_handles_errors(hass) -> None:
         status=503,
         message="unavailable",
     )
-    assert await _invoke(response_error) == []
+    manager, sessions = await _invoke(response_error)
+    assert sessions == []
+    entry = manager._cache[("EV-ERR", day.strftime("%Y-%m-%d"))]
+    assert entry.state == SESSION_CACHE_STATE_UNAVAILABLE
+    assert entry.has_valid_cache is False
 
     assert (
         await SessionHistoryManager(
@@ -938,7 +1052,11 @@ async def test_session_history_async_fetch_handles_errors(hass) -> None:
         )._async_fetch_sessions_today("EV-NULL", day_local=day)
     ) == []
 
-    assert await _invoke(RuntimeError("boom")) == []
+    manager, sessions = await _invoke(RuntimeError("boom"))
+    assert sessions == []
+    entry = manager._cache[("EV-ERR", day.strftime("%Y-%m-%d"))]
+    assert entry.state == SESSION_CACHE_STATE_UNAVAILABLE
+    assert entry.has_valid_cache is False
 
 
 @pytest.mark.asyncio
@@ -1309,6 +1427,9 @@ async def test_session_history_reuses_cached_data_on_invalid_payload(hass) -> No
     assert manager.service_available is False
     assert manager.service_using_stale is True
     assert manager.service_last_error is not None
+    entry = manager._cache[("EV-BAD", day_key)]
+    assert entry.state == SESSION_CACHE_STATE_STALE_REUSED
+    assert entry.has_valid_cache is True
     assert manager._service_last_payload_signature == {
         "endpoint": "/session_history",
         "status": 200,
@@ -1349,6 +1470,9 @@ async def test_session_history_reuses_cached_data_when_criteria_unavailable(
 
     assert sessions == [{"session_id": "cached-criteria"}]
     assert manager.service_using_stale is True
+    entry = manager._cache[("EV-BAD", day_key)]
+    assert entry.state == SESSION_CACHE_STATE_STALE_REUSED
+    assert entry.has_valid_cache is True
 
 
 @pytest.mark.asyncio
@@ -1379,6 +1503,9 @@ async def test_session_history_reuses_cached_data_when_criteria_fails_genericall
 
     assert sessions == [{"session_id": "cached-criteria-generic"}]
     assert manager.service_using_stale is True
+    entry = manager._cache[("EV-BAD", day_key)]
+    assert entry.state == SESSION_CACHE_STATE_STALE_REUSED
+    assert entry.has_valid_cache is True
 
 
 @pytest.mark.asyncio
@@ -1412,6 +1539,9 @@ async def test_session_history_reuses_cached_data_when_service_unavailable(
 
     assert sessions == [{"session_id": "cached-page"}]
     assert manager.service_using_stale is True
+    entry = manager._cache[("EV-BAD", day_key)]
+    assert entry.state == SESSION_CACHE_STATE_STALE_REUSED
+    assert entry.has_valid_cache is True
 
 
 @pytest.mark.asyncio
@@ -1460,9 +1590,34 @@ async def test_session_history_fetch_handles_empty_serial_and_block(
     assert cached == ["cached"]
 
 
+def test_session_history_blocked_without_valid_cache_remains_unavailable(hass) -> None:
+    manager = SessionHistoryManager(
+        hass,
+        lambda: None,
+        cache_ttl=60,
+        data_supplier=lambda: {},
+        publish_callback=lambda _: None,
+    )
+    day_key = "2025-10-16"
+    manager._cache[("EV-ALPHA", day_key)] = SessionCacheEntry(
+        cached_at_mono=time.monotonic(),
+        sessions=[],
+        state=SESSION_CACHE_STATE_UNAVAILABLE,
+        last_error="down",
+        has_valid_cache=False,
+    )
+    manager._block_until["EV-ALPHA"] = time.monotonic() + 30
+
+    view = manager.get_cache_view("EV-ALPHA", day_key)
+
+    assert view.blocked is True
+    assert view.state == SESSION_CACHE_STATE_UNAVAILABLE
+    assert view.has_valid_cache is False
+
+
 @pytest.mark.asyncio
 async def test_session_history_fetch_handles_page_unauthorized(hass) -> None:
-    """Unauthorized responses during pagination should be cached as empty."""
+    """Unauthorized responses during pagination should mark the entry unavailable."""
 
     class FailingClient:
         async def session_history(self, *_args, **_kwargs):
@@ -1481,7 +1636,10 @@ async def test_session_history_fetch_handles_page_unauthorized(hass) -> None:
     sessions = await manager._async_fetch_sessions_today("EV-DENY", day_local=day)
     assert sessions == []
     day_key = day.strftime("%Y-%m-%d")
-    assert manager._cache[("EV-DENY", day_key)][1] == []
+    entry = manager._cache[("EV-DENY", day_key)]
+    assert entry.sessions == []
+    assert entry.state == SESSION_CACHE_STATE_UNAVAILABLE
+    assert entry.has_valid_cache is False
 
 
 def test_session_history_normalise_handles_parse_failures(hass, monkeypatch) -> None:

--- a/tests/components/enphase_ev/test_session_history_additional.py
+++ b/tests/components/enphase_ev/test_session_history_additional.py
@@ -184,6 +184,9 @@ async def test_fetch_sessions_criteria_unavailable(monkeypatch):
     result = await manager._async_fetch_sessions_today("SN", day_local=now)
     assert result == []
     assert manager.service_available is False
+    entry = manager._cache[("SN", now.strftime("%Y-%m-%d"))]
+    assert entry.state == sh_mod.SESSION_CACHE_STATE_UNAVAILABLE
+    assert entry.has_valid_cache is False
 
 
 @pytest.mark.asyncio
@@ -209,6 +212,9 @@ async def test_fetch_sessions_criteria_unauthorized(monkeypatch):
     result = await manager._async_fetch_sessions_today("SN", day_local=now)
     assert result == []
     assert manager.service_available is True
+    entry = manager._cache[("SN", now.strftime("%Y-%m-%d"))]
+    assert entry.state == sh_mod.SESSION_CACHE_STATE_UNAVAILABLE
+    assert entry.has_valid_cache is False
 
 
 @pytest.mark.asyncio
@@ -237,6 +243,9 @@ async def test_fetch_sessions_criteria_http_error(monkeypatch):
     result = await manager._async_fetch_sessions_today("SN", day_local=now)
     assert result == []
     assert "SN" in manager._block_until
+    entry = manager._cache[("SN", now.strftime("%Y-%m-%d"))]
+    assert entry.state == sh_mod.SESSION_CACHE_STATE_UNAVAILABLE
+    assert entry.has_valid_cache is False
 
 
 @pytest.mark.asyncio
@@ -259,6 +268,9 @@ async def test_fetch_sessions_marks_service_unavailable(monkeypatch):
     assert manager.service_available is False
     assert manager.service_backoff_active is True
     assert manager.service_last_error
+    entry = manager._cache[("SN", now.strftime("%Y-%m-%d"))]
+    assert entry.state == sh_mod.SESSION_CACHE_STATE_UNAVAILABLE
+    assert entry.has_valid_cache is False
 
 
 def test_mark_service_available_resets_state():


### PR DESCRIPTION
## Summary

Fix session-history failure semantics so outages no longer look like valid empty days.

This changes the session-history cache to track explicit `valid`, `stale_reused`, and `unavailable` states, stops caching failed fetches as `[]`, preserves stale reuse from prior successful payloads, and updates coordinator scheduling and diagnostics to respect the new semantics.

## Related Issues

- Follow-up to the refresh/session-history optimization work.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/session_history.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/coordinator_diagnostics.py tests/components/enphase_ev/test_helper_modules.py tests/components/enphase_ev/test_session_history_additional.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/session_history.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/coordinator_diagnostics.py tests/components/enphase_ev/test_helper_modules.py tests/components/enphase_ev/test_session_history_additional.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_helper_modules.py tests/components/enphase_ev/test_session_history_additional.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/session_history.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/coordinator_diagnostics.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/coordinator_diagnostics.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_additional_coverage.py"
```

Additional validation:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_session_history_additional.py tests/components/enphase_ev/test_helper_modules.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py --fail-under=100"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Session-history diagnostics now include cache-state counts so `valid`, `stale_reused`, and `unavailable` entries are visible in diagnostics.
- Entity payload shape is unchanged: unavailable/no-cache session history still renders as `[]`, but no longer creates a fake valid-empty cache hit.
