### PR TITLE
Validate quality scale evidence in CI

### DIFF
--- a/.github/workflows/quality-scale.yml
+++ b/.github/workflows/quality-scale.yml
@@ -6,22 +6,30 @@ permissions:
 on:
   pull_request:
     paths:
-      - "quality_scale.yaml"
-      - "scripts/validate_quality_scale.py"
+      - "custom_components/enphase_ev/**"
+      - "tests/components/enphase_ev/**"
+      - "tests/scripts/test_validate_quality_scale.py"
       - "README.md"
       - "docs/**/*.md"
-      - "custom_components/enphase_ev/manifest.json"
+      - "quality_scale.yaml"
+      - "scripts/validate_quality_scale.py"
+      - "devtools/docker/requirements-dev.txt"
+      - ".pre-commit-config.yaml"
       - ".github/workflows/quality-scale.yml"
   push:
     branches:
       - main
       - "release/**"
     paths:
-      - "quality_scale.yaml"
-      - "scripts/validate_quality_scale.py"
+      - "custom_components/enphase_ev/**"
+      - "tests/components/enphase_ev/**"
+      - "tests/scripts/test_validate_quality_scale.py"
       - "README.md"
       - "docs/**/*.md"
-      - "custom_components/enphase_ev/manifest.json"
+      - "quality_scale.yaml"
+      - "scripts/validate_quality_scale.py"
+      - "devtools/docker/requirements-dev.txt"
+      - ".pre-commit-config.yaml"
       - ".github/workflows/quality-scale.yml"
   workflow_dispatch:
 
@@ -34,15 +42,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: actions/setup-python@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
         with:
           python-version: "3.13"
           cache: "pip"
           cache-dependency-path: |
+            devtools/docker/requirements-dev.txt
             .github/workflows/quality-scale.yml
-      - name: Install dependencies
+      - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          python -m pip install PyYAML
-      - name: Validate quality scale
-        run: python scripts/validate_quality_scale.py
+          python -m pip install --upgrade -r devtools/docker/requirements-dev.txt
+      - name: Validate quality scale evidence
+        run: |
+          python scripts/validate_quality_scale.py
+          pytest -q tests/scripts/test_validate_quality_scale.py

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
       - 'tests/components/enphase_ev/**'
       - '.pre-commit-config.yaml'
       - '.ruff.toml'
+      - '.github/workflows/ci.yml'
       - '.github/workflows/tests.yml'
   workflow_dispatch:
   workflow_call:
@@ -64,11 +65,13 @@ jobs:
         with:
           python-version: '3.13'
           cache: 'pip'
-          cache-dependency-path: .github/workflows/tests.yml
+          cache-dependency-path: |
+            devtools/docker/requirements-dev.txt
+            .github/workflows/tests.yml
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade pytest pytest-homeassistant-custom-component "homeassistant>=2024.12.0" aiohttp async-timeout voluptuous
+          pip install --upgrade -r devtools/docker/requirements-dev.txt aiohttp async-timeout voluptuous
       - name: Run translation regression tests
         run: |
           pytest -q tests/components/enphase_ev/test_service_translations.py
@@ -91,11 +94,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           cache: 'pip'
-          cache-dependency-path: .github/workflows/tests.yml
+          cache-dependency-path: |
+            devtools/docker/requirements-dev.txt
+            .github/workflows/tests.yml
       - name: Install deps
         run: |
           python -m pip install --upgrade pip
-          pip install --upgrade pytest pytest-asyncio pytest-cov pytest-homeassistant-custom-component "homeassistant>=2024.12.0" aiohttp async-timeout voluptuous
+          pip install --upgrade -r devtools/docker/requirements-dev.txt aiohttp async-timeout voluptuous
       - name: Run tests
         id: pytest
         continue-on-error: true
@@ -117,3 +122,52 @@ jobs:
       - name: Fail if tests failed
         if: ${{ steps.pytest.outcome == 'failure' }}
         run: exit 1
