### PR TITLE
[codex] Reject advisory firmware install requests

### DIFF
--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -11,6 +11,7 @@ from homeassistant.components.update import (
 )
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -185,6 +186,12 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         await self._async_refresh_catalog()
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Reject install requests; these entities only advertise firmware status."""
+        raise HomeAssistantError("Firmware updates are advisory only")
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -365,6 +372,12 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         await self._async_refresh_state()
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        """Reject install requests; these entities only advertise firmware status."""
+        raise HomeAssistantError("Firmware updates are advisory only")
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 from homeassistant.components.update import UpdateEntityDescription
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from unittest.mock import AsyncMock, MagicMock
@@ -406,6 +407,22 @@ async def test_gateway_update_entity_states_and_release_url_selection(hass) -> N
     assert entity.available is False
 
 
+@pytest.mark.asyncio
+async def test_gateway_update_entity_rejects_install_requests(hass) -> None:
+    entity = FirmwareUpdateEntity(
+        coordinator=DummyCoordinator(),
+        manager=DummyCatalogManager(_catalog_payload()),
+        device_type="envoy",
+        translation_key="gateway_firmware",
+        description=UpdateEntityDescription(key="gateway_firmware"),
+        installed_version_getter=_gateway_installed_version,
+    )
+    entity.hass = hass
+
+    with pytest.raises(HomeAssistantError, match="advisory only"):
+        await entity.async_install(version=None, backup=False)
+
+
 def test_firmware_update_entities_fall_back_to_type_device_identifiers() -> None:
     coord = DummyCoordinator()
     coord.inventory_view = SimpleNamespace(
@@ -572,6 +589,21 @@ async def test_charger_update_entity_clears_release_metadata_without_catalog_ent
     assert (
         entity.extra_state_attributes["catalog_generated_at"] == "2026-03-01T00:00:00Z"
     )
+
+
+@pytest.mark.asyncio
+async def test_charger_update_entity_rejects_install_requests(hass) -> None:
+    entity = ChargerFirmwareUpdateEntity(
+        coordinator=DummyCoordinator(),
+        manager=DummyEvseFirmwareManager(_evse_payload()),
+        catalog_manager=DummyCatalogManager(_catalog_payload()),
+        serial=TEST_EVSE_SERIAL,
+        description=UpdateEntityDescription(key="charger_firmware"),
+    )
+    entity.hass = hass
+
+    with pytest.raises(HomeAssistantError, match="advisory only"):
+        await entity.async_install(version=None, backup=False)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- reject install requests for advisory firmware update entities instead of falling through to the base `UpdateEntity` implementation
- return a clear Home Assistant error for gateway and charger advisory update entities
- add regression tests covering manual install attempts for both entity types

## Testing
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_update_module.py -q"`
