### PR TITLE
Improve refresh pipeline performance

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -234,6 +234,18 @@ class EndpointFamilyPolicy:
     support_state_on_success: bool = False
 
 
+@dataclass(slots=True)
+class RefreshPipelineContext:
+    """Mutable state shared by one coordinator refresh pipeline."""
+
+    started_mono: float
+    refresh_started_utc: datetime
+    phase_timings: dict[str, float]
+    fallback_data: dict[str, dict]
+    first_refresh: bool
+    status_used_stale: bool = False
+
+
 class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def __init__(self, hass: HomeAssistant, config, config_entry=None):
         self.hass = hass
@@ -2229,66 +2241,185 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             resolved.get("charger_config", {}),
         )
 
-    async def _async_update_data(self) -> dict:
-        t0 = time.monotonic()
+    def _start_refresh_pipeline(self) -> RefreshPipelineContext:
         refresh_started_utc = dt_util.utcnow()
         if refresh_started_utc.tzinfo is None:
             refresh_started_utc = refresh_started_utc.replace(tzinfo=_tz.utc)
-        phase_timings: dict[str, float] = {}
         fallback_data: dict[str, dict] = {}
-        status_used_stale = False
-        first_refresh = not self._has_successful_refresh
         if isinstance(self.data, dict):
             try:
                 fallback_data = dict(self.data)
             except Exception:
                 fallback_data = self.data
+        return RefreshPipelineContext(
+            started_mono=time.monotonic(),
+            refresh_started_utc=refresh_started_utc,
+            phase_timings={},
+            fallback_data=fallback_data,
+            first_refresh=not self._has_successful_refresh,
+        )
+
+    async def _async_run_site_only_refresh_pipeline(
+        self,
+        context: RefreshPipelineContext,
+    ) -> dict:
+        phase_timings = context.phase_timings
+        self._backoff_until = None
+        self._clear_backoff_timer()
+        self._clear_auth_repair_issues_on_success()
+        self.diagnostics.clear_network_issue()
+        self.diagnostics.clear_cloud_issue()
+        self.diagnostics.clear_dns_issue()
+        self._unauth_errors = 0
+        self._rate_limit_hits = 0
+        self._http_errors = 0
+        self._network_errors = 0
+        self._dns_failures = 0
+        self._last_error = None
+        self.backoff_ends_utc = None
+        self._has_successful_refresh = True
+        site_energy_start = time.monotonic()
+        await self.energy._async_refresh_site_energy()
+        self.discovery_snapshot.sync_site_energy_discovery_state()
+        self._sync_site_energy_issue()
+        phase_timings["site_energy_s"] = round(time.monotonic() - site_energy_start, 3)
+        if not context.first_refresh:
+            followup_plan = build_site_only_followup_plan(
+                self,
+                force_full=self.endpoint_manual_bypass_active(),
+            )
+            if followup_plan.stages:
+                await self.refresh_runner.async_run_refresh_plan(
+                    phase_timings,
+                    plan=followup_plan,
+                )
+        if not self._auth_refresh_suspended_active():
+            self._clear_auth_refresh_rejection_state()
+        self._prune_runtime_caches(active_serials=(), keep_day_keys=())
+        self._sync_battery_profile_pending_issue()
+        self.last_success_utc = dt_util.utcnow()
+        self.latency_ms = int((time.monotonic() - context.started_mono) * 1000)
+        self._finish_refresh_pipeline(context)
+        return {}
+
+    def _record_status_refresh_success(
+        self,
+        context: RefreshPipelineContext,
+    ) -> None:
+        if self._unauth_errors:
+            self._clear_auth_repair_issues_on_success()
+        self._unauth_errors = 0
+        self._rate_limit_hits = 0
+        self._http_errors = 0
+        self._payload_errors = 0
+        self.diagnostics.clear_network_issue()
+        self._network_errors = 0
+        self.diagnostics.clear_cloud_issue()
+        self._backoff_until = None
+        self._clear_backoff_timer()
+        self._last_error = None
+        self.diagnostics.clear_dns_issue()
+        self._dns_failures = 0
+        if not context.status_used_stale:
+            self.last_success_utc = dt_util.utcnow()
+            self.payload_using_stale = False
+            self.payload_failure_kind = None
+            self.last_failure_endpoint = None
+        else:
+            self._last_error = self.last_failure_description
+
+    async def _async_run_post_status_refresh_pipeline(
+        self,
+        context: RefreshPipelineContext,
+    ) -> None:
+        if not context.first_refresh:
+            followup_plan = build_followup_plan(
+                self,
+                force_full=self.endpoint_manual_bypass_active(),
+            )
+            if followup_plan.stages:
+                await self.refresh_runner.async_run_refresh_plan(
+                    context.phase_timings,
+                    plan=followup_plan,
+                )
+        if not self._auth_refresh_suspended_active():
+            self._clear_auth_refresh_rejection_state()
+
+    async def _async_run_post_session_refresh_pipeline(
+        self,
+        context: RefreshPipelineContext,
+        out: dict[str, dict],
+        day_local_default: datetime,
+    ) -> None:
+        if context.first_refresh:
+            return
+        post_session_plan = build_post_session_followup_plan(
+            self,
+            day_local_default,
+            force_full=self.endpoint_manual_bypass_active(),
+        )
+        if post_session_plan.stages:
+            await self.refresh_runner.async_run_refresh_plan(
+                context.phase_timings,
+                plan=post_session_plan,
+            )
+        try:
+            self.evse_timeseries.merge_charger_payloads(
+                out, day_local=day_local_default
+            )
+        except Exception:
+            pass
+        self.discovery_snapshot.sync_site_energy_discovery_state()
+        self._sync_site_energy_issue()
+        self._sync_battery_profile_pending_issue()
+        heatpump_plan = build_heatpump_followup_plan(
+            self,
+            force_full=self.endpoint_manual_bypass_active(),
+        )
+        if heatpump_plan.stages:
+            await self.refresh_runner.async_run_refresh_plan(
+                context.phase_timings,
+                plan=heatpump_plan,
+            )
+
+    def _apply_refresh_polling_interval(self, polling_state: dict[str, object]) -> None:
+        if self.config_entry is None:
+            return
+        target = polling_state["target"]
+        if (
+            not self.update_interval
+            or int(self.update_interval.total_seconds()) != target
+        ):
+            new_interval = timedelta(seconds=target)
+            self.update_interval = new_interval
+            if hasattr(self, "async_set_update_interval"):
+                try:
+                    self.async_set_update_interval(new_interval)
+                except Exception:
+                    pass
+
+    def _finish_refresh_pipeline(
+        self,
+        context: RefreshPipelineContext,
+    ) -> None:
+        phase_timings = context.phase_timings
+        phase_timings["total_s"] = round(time.monotonic() - context.started_mono, 3)
+        self._phase_timings = phase_timings.copy()
+        if context.first_refresh:
+            self._bootstrap_phase_timings = phase_timings.copy()
+        self._refresh_cached_topology()
+        self.discovery_snapshot.schedule_save()
+
+    async def _async_update_data(self) -> dict:
+        context = self._start_refresh_pipeline()
+        t0 = context.started_mono
+        refresh_started_utc = context.refresh_started_utc
+        phase_timings = context.phase_timings
+        fallback_data = context.fallback_data
+        first_refresh = context.first_refresh
 
         if self.site_only or not self.serials:
-            self._backoff_until = None
-            self._clear_backoff_timer()
-            self._clear_auth_repair_issues_on_success()
-            self.diagnostics.clear_network_issue()
-            self.diagnostics.clear_cloud_issue()
-            self.diagnostics.clear_dns_issue()
-            self._unauth_errors = 0
-            self._rate_limit_hits = 0
-            self._http_errors = 0
-            self._network_errors = 0
-            self._dns_failures = 0
-            self._last_error = None
-            self.backoff_ends_utc = None
-            self._has_successful_refresh = True
-            site_energy_start = time.monotonic()
-            await self.energy._async_refresh_site_energy()
-            self.discovery_snapshot.sync_site_energy_discovery_state()
-            self._sync_site_energy_issue()
-            phase_timings["site_energy_s"] = round(
-                time.monotonic() - site_energy_start, 3
-            )
-            if not first_refresh:
-                followup_plan = build_site_only_followup_plan(
-                    self,
-                    force_full=self.endpoint_manual_bypass_active(),
-                )
-                if followup_plan.stages:
-                    await self.refresh_runner.async_run_refresh_plan(
-                        phase_timings,
-                        plan=followup_plan,
-                    )
-            if not self._auth_refresh_suspended_active():
-                self._clear_auth_refresh_rejection_state()
-            self._prune_runtime_caches(active_serials=(), keep_day_keys=())
-            self._sync_battery_profile_pending_issue()
-            self.last_success_utc = dt_util.utcnow()
-            self.latency_ms = int((time.monotonic() - t0) * 1000)
-            phase_timings["total_s"] = round(time.monotonic() - t0, 3)
-            self._phase_timings = phase_timings.copy()
-            if first_refresh:
-                self._bootstrap_phase_timings = phase_timings.copy()
-            self._refresh_cached_topology()
-            self.discovery_snapshot.schedule_save()
-            return {}
+            return await self._async_run_site_only_refresh_pipeline(context)
 
         # Helper to normalize epoch-like inputs to seconds
         def _sec(v):
@@ -2454,7 +2585,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 )
                 phase_timings["status_s"] = round(time.monotonic() - status_start, 3)
                 data = dict(self._status_payload_cache)
-                status_used_stale = True
+                context.status_used_stale = True
             else:
                 self.payload_using_stale = False
                 self._note_payload_endpoint_failure(
@@ -2500,7 +2631,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 )
                 phase_timings["status_s"] = round(time.monotonic() - status_start, 3)
                 data = dict(self._status_payload_cache)
-                status_used_stale = True
+                context.status_used_stale = True
                 self._payload_errors = 0
                 self._backoff_until = None
                 self._clear_backoff_timer()
@@ -2647,42 +2778,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         finally:
             self.latency_ms = int((time.monotonic() - t0) * 1000)
 
-        # Success path: reset counters, record last success
-        if self._unauth_errors:
-            # Clear any outstanding reauth issues on success
-            self._clear_auth_repair_issues_on_success()
-        self._unauth_errors = 0
-        self._rate_limit_hits = 0
-        self._http_errors = 0
-        self._payload_errors = 0
-        self.diagnostics.clear_network_issue()
-        self._network_errors = 0
-        self.diagnostics.clear_cloud_issue()
-        self._backoff_until = None
-        self._clear_backoff_timer()
-        self._last_error = None
-        self.diagnostics.clear_dns_issue()
-        self._dns_failures = 0
-        if not status_used_stale:
-            self.last_success_utc = dt_util.utcnow()
-            self.payload_using_stale = False
-            self.payload_failure_kind = None
-            self.last_failure_endpoint = None
-        else:
-            self._last_error = self.last_failure_description
-
-        if not first_refresh:
-            followup_plan = build_followup_plan(
-                self,
-                force_full=self.endpoint_manual_bypass_active(),
-            )
-            if followup_plan.stages:
-                await self.refresh_runner.async_run_refresh_plan(
-                    phase_timings,
-                    plan=followup_plan,
-                )
-        if not self._auth_refresh_suspended_active():
-            self._clear_auth_refresh_rejection_state()
+        self._record_status_refresh_success(context)
+        await self._async_run_post_status_refresh_pipeline(context)
 
         prev_data = self.data if isinstance(self.data, dict) else {}
         self._has_successful_refresh = True