+
+  targeted-coverage:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+          cache-dependency-path: |
+            devtools/docker/requirements-dev.txt
+            .github/workflows/tests.yml
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade -r devtools/docker/requirements-dev.txt aiohttp async-timeout voluptuous coverage
+      - name: Detect changed integration modules
+        id: changed
+        shell: bash
+        run: |
+          git fetch origin "${{ github.base_ref }}" --depth=1
+          mapfile -t changed < <(
+            git diff --name-only "origin/${{ github.base_ref }}...HEAD" -- "custom_components/enphase_ev/*.py" |
+            while IFS= read -r path; do
+              [ -f "$path" ] && printf '%s\n' "$path"
+            done
+          )
+          if [ "${#changed[@]}" -eq 0 ]; then
+            echo "No changed integration Python modules; skipping targeted coverage."
+            echo "include=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf 'Changed integration modules:\n'
+          printf '  %s\n' "${changed[@]}"
+          include=$(IFS=,; echo "${changed[*]}")
+          echo "include=${include}" >> "$GITHUB_OUTPUT"
+      - name: Enforce 100% coverage on changed integration modules
+        if: ${{ steps.changed.outputs.include != '' }}
+        run: |
+          COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase
+          COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q
+          COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include="${{ steps.changed.outputs.include }}" --fail-under=100

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,12 +4,12 @@ repos:
     hooks:
       - id: black
         args: [--check]
-        files: "^(custom_components/enphase_ev|tests/components/enphase_ev)/.*\\.py$"
+        files: "^((custom_components/enphase_ev|tests/components/enphase_ev)/.*|scripts/validate_quality_scale|tests/scripts/test_validate_quality_scale)\\.py$"
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.9
     hooks:
       - id: ruff
-        files: "^(custom_components/enphase_ev|tests/components/enphase_ev)/.*\\.py$"
+        files: "^((custom_components/enphase_ev|tests/components/enphase_ev)/.*|scripts/validate_quality_scale|tests/scripts/test_validate_quality_scale)\\.py$"
   - repo: https://github.com/codespell-project/codespell
     rev: v2.4.2
     hooks:

--- a/devtools/docker/requirements-dev.txt
+++ b/devtools/docker/requirements-dev.txt
@@ -3,6 +3,7 @@ pytest
 pytest-asyncio
 pytest-homeassistant-custom-component
 pytest-cov
+PyYAML
 ruff
 black
 freezegun

--- a/quality_scale.yaml
+++ b/quality_scale.yaml
@@ -39,66 +39,218 @@ rules:
   # Silver rules (implemented)
   config_flow:
     status: done
+    references:
+      code:
+        - custom_components/enphase_ev/config_flow.py
+      tests:
+        - tests/components/enphase_ev/test_config_flow_coverage.py
+      docs:
+        - README.md
   options_flow:
     status: done
+    references:
+      code:
+        - custom_components/enphase_ev/config_flow.py
+      tests:
+        - tests/components/enphase_ev/test_config_flow_coverage.py
+      docs:
+        - README.md
   inject_websession:
     status: done
+    references:
+      code:
+        - custom_components/enphase_ev/config_flow.py
+        - custom_components/enphase_ev/__init__.py
+      tests:
+        - tests/components/enphase_ev/test_api_http_flow.py
   common_modules:
     status: done
+    references:
+      code:
+        - custom_components/enphase_ev/api.py
+        - custom_components/enphase_ev/coordinator.py
+        - custom_components/enphase_ev/runtime_helpers.py
+      tests:
+        - tests/components/enphase_ev/test_api_helpers.py
+        - tests/components/enphase_ev/test_helper_modules.py
   entity_category:
     status: done
+    references:
+      code:
+        - custom_components/enphase_ev/binary_sensor.py
+        - custom_components/enphase_ev/button.py
+        - custom_components/enphase_ev/sensor.py
+      tests:
+        - tests/components/enphase_ev/test_binary_sensor_module.py
+        - tests/components/enphase_ev/test_sensor_edge_cases.py
   integration_owner:
     status: done
+    references:
+      code:
+        - custom_components/enphase_ev/manifest.json
+      tests:
+        - tests/components/enphase_ev/test_manifest.py
+      docs:
+        - README.md
   appropriate_polling:
     status: done
