### PR TITLE
Preserve AC Battery status fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### 🐛 Bug fixes
-- None
+- Seed AC Battery status and last-reported data from the battery status endpoint when the dedicated AC Battery devices page does not return parsed rows.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/ac_battery_runtime.py
+++ b/custom_components/enphase_ev/ac_battery_runtime.py
@@ -185,10 +185,44 @@ class AcBatteryRuntime:
         if refresh_topology:
             self._battery_runtime._refresh_cached_topology()
 
+    def _preserve_ac_battery_status_fallback(self) -> bool:
+        # Battery status refresh runs before the dedicated AC Battery devices page.
+        # If that page is empty or unparsable, keep the known battery-status rows
+        # instead of erasing AC Battery entities before Home Assistant sees them.
+        state = self.battery_state
+        details = getattr(state, "_ac_battery_aggregate_status_details", None)
+        if not isinstance(details, dict):
+            return False
+        if details.get("status_source") != "battery_status":
+            return False
+        rows = getattr(state, "_ac_battery_data", None)
+        if not isinstance(rows, dict):
+            return False
+        valid_rows = {
+            key: snapshot
+            for key, snapshot in rows.items()
+            if isinstance(snapshot, dict)
+        }
+        if not valid_rows:
+            return False
+        order = [
+            key
+            for key in getattr(state, "_ac_battery_order", []) or []
+            if key in valid_rows
+        ]
+        order.extend(key for key in valid_rows if key not in order)
+        state._ac_battery_data = valid_rows
+        state._ac_battery_order = list(dict.fromkeys(order))
+        self.refresh_ac_battery_summary()
+        self._battery_runtime._refresh_cached_topology()
+        return True
+
     def parse_ac_battery_devices_page(self, html_text: object) -> None:
         state = self.battery_state
         page_text = self._battery_runtime._coerce_optional_text(html_text)
         if not page_text:
+            if self._preserve_ac_battery_status_fallback():
+                return
             state._ac_battery_data = {}
             state._ac_battery_order = []
             state._ac_battery_aggregate_status = None
@@ -286,6 +320,9 @@ class AcBatteryRuntime:
                 worst_severity = severity
                 worst_status = status_normalized
                 worst_key = key
+
+        if not rows and self._preserve_ac_battery_status_fallback():
+            return
 
         aggregate_sleep_state = None
         if sleep_states:

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -49,6 +49,7 @@ from .parsing_helpers import (
     coerce_optional_bool,
     coerce_optional_float,
     coerce_optional_text,
+    parse_inverter_last_report,
 )
 from .runtime_helpers import coerce_int, coerce_optional_int
 from .service_validation import raise_translated_service_validation
@@ -2530,7 +2531,157 @@ class BatteryRuntime:
                 payload.get("excluded_count")
             ),
         }
+        self._sync_ac_battery_from_battery_status(snapshots)
         self._refresh_cached_topology()
