### PR TITLE
Fix EV charger review findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Seed AC Battery status and last-reported data from the battery status endpoint when the dedicated AC Battery devices page does not return parsed rows.
+- Routed IQ EV Charger device services through the target device's owning site or config entry so multi-site installs do not send start, stop, trigger, or schedule-sync requests to the wrong site when another entry has no discovered serials yet.
+- Kept the "Store password for automatic reauthentication" checkbox aligned with the existing entry setting during reconfigure and reauthentication flows instead of defaulting back to storing newly entered passwords.
+- Cancelled pending EV charger amp-restart and live-stream stop tasks during config entry unload so stale tasks cannot call the cloud client after reload or removal.
 
 ### 🔧 Improvements
 - None

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -977,7 +977,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         stored_remember_password = bool(
             self._reconfigure_entry.data.get(CONF_REMEMBER_PASSWORD)
         )
-        self._remember_password = True
+        self._remember_password = stored_remember_password
         self._site_only = bool(self._reconfigure_entry.data.get(CONF_SITE_ONLY, False))
         self._include_inverters = bool(
             self._reconfigure_entry.data.get(CONF_INCLUDE_INVERTERS, True)
@@ -1003,7 +1003,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         stored_remember_password = bool(
             self._reauth_entry.data.get(CONF_REMEMBER_PASSWORD)
         )
-        self._remember_password = True
+        self._remember_password = stored_remember_password
         self._site_only = bool(self._reauth_entry.data.get(CONF_SITE_ONLY, False))
         self._include_inverters = bool(
             self._reauth_entry.data.get(CONF_INCLUDE_INVERTERS, True)

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1136,6 +1136,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         if self._warmup_task is not None:
             self._warmup_task.cancel()
             self._warmup_task = None
+        if self._streaming_stop_task is not None:
+            self._streaming_stop_task.cancel()
+            self._streaming_stop_task = None
+        for task in list(self._amp_restart_tasks.values()):
+            task.cancel()
+        self._amp_restart_tasks.clear()
+        self._clear_streaming_state()
         self.discovery_snapshot.cancel_pending_save()
         session_manager = getattr(self, "session_history", None)
         if session_manager is not None and hasattr(session_manager, "clear"):

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -78,11 +78,7 @@ def async_setup_services(
             message=message,
         )
 
-    async def _resolve_sn(device_id: str) -> str | None:
-        dev_reg = dr.async_get(hass)
-        dev = dev_reg.async_get(device_id)
-        if not dev:
-            return None
+    def _serial_from_device(dev) -> str | None:
         for domain, sn in dev.identifiers:
             if domain == DOMAIN:
                 if sn.startswith("site:"):
@@ -92,11 +88,7 @@ def async_setup_services(
                 return sn
         return None
 
-    async def _resolve_site_id(device_id: str) -> str | None:
-        dev_reg = dr.async_get(hass)
-        dev = dev_reg.async_get(device_id)
-        if not dev:
-            return None
+    def _site_id_from_device(dev_reg, dev) -> str | None:
         for domain, identifier in dev.identifiers:
             if domain == DOMAIN and identifier.startswith("site:"):
                 return identifier.partition(":")[2]
@@ -117,10 +109,127 @@ def async_setup_services(
                             return parsed[0]
         return None
 
-    async def _get_coordinator_for_sn(sn: str) -> EnphaseCoordinator | None:
-        for coord in iter_coordinators(hass):
-            if not coord.serials or sn in coord.serials or sn in (coord.data or {}):
+    async def _resolve_site_id(device_id: str) -> str | None:
+        dev_reg = dr.async_get(hass)
+        dev = dev_reg.async_get(device_id)
+        if not dev:
+            return None
+        return _site_id_from_device(dev_reg, dev)
+
+    def _iter_loaded_coordinators() -> list[EnphaseCoordinator]:
+        coordinators: list[EnphaseCoordinator] = []
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            runtime_data = getattr(entry, "runtime_data", None)
+            if isinstance(runtime_data, EnphaseRuntimeData):
+                coordinators.append(runtime_data.coordinator)
+        return coordinators
+
+    def _coordinator_has_serial(coord: EnphaseCoordinator, sn: str) -> bool:
+        data = coord.data if isinstance(getattr(coord, "data", None), dict) else {}
+        return sn in (getattr(coord, "serials", None) or set()) or sn in data
+
+    def _coordinator_can_fallback_for_serial(
+        coord: EnphaseCoordinator, sn: str, site_id: str | None
+    ) -> bool:
+        if site_id is not None and str(getattr(coord, "site_id", "")) != site_id:
+            return False
+        if getattr(coord, "site_only", False):
+            return False
+        serials = getattr(coord, "serials", None) or set()
+        data = coord.data if isinstance(getattr(coord, "data", None), dict) else {}
+        return bool(not serials and not data and sn)
+
+    def _device_config_entry_ids(device) -> list[str]:
+        entry_ids: list[str] = []
+        config_entries = getattr(device, "config_entries", None)
+        if config_entries:
+            entry_ids.extend(str(entry_id) for entry_id in config_entries)
+        config_entry_id = getattr(device, "config_entry_id", None)
+        if config_entry_id:
+            entry_ids.append(str(config_entry_id))
+        return list(dict.fromkeys(entry_ids))
+
+    def _config_entry_ids_for_device(dev_reg, dev) -> list[str]:
+        entry_ids = _device_config_entry_ids(dev)
+        if entry_ids:
+            return entry_ids
+        via = dev.via_device_id
+        if not via:
+            return []
+        parent = dev_reg.async_get(via)
+        if not parent:
+            return []
+        return _device_config_entry_ids(parent)
+
+    async def _resolve_device_routing_context(
+        device_id: str,
+    ) -> tuple[str, str | None, list[str]] | None:
+        dev_reg = dr.async_get(hass)
+        dev = dev_reg.async_get(device_id)
+        if not dev:
+            return None
+        sn = _serial_from_device(dev)
+        if not sn:
+            return None
+        return (
+            sn,
+            _site_id_from_device(dev_reg, dev),
+            _config_entry_ids_for_device(dev_reg, dev),
+        )
+
+    async def _get_coordinator_for_sn(
+        sn: str,
+        *,
+        site_id: str | None = None,
+        config_entry_ids: list[str] | None = None,
+    ) -> EnphaseCoordinator | None:
+        sn = str(sn)
+        for entry_id in config_entry_ids or []:
+            coord = _get_coordinator_for_entry_id(entry_id)
+            if coord is None:
+                continue
+            if _coordinator_has_serial(coord, sn):
                 return coord
+
+        all_coordinators = _iter_loaded_coordinators()
+        if site_id is not None:
+            site_coordinators = [
+                coord
+                for coord in all_coordinators
+                if str(getattr(coord, "site_id", "")) == site_id
+            ]
+            exact_matches = [
+                coord
+                for coord in site_coordinators
+                if _coordinator_has_serial(coord, sn)
+            ]
+            if len(exact_matches) == 1:
+                return exact_matches[0]
+            if exact_matches:
+                return None
+            fallback_candidates = [
+                coord
+                for coord in site_coordinators
+                if _coordinator_can_fallback_for_serial(coord, sn, site_id)
+            ]
+            if len(fallback_candidates) == 1:
+                return fallback_candidates[0]
+            return None
+
+        exact_matches = [
+            coord for coord in all_coordinators if _coordinator_has_serial(coord, sn)
+        ]
+        if len(exact_matches) == 1:
+            return exact_matches[0]
+        if exact_matches:
+            return None
+        fallback_candidates = [
+            coord
+            for coord in all_coordinators
+            if _coordinator_can_fallback_for_serial(coord, sn, None)
+        ]
+        if len(fallback_candidates) == 1:
+            return fallback_candidates[0]
         return None
 
     def _get_coordinator_for_entry_id(entry_id: str) -> EnphaseCoordinator | None:
@@ -497,10 +606,15 @@ def async_setup_services(
             return
         connector_id = int(call.data.get("connector_id", 1))
         for device_id in device_ids:
-            sn = await _resolve_sn(device_id)
-            if not sn:
+            routing_context = await _resolve_device_routing_context(device_id)
+            if routing_context is None:
                 continue
-            coord = await _get_coordinator_for_sn(sn)
+            sn, site_id, config_entry_ids = routing_context
+            coord = await _get_coordinator_for_sn(
+                sn,
+                site_id=site_id,
+                config_entry_ids=config_entry_ids,
+            )
             if not coord:
                 continue
             level = call.data.get("charging_level")
@@ -513,10 +627,15 @@ def async_setup_services(
         if not device_ids:
             return
         for device_id in device_ids:
-            sn = await _resolve_sn(device_id)
-            if not sn:
+            routing_context = await _resolve_device_routing_context(device_id)
+            if routing_context is None:
                 continue
-            coord = await _get_coordinator_for_sn(sn)
+            sn, site_id, config_entry_ids = routing_context
+            coord = await _get_coordinator_for_sn(
+                sn,
+                site_id=site_id,
+                config_entry_ids=config_entry_ids,
+            )
             if not coord:
                 continue
             await coord.async_stop_charging(sn)
@@ -528,10 +647,15 @@ def async_setup_services(
         message = call.data["requested_message"]
         results: list[dict[str, object]] = []
         for device_id in device_ids:
-            sn = await _resolve_sn(device_id)
-            if not sn:
+            routing_context = await _resolve_device_routing_context(device_id)
+            if routing_context is None:
                 continue
-            coord = await _get_coordinator_for_sn(sn)
+            sn, site_id, config_entry_ids = routing_context
+            coord = await _get_coordinator_for_sn(
+                sn,
+                site_id=site_id,
+                config_entry_ids=config_entry_ids,
+            )
             if not coord:
                 continue
             reply = await coord.async_trigger_ocpp_message(sn, message)
@@ -868,10 +992,15 @@ def async_setup_services(
         device_ids = _extract_device_ids(call)
         if device_ids:
             for device_id in device_ids:
-                sn = await _resolve_sn(device_id)
-                if not sn:
+                routing_context = await _resolve_device_routing_context(device_id)
+                if routing_context is None:
                     continue
-                coord = await _get_coordinator_for_sn(sn)
+                sn, site_id, config_entry_ids = routing_context
+                coord = await _get_coordinator_for_sn(
+                    sn,
+                    site_id=site_id,
+                    config_entry_ids=config_entry_ids,
+                )
                 if not coord or not hasattr(coord, "schedule_sync"):
                     continue
                 await coord.schedule_sync.async_refresh(reason="service", serials=[sn])

--- a/tests/components/enphase_ev/test_config_flow_coverage.py
+++ b/tests/components/enphase_ev/test_config_flow_coverage.py
@@ -1235,7 +1235,7 @@ async def test_finalize_login_entry_reauth_updates_entry(hass) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reconfigure_step_remember_password_defaults_enabled(hass) -> None:
+async def test_reconfigure_step_preserves_remember_password_default(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1262,11 +1262,11 @@ async def test_reconfigure_step_remember_password_defaults_enabled(hass) -> None
         if isinstance(item, VolOptional) and item.schema == CONF_REMEMBER_PASSWORD
     )
     default = key.default() if callable(key.default) else key.default
-    assert default is True
+    assert default is False
 
 
 @pytest.mark.asyncio
-async def test_reauth_step_remember_password_defaults_enabled(hass) -> None:
+async def test_reauth_step_preserves_remember_password_default(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1293,7 +1293,7 @@ async def test_reauth_step_remember_password_defaults_enabled(hass) -> None:
         if isinstance(item, VolOptional) and item.schema == CONF_REMEMBER_PASSWORD
     )
     default = key.default() if callable(key.default) else key.default
-    assert default is True
+    assert default is False
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -1107,13 +1107,33 @@ def test_cleanup_runtime_state_clears_session_history(coordinator_factory):
     coord = coordinator_factory(serials=["EV1"])
     clear = MagicMock()
     prune = MagicMock()
+    warmup_task = MagicMock()
+    stream_stop_task = MagicMock()
+    amp_restart_task = MagicMock()
     coord.session_history = SimpleNamespace(clear=clear, prune=prune)
     coord._session_history_cache_shim = {
         ("EV1", "2020-01-02"): (1.0, [])
     }  # noqa: SLF001
+    coord._warmup_task = warmup_task  # noqa: SLF001
+    coord._streaming_stop_task = stream_stop_task  # noqa: SLF001
+    coord._amp_restart_tasks = {"EV1": amp_restart_task}  # noqa: SLF001
+    coord._streaming = True  # noqa: SLF001
+    coord._streaming_until = 123.0  # noqa: SLF001
+    coord._streaming_manual = True  # noqa: SLF001
+    coord._streaming_targets = {"EV1": True}  # noqa: SLF001
 
     coord.cleanup_runtime_state()
 
+    warmup_task.cancel.assert_called_once()
+    stream_stop_task.cancel.assert_called_once()
+    amp_restart_task.cancel.assert_called_once()
+    assert coord._warmup_task is None  # noqa: SLF001
+    assert coord._streaming_stop_task is None  # noqa: SLF001
+    assert coord._amp_restart_tasks == {}  # noqa: SLF001
+    assert coord._streaming is False  # noqa: SLF001
+    assert coord._streaming_until is None  # noqa: SLF001
+    assert coord._streaming_manual is False  # noqa: SLF001
+    assert coord._streaming_targets == {}  # noqa: SLF001
     clear.assert_called_once()
     assert coord._session_history_cache_shim == {}  # noqa: SLF001
 

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -1392,10 +1392,11 @@ async def test_registered_services_cover_branches(
     )
 
     class FakeCoordinator:
-        def __init__(self, site, serials, data, start_results):
+        def __init__(self, site, serials, data, start_results, *, site_only=False):
             self.site_id = site
             self.serials = set(serials)
             self.data = data
+            self.site_only = site_only
             self._start_results = start_results
             self._streaming = False
             self.schedule_sync = SimpleNamespace(async_refresh=AsyncMock())
@@ -1429,6 +1430,13 @@ async def test_registered_services_cover_branches(
             )
             self.async_request_refresh = AsyncMock()
 
+    coord_site_only = FakeCoordinator(
+        site_id,
+        serials=set(),
+        data={},
+        start_results={},
+        site_only=True,
+    )
     coord_primary = FakeCoordinator(
         site_id,
         serials={second_serial},
@@ -1539,6 +1547,15 @@ async def test_registered_services_cover_branches(
         limit=80,
     )
 
+    entry_site_only = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: site_id},
+        title="Site Only",
+        unique_id="entry-site-only",
+    )
+    entry_site_only.add_to_hass(hass)
+    entry_site_only.runtime_data = EnphaseRuntimeData(coordinator=coord_site_only)
+
     start_call = SimpleNamespace(
         data={
             "device_id": [charger_one.id, site_device.id, charger_two.id],
@@ -1552,10 +1569,12 @@ async def test_registered_services_cover_branches(
     assert call(first_serial, requested_amps=30, connector_id=2) in await_args
     assert call(second_serial, requested_amps=30, connector_id=2) in await_args
     assert coord_primary.async_start_charging.await_count == 2
+    coord_site_only.async_start_charging.assert_not_awaited()
 
     stop_call = SimpleNamespace(data={"device_id": charger_one.id})
     await svc_stop(stop_call)
     coord_primary.async_stop_charging.assert_awaited_once_with(first_serial)
+    coord_site_only.async_stop_charging.assert_not_awaited()
 
     trigger_call = SimpleNamespace(
         data={"device_id": charger_two.id, "requested_message": "status"}
@@ -1604,6 +1623,7 @@ async def test_registered_services_cover_branches(
     await svc_sync(SimpleNamespace(data={}))
     assert coord_primary.schedule_sync.async_refresh.await_count >= 2
 
+    entry_site_only.runtime_data = None
     entry_one.runtime_data = None
     entry_two.runtime_data = None
     entry_three.runtime_data = None
@@ -1634,6 +1654,474 @@ async def test_registered_services_cover_branches(
         )
     with pytest.raises(ServiceValidationError):
         await svc_request_grid_otp(SimpleNamespace(data={"site_id": "missing-site"}))
+
+
+@pytest.mark.asyncio
+async def test_device_service_routing_prefers_owning_entry_over_empty_serial_fallback(
+    hass: HomeAssistant, monkeypatch
+) -> None:
+    registered: dict[tuple[str, str], dict[str, object]] = {}
+
+    def fake_register(self, domain, service, handler, schema=None, **kwargs):
+        registered[(domain, service)] = {
+            "handler": handler,
+            "schema": schema,
+            "kwargs": kwargs,
+        }
+
+    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.services.ha_service",
+        SimpleNamespace(async_extract_referenced_device_ids=lambda *_args: []),
+    )
+
+    serial = "EV-ROUTE-1"
+    site_id = "site-route"
+    site_only_coord = SimpleNamespace(
+        site_id=site_id,
+        site_only=True,
+        serials=set(),
+        data={},
+        async_start_charging=AsyncMock(return_value={"status": "wrong"}),
+    )
+    owning_coord = SimpleNamespace(
+        site_id=site_id,
+        site_only=False,
+        serials={serial},
+        data={serial: {}},
+        async_start_charging=AsyncMock(return_value={"status": "ok"}),
+    )
+
+    site_only_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: site_id},
+        title="Site Only",
+        unique_id="site-only-entry",
+    )
+    site_only_entry.add_to_hass(hass)
+    site_only_entry.runtime_data = EnphaseRuntimeData(coordinator=site_only_coord)
+
+    owning_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: site_id},
+        title="Owning Entry",
+        unique_id="owning-entry",
+    )
+    owning_entry.add_to_hass(hass)
+    owning_entry.runtime_data = EnphaseRuntimeData(coordinator=owning_coord)
+
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=owning_entry.entry_id,
+        identifiers={(DOMAIN, serial)},
+        manufacturer="Enphase",
+        name="Routed Charger",
+    )
+
+    async_setup_services(hass)
+    svc_start = registered[(DOMAIN, "start_charging")]["handler"]
+
+    await svc_start(
+        SimpleNamespace(
+            data={
+                "device_id": device.id,
+                "charging_level": 24,
+                "connector_id": 1,
+            }
+        )
+    )
+
+    owning_coord.async_start_charging.assert_awaited_once_with(
+        serial, requested_amps=24, connector_id=1
+    )
+    site_only_coord.async_start_charging.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_device_service_routing_prefers_global_exact_match_before_empty_entry(
+    hass: HomeAssistant, monkeypatch
+) -> None:
+    registered: dict[tuple[str, str], dict[str, object]] = {}
+
+    def fake_register(self, domain, service, handler, schema=None, **kwargs):
+        registered[(domain, service)] = {
+            "handler": handler,
+            "schema": schema,
+            "kwargs": kwargs,
+        }
+
+    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.services.ha_service",
+        SimpleNamespace(async_extract_referenced_device_ids=lambda *_args: []),
+    )
+
+    serial = "EV-STALE-ENTRY-1"
+    empty_coord = SimpleNamespace(
+        site_id="empty-site",
+        site_only=False,
+        serials=set(),
+        data={},
+        async_start_charging=AsyncMock(return_value={"status": "wrong"}),
+    )
+    owning_coord = SimpleNamespace(
+        site_id="owning-site",
+        site_only=False,
+        serials={serial},
+        data={serial: {}},
+        async_start_charging=AsyncMock(return_value={"status": "ok"}),
+    )
+
+    empty_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "empty-site"},
+        title="Empty Entry",
+        unique_id="empty-entry",
+    )
+    empty_entry.add_to_hass(hass)
+    empty_entry.runtime_data = EnphaseRuntimeData(coordinator=empty_coord)
+
+    owning_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "owning-site"},
+        title="Owning Entry",
+        unique_id="owning-entry",
+    )
+    owning_entry.add_to_hass(hass)
+    owning_entry.runtime_data = EnphaseRuntimeData(coordinator=owning_coord)
+
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=empty_entry.entry_id,
+        identifiers={(DOMAIN, serial)},
+        manufacturer="Enphase",
+        name="Stale Entry Charger",
+    )
+
+    async_setup_services(hass)
+    svc_start = registered[(DOMAIN, "start_charging")]["handler"]
+
+    await svc_start(
+        SimpleNamespace(
+            data={
+                "device_id": device.id,
+                "charging_level": 32,
+                "connector_id": 1,
+            }
+        )
+    )
+
+    owning_coord.async_start_charging.assert_awaited_once_with(
+        serial, requested_amps=32, connector_id=1
+    )
+    empty_coord.async_start_charging.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_device_service_routing_skips_ambiguous_empty_serial_fallback(
+    hass: HomeAssistant, monkeypatch
+) -> None:
+    registered: dict[tuple[str, str], dict[str, object]] = {}
+
+    def fake_register(self, domain, service, handler, schema=None, **kwargs):
+        registered[(domain, service)] = {
+            "handler": handler,
+            "schema": schema,
+            "kwargs": kwargs,
+        }
+
+    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.services.ha_service",
+        SimpleNamespace(async_extract_referenced_device_ids=lambda *_args: []),
+    )
+
+    serial = "EV-AMBIGUOUS-EMPTY-1"
+    first_empty_coord = SimpleNamespace(
+        site_id="first-empty-site",
+        site_only=False,
+        serials=set(),
+        data={},
+        async_start_charging=AsyncMock(return_value={"status": "first"}),
+    )
+    second_empty_coord = SimpleNamespace(
+        site_id="second-empty-site",
+        site_only=False,
+        serials=set(),
+        data={},
+        async_start_charging=AsyncMock(return_value={"status": "second"}),
+    )
+
+    first_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "first-empty-site"},
+        title="First Empty Entry",
+        unique_id="first-empty-entry",
+    )
+    first_entry.add_to_hass(hass)
+    first_entry.runtime_data = EnphaseRuntimeData(coordinator=first_empty_coord)
+
+    second_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "second-empty-site"},
+        title="Second Empty Entry",
+        unique_id="second-empty-entry",
+    )
+    second_entry.add_to_hass(hass)
+    second_entry.runtime_data = EnphaseRuntimeData(coordinator=second_empty_coord)
+
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=first_entry.entry_id,
+        identifiers={(DOMAIN, serial)},
+        manufacturer="Enphase",
+        name="Ambiguous Empty Charger",
+    )
+
+    async_setup_services(hass)
+    svc_start = registered[(DOMAIN, "start_charging")]["handler"]
+
+    await svc_start(
+        SimpleNamespace(
+            data={
+                "device_id": device.id,
+                "charging_level": 16,
+                "connector_id": 1,
+            }
+        )
+    )
+
+    first_empty_coord.async_start_charging.assert_not_awaited()
+    second_empty_coord.async_start_charging.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_device_service_routing_allows_single_empty_serial_fallback(
+    hass: HomeAssistant, monkeypatch
+) -> None:
+    registered: dict[tuple[str, str], dict[str, object]] = {}
+
+    def fake_register(self, domain, service, handler, schema=None, **kwargs):
+        registered[(domain, service)] = {
+            "handler": handler,
+            "schema": schema,
+            "kwargs": kwargs,
+        }
+
+    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.services.ha_service",
+        SimpleNamespace(async_extract_referenced_device_ids=lambda *_args: []),
+    )
+
+    serial = "EV-SINGLE-EMPTY-1"
+    empty_coord = SimpleNamespace(
+        site_id="single-empty-site",
+        site_only=False,
+        serials=set(),
+        data={},
+        async_start_charging=AsyncMock(return_value={"status": "fallback"}),
+    )
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "single-empty-site"},
+        title="Single Empty Entry",
+        unique_id="single-empty-entry",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=empty_coord)
+
+    device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, serial)},
+        manufacturer="Enphase",
+        name="Single Empty Charger",
+    )
+
+    async_setup_services(hass)
+    svc_start = registered[(DOMAIN, "start_charging")]["handler"]
+
+    await svc_start(
+        SimpleNamespace(
+            data={
+                "device_id": device.id,
+                "charging_level": 12,
+                "connector_id": 1,
+            }
+        )
+    )
+
+    empty_coord.async_start_charging.assert_awaited_once_with(
+        serial, requested_amps=12, connector_id=1
+    )
+
+
+@pytest.mark.asyncio
+async def test_device_service_routing_helper_guard_paths(
+    hass: HomeAssistant, monkeypatch
+) -> None:
+    registered: dict[tuple[str, str], dict[str, object]] = {}
+
+    def fake_register(self, domain, service, handler, schema=None, **kwargs):
+        registered[(domain, service)] = {
+            "handler": handler,
+            "schema": schema,
+            "kwargs": kwargs,
+        }
+
+    def extract_helper(func, target):
+        for cell in func.__closure__ or ():
+            value = cell.cell_contents
+            if callable(value) and getattr(value, "__name__", "") == target:
+                return value
+        raise AssertionError(f"helper {target} not found")
+
+    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.services.ha_service",
+        SimpleNamespace(async_extract_referenced_device_ids=lambda *_args: []),
+    )
+
+    async_setup_services(hass)
+    svc_start = registered[(DOMAIN, "start_charging")]["handler"]
+    resolve_context = extract_helper(svc_start, "_resolve_device_routing_context")
+    get_coord = extract_helper(svc_start, "_get_coordinator_for_sn")
+    config_ids_for_device = extract_helper(
+        resolve_context, "_config_entry_ids_for_device"
+    )
+    can_fallback = extract_helper(get_coord, "_coordinator_can_fallback_for_serial")
+
+    assert not can_fallback(
+        SimpleNamespace(site_id="other-site", site_only=False, serials=set(), data={}),
+        "EV-GUARD",
+        "site-guard",
+    )
+    assert not can_fallback(
+        SimpleNamespace(site_id="site-guard", site_only=True, serials=set(), data={}),
+        "EV-GUARD",
+        "site-guard",
+    )
+    assert config_ids_for_device(
+        SimpleNamespace(async_get=Mock()),
+        SimpleNamespace(
+            config_entries=None, config_entry_id="legacy-entry", via_device_id=None
+        ),
+    ) == ["legacy-entry"]
+    assert (
+        config_ids_for_device(
+            SimpleNamespace(async_get=Mock()),
+            SimpleNamespace(
+                config_entries=None, config_entry_id=None, via_device_id=None
+            ),
+        )
+        == []
+    )
+    assert (
+        config_ids_for_device(
+            SimpleNamespace(async_get=Mock(return_value=None)),
+            SimpleNamespace(
+                config_entries=None, config_entry_id=None, via_device_id="missing"
+            ),
+        )
+        == []
+    )
+    parent_device = SimpleNamespace(
+        config_entries={"parent-entry"}, config_entry_id=None, via_device_id=None
+    )
+    assert config_ids_for_device(
+        SimpleNamespace(async_get=Mock(return_value=parent_device)),
+        SimpleNamespace(
+            config_entries=None, config_entry_id=None, via_device_id="parent"
+        ),
+    ) == ["parent-entry"]
+
+    site_serial = "EV-SITE-DUPE"
+    site_dup_one = SimpleNamespace(
+        site_id="site-dupe",
+        site_only=False,
+        serials={site_serial},
+        data={},
+    )
+    site_dup_two = SimpleNamespace(
+        site_id="site-dupe",
+        site_only=False,
+        serials={site_serial},
+        data={},
+    )
+    for index, coord in enumerate((site_dup_one, site_dup_two), start=1):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_SITE_ID: "site-dupe"},
+            title=f"Site Duplicate {index}",
+            unique_id=f"site-duplicate-{index}",
+        )
+        entry.add_to_hass(hass)
+        entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    assert await get_coord(site_serial, site_id="site-dupe") is None
+
+    for index in range(2):
+        coord = SimpleNamespace(
+            site_id="site-empty-dupe",
+            site_only=False,
+            serials=set(),
+            data={},
+        )
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_SITE_ID: "site-empty-dupe"},
+            title=f"Site Empty Duplicate {index}",
+            unique_id=f"site-empty-duplicate-{index}",
+        )
+        entry.add_to_hass(hass)
+        entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    assert await get_coord("EV-SITE-EMPTY-DUPE", site_id="site-empty-dupe") is None
+
+    global_serial = "EV-GLOBAL-DUPE"
+    global_dup_one = SimpleNamespace(
+        site_id="global-dupe-one",
+        site_only=False,
+        serials={global_serial},
+        data={},
+    )
+    global_dup_two = SimpleNamespace(
+        site_id="global-dupe-two",
+        site_only=False,
+        serials={global_serial},
+        data={},
+    )
+    for index, coord in enumerate((global_dup_one, global_dup_two), start=1):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={CONF_SITE_ID: coord.site_id},
+            title=f"Global Duplicate {index}",
+            unique_id=f"global-duplicate-{index}",
+        )
+        entry.add_to_hass(hass)
+        entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    assert await get_coord(global_serial) is None
+
+    site_fallback_coord = SimpleNamespace(
+        site_id="site-fallback",
+        site_only=False,
+        serials=set(),
+        data={},
+    )
+    site_fallback_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "site-fallback"},
+        title="Site Fallback",
+        unique_id="site-fallback-entry",
+    )
+    site_fallback_entry.add_to_hass(hass)
+    site_fallback_entry.runtime_data = EnphaseRuntimeData(
+        coordinator=site_fallback_coord
+    )
+
+    assert (
+        await get_coord("EV-SITE-FALLBACK", site_id="site-fallback")
+        is site_fallback_coord
+    )
 
 
 def test_register_services_supports_response_fallback(
@@ -1696,12 +2184,13 @@ async def test_service_helper_resolve_functions_cover_none_branches(
                 return value
         raise AssertionError(f"helper {target} not found")
 
-    resolve_sn = _extract_helper(svc_start, "_resolve_sn")
+    resolve_device_routing_context = _extract_helper(
+        svc_start, "_resolve_device_routing_context"
+    )
     resolve_site = _extract_helper(svc_clear, "_resolve_site_id")
 
     dev_reg = dr.async_get(hass)
-    missing_sn = await resolve_sn("does-not-exist")
-    assert missing_sn is None
+    assert await resolve_device_routing_context("does-not-exist") is None
 
     site_device = dev_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,
@@ -1709,7 +2198,7 @@ async def test_service_helper_resolve_functions_cover_none_branches(
         manufacturer="Enphase",
         name="Site Device",
     )
-    assert await resolve_sn(site_device.id) is None
+    assert await resolve_device_routing_context(site_device.id) is None
     assert await resolve_site(site_device.id) == "ABC123"
 
     child_no_parent = dev_reg.async_get_or_create(
@@ -1718,7 +2207,7 @@ async def test_service_helper_resolve_functions_cover_none_branches(
         manufacturer="Vendor",
         name="Third Party Device",
     )
-    assert await resolve_sn(child_no_parent.id) is None
+    assert await resolve_device_routing_context(child_no_parent.id) is None
     assert await resolve_site(child_no_parent.id) is None
 
     dev_reg.async_get_or_create(
@@ -1734,6 +2223,11 @@ async def test_service_helper_resolve_functions_cover_none_branches(
         name="Child Device",
         via_device=(DOMAIN, "site:PARENT"),
     )
+    assert await resolve_device_routing_context(child_with_via.id) == (
+        "EVCHILD",
+        "PARENT",
+        [config_entry.entry_id],
+    )
     assert await resolve_site(child_with_via.id) == "PARENT"
 
     type_device = dev_reg.async_get_or_create(
@@ -1742,7 +2236,7 @@ async def test_service_helper_resolve_functions_cover_none_branches(
         manufacturer="Enphase",
         name="Gateway (1)",
     )
-    assert await resolve_sn(type_device.id) is None
+    assert await resolve_device_routing_context(type_device.id) is None
     assert await resolve_site(type_device.id) == "TYPED"
 
     child_with_type_parent = dev_reg.async_get_or_create(


### PR DESCRIPTION
## Summary

Fixes EV charger review findings around multi-entry service routing, reauth password-storage defaults, and config-entry unload cleanup.

- Route EV charger device services through the target device's serial, site, and config-entry context before falling back to an empty-serial coordinator.
- Preserve the existing `remember_password` setting as the reauth/reconfigure form default so password storage remains explicit.
- Cancel EV charger amp-restart tasks and scheduled live-stream stop tasks during unload cleanup.
- Add regression coverage for exact-owner routing, stale/empty entry routing, ambiguous empty fallbacks, reauth defaults, and unload cleanup.

## Related Issues

Review findings addressed in this PR.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/services.py,custom_components/enphase_ev/config_flow.py,custom_components/enphase_ev/coordinator.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
git diff --check
```

Results:

- Full pytest: `2958 passed`
- Coverage pytest: `2885 passed`
- Coverage report: `100%` for `custom_components/enphase_ev/services.py`, `custom_components/enphase_ev/config_flow.py`, and `custom_components/enphase_ev/coordinator.py`
- Pre-commit: Black, Ruff, and codespell passed
- Quality scale: platinum OK

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The pre-commit command mounts the backing `.git` directory because this Codex checkout is a linked worktree and the Docker container otherwise sees a `.git` pointer to an unmounted host path.