+    references:
+      code:
+        - custom_components/enphase_ev/const.py
+        - custom_components/enphase_ev/refresh_plan.py
+        - custom_components/enphase_ev/refresh_runner.py
+      tests:
+        - tests/components/enphase_ev/test_coordinator_redesign.py
+        - tests/components/enphase_ev/test_rate_limit_and_switch_kick.py
+      docs:
+        - README.md
   log_when_unavailable:
     status: done
+    references:
+      code:
+        - custom_components/enphase_ev/api.py
+        - custom_components/enphase_ev/coordinator.py
+      tests:
+        - tests/components/enphase_ev/test_latency_and_connectivity.py
+        - tests/components/enphase_ev/test_coordinator_behavior.py
   integration_diagnostics:
     status: done
+    references:
+      code:
+        - custom_components/enphase_ev/diagnostics.py
+      tests:
+        - tests/components/enphase_ev/test_diagnostics.py
+      docs:
+        - README.md
   system_health:
     status: done
+    references:
+      code:
+        - custom_components/enphase_ev/system_health.py
+      tests:
+        - tests/components/enphase_ev/test_system_health.py
+      docs:
+        - README.md
   icon_translations:
     status: done
+    references:
+      code:
+        - custom_components/enphase_ev/icons.json
+        - custom_components/enphase_ev/strings.json
+      tests:
+        - tests/components/enphase_ev/test_service_translations.py
   docs_high_level_description:
     status: done
+    references:
+      docs:
+        - README.md
   docs_configuration_parameters:
     status: done
+    references:
+      docs:
+        - README.md
   docs_supported_functions:
     status: done
+    references:
+      docs:
+        - README.md
   docs_data_update:
     status: done
+    references:
+      docs:
+        - README.md
   docs_known_limitations:
     status: done
+    references:
+      docs:
+        - README.md
   docs_troubleshooting:
     status: done
+    references:
+      docs:
+        - README.md
 
   # Gold rules (current status)
   devices:
     status: done
     comment: Charger DeviceInfo now exposes manufacturer/model/hw/sw and new chargers are created dynamically without reload.
+    references:
+      code:
+        - custom_components/enphase_ev/entity.py
+        - custom_components/enphase_ev/device_info_helpers.py
+        - custom_components/enphase_ev/inventory_view.py
+      tests:
+        - tests/components/enphase_ev/test_device_info.py
+        - tests/components/enphase_ev/test_device_types.py
+      docs:
+        - README.md
   docs_installation_instructions:
     status: done
     comment: README includes HACS and manual steps.
+    references:
+      docs:
+        - README.md
   docs_installation_parameters:
     status: done
     comment: README documents required inputs and options.
+    references:
+      docs:
+        - README.md
   docs_removal_instructions:
     status: done
     comment: README includes a Removing the integration section with standard steps.
+    references:
+      docs:
+        - README.md
   docs_supported_devices:
     status: done
     comment: README lists supported and unsupported/not tested devices.
+    references:
+      docs:
+        - README.md
   docs_actions:
     status: done
     comment: Structured Actions section in README covers all services and fields.
+    references:
+      code:
+        - custom_components/enphase_ev/services.yaml
+        - custom_components/enphase_ev/services.py
+      tests:
+        - tests/components/enphase_ev/test_device_action.py
+        - tests/components/enphase_ev/test_battery_runtime_grid_control.py
+      docs:
+        - README.md
   reconfiguration_flow:
     status: done
     comment: async_step_reconfigure implemented with validation and in-place update.
+    references:
+      code:
+        - custom_components/enphase_ev/config_flow.py
+      tests:
+        - tests/components/enphase_ev/test_reconfigure_flow.py
+      docs:
+        - README.md
 
   # Platinum rules (current status)
   dynamic_devices:
     status: done
     comment: Platforms listen for coordinator updates and register charger entities when new serials appear at runtime.
+    references:
+      code:
+        - custom_components/enphase_ev/inventory_runtime.py
+        - custom_components/enphase_ev/sensor.py
+        - custom_components/enphase_ev/switch.py
+      tests:
+        - tests/components/enphase_ev/test_inventory_runtime.py
+        - tests/components/enphase_ev/test_entity_wiring.py
+        - tests/components/enphase_ev/test_switch_module.py
+      docs:
+        - README.md
   discovery_update_info:
     status: n/a
     comment: Cloud-only integration; no local discovery (zeroconf/bluetooth/mqtt) applicable today.