+
+    def _sync_ac_battery_from_battery_status(
+        self, snapshots: dict[str, dict[str, object]]
+    ) -> None:
+        """Seed AC Battery records from battery status when the HTML page is empty."""
+
+        coord = self.coordinator
+        state = self.battery_state
+        if getattr(coord, "battery_has_acb", None) is not True:
+            return
+        inventory_view = getattr(coord, "inventory_view", None)
+        has_type_for_entities = getattr(inventory_view, "has_type_for_entities", None)
+        if callable(has_type_for_entities) and not has_type_for_entities("ac_battery"):
+            return
+
+        existing = getattr(state, "_ac_battery_data", None)
+        rows: dict[str, dict[str, object]] = (
+            {
+                str(key): dict(value)
+                for key, value in existing.items()
+                if isinstance(value, dict)
+            }
+            if isinstance(existing, dict)
+            else {}
+        )
+
+        known_ids: set[str] = {
+            str(snapshot.get("battery_id"))
+            for snapshot in rows.values()
+            if snapshot.get("battery_id") is not None
+        }
+        known_serials: set[str] = {
+            str(snapshot.get("serial_number"))
+            for snapshot in rows.values()
+            if snapshot.get("serial_number") is not None
+        }
+        type_bucket = (
+            inventory_view.type_bucket("ac_battery")
+            if callable(getattr(inventory_view, "type_bucket", None))
+            else None
+        )
+        members = type_bucket.get("devices") if isinstance(type_bucket, dict) else None
+        if isinstance(members, list):
+            for member in members:
+                for key in ("id", "device_id", "device_uid", "uid"):
+                    value = member.get(key)
+                    if value is not None:
+                        known_ids.add(str(value))
+                for key in ("serial_number", "serial", "serialNumber"):
+                    value = member.get(key)
+                    if value is not None:
+                        known_serials.add(str(value))
+
+        acb_only_site = getattr(
+            coord, "battery_has_encharge", None
+        ) is not True and bool(snapshots)
+        if not acb_only_site and not known_ids and not known_serials:
+            return
+
+        order = list(getattr(state, "_ac_battery_order", []) or [])
+        status_map: dict[str, str] = {}
+        status_text_map: dict[str, str | None] = {}
+        worst_key: str | None = None
+        worst_status: str | None = None
+        worst_severity = self._battery_status_severity_value("normal")
+        synced_count = 0
+
+        for key, source in snapshots.items():
+            battery_id = self._normalize_battery_id(source.get("battery_id"))
+            serial = self._coerce_optional_text(source.get("serial_number")) or key
+            if (
+                not acb_only_site
+                and battery_id not in known_ids
+                and serial not in known_serials
+                and key not in known_serials
+            ):
+                continue
+
+            row = dict(rows.get(key, {}))
+            row.setdefault("serial_number", serial)
+            if battery_id is not None:
+                row["battery_id"] = battery_id
+            # Keep this fallback to inventory/status fields. The battery-status
+            # endpoint's available_power/max_power values describe capability,
+            # not the AC Battery's current live power.
+            for source_key, target_key in (
+                ("current_charge_pct", "current_charge_pct"),
+                ("cycle_count", "cycle_count"),
+                ("status_text", "status_text"),
+                ("status_normalized", "status_normalized"),
+                ("available_energy_kwh", "available_energy_kwh"),
+                ("max_capacity_kwh", "max_capacity_kwh"),
+                ("battery_mode", "battery_mode"),
+                ("rated_power", "rated_power"),
+                ("battery_phase_count", "battery_phase_count"),
+            ):
+                if source.get(source_key) is not None:
+                    row[target_key] = source[source_key]
+            if source.get("last_report") is not None:
+                parsed_last_report = parse_inverter_last_report(
+                    source.get("last_report")
+                )
+                if parsed_last_report is not None:
+                    row["last_reported"] = parsed_last_report
+            rows[key] = row
+            synced_count += 1
+            if key not in order:
+                order.append(key)
+
+            normalized_status = self._coerce_optional_text(row.get("status_normalized"))
+            if normalized_status is None:
+                normalized_status = "unknown"
+            status_map[key] = normalized_status
+            status_text_map[key] = self._coerce_optional_text(row.get("status_text"))
+            severity = self._battery_status_severity_value(normalized_status)
+            if severity > worst_severity or worst_status is None:
+                worst_severity = severity
+                worst_status = normalized_status
+                worst_key = key
+
+        if synced_count == 0:
+            return
+
+        state._ac_battery_data = rows
+        state._ac_battery_order = list(dict.fromkeys(order))
+        details = dict(getattr(state, "_ac_battery_aggregate_status_details", {}) or {})
+        details.update(
+            {
+                "battery_count": len(rows),
+                "status_source": "battery_status",
+                "per_battery_status": status_map,
+                "per_battery_status_text": status_text_map,
+                "worst_storage_key": worst_key,
+                "worst_status": worst_status,
+                "battery_ids": {
+                    serial_key: snapshot.get("battery_id")
+                    for serial_key, snapshot in rows.items()
+                },
+            }
+        )
+        if "sleep_state" not in details:
+            details["sleep_state"] = getattr(state, "_ac_battery_sleep_state", None)
+        if "selected_sleep_min_soc" not in details:
+            details["selected_sleep_min_soc"] = getattr(
+                state, "_ac_battery_selected_sleep_min_soc", None
+            )
+        state._ac_battery_aggregate_status_details = details
+        state._ac_battery_aggregate_status = worst_status or "unknown"
+        self._ac_battery_runtime.refresh_ac_battery_summary()
 
     def parse_battery_site_settings_payload(self, payload: object) -> None:
         state = self.battery_state

