### PR TITLE
Add codespell and quality scale workflows

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,0 +1,4 @@
+caf
+gude
+hass
+valide

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,84 @@
+name: Codespell
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "custom_components/enphase_ev/**/*.py"
+      - "custom_components/enphase_ev/**/*.yaml"
+      - "custom_components/enphase_ev/**/*.yml"
+      - "custom_components/enphase_ev/strings.json"
+      - "custom_components/enphase_ev/translations/en*.json"
+      - "scripts/**/*.py"
+      - "tests/components/enphase_ev/**/*.py"
+      - "tests/scripts/**/*.py"
+      - ".codespellignore"
+      - ".pre-commit-config.yaml"
+      - "*.md"
+      - "*.yaml"
+      - "*.yml"
+      - "**/*.md"
+      - "**/*.yaml"
+      - "**/*.yml"
+      - ".github/workflows/codespell.yml"
+  push:
+    branches:
+      - main
+      - "release/**"
+    paths:
+      - "custom_components/enphase_ev/**/*.py"
+      - "custom_components/enphase_ev/**/*.yaml"
+      - "custom_components/enphase_ev/**/*.yml"
+      - "custom_components/enphase_ev/strings.json"
+      - "custom_components/enphase_ev/translations/en*.json"
+      - "scripts/**/*.py"
+      - "tests/components/enphase_ev/**/*.py"
+      - "tests/scripts/**/*.py"
+      - ".codespellignore"
+      - ".pre-commit-config.yaml"
+      - "*.md"
+      - "*.yaml"
+      - "*.yml"
+      - "**/*.md"
+      - "**/*.yaml"
+      - "**/*.yml"
+      - ".github/workflows/codespell.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  codespell:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: |
+            .pre-commit-config.yaml
+            .github/workflows/codespell.yml
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install pre-commit
+      - name: Run codespell
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1
+            changed_files="$(git diff --name-only "origin/${{ github.base_ref }}" HEAD)"
+            if printf '%s\n' "$changed_files" | grep -Eq '^(\.codespellignore|\.pre-commit-config\.yaml)$'; then
+              pre-commit run codespell --all-files
+            else
+              pre-commit run codespell --from-ref "origin/${{ github.base_ref }}" --to-ref HEAD
+            fi
+          else
+            pre-commit run codespell --all-files
+          fi

--- a/.github/workflows/quality-scale.yml
+++ b/.github/workflows/quality-scale.yml
@@ -1,0 +1,48 @@
+name: Quality Scale
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    paths:
+      - "quality_scale.yaml"
+      - "scripts/validate_quality_scale.py"
+      - "README.md"
+      - "docs/**/*.md"
+      - "custom_components/enphase_ev/manifest.json"
+      - ".github/workflows/quality-scale.yml"
+  push:
+    branches:
+      - main
+      - "release/**"
+    paths:
+      - "quality_scale.yaml"
+      - "scripts/validate_quality_scale.py"
+      - "README.md"
+      - "docs/**/*.md"
+      - "custom_components/enphase_ev/manifest.json"
+      - ".github/workflows/quality-scale.yml"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          cache: "pip"
+          cache-dependency-path: |
+            .github/workflows/quality-scale.yml
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install PyYAML
+      - name: Validate quality scale
+        run: python scripts/validate_quality_scale.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,7 +42,12 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             git fetch origin "${{ github.base_ref }}" --depth=1
-            pre-commit run --from-ref "origin/${{ github.base_ref }}" --to-ref HEAD
+            changed_files="$(git diff --name-only "origin/${{ github.base_ref }}" HEAD)"
+            if printf '%s\n' "$changed_files" | grep -Eq '^(\.pre-commit-config\.yaml|\.ruff\.toml)$'; then
+              pre-commit run --all-files
+            else
+              pre-commit run --from-ref "origin/${{ github.base_ref }}" --to-ref HEAD
+            fi
           else
             pre-commit run --all-files
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,3 +10,10 @@ repos:
     hooks:
       - id: ruff
         files: "^(custom_components/enphase_ev|tests/components/enphase_ev)/.*\\.py$"
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.2
+    hooks:
+      - id: codespell
+        name: codespell docs, yaml, python, and user-facing strings
+        args: [--ignore-words=.codespellignore]
+        files: "^(.*\\.md|.*\\.ya?ml|(custom_components/enphase_ev|tests/components/enphase_ev|scripts|tests/scripts)/.*\\.py|custom_components/enphase_ev/(strings\\.json|translations/en.*\\.json))$"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,8 @@ docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "p
 
 > Tip: `pre-commit` still runs inside the Docker environment, so local hook installation is optional rather than required.
 
+> Tip: `pre-commit` runs a scoped codespell check over Markdown, YAML, Python, and English user-facing translation JSON. Add intentional project terms to `.codespellignore`.
+
 > Tip: the `ha-runtime` service is for manual verification only. Keep automated checks on `ha-dev` so test and lint runs stay fast and deterministic.
 
 > Tip: `ha-runtime` inherits the `TZ` environment variable from your shell and defaults to `UTC` when `TZ` is unset.

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -10,7 +10,7 @@
   "config_flow": true,
   "documentation": "https://github.com/barneyonline/ha-enphase-energy",
   "import_executor": true,
-  "integration_type": "device",
+  "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/barneyonline/ha-enphase-energy/issues",
   "loggers": [

--- a/tests/components/enphase_ev/test_manifest.py
+++ b/tests/components/enphase_ev/test_manifest.py
@@ -14,9 +14,7 @@ def test_manifest_keys_present():
 
     assert data.get("version"), "manifest must include version"
     assert data.get("config_flow") is True, "config_flow must be true"
-    assert (
-        data.get("integration_type") == "device"
-    ), "integration_type should be 'device'"
+    assert data.get("integration_type") == "hub", "integration_type should be 'hub'"
     assert (
         data.get("iot_class") == "cloud_polling"
     ), "iot_class should be 'cloud_polling'"


### PR DESCRIPTION
## Summary

Add lightweight repository hygiene checks before future HACS/Core review work:

- Change the Enphase Energy manifest `integration_type` from `device` to `hub` to better reflect one integration coordinating multiple Enphase device categories and services.
- Add a scoped `codespell` pre-commit hook plus a dedicated Codespell workflow for Markdown, YAML, Python, and English user-facing translation JSON.
- Add a dedicated Quality Scale workflow that runs `scripts/validate_quality_scale.py` for quality checklist, docs, and manifest changes.
- Keep the main Tests workflow focused on integration/test changes while still forcing full pre-commit when hook configuration changes.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Repository hygiene / CI metadata.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_manifest.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
```

Additional validation:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc 'python -m pip install --quiet --root-user-action=ignore pre-commit && pre-commit run codespell --files .github/workflows/codespell.yml .github/workflows/quality-scale.yml .pre-commit-config.yaml CONTRIBUTING.md custom_components/enphase_ev/manifest.json tests/components/enphase_ev/test_manifest.py'
```

I also checked the new codespell and quality-scale commands against a temporary checkout of latest `origin/main` with the new `.codespellignore` overlaid; both passed.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This is not user-facing integration behavior, so no changelog entry or screenshots are included.

The local `pre-commit run --all-files` command includes an explicit `.git` mount because this Codex checkout is a Git worktree whose `.git` file points outside the Docker workspace mount.