+    references:
+      code:
+        - custom_components/enphase_ev/manifest.json
+      docs:
+        - README.md

--- a/scripts/validate_quality_scale.py
+++ b/scripts/validate_quality_scale.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
@@ -12,58 +13,162 @@ except Exception:
     )
     raise
 
+QUALITY_LEVEL_ORDER = ("silver", "gold", "platinum")
+NA_ALLOWED_RULES = {"discovery_update_info"}
+
+
+def _load_yaml(path: Path) -> dict:
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def _status_for_rule(entry: object) -> str:
+    if isinstance(entry, dict):
+        return str(entry.get("status") or "").strip().lower()
+    if isinstance(entry, str):
+        return entry.strip().lower()
+    return ""
+
+
+def _references_for_rule(entry: object) -> dict[str, list[str]]:
+    if not isinstance(entry, dict):
+        return {}
+    references = entry.get("references")
+    if not isinstance(references, dict):
+        return {}
+    normalized: dict[str, list[str]] = {}
+    for key in ("code", "tests", "docs"):
+        values = references.get(key)
+        if isinstance(values, str):
+            normalized[key] = [values]
+        elif isinstance(values, list):
+            normalized[key] = [str(value) for value in values if str(value).strip()]
+    return normalized
+
+
+def _claimed_level(root: Path) -> str:
+    manifest_path = root / "custom_components" / "enphase_ev" / "manifest.json"
+    if not manifest_path.exists():
+        raise ValueError(f"{manifest_path} not found")
+    manifest = json.loads(manifest_path.read_text())
+    level = str(manifest.get("quality_scale") or "silver").strip().lower()
+    if level not in QUALITY_LEVEL_ORDER:
+        raise ValueError(f"Unsupported manifest quality_scale value: {level!r}")
+    return level
+
+
+def _required_levels_for_claim(level: str) -> tuple[str, ...]:
+    claimed_index = QUALITY_LEVEL_ORDER.index(level)
+    return QUALITY_LEVEL_ORDER[: claimed_index + 1]
+
+
+def _reference_path_exists(root: Path, reference: str) -> bool:
+    path_text = reference.split("#", 1)[0].strip()
+    if not path_text:
+        return False
+    return (root / path_text).exists()
+
+
+def validate_quality_scale(root: Path) -> tuple[int, list[str]]:
+    qs_path = root / "quality_scale.yaml"
+    if not qs_path.exists():
+        return 2, [f"ERROR: {qs_path} not found"]
+    try:
+        claimed_level = _claimed_level(root)
+    except (json.JSONDecodeError, ValueError) as err:
+        return 2, [f"ERROR: {err}"]
+
+    data = _load_yaml(qs_path)
+    levels = data.get("levels") or {}
+    rules = data.get("rules") or {}
+
+    messages: list[str] = []
+    missing: list[str] = []
+    not_accepted: list[tuple[str, str]] = []
+    not_allowed_na: list[str] = []
+    missing_references: list[str] = []
+    missing_comments: list[str] = []
+    bad_references: list[tuple[str, str]] = []
+
+    for level in _required_levels_for_claim(claimed_level):
+        required = (levels.get(level) or {}).get("required") or []
+        if not required:
+            messages.append(
+                f"ERROR: No {level}.required rules defined in quality_scale.yaml"
+            )
+            return 2, messages
+        for rule in required:
+            entry = rules.get(rule)
+            if entry is None:
+                missing.append(rule)
+                continue
+            status = _status_for_rule(entry)
+            if status == "done":
+                pass
+            elif status == "n/a":
+                if rule not in NA_ALLOWED_RULES:
+                    not_allowed_na.append(rule)
+                elif not (
+                    isinstance(entry, dict) and str(entry.get("comment") or "").strip()
+                ):
+                    missing_comments.append(rule)
+            else:
+                not_accepted.append((rule, status or "<unset>"))
+            references = _references_for_rule(entry)
+            if not any(references.values()):
+                missing_references.append(rule)
+                continue
+            for refs in references.values():
+                for reference in refs:
+                    if not _reference_path_exists(root, reference):
+                        bad_references.append((rule, reference))
+
+    if (
+        missing
+        or not_accepted
+        or not_allowed_na
+        or missing_references
+        or missing_comments
+        or bad_references
+    ):
+        messages.append(
+            f"Integration Quality Scale check failed for manifest level "
+            f"{claimed_level!r}:\n"
+        )
+        if missing:
+            messages.append("- Missing rule entries:")
+            messages.extend(f"  - {rule}" for rule in missing)
+        if not_accepted:
+            messages.append("- Rules not marked done:")
+            messages.extend(f"  - {rule}: {status}" for rule, status in not_accepted)
+        if not_allowed_na:
+            messages.append("- Rules marked n/a without an allowlist exception:")
+            messages.extend(f"  - {rule}" for rule in not_allowed_na)
+        if missing_comments:
+            messages.append("- n/a rules missing explanatory comments:")
+            messages.extend(f"  - {rule}" for rule in missing_comments)
+        if missing_references:
+            messages.append("- Rules missing code/test/doc references:")
+            messages.extend(f"  - {rule}" for rule in missing_references)
+        if bad_references:
+            messages.append("- Rule references that do not exist:")
+            messages.extend(
+                f"  - {rule}: {reference}" for rule, reference in bad_references
+            )
+        return 1, messages
+
+    messages.append(
+        f"Integration Quality Scale ({claimed_level}) OK: all claimed-level rules "
+        "are documented."
+    )
+    return 0, messages
+
 
 def main() -> int:
     root = Path(__file__).resolve().parents[1]
