### PR TITLE
Prepare release 2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,32 @@ All notable changes to this project will be documented in this file.
 ### 🔄 Other changes
 - None
 
+## v2.9.1 - 2026-04-24
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Rejected advisory firmware update install requests with a clear Home Assistant error so IQ Gateway and IQ EV Charger firmware entities remain status-only.
+- Aligned Charge from Grid battery schedule writes and toggles with the Enlighten web flow, including ITC disclaimer acceptance, CFG validation preflight handling, and lean CFG settings commits.
+- Handled unavailable EV charger session-history cache states so failed or missing cache lookups retry on the normal session-history cadence instead of every fast coordinator poll, while preserving stale valid data when available.
+- Seeded AC Battery status and last-reported data from the battery status endpoint when the dedicated AC Battery devices page does not return parsed rows.
+
+### 🔧 Improvements
+- Reduced coordinator refresh latency by dynamically planning only due follow-up endpoint families and by running post-status EVSE enrichment lookups concurrently.
+- Improved refresh pipeline structure and grouped refresh execution so topology updates can be deferred until related refresh stages complete.
+- Added session-history cache-state diagnostics to make valid, stale-reused, and unavailable cache entries visible in diagnostics.
+
+### 🔄 Other changes
+- Added codespell, quality-scale, and quality-scale evidence validation coverage to CI and pre-commit.
+- Added the checked-in quality scale evidence file and expanded validator test coverage.
+- Corrected the manifest integration type to `hub`.
+- Updated contributor workflow guidance.
+- Bumped the integration manifest version to `2.9.1`.
+
 ## v2.9.0 - 2026-04-23
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.9.0"
+  "version": "2.9.1"
 }


### PR DESCRIPTION
## Summary

Prepare release `2.9.1` by bumping the integration manifest version and adding the `v2.9.1` changelog section for merged changes since `v2.9.0`.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release preparation: manifest version and changelog update.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_manifest.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Additional validation:

```bash
docker compose -f devtools/docker/docker-compose.yml build ha-dev
docker compose -f devtools/docker/docker-compose.yml up -d --force-recreate ha-runtime
python scripts/smoke_status.py
python scripts/service_status.py --output-dir /tmp/enphase-service-status-check --timeout 15
```

The local Home Assistant dev runtime was shut down before pushing this PR.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No runtime code changed. The local dev runtime was rebuilt and verified with the configured Enphase account before shutdown. The gateway firmware update entity remained `unknown` because the wiped dev config no longer had the local firmware catalog file; this was left unchanged intentionally.