@@ -3594,7 +3691,6 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 )
                 if previous_lifetime_kwh is not None:
                     entry.setdefault("lifetime_kwh", previous_lifetime_kwh)
-            entry.update(_build_evse_power_snapshot(sn, entry, previous_entry))
             if PHASE_SWITCH_CONFIG_SETTING in config_values:
                 entry["phase_switch_config"] = config_values[
                     PHASE_SWITCH_CONFIG_SETTING
@@ -4027,63 +4123,19 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         phase_timings["sessions_s"] = round(time.monotonic() - sessions_start, 3)
         self._sync_session_history_issue()
 
-        if not first_refresh:
-            post_session_plan = build_post_session_followup_plan(
-                self,
-                day_local_default,
-                force_full=self.endpoint_manual_bypass_active(),
-            )
-            if post_session_plan.stages:
-                await self.refresh_runner.async_run_refresh_plan(
-                    phase_timings,
-                    plan=post_session_plan,
-                )
-            try:
-                self.evse_timeseries.merge_charger_payloads(
-                    out, day_local=day_local_default
-                )
-            except Exception:
-                pass
-            self.discovery_snapshot.sync_site_energy_discovery_state()
-            self._sync_site_energy_issue()
-            self._sync_battery_profile_pending_issue()
-            heatpump_plan = build_heatpump_followup_plan(
-                self,
-                force_full=self.endpoint_manual_bypass_active(),
-            )
-            if heatpump_plan.stages:
-                await self.refresh_runner.async_run_refresh_plan(
-                    phase_timings,
-                    plan=heatpump_plan,
-                )
+        await self._async_run_post_session_refresh_pipeline(
+            context,
+            out,
+            day_local_default,
+        )
+        self._apply_refresh_polling_interval(polling_state)
 
-        # Dynamic poll rate: fast while any charging, within a fast window, or streaming
-        if self.config_entry is not None:
-            target = polling_state["target"]
-            if (
-                not self.update_interval
-                or int(self.update_interval.total_seconds()) != target
-            ):
-                new_interval = timedelta(seconds=target)
-                self.update_interval = new_interval
-                # Older cores require async_set_update_interval for dynamic changes
-                if hasattr(self, "async_set_update_interval"):
-                    try:
-                        self.async_set_update_interval(new_interval)
-                    except Exception:
-                        pass
-
-        phase_timings["total_s"] = round(time.monotonic() - t0, 3)
-        self._phase_timings = phase_timings
-        if first_refresh:
-            self._bootstrap_phase_timings = phase_timings.copy()
-        self._refresh_cached_topology()
-        self.discovery_snapshot.schedule_save()
+        self._finish_refresh_pipeline(context)
         if _LOGGER.isEnabledFor(logging.DEBUG):
             _LOGGER.debug(
                 "Coordinator refresh timings for site %s: %s",
                 redact_site_id(self.site_id),
-                phase_timings,
+                self._phase_timings,
             )
 
         return out

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import inspect
 import logging
 import re
@@ -54,6 +55,7 @@ _LOGGER = logging.getLogger(__name__)
 DEVICES_INVENTORY_CACHE_TTL = 300.0
 HEMS_DEVICES_STALE_AFTER_S = 90.0
 HEMS_DEVICES_CACHE_TTL = 15.0
+SYSTEM_DASHBOARD_DETAIL_CONCURRENCY = 3
 SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES: tuple[str, ...] = (
     "envoys",
     "meters",
@@ -1991,15 +1993,36 @@ class InventoryRuntime:
             )
             else {}
         )
+        detail_failures: dict[str, str] = {}
         if callable(details_fetcher):
-            for source_type in SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES:
-                try:
-                    payload = await details_fetcher(source_type)
-                except Exception as err:  # noqa: BLE001
+            semaphore = asyncio.Semaphore(SYSTEM_DASHBOARD_DETAIL_CONCURRENCY)
+
+            async def _fetch_detail(
+                source_type: str,
+            ) -> tuple[str, dict[str, object] | None, Exception | None]:
+                async with semaphore:
+                    try:
+                        payload = await details_fetcher(source_type)
+                    except Exception as err:  # noqa: BLE001
+                        return source_type, None, err
+                return source_type, payload if isinstance(payload, dict) else None, None
+
+            detail_results = await asyncio.gather(
+                *(
+                    _fetch_detail(source_type)
+                    for source_type in SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES
+                )
+            )
+            for source_type, payload, err in detail_results:
+                if err is not None:
                     if first_error is None:
                         first_error = err
+                    detail_failures[source_type] = (
+                        redact_text(err, site_ids=(self.site_id,))
+                        or err.__class__.__name__
+                    )
                     continue
-                if not isinstance(payload, dict):
+                if payload is None:
                     continue
                 fetched_payload = True
                 canonical_type = self._system_dashboard_type_key(source_type)