-    qs_path = root / "quality_scale.yaml"
-    if not qs_path.exists():
-        print(f"ERROR: {qs_path} not found", file=sys.stderr)
-        return 2
-    data = yaml.safe_load(qs_path.read_text()) or {}
-
-    levels = (data or {}).get("levels") or {}
-    rules = (data or {}).get("rules") or {}
-
-    silver = (levels.get("silver") or {}).get("required") or []
-    if not silver:
-        print(
-            "ERROR: No silver.required rules defined in quality_scale.yaml",
-            file=sys.stderr,
-        )
-        return 2
-
-    missing: list[str] = []
-    not_done: list[tuple[str, str]] = []
-
-    for rule in silver:
-        entry = rules.get(rule)
-        if entry is None:
-            missing.append(rule)
-            continue
-        status = None
-        if isinstance(entry, dict):
-            status = str(entry.get("status") or "").strip().lower()
-        elif isinstance(entry, str):
-            status = entry.strip().lower()
-        else:
-            status = ""
-        if status != "done":
-            not_done.append((rule, status or "<unset>"))
-
-    if missing or not_done:
-        print("Integration Quality Scale check failed:\n")
-        if missing:
-            print("- Missing rule entries:")
-            for r in missing:
-                print(f"  • {r}")
-        if not_done:
-            print("- Rules not marked done:")
-            for r, st in not_done:
-                print(f"  • {r}: {st}")
-        return 1
-
-    print("Integration Quality Scale (silver) OK: all required rules are done.")
-    return 0
+    exit_code, messages = validate_quality_scale(root)
+    output = sys.stderr if exit_code else sys.stdout
+    print("\n".join(messages), file=output)
+    return exit_code
 
 
 if __name__ == "__main__":