--- a/tests/components/enphase_ev/test_battery_runtime.py
+++ b/tests/components/enphase_ev/test_battery_runtime.py
@@ -722,6 +722,136 @@ def test_battery_runtime_parse_status_payload_updates_runtime_state(
     assert coord.battery_aggregate_status == "normal"
 
 
+def test_battery_runtime_parse_status_payload_seeds_ac_battery_fallback(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._selected_type_keys = {"ac_battery"}  # noqa: SLF001
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._battery_has_acb = True  # noqa: SLF001
+    coord._battery_has_encharge = False  # noqa: SLF001
+
+    coord.battery_runtime.parse_battery_status_payload(
+        {
+            "storages": [
+                {
+                    "id": 110528990,
+                    "serial_number": "BAT-AC-1",
+                    "current_charge": "1%",
+                    "available_energy": 0.01,
+                    "max_capacity": 1.24,
+                    "statusText": "Normal",
+                    "status": "normal",
+                    "last_report": 1_776_981_758,
+                    "cycle_count": 53,
+                    "battery_mode": "Self-Consumption",
+                    "rated_power": "N/A",
+                    "battery_phase_count": "N/A",
+                }
+            ]
+        }
+    )
+
+    assert coord.iter_ac_battery_serials() == ["BAT-AC-1"]
+    snapshot = coord.ac_battery_storage("BAT-AC-1")
+    assert snapshot is not None
+    assert snapshot["battery_id"] == "110528990"
+    assert snapshot["current_charge_pct"] == 1.0
+    assert snapshot["status_normalized"] == "normal"
+    assert snapshot["cycle_count"] == 53
+    assert snapshot["last_reported"] == datetime.fromtimestamp(1_776_981_758, UTC)
+    assert coord.ac_battery_aggregate_status == "normal"
+    assert coord.ac_battery_status_summary["status_source"] == "battery_status"
+
+
+@pytest.mark.asyncio
+async def test_ac_battery_devices_refresh_preserves_status_fallback_rows(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._selected_type_keys = {"ac_battery"}  # noqa: SLF001
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._battery_has_acb = True  # noqa: SLF001
+    coord._battery_has_encharge = False  # noqa: SLF001
+    coord.client.ac_battery_devices_page = AsyncMock(
+        return_value="<html><table id='ac_batteries'></table></html>"
+    )
+
+    coord.battery_runtime.parse_battery_status_payload(
+        {
+            "storages": [
+                {
+                    "id": 110528990,
+                    "serial_number": "BAT-AC-1",
+                    "current_charge": "1%",
+                    "statusText": "Normal",
+                    "status": "normal",
+                    "last_report": 1_776_981_758,
+                }
+            ]
+        }
+    )
+
+    await coord.battery_runtime.async_refresh_ac_battery_devices(force=True)
+
+    assert coord.iter_ac_battery_serials() == ["BAT-AC-1"]
+    assert coord.ac_battery_storage("BAT-AC-1")["battery_id"] == "110528990"
+    assert coord.ac_battery_aggregate_status == "normal"
+    assert coord.ac_battery_status_summary["status_source"] == "battery_status"
+    assert coord._ac_battery_devices_payload["battery_count"] == 1  # noqa: SLF001
+
+
+def test_battery_runtime_ac_battery_status_fallback_guard_paths(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._battery_has_acb = True  # noqa: SLF001
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord._selected_type_keys = {"envoy"}  # noqa: SLF001
+
+    coord.battery_runtime._sync_ac_battery_from_battery_status(  # noqa: SLF001
+        {"BAT-AC-1": {"serial_number": "BAT-AC-1"}}
+    )
+    assert coord.iter_ac_battery_serials() == []
+
+    coord._selected_type_keys = {"ac_battery"}  # noqa: SLF001
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._type_device_buckets = {}  # noqa: SLF001
+    coord.battery_runtime._sync_ac_battery_from_battery_status(  # noqa: SLF001
+        {"BAT-AC-1": {"serial_number": "BAT-AC-1"}}
+    )
+    assert coord.iter_ac_battery_serials() == []
+
+    coord._type_device_buckets = {  # noqa: SLF001
+        "ac_battery": {
+            "count": 1,
+            "devices": [
+                "bad-member",
+                {"id": "110528990", "serial_number": "BAT-AC-1"},
+            ],
+        }
+    }
+    coord.battery_runtime._sync_ac_battery_from_battery_status(  # noqa: SLF001
+        {"BAT-SKIP": {"battery_id": "999", "serial_number": "BAT-SKIP"}}
+    )
+    assert coord.iter_ac_battery_serials() == []
+
+    coord.battery_runtime._sync_ac_battery_from_battery_status(  # noqa: SLF001
+        {
+            "BAT-SKIP": {"battery_id": "999", "serial_number": "BAT-SKIP"},
+            "BAT-AC-1": {
+                "battery_id": "110528990",
+                "serial_number": "BAT-AC-1",
+                "status_text": None,
+                "status_normalized": None,
+            },
+        }
+    )
+
+    assert coord.iter_ac_battery_serials() == ["BAT-AC-1"]
+    assert coord.ac_battery_aggregate_status == "unknown"
+
+
 def test_battery_runtime_parse_profile_payload_updates_profile_state(
     coordinator_factory,
 ) -> None:
@@ -1400,6 +1530,21 @@ def test_ac_battery_runtime_helper_branches(coordinator_factory, monkeypatch) ->
     )
     assert runtime._ac_battery_parse_int("1") is None  # noqa: SLF001
     assert runtime._ac_battery_key() is None  # noqa: SLF001
+
+    coord._ac_battery_aggregate_status_details = None  # noqa: SLF001
+    assert runtime._preserve_ac_battery_status_fallback() is False  # noqa: SLF001
+    coord._ac_battery_aggregate_status_details = {  # noqa: SLF001
+        "status_source": "battery_status"
+    }
+    coord._ac_battery_data = None  # noqa: SLF001
+    assert runtime._preserve_ac_battery_status_fallback() is False  # noqa: SLF001
+    coord._ac_battery_data = {"bad": "not-a-dict"}  # noqa: SLF001
+    assert runtime._preserve_ac_battery_status_fallback() is False  # noqa: SLF001
+
+    coord._ac_battery_data = {"BAT-AC-1": {"serial_number": "BAT-AC-1"}}  # noqa: SLF001
+    coord._ac_battery_order = []  # noqa: SLF001
+    coord.battery_runtime.parse_ac_battery_devices_page(None)
+    assert coord.iter_ac_battery_serials() == ["BAT-AC-1"]
 
 
 def test_ac_battery_runtime_parse_devices_page_edge_branches(


### PR DESCRIPTION
## Summary

Fixes #464.

Seed AC Battery rows from the cloud battery-status payload when the dedicated AC Battery devices page does not return parsed rows, and preserve those fallback rows during the later AC Battery devices refresh. This prevents AC Battery status, charge, and last-reported entities from staying unavailable on ACB-only sites where `battery_status.json` contains storage records but `/systems/<site>/devices?status=active` is empty or unparsable for the beta AC Battery parser.

## Related Issues

- Fixes #464

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/ac_battery_runtime.py custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_battery_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/ac_battery_runtime.py custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_battery_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_runtime.py -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/ac_battery_runtime.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Notes:
- `pre-commit` needed the host `.git` directory mounted because this checkout is a git worktree and `/workspace/.git` points outside the default Docker mount.
- Full pytest result: `2933 passed`.
- Targeted touched-module coverage result: `ac_battery_runtime.py` 100%, `battery_runtime.py` 100%.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The supplied diagnostics for issue #464 showed `hasAcb=true`, `hasEncharge=false`, and two AC Battery storage records in `battery_status.json`, while the dedicated AC Battery devices payload remained empty/null. This PR uses the available cloud status payload as a read-only fallback for status, charge, IDs, cycle count, battery mode, and last-reported data. It intentionally does not treat `available_power` or `max_power` from `battery_status.json` as live AC Battery power.