@@ -2048,6 +2071,7 @@ class InventoryRuntime:
         self._update_shared_state(
             _system_dashboard_devices_tree_payload=tree_payload_out,
             _system_dashboard_devices_details_payloads=redacted_details,
+            _system_dashboard_detail_failures=detail_failures,
             _system_dashboard_type_summaries=type_summaries,
             _system_dashboard_hierarchy_summary=hierarchy_summary,
             _system_dashboard_hierarchy_index=hierarchy_index,
@@ -2984,6 +3008,7 @@ class InventoryRuntime:
         devices_details_payloads = getattr(
             self, "_system_dashboard_devices_details_payloads", None
         )
+        detail_failures = getattr(self, "_system_dashboard_detail_failures", None)
         hierarchy_summary = getattr(self, "_system_dashboard_hierarchy_summary", None)
         type_summaries = getattr(self, "_system_dashboard_type_summaries", None)
         out: dict[str, object] = {
@@ -2995,6 +3020,11 @@ class InventoryRuntime:
             "devices_details_payloads": (
                 self._copy_diagnostics_value(devices_details_payloads)
                 if isinstance(devices_details_payloads, dict)
+                else {}
+            ),
+            "detail_failures": (
+                self._copy_diagnostics_value(detail_failures)
+                if isinstance(detail_failures, dict)
                 else {}
             ),
             "hierarchy_summary": (

--- a/custom_components/enphase_ev/refresh_plan.py
+++ b/custom_components/enphase_ev/refresh_plan.py
@@ -5,7 +5,25 @@ from functools import partial
 from typing import Any, Callable
 
 CallbackFactory = Callable[[Any], object]
-BoundRefreshCall = tuple[str, str, Callable[[], object]]
+BoundRefreshCall = tuple[str, str, Callable[[], object], str | None]
+
+REFRESH_TASK_ENDPOINT_FAMILIES: dict[str, str] = {
+    "battery_site_settings_s": "battery_site_settings",
+    "battery_backup_history_s": "battery_backup_history",
+    "battery_settings_s": "battery_settings",
+    "battery_schedules_s": "battery_schedules",
+    "storm_guard_s": "storm_guard",
+    "storm_alert_s": "storm_alert",
+    "grid_control_check_s": "grid_control_check",
+    "dry_contact_settings_s": "dry_contact_settings",
+    "battery_status_s": "battery_status",
+    "ac_battery_devices_s": "ac_battery_devices",
+    "ac_battery_telemetry_s": "ac_battery_telemetry",
+    "devices_inventory_s": "inventory_topology",
+    "hems_devices_s": "inventory_topology",
+    "system_dashboard_s": "inventory_topology",
+    "inverters_s": "inverter_inventory",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -13,6 +31,7 @@ class RefreshTask:
     timing_key: str
     log_label: str
     callback_factory: CallbackFactory
+    endpoint_family: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -46,12 +65,18 @@ def method_task(
     log_label: str,
     method_name: str,
     /,
+    endpoint_family: str | None = None,
     **kwargs: object,
 ) -> RefreshTask:
     return RefreshTask(
         timing_key=timing_key,
         log_label=log_label,
         callback_factory=lambda owner: getattr(owner, method_name)(**kwargs),
+        endpoint_family=(
+            endpoint_family
+            if endpoint_family is not None
+            else REFRESH_TASK_ENDPOINT_FAMILIES.get(timing_key)
+        ),
     )
 
 
@@ -61,6 +86,7 @@ def object_method_task(
     object_name: str,
     method_name: str,
     /,
+    endpoint_family: str | None = None,
     **kwargs: object,
 ) -> RefreshTask:
     return RefreshTask(
@@ -69,6 +95,11 @@ def object_method_task(
         callback_factory=lambda owner: getattr(
             getattr(owner, object_name), method_name
         )(**kwargs),
+        endpoint_family=(
+            endpoint_family
+            if endpoint_family is not None
+            else REFRESH_TASK_ENDPOINT_FAMILIES.get(timing_key)
+        ),
     )
 
 
@@ -76,11 +107,18 @@ def callback_task(
     timing_key: str,
     log_label: str,
     callback_factory: CallbackFactory,
+    *,
+    endpoint_family: str | None = None,
 ) -> RefreshTask:
     return RefreshTask(
         timing_key=timing_key,
         log_label=log_label,
         callback_factory=callback_factory,
+        endpoint_family=(
+            endpoint_family
+            if endpoint_family is not None
+            else REFRESH_TASK_ENDPOINT_FAMILIES.get(timing_key)
+        ),
     )
 
 
@@ -92,6 +130,7 @@ def bind_refresh_tasks(
             task.timing_key,
             task.log_label,
             partial(task.callback_factory, owner),
+            task.endpoint_family,
         )
         for task in tasks
     )

--- a/custom_components/enphase_ev/refresh_runner.py
+++ b/custom_components/enphase_ev/refresh_runner.py
@@ -8,18 +8,39 @@ from datetime import datetime
 from datetime import timezone as _tz
 from typing import TYPE_CHECKING, Callable
 
+import aiohttp
 from homeassistant.exceptions import ConfigEntryAuthFailed
 from homeassistant.util import dt as dt_util
 
-from .api import EnphaseLoginWallUnauthorized
+from .api import (
+    EnphaseLoginWallUnauthorized,
+    InvalidPayloadError,
+    OptionalEndpointUnavailable,
+)
 from .const import DOMAIN, DEFAULT_CHARGE_LEVEL_SETTING, PHASE_SWITCH_CONFIG_SETTING
 from .log_redaction import redact_site_id, redact_text
-from .refresh_plan import RefreshPlan, bind_refresh_plan, warmup_plan
+from .refresh_plan import BoundRefreshCall, RefreshPlan, bind_refresh_plan, warmup_plan
 
 if TYPE_CHECKING:
     from .coordinator import EnphaseCoordinator
 
 _LOGGER = logging.getLogger(__name__)
+
+_SKIPPABLE_REFRESH_ERRORS = (
+    aiohttp.ClientError,
+    asyncio.TimeoutError,
+    InvalidPayloadError,
+    OptionalEndpointUnavailable,
+)
+
+
+def _unpack_refresh_call(
+    call: BoundRefreshCall | tuple[str, str, Callable[[], object]],
+) -> tuple[str, str, Callable[[], object], str | None]:
+    if len(call) == 3:
+        timing_key, log_label, callback_factory = call
+        return timing_key, log_label, callback_factory, None
+    return call
 
 
 class RefreshRunner:
@@ -33,6 +54,8 @@ class RefreshRunner:
         timing_key: str,
         log_label: str,
         callback_factory: Callable[[], object],
+        *,
+        endpoint_family: str | None = None,
     ) -> tuple[str, float | None]:
         started = time.monotonic()
         try:
@@ -49,20 +72,33 @@ class RefreshRunner:
             raise ConfigEntryAuthFailed from err
         except ConfigEntryAuthFailed:
             raise
-        except Exception as err:  # noqa: BLE001
+        except _SKIPPABLE_REFRESH_ERRORS as err:
+            if endpoint_family is not None:
+                self._coordinator._note_endpoint_family_failure(endpoint_family, err)
             _LOGGER.debug(
                 "Skipping %s refresh for site %s: %s",
                 log_label,
                 redact_site_id(self._coordinator.site_id),
                 redact_text(err, site_ids=(self._coordinator.site_id,)),
             )
+        except Exception as err:
+            self._coordinator.last_failure_utc = dt_util.utcnow()
+            self._coordinator.last_failure_status = None
+            self._coordinator.last_failure_description = (
+                redact_text(err, site_ids=(self._coordinator.site_id,))
+                or err.__class__.__name__
+            )
+            self._coordinator.last_failure_response = None
+            self._coordinator.last_failure_source = "refresh_stage"
+            self._coordinator.last_failure_endpoint = timing_key
+            raise
         return timing_key, round(time.monotonic() - started, 3)
 
     async def async_run_refresh_calls(
         self,
         phase_timings: dict[str, float],
         *,
-        calls: tuple[tuple[str, str, Callable[[], object]], ...],
+        calls: tuple[BoundRefreshCall | tuple[str, str, Callable[[], object]], ...],
         stage_key: str | None = None,
         defer_topology: bool = False,
     ) -> None:
@@ -70,13 +106,29 @@ class RefreshRunner:
             self._coordinator._begin_topology_refresh_batch()
 
         group_started = time.monotonic()
+        tasks: list[asyncio.Task[tuple[str, float | None]]] = []
         try:
-            results = await asyncio.gather(
-                *(
-                    self.async_run_refresh_call(timing_key, log_label, callback_factory)
-                    for timing_key, log_label, callback_factory in calls
+            tasks = [
+                asyncio.create_task(
+                    self.async_run_refresh_call(
+                        timing_key,
+                        log_label,
+                        callback_factory,
+                        endpoint_family=endpoint_family,
+                    )
                 )
-            )
+                for timing_key, log_label, callback_factory, endpoint_family in (
+                    _unpack_refresh_call(call) for call in calls
+                )
+            ]
+            results = await asyncio.gather(*tasks)
+        except (asyncio.CancelledError, Exception):
+            for task in tasks:
+                if not task.done():
+                    task.cancel()
+            if tasks:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            raise
         finally:
             if defer_topology:
                 self._coordinator._end_topology_refresh_batch()
@@ -91,7 +143,7 @@ class RefreshRunner:
         self,
         phase_timings: dict[str, float],
         *,
-        calls: tuple[tuple[str, str, Callable[[], object]], ...],
+        calls: tuple[BoundRefreshCall | tuple[str, str, Callable[[], object]], ...],
         stage_key: str | None = None,
         defer_topology: bool = False,
     ) -> None:
@@ -100,11 +152,14 @@ class RefreshRunner:
 
         group_started = time.monotonic()
         try:
-            for timing_key, log_label, callback_factory in calls:
+            for timing_key, log_label, callback_factory, endpoint_family in (
+                _unpack_refresh_call(call) for call in calls
+            ):
                 key, duration = await self.async_run_refresh_call(
                     timing_key,
                     log_label,
                     callback_factory,
+                    endpoint_family=endpoint_family,
                 )
                 if duration is not None:
                     phase_timings[key] = duration
@@ -119,8 +174,12 @@ class RefreshRunner:
         self,
         phase_timings: dict[str, float],
         *,
-        parallel_calls: tuple[tuple[str, str, Callable[[], object]], ...] = (),
-        ordered_calls: tuple[tuple[str, str, Callable[[], object]], ...] = (),
+        parallel_calls: tuple[
+            BoundRefreshCall | tuple[str, str, Callable[[], object]], ...
+        ] = (),
+        ordered_calls: tuple[
+            BoundRefreshCall | tuple[str, str, Callable[[], object]], ...
+        ] = (),
         stage_key: str | None = None,
         defer_topology: bool = False,
     ) -> None:

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -165,6 +165,7 @@ class InventoryState:
     _system_dashboard_devices_details_payloads: dict[str, dict[str, object]] = field(
         default_factory=dict
     )
+    _system_dashboard_detail_failures: dict[str, str] = field(default_factory=dict)
     _system_dashboard_hierarchy_index: dict[str, dict[str, object]] = field(
         default_factory=dict
     )

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -4678,7 +4678,7 @@ async def test_async_update_data_site_only_ignores_battery_schedule_refresh_erro
     )  # noqa: SLF001
     coord._async_refresh_battery_settings = AsyncMock(return_value=None)  # noqa: SLF001
     coord._async_refresh_battery_schedules = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("boom")
+        side_effect=aiohttp.ClientError("boom")
     )
     coord._async_refresh_storm_guard_profile = AsyncMock(
         return_value=None
@@ -4741,7 +4741,7 @@ async def test_async_update_data_ignores_battery_schedule_refresh_errors(
     )  # noqa: SLF001
     coord._async_refresh_battery_settings = AsyncMock(return_value=None)  # noqa: SLF001
     coord._async_refresh_battery_schedules = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("boom")
+        side_effect=aiohttp.ClientError("boom")
     )
     coord._async_refresh_storm_guard_profile = AsyncMock(
         return_value=None

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -739,7 +739,7 @@ async def test_async_update_data_site_only_handles_heatpump_refresh_failure(
     coord.inventory_runtime._async_refresh_hems_devices = AsyncMock(return_value=None)  # type: ignore[method-assign]  # noqa: SLF001
     coord._async_refresh_inverters = AsyncMock(return_value=None)  # noqa: SLF001
     coord._async_refresh_heatpump_power = AsyncMock(
-        side_effect=RuntimeError("boom")
+        side_effect=aiohttp.ClientError("boom")
     )  # noqa: SLF001
 
     assert await coord._async_update_data() == {}  # noqa: SLF001
@@ -752,10 +752,10 @@ async def test_update_data_ignores_grid_control_and_hems_refresh_errors_site_onl
     coord = coordinator_factory(serials=[])
     coord.site_only = True
     coord.battery_runtime.async_refresh_grid_control_check = AsyncMock(  # type: ignore[method-assign]
-        side_effect=RuntimeError("boom")
+        side_effect=aiohttp.ClientError("boom")
     )
     coord.inventory_runtime._async_refresh_hems_devices = AsyncMock(  # type: ignore[method-assign]
-        side_effect=RuntimeError("boom")
+        side_effect=aiohttp.ClientError("boom")
     )  # noqa: SLF001
 
     assert await coord._async_update_data() == {}
@@ -847,10 +847,10 @@ async def test_async_update_data_site_only_ignores_runtime_and_daily_refresh_err
     )
     coord._async_refresh_inverters = AsyncMock(return_value=None)  # noqa: SLF001
     coord._async_refresh_heatpump_runtime_state = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("runtime")
+        side_effect=aiohttp.ClientError("runtime")
     )
     coord._async_refresh_heatpump_daily_consumption = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("daily")