--- a/tests/scripts/test_validate_quality_scale.py
+++ b/tests/scripts/test_validate_quality_scale.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import sys
+
+
+def _load_module():
+    root = Path(__file__).resolve().parents[2]
+    module_path = root / "scripts" / "validate_quality_scale.py"
+    spec = importlib.util.spec_from_file_location("validate_quality_scale", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+validate_quality_scale = _load_module()
+
+
+def _write_manifest(root: Path, quality_scale: str = "platinum") -> None:
+    manifest_dir = root / "custom_components" / "enphase_ev"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "manifest.json").write_text(
+        json.dumps({"quality_scale": quality_scale})
+    )
+
+
+def _write_reference(root: Path, path: str) -> None:
+    reference = root / path
+    reference.parent.mkdir(parents=True, exist_ok=True)
+    reference.write_text("ok")
+
+
+def _write_quality_scale(root: Path, body: str) -> None:
+    (root / "quality_scale.yaml").write_text(body)
+
+
+def test_repository_quality_scale_matches_manifest_claim() -> None:
+    root = Path(__file__).resolve().parents[2]
+
+    exit_code, messages = validate_quality_scale.validate_quality_scale(root)
+
+    assert exit_code == 0, "\n".join(messages)
+
+
+def test_platinum_claim_requires_gold_and_platinum_rules(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, "platinum")
+    _write_reference(tmp_path, "README.md")
+    _write_quality_scale(
+        tmp_path,
+        """
+levels:
+  silver:
+    required: [config_flow]
+  gold:
+    required: [devices]
+  platinum:
+    required: [dynamic_devices]
+rules:
+  config_flow:
+    status: done
+    references:
+      docs: [README.md]
+  dynamic_devices:
+    status: done
+    references:
+      docs: [README.md]
+""",
+    )
+
+    exit_code, messages = validate_quality_scale.validate_quality_scale(tmp_path)
+
+    assert exit_code == 1
+    assert "devices" in "\n".join(messages)
+
+
+def test_na_rules_need_explanatory_comments(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, "silver")
+    _write_reference(tmp_path, "README.md")
+    _write_quality_scale(
+        tmp_path,
+        """
+levels:
+  silver:
+    required: [discovery_update_info]
+rules:
+  discovery_update_info:
+    status: n/a
+    references:
+      docs: [README.md]
+""",
+    )
+
+    exit_code, messages = validate_quality_scale.validate_quality_scale(tmp_path)
+
+    assert exit_code == 1
+    assert "n/a rules missing explanatory comments" in "\n".join(messages)
+
+
+def test_na_status_is_restricted_to_allowlisted_rules(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, "silver")
+    _write_reference(tmp_path, "README.md")
+    _write_quality_scale(
+        tmp_path,
+        """
+levels:
+  silver:
+    required: [config_flow]
+rules:
+  config_flow:
+    status: n/a
+    comment: Not actually acceptable for this rule.
+    references:
+      docs: [README.md]
+""",
+    )
+
+    exit_code, messages = validate_quality_scale.validate_quality_scale(tmp_path)
+
+    assert exit_code == 1
+    assert "Rules marked n/a without an allowlist exception" in "\n".join(messages)
+
+
+def test_rule_references_must_exist(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, "silver")
+    _write_quality_scale(
+        tmp_path,
+        """
+levels:
+  silver:
+    required: [config_flow]
+rules:
+  config_flow:
+    status: done
+    references:
+      code: [custom_components/enphase_ev/config_flow.py]
+""",
+    )
+
+    exit_code, messages = validate_quality_scale.validate_quality_scale(tmp_path)
+
+    assert exit_code == 1
+    assert "Rule references that do not exist" in "\n".join(messages)
+
+
+def test_manifest_quality_scale_must_be_supported(tmp_path: Path) -> None:
+    _write_manifest(tmp_path, "diamond")
+    _write_quality_scale(
+        tmp_path,
+        """
+levels:
+  silver:
+    required: [config_flow]
+rules:
+  config_flow:
+    status: done
+""",
+    )
+
+    exit_code, messages = validate_quality_scale.validate_quality_scale(tmp_path)
+
+    assert exit_code == 2
+    assert "Unsupported manifest quality_scale value" in "\n".join(messages)


### PR DESCRIPTION
## Summary

Add stricter Integration Quality Scale validation and run it as a dedicated CI workflow. The validator now checks the manifest's claimed quality tier, requires evidence references for each claimed rule, restricts `n/a` to explicit allowlisted exceptions, and verifies referenced files exist. This also adds regression tests for the validator, includes PyYAML in dev requirements, and keeps targeted coverage enforcement for changed integration modules.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py && pytest -q tests/scripts/test_validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python - <<'PY'
from pathlib import Path
import yaml
for path in ['.github/workflows/tests.yml', '.github/workflows/quality-scale.yml', '.pre-commit-config.yaml', 'quality_scale.yaml']:
    yaml.safe_load(Path(path).read_text())
    print(f'{path}: ok')
PY"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc "pre-commit run --all-files"
```

The temporary `.git` mount is only needed for this local linked worktree; normal GitHub Actions checkouts do not need it.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

CI/tooling-only change. No Home Assistant runtime behavior changed.