+        side_effect=aiohttp.ClientError("daily")
     )
     coord._async_refresh_heatpump_power = AsyncMock(  # noqa: SLF001
         side_effect=lambda: order.append("heatpump_power")
@@ -3506,7 +3506,9 @@ async def test_startup_warmup_runner_and_task_edge_paths(
     coord = coordinator_factory()
     coord.async_set_updated_data = Mock(side_effect=RuntimeError("publish"))  # type: ignore[assignment]
     coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]
-    coord._async_refresh_battery_site_settings = None  # type: ignore[assignment]  # noqa: SLF001
+    coord._async_refresh_battery_site_settings = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value=None
+    )
 
     await coord.refresh_runner.async_startup_warmup_runner()
 
@@ -3528,7 +3530,7 @@ async def test_startup_warmup_runner_and_task_edge_paths(
     coord = coordinator_factory()
     coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]
     coord._async_refresh_heatpump_power = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
-        side_effect=RuntimeError("heatpump")
+        side_effect=aiohttp.ClientError("heatpump")
     )
     await coord.refresh_runner.async_startup_warmup_runner()
     assert "heatpump_power_s" in coord._warmup_phase_timings  # noqa: SLF001
@@ -3537,10 +3539,10 @@ async def test_startup_warmup_runner_and_task_edge_paths(
     coord = coordinator_factory()
     coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]
     coord._async_refresh_heatpump_runtime_state = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
-        side_effect=RuntimeError("runtime")
+        side_effect=aiohttp.ClientError("runtime")
     )
     coord._async_refresh_heatpump_daily_consumption = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
-        side_effect=RuntimeError("daily")
+        side_effect=aiohttp.ClientError("daily")
     )
     await coord.refresh_runner.async_startup_warmup_runner()
     assert "heatpump_runtime_s" in coord._warmup_phase_timings  # noqa: SLF001
@@ -5451,7 +5453,7 @@ async def test_update_data_site_only_continues_when_backup_history_refresh_fails
     coord._async_refresh_battery_site_settings = AsyncMock()  # noqa: SLF001
     coord.battery_runtime.async_refresh_battery_status = AsyncMock()  # type: ignore[method-assign]  # noqa: SLF001
     coord._async_refresh_battery_backup_history = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("boom")
+        side_effect=aiohttp.ClientError("boom")
     )
     coord._async_refresh_battery_settings = AsyncMock()  # noqa: SLF001
     coord._async_refresh_storm_guard_profile = AsyncMock()  # noqa: SLF001
@@ -5477,38 +5479,38 @@ async def test_update_data_site_only_ignores_optional_refresh_failures(
         return_value=None
     )  # noqa: SLF001
     coord._async_refresh_battery_site_settings = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("site settings")
+        side_effect=aiohttp.ClientError("site settings")
     )
     coord.battery_runtime.async_refresh_battery_status = AsyncMock()  # type: ignore[method-assign]  # noqa: SLF001
     coord._async_refresh_battery_backup_history = AsyncMock()  # noqa: SLF001
     coord._async_refresh_battery_settings = AsyncMock()  # noqa: SLF001
     coord._async_refresh_battery_schedules = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("schedules")
+        side_effect=aiohttp.ClientError("schedules")
     )
     coord._async_refresh_storm_guard_profile = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("storm guard")
+        side_effect=aiohttp.ClientError("storm guard")
     )
     coord._async_refresh_storm_alert = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("storm alert")
+        side_effect=aiohttp.ClientError("storm alert")
     )
     coord.battery_runtime.async_refresh_grid_control_check = AsyncMock(  # type: ignore[method-assign]
-        side_effect=RuntimeError("grid")
+        side_effect=aiohttp.ClientError("grid")
     )
     coord.inventory_runtime._async_refresh_devices_inventory = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
-        side_effect=RuntimeError("inventory")
+        side_effect=aiohttp.ClientError("inventory")
     )
     coord._async_refresh_dry_contact_settings = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("dry contact")
+        side_effect=aiohttp.ClientError("dry contact")
     )
     coord.inventory_runtime._async_refresh_hems_devices = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
-        side_effect=RuntimeError("hems")
+        side_effect=aiohttp.ClientError("hems")
     )
     coord._async_refresh_inverters = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("inverters")
+        side_effect=aiohttp.ClientError("inverters")
     )
     coord._async_refresh_current_power_consumption = AsyncMock()  # noqa: SLF001
     coord._async_refresh_heatpump_power = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("heatpump")
+        side_effect=aiohttp.ClientError("heatpump")
     )
     coord.heatpump_runtime.heatpump_power_refresh_due = lambda: True  # type: ignore[method-assign]
 
@@ -5556,7 +5558,7 @@ async def test_update_data_normal_continues_when_backup_history_refresh_fails(
     coord._async_refresh_battery_site_settings = AsyncMock()  # noqa: SLF001
     coord.battery_runtime.async_refresh_battery_status = AsyncMock()  # type: ignore[method-assign]  # noqa: SLF001
     coord._async_refresh_battery_backup_history = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("boom")
+        side_effect=aiohttp.ClientError("boom")
     )
     coord._async_refresh_battery_settings = AsyncMock()  # noqa: SLF001
     coord._async_refresh_storm_guard_profile = AsyncMock()  # noqa: SLF001
@@ -5603,35 +5605,35 @@ async def test_update_data_normal_ignores_optional_refresh_failures(
         return_value=None
     )  # noqa: SLF001
     coord.evse_timeseries.async_refresh = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("timeseries")
+        side_effect=aiohttp.ClientError("timeseries")
     )
     coord._async_refresh_battery_site_settings = AsyncMock()  # noqa: SLF001
     coord.battery_runtime.async_refresh_battery_status = AsyncMock()  # type: ignore[method-assign]  # noqa: SLF001
     coord._async_refresh_battery_backup_history = AsyncMock()  # noqa: SLF001
     coord._async_refresh_battery_settings = AsyncMock()  # noqa: SLF001
     coord._async_refresh_battery_schedules = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("schedules")
+        side_effect=aiohttp.ClientError("schedules")
     )
     coord._async_refresh_storm_guard_profile = AsyncMock()  # noqa: SLF001
     coord._async_refresh_storm_alert = AsyncMock()  # noqa: SLF001
     coord.battery_runtime.async_refresh_grid_control_check = AsyncMock(  # type: ignore[method-assign]
-        side_effect=RuntimeError("grid")
+        side_effect=aiohttp.ClientError("grid")
     )
     coord.inventory_runtime._async_refresh_devices_inventory = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
-        side_effect=RuntimeError("inventory")
+        side_effect=aiohttp.ClientError("inventory")
     )
     coord._async_refresh_dry_contact_settings = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("dry contact")
+        side_effect=aiohttp.ClientError("dry contact")
     )
     coord.inventory_runtime._async_refresh_hems_devices = AsyncMock(  # type: ignore[method-assign]  # noqa: SLF001
-        side_effect=RuntimeError("hems")
+        side_effect=aiohttp.ClientError("hems")
     )
     coord._async_refresh_inverters = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("inverters")
+        side_effect=aiohttp.ClientError("inverters")
     )
     coord._async_refresh_current_power_consumption = AsyncMock()  # noqa: SLF001
     coord._async_refresh_heatpump_power = AsyncMock(  # noqa: SLF001
-        side_effect=RuntimeError("heatpump")
+        side_effect=aiohttp.ClientError("heatpump")
     )
     coord._get_charge_mode = AsyncMock(return_value="IMMEDIATE")  # type: ignore[assignment]  # noqa: SLF001
     coord.evse_runtime.async_resolve_green_battery_settings = AsyncMock(  # type: ignore[method-assign]

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
+import aiohttp
 import pytest
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
@@ -453,6 +454,8 @@ def test_followup_refresh_stage_binds_zero_arg_calls() -> None:
 
     assert bound.parallel_calls[0][2]() == "site-settings"
     assert bound.ordered_calls[-1][2]() == "hems-devices"
+    assert bound.parallel_calls[0][3] == "battery_site_settings"
+    assert bound.ordered_calls[-1][3] == "inventory_topology"
     assert owner.calls == ["battery_site_settings", "hems_devices"]
 
 
@@ -771,6 +774,53 @@ async def test_coordinator_run_refresh_calls_tracks_stage_and_topology_batch(
 
 
 @pytest.mark.asyncio
+async def test_coordinator_run_refresh_calls_drains_siblings_before_batch_end(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    started = asyncio.Event()
+    drained = False
+    end_saw_drained = False
+
+    async def _slow() -> None:
+        nonlocal drained
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            drained = True
+            raise
+
+    async def _fail() -> None:
+        await started.wait()
+        raise RuntimeError("boom")
+
+    def _end_topology_batch() -> None:
+        nonlocal end_saw_drained
+        end_saw_drained = drained
+
+    coord._begin_topology_refresh_batch = MagicMock()  # type: ignore[method-assign]  # noqa: SLF001
+    coord._end_topology_refresh_batch = MagicMock(  # type: ignore[method-assign]  # noqa: SLF001
+        side_effect=_end_topology_batch
+    )
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await coord.refresh_runner.async_run_refresh_calls(
+            {},
+            calls=(
+                ("slow_s", "slow", _slow),
+                ("fail_s", "fail", _fail),
+            ),
+            defer_topology=True,
+        )
+
+    coord._begin_topology_refresh_batch.assert_called_once_with()  # noqa: SLF001
+    coord._end_topology_refresh_batch.assert_called_once_with()  # noqa: SLF001
+    assert drained is True
+    assert end_saw_drained is True
+
+
+@pytest.mark.asyncio
 async def test_refresh_runner_staged_calls_track_empty_stage_timing(
     coordinator_factory,
 ) -> None:
@@ -957,3 +1007,48 @@ async def test_refresh_runner_does_not_swallow_config_entry_auth_failed(
 
     with pytest.raises(ConfigEntryAuthFailed, match="reauth"):
         await coord.refresh_runner.async_run_refresh_call("k", "label", _raise)
+
+
+@pytest.mark.asyncio
+async def test_refresh_runner_tracks_skipped_endpoint_failure(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    async def _raise() -> None:
+        raise aiohttp.ClientError("inventory down")
+
+    timing_key, duration = await coord.refresh_runner.async_run_refresh_call(
+        "devices_inventory_s",
+        "device inventory",
+        _raise,
+        endpoint_family="inventory_topology",
+    )
+
+    health = coord.diagnostics.endpoint_family_health_diagnostics()[
+        "inventory_topology"
+    ]
+    assert timing_key == "devices_inventory_s"
+    assert duration is not None
+    assert health["consecutive_failures"] == 1
+    assert health["last_error"] == "inventory down"
+
+
+@pytest.mark.asyncio
+async def test_refresh_runner_surfaces_unexpected_stage_errors(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    async def _raise() -> None:
+        raise RuntimeError("programming bug")
+
+    with pytest.raises(RuntimeError, match="programming bug"):
+        await coord.refresh_runner.async_run_refresh_call(
+            "devices_inventory_s",
+            "device inventory",
+            _raise,
+        )
+
+    assert coord.last_failure_source == "refresh_stage"
+    assert coord.last_failure_endpoint == "devices_inventory_s"

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -1300,6 +1301,42 @@ async def test_inventory_runtime_refresh_system_dashboard_handles_missing_fetche
 
 
 @pytest.mark.asyncio
+async def test_inventory_runtime_refresh_system_dashboard_fetches_details_concurrently(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    monkeypatch.setattr(
+        inventory_runtime_mod,
+        "SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES",
+        ("envoys", "meters", "encharges", "inverters"),
+    )
+    monkeypatch.setattr(
+        inventory_runtime_mod,
+        "SYSTEM_DASHBOARD_DETAIL_CONCURRENCY",
+        2,
+    )
+    active = 0
+    max_active = 0
+
+    async def _details(source_type: str):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0)
+        active -= 1
+        return {source_type: [{"device_uid": source_type}]}
+
+    coord.client.devices_tree = AsyncMock(return_value={"devices": []})
+    coord.client.devices_details = AsyncMock(side_effect=_details)
+
+    await runtime._async_refresh_system_dashboard(force=True)  # noqa: SLF001
+
+    assert max_active == 2
+    assert coord.client.devices_details.await_count == 4
+
+
+@pytest.mark.asyncio
 async def test_inventory_runtime_refresh_system_dashboard_handles_fetch_exceptions(
     coordinator_factory, monkeypatch
 ) -> None:
@@ -1337,6 +1374,7 @@ async def test_inventory_runtime_refresh_system_dashboard_handles_fetch_exceptio
     assert diagnostics["devices_details_payloads"]["envoy"]["meters"] == {
         "meters": [{"name": "Meter"}]
     }
+    assert diagnostics["detail_failures"] == {"envoys": "detail"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Improve refresh orchestration performance and observability for Enphase EV refreshes.

- Parallelize bounded system-dashboard detail fetches and expose per-detail failures in diagnostics.
- Avoid rebuilding EVSE power snapshots twice during a single coordinator refresh.
- Split `_async_update_data()` into explicit refresh pipeline stages.
- Carry endpoint-family metadata through refresh plans so skipped follow-up stages update endpoint health.
- Tighten `RefreshRunner` exception handling so only expected endpoint failures are skipped, while unexpected refresh-stage failures surface and drain sibling parallel tasks before cleanup.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Performance and refresh diagnostics improvement.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/refresh_plan.py custom_components/enphase_ev/refresh_runner.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_inventory_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/inventory_runtime.py,custom_components/enphase_ev/refresh_runner.py,custom_components/enphase_ev/refresh_plan.py,custom_components/enphase_ev/state_models.py --fail-under=100"
git diff --check origin/main..HEAD
```

Results:

- `ruff check .`: passed
- `python scripts/validate_quality_scale.py`: passed
- `pre-commit run --all-files`: passed
- `pytest -q tests/components/enphase_ev`: passed, 2877 tests in the coverage run
- `pytest -q`: passed, 2944 tests
- targeted coverage for touched production modules: 100%
- `git diff --check origin/main..HEAD`: passed

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No user-facing strings, docs, or translations changed. The `pre-commit` command includes an additional Git metadata mount because this Codex worktree's `.git` file points outside `/workspace` inside Docker.