### PR TITLE
Harden Enphase service routing and refresh metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,14 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Seed AC Battery status and last-reported data from the battery status endpoint when the dedicated AC Battery devices page does not return parsed rows.
+- Preserved the password-storage opt-out choice across reauthentication and reconfiguration flows.
+- Rejected charger and site services with a clear validation error when no target or owning coordinator can be resolved.
 
 ### 🔧 Improvements
-- None
+- Added refresh performance diagnostics, including per-stage timing and cloud-call counts for steady and fast polling.
 
 ### 🔄 Other changes
-- None
+- Split large API, battery runtime, sensor, and coordinator helper logic into smaller typed modules with focused regression coverage.
 
 ## v2.9.1 - 2026-04-24
 

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -8,7 +8,7 @@ import json
 import logging
 import re
 from contextlib import asynccontextmanager
-from datetime import date, datetime, timedelta, timezone
+from datetime import date, datetime, timezone
 from http import HTTPStatus
 from urllib.parse import unquote
 import uuid
@@ -31,8 +31,9 @@ from .const import (
     MFA_VALIDATE_URL,
     SITE_SEARCH_URL,
 )
+from . import api_parsers
+from .api_models import AuthTokens, ChargerInfo, SiteInfo, TextResponse
 from .log_redaction import redact_identifier, redact_site_id, redact_text
-from .runtime_helpers import coerce_optional_text as helper_coerce_optional_text
 
 _LOGGER = logging.getLogger(__name__)
 _EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b")
@@ -266,15 +267,6 @@ class InvalidPayloadError(aiohttp.ClientError):
         return self.signature.to_dict()
 
 
-@dataclass(slots=True, frozen=True)
-class TextResponse:
-    status: int
-    text: str
-    url: str
-    headers: dict[str, str]
-    location: str | None = None
-
-
 def _is_optional_non_json_payload(err: InvalidPayloadError) -> bool:
     """Return True when an optional endpoint returned a non-JSON success page."""
 
@@ -482,33 +474,6 @@ def _payload_preview_and_hash(
     preview = _truncate_preview(preview, max_length=max_preview) if preview else ""
     body_sha256 = hashlib.sha256(raw_bytes).hexdigest()
     return len(raw_bytes), body_sha256, preview or None
-
-
-@dataclass(slots=True)
-class AuthTokens:
-    """Container for Enlighten authentication state."""
-
-    cookie: str
-    session_id: str | None = None
-    access_token: str | None = None
-    token_expires_at: int | None = None
-    raw_cookies: dict[str, str] | None = None
-
-
-@dataclass(slots=True)
-class SiteInfo:
-    """Basic representation of an Enlighten site."""
-
-    site_id: str
-    name: str | None = None
-
-
-@dataclass(slots=True)
-class ChargerInfo:
-    """Metadata about a charger discovered for a site."""
-
-    serial: str
-    name: str | None = None
 
 
 _SYSTEM_DASHBOARD_DETAIL_QUERY_MAP: dict[str, str] = {
@@ -1198,80 +1163,13 @@ async def _submit_login_form(
 def _normalize_sites(payload: Any) -> list[SiteInfo]:
     """Normalize site payloads from various Enlighten APIs."""
 
-    sites: list[SiteInfo] = []
-    seen: dict[str, SiteInfo] = {}
-
-    if isinstance(payload, dict):
-        for key in ("sites", "data", "items"):
-            nested = payload.get(key)
-            if isinstance(nested, list):
-                payload = nested
-                break
-
-    if isinstance(payload, list):
-        items = payload
-    else:
-        items = []
-
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        site_id = item.get("site_id") or item.get("siteId") or item.get("id")
-        name = (
-            item.get("name")
-            or item.get("site_name")
-            or item.get("siteName")
-            or item.get("title")
-            or item.get("displayName")
-            or item.get("display_name")
-        )
-        if site_id is None:
-            continue
-        site_id_str = str(site_id)
-        existing = seen.get(site_id_str)
-        if existing:
-            if not existing.name and name:
-                existing.name = str(name)
-            continue
-        info = SiteInfo(site_id=site_id_str, name=str(name) if name else None)
-        seen[site_id_str] = info
-        sites.append(info)
-    return sites
+    return api_parsers.normalize_sites(payload)
 
 
 def _normalize_chargers(payload: Any) -> list[ChargerInfo]:
     """Normalize charger list payloads into ChargerInfo entries."""
 
-    chargers: list[ChargerInfo] = []
-
-    if isinstance(payload, dict):
-        payload = payload.get("data") or payload
-
-    if isinstance(payload, dict):
-        # Some responses use { "chargers": [...] }
-        payload = payload.get("chargers") or payload.get("evChargerData") or payload
-
-    if isinstance(payload, list):
-        items = payload
-    else:
-        items = []
-
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        serial = (
-            item.get("serial")
-            or item.get("serialNumber")
-            or item.get("sn")
-            or item.get("id")
-        )
-        if not serial:
-            continue
-        name = item.get("name") or item.get("displayName") or item.get("display_name")
-        chargers.append(
-            ChargerInfo(serial=str(serial), name=str(name) if name else None)
-        )
-    return chargers
+    return api_parsers.normalize_chargers(payload)
 
 
 async def _build_tokens_and_sites(
@@ -1906,6 +1804,7 @@ class EnphaseEVClient:
         self._hems_site_supported: bool | None = None
         self._reauth_cb: Callable[[], Awaitable[bool]] | None = reauth_callback
         self._last_unauthorized_request: str | None = None
+        self._request_count = 0
         self._payload_failure_log_state: dict[str, PayloadFailureSignature] = {}
         self._h = {
             "Accept": "application/json, text/plain, */*",
@@ -1927,6 +1826,17 @@ class EnphaseEVClient:
         """Return the most recent request that received a 401 response."""
 
         return self._last_unauthorized_request
+
+    def reset_request_count(self) -> None:
+        """Reset the lightweight cloud request counter."""
+
+        self._request_count = 0
+
+    @property
+    def request_count(self) -> int:
+        """Return the number of HTTP attempts since the last counter reset."""
+
+        return int(getattr(self, "_request_count", 0) or 0)
 
     def update_credentials(
         self,
@@ -3984,6 +3894,7 @@ class EnphaseEVClient:
                     async with self._request_session(
                         cookie_header_only=use_cookie_header_only
                     ) as request_session:
+                        self._request_count += 1
                         async with request_session.request(
                             method, url, headers=base_headers, **kwargs
                         ) as r:
@@ -5499,54 +5410,7 @@ class EnphaseEVClient:
     ) -> dict[str, object] | None:
         """Normalize app-api latest power payloads into a common shape."""
 
-        data = payload
-        if isinstance(data, dict) and isinstance(data.get("data"), dict):
-            data = data.get("data")
-        if not isinstance(data, dict):
-            return None
-
-        latest = data.get("latest_power")
-        if not isinstance(latest, dict):
-            latest = data
-
-        value = cls._coerce_non_boolean_number(latest.get("value"))
-        if value is None:
-            return None
-
-        normalized: dict[str, object] = {"value": value}
-
-        units = latest.get("units")
-        if units is not None:
-            try:
-                units_text = str(units).strip()
-            except Exception:  # noqa: BLE001
-                units_text = ""
-            if units_text:
-                normalized["units"] = units_text
-
-        precision = cls._coerce_non_boolean_number(latest.get("precision"))
-        if precision is not None:
-            try:
-                precision_int = int(precision)
-            except Exception:  # noqa: BLE001
-                precision_int = None
-            if precision_int is not None:
-                normalized["precision"] = precision_int
-
-        sample_time = latest.get("time")
-        if sample_time is not None:
-            sample_time_val = cls._coerce_non_boolean_number(sample_time)
-            if sample_time_val is not None:
-                if sample_time_val > 10**12:
-                    sample_time_val /= 1000.0
-                try:
-                    sample_time_int = int(sample_time_val)
-                except Exception:  # noqa: BLE001
-                    sample_time_int = None
-                if sample_time_int is not None:
-                    normalized["time"] = sample_time_int
-
-        return normalized
+        return api_parsers.normalize_latest_power_payload(payload)
 
     async def latest_power(self) -> dict[str, object] | None:
         """Return the latest site power sample for the configured site.
@@ -5608,52 +5472,11 @@ class EnphaseEVClient:
 
     @staticmethod
     def _normalize_evse_timeseries_serial(value: object) -> str | None:
-        if value is None:
-            return None
-        try:
-            text = str(value).strip()
-        except Exception:  # noqa: BLE001
-            return None
-        return text or None
+        return api_parsers.normalize_evse_timeseries_serial(value)
 
     @staticmethod
     def _parse_evse_timeseries_date_key(value: object) -> str | None:
-        if value is None:
-            return None
-        if isinstance(value, datetime):
-            return value.date().isoformat()
-        if isinstance(value, date):
-            return value.isoformat()
-        if isinstance(value, (int, float)):
-            try:
-                ts_val = float(value)
-                if ts_val > 10**12:
-                    ts_val /= 1000.0
-                return (
-                    datetime.fromtimestamp(ts_val, tz=timezone.utc).date().isoformat()
-                )
-            except Exception:  # noqa: BLE001
-                return None
-        if not isinstance(value, str):
-            return None
-        cleaned = value.strip()
-        if not cleaned:
-            return None
-        if len(cleaned) >= 10:
-            try:
-                return (
-                    datetime.fromisoformat(cleaned.replace("Z", "+00:00"))
-                    .date()
-                    .isoformat()
-                )
-            except Exception:  # noqa: BLE001
-                pass
-            try:
-                datetime.strptime(cleaned[:10], "%Y-%m-%d")
-                return cleaned[:10]
-            except Exception:  # noqa: BLE001
-                pass
-        return None
+        return api_parsers.parse_evse_timeseries_date_key(value)
 
     @classmethod
     def _coerce_evse_timeseries_energy(
@@ -5663,78 +5486,26 @@ class EnphaseEVClient:
         key_hint: str | None = None,
         unit_hint: object | None = None,
     ) -> float | None:
-        numeric = cls._coerce_lifetime_energy_value(value)
-        if numeric is None:
-            return None
-        try:
-            unit_text = str(unit_hint).strip().lower() if unit_hint is not None else ""
-        except Exception:  # noqa: BLE001
-            unit_text = ""
-        hint = (key_hint or "").lower()
-        if "wh" in hint and "kwh" not in hint:
-            return round(numeric / 1000.0, 6)
-        if unit_text in {"wh", "watt_hour", "watt-hours", "watt_hours"}:
-            return round(numeric / 1000.0, 6)
-        return round(numeric, 6)
+        return api_parsers.coerce_evse_timeseries_energy(
+            value,
+            key_hint=key_hint,
+            unit_hint=unit_hint,
+        )
 
     @classmethod
     def _normalize_evse_timeseries_metadata(cls, payload: object) -> dict[str, object]:
-        if not isinstance(payload, dict):
-            return {}
-        interval = cls._coerce_lifetime_energy_value(
-            payload.get("interval_minutes")
-            or payload.get("interval")
-            or payload.get("interval_min")
-            or payload.get("intervalMinutes")
-        )
-        metadata: dict[str, object] = {}
-        if interval is not None and interval > 0:
-            metadata["interval_minutes"] = interval
-        last_report = (
-            payload.get("last_report_date")
-            or payload.get("lastReportDate")
-            or payload.get("last_reported_at")
-            or payload.get("lastReportedAt")
-        )
-        if last_report is not None:
-            metadata["last_report_date"] = last_report
-        return metadata
+        return api_parsers.normalize_evse_timeseries_metadata(payload)
 
     @classmethod
     def _daily_values_from_mapping(
         cls,
         payload: dict[str, object],
     ) -> tuple[dict[str, float], float | None]:
-        day_values: dict[str, float] = {}
-        current_value: float | None = None
-        unit_hint = payload.get("unit") or payload.get("source_unit")
-        for key, raw in payload.items():
-            day_key = cls._parse_evse_timeseries_date_key(key)
-            if day_key is None:
-                continue
-            numeric = cls._coerce_evse_timeseries_energy(
-                raw, key_hint=str(key), unit_hint=unit_hint
-            )
-            if numeric is None:
-                continue
-            day_values[day_key] = numeric
-        for key in (
-            "energy_kwh",
-            "value_kwh",
-            "daily_energy_kwh",
-            "daily_kwh",
-            "energy",
-            "value",
-            "energy_wh",
-            "daily_energy_wh",
-        ):
-            if key not in payload:
-                continue
-            current_value = cls._coerce_evse_timeseries_energy(
-                payload.get(key), key_hint=key, unit_hint=unit_hint
-            )
-            break
-        return day_values, current_value
+        return api_parsers.daily_values_from_mapping(
+            payload,
+            parse_date_key=cls._parse_evse_timeseries_date_key,
+            coerce_energy=cls._coerce_evse_timeseries_energy,
+        )
 
     @classmethod
     def _daily_values_from_sequence(
@@ -5744,58 +5515,13 @@ class EnphaseEVClient:
         start_date_value: object | None = None,
         unit_hint: object | None = None,
     ) -> tuple[dict[str, float], float | None]:
-        day_values: dict[str, float] = {}
-        current_value: float | None = None
-        start_day = cls._parse_evse_timeseries_date_key(start_date_value)
-        start_dt = None
-        if start_day is not None:
-            try:
-                start_dt = datetime.fromisoformat(start_day)
-            except Exception:  # noqa: BLE001
-                start_dt = None
-        for idx, item in enumerate(values):
-            if isinstance(item, dict):
-                day_key = cls._parse_evse_timeseries_date_key(
-                    item.get("date")
-                    or item.get("day")
-                    or item.get("start_date")
-                    or item.get("startDate")
-                    or item.get("timestamp")
-                    or item.get("time")
-                )
-                item_unit = item.get("unit") or unit_hint
-                for key in (
-                    "energy_kwh",
-                    "value_kwh",
-                    "daily_energy_kwh",
-                    "energy",
-                    "value",
-                    "energy_wh",
-                    "daily_energy_wh",
-                ):
-                    if key not in item:
-                        continue
-                    numeric = cls._coerce_evse_timeseries_energy(
-                        item.get(key), key_hint=key, unit_hint=item_unit
-                    )
-                    if numeric is None:
-                        continue
-                    if day_key is not None:
-                        day_values[day_key] = numeric
-                    else:
-                        current_value = numeric
-                    break
-                continue
-            numeric = cls._coerce_evse_timeseries_energy(item, unit_hint=unit_hint)
-            if numeric is None:
-                continue
-            if start_dt is not None:
-                day_values[(start_dt + timedelta(days=idx)).date().isoformat()] = (
-                    numeric
-                )
-            else:
-                current_value = numeric
-        return day_values, current_value
+        return api_parsers.daily_values_from_sequence(
+            values,
+            start_date_value=start_date_value,
+            unit_hint=unit_hint,
+            parse_date_key=cls._parse_evse_timeseries_date_key,
+            coerce_energy=cls._coerce_evse_timeseries_energy,
+        )
 
     @classmethod
     def _normalize_evse_daily_entry(
@@ -5805,56 +5531,13 @@ class EnphaseEVClient:
         *,
         base_metadata: dict[str, object] | None = None,
     ) -> dict[str, object] | None:
-        metadata = dict(base_metadata or {})
-        day_values: dict[str, float] = {}
-        current_value: float | None = None
-        if isinstance(payload, dict):
-            metadata.update(cls._normalize_evse_timeseries_metadata(payload))
-            record_serial = cls._normalize_evse_timeseries_serial(
-                payload.get("serial")
-                or payload.get("serial_number")
-                or payload.get("device_serial")
-                or payload.get("charger_serial")
-                or payload.get("sn")
-            )
-            if record_serial and record_serial != serial:
-                serial = record_serial
-            nested = (
-                payload.get("days")
-                or payload.get("daily")
-                or payload.get("values")
-                or payload.get("series")
-                or payload.get("data")
-            )
-            if isinstance(nested, list):
-                day_values, current_value = cls._daily_values_from_sequence(
-                    nested,
-                    start_date_value=payload.get("start_date")
-                    or payload.get("startDate"),
-                    unit_hint=payload.get("unit") or payload.get("source_unit"),
-                )
-            elif isinstance(nested, dict):
-                day_values, current_value = cls._daily_values_from_mapping(nested)
-            else:
-                day_values, current_value = cls._daily_values_from_mapping(payload)
-        elif isinstance(payload, list):
-            day_values, current_value = cls._daily_values_from_sequence(payload)
-        else:
-            current_value = cls._coerce_evse_timeseries_energy(payload)
-        if not day_values and current_value is None:
-            return None
-        current_day = max(day_values) if day_values else None
-        return {
-            "serial": serial,
-            "day_values_kwh": day_values,
-            "energy_kwh": (
-                day_values.get(current_day)
-                if current_day is not None
-                else current_value
-            ),
-            "current_value_kwh": current_value,
-            **metadata,
-        }
+        return api_parsers.normalize_evse_daily_entry(
+            serial,
+            payload,
+            base_metadata=base_metadata,
+            parse_date_key=cls._parse_evse_timeseries_date_key,
+            coerce_energy=cls._coerce_evse_timeseries_energy,
+        )
 
     @classmethod
     def _normalize_evse_lifetime_entry(
@@ -5864,78 +5547,12 @@ class EnphaseEVClient:
         *,
         base_metadata: dict[str, object] | None = None,
     ) -> dict[str, object] | None:
-        metadata = dict(base_metadata or {})
-        energy_kwh: float | None = None
-        if isinstance(payload, dict):
-            metadata.update(cls._normalize_evse_timeseries_metadata(payload))
-            record_serial = cls._normalize_evse_timeseries_serial(
-                payload.get("serial")
-                or payload.get("serial_number")
-                or payload.get("device_serial")
-                or payload.get("charger_serial")
-                or payload.get("sn")
-            )
-            if record_serial and record_serial != serial:
-                serial = record_serial
-            unit_hint = payload.get("unit") or payload.get("source_unit")
-            for key in (
-                "energy_kwh",
-                "value_kwh",
-                "lifetime_energy_kwh",
-                "lifetime_kwh",
-                "total_kwh",
-                "energy_wh",
-                "lifetime_energy_wh",
-                "value_wh",
-                "energy",
-                "value",
-            ):
-                if key not in payload:
-                    continue
-                energy_kwh = cls._coerce_evse_timeseries_energy(
-                    payload.get(key), key_hint=key, unit_hint=unit_hint
-                )
-                if energy_kwh is not None:
-                    break
-            if energy_kwh is None:
-                values = (
-                    payload.get("values")
-                    or payload.get("series")
-                    or payload.get("data")
-                )
-                if isinstance(values, list):
-                    for item in reversed(values):
-                        if isinstance(item, dict):
-                            for key in (
-                                "energy_kwh",
-                                "value_kwh",
-                                "lifetime_energy_kwh",
-                                "energy_wh",
-                                "value_wh",
-                                "value",
-                            ):
-                                if key not in item:
-                                    continue
-                                energy_kwh = cls._coerce_evse_timeseries_energy(
-                                    item.get(key),
-                                    key_hint=key,
-                                    unit_hint=item.get("unit") or unit_hint,
-                                )
-                                if energy_kwh is not None:
-                                    break
-                            if energy_kwh is not None:
-                                break
-                        else:
-                            energy_kwh = cls._coerce_evse_timeseries_energy(
-                                item, unit_hint=unit_hint
-                            )
-                            if energy_kwh is not None:
-                                break
-        else:
-            energy_kwh = cls._coerce_evse_timeseries_energy(payload)
-        if energy_kwh is None:
-            return None
-        return {"serial": serial, "energy_kwh": energy_kwh, **metadata}
+        return api_parsers.normalize_evse_lifetime_entry(
+            serial,
+            payload,
+            base_metadata=base_metadata,
+            coerce_energy=cls._coerce_evse_timeseries_energy,
+        )
 
     @classmethod
     def _normalize_evse_timeseries_payload(
@@ -5944,66 +5561,12 @@ class EnphaseEVClient:
         *,
         daily: bool,
     ) -> dict[str, dict[str, object]] | None:
-        data = payload
-        if isinstance(data, dict) and isinstance(data.get("data"), (dict, list)):
-            data = data.get("data")
-        base_metadata = cls._normalize_evse_timeseries_metadata(
-            payload if isinstance(payload, dict) else {}
+        return api_parsers.normalize_evse_timeseries_payload(
+            payload,
+            daily=daily,
+            parse_date_key=cls._parse_evse_timeseries_date_key,
+            coerce_energy=cls._coerce_evse_timeseries_energy,
         )
-        if isinstance(data, dict):
-            candidates = (
-                data.get("results")
-                or data.get("chargers")
-                or data.get("devices")
-                or data.get("timeseries")
-            )
-            if isinstance(candidates, list):
-                data = candidates
-        normalized: dict[str, dict[str, object]] = {}
-        if isinstance(data, list):
-            for item in data:
-                if not isinstance(item, dict):
-                    continue
-                serial = cls._normalize_evse_timeseries_serial(
-                    item.get("serial")
-                    or item.get("serial_number")
-                    or item.get("device_serial")
-                    or item.get("charger_serial")
-                    or item.get("sn")
-                )
-                if not serial:
-                    continue
-                entry = (
-                    cls._normalize_evse_daily_entry(
-                        serial, item, base_metadata=base_metadata
-                    )
-                    if daily
-                    else cls._normalize_evse_lifetime_entry(
-                        serial, item, base_metadata=base_metadata
-                    )
-                )
-                if entry is not None:
-                    normalized[serial] = entry
-            return normalized
-        if not isinstance(data, dict):
-            return None
-        for key, value in data.items():
-            serial = cls._normalize_evse_timeseries_serial(key)
-            if not serial:
-                continue
-            entry = (
-                cls._normalize_evse_daily_entry(
-                    serial, value, base_metadata=base_metadata
-                )
-                if daily
-                else cls._normalize_evse_lifetime_entry(
-                    serial, value, base_metadata=base_metadata
-                )
-            )
-            if entry is None:
-                continue
-            normalized[serial] = entry
-        return normalized
 
     async def evse_timeseries_daily_energy(
         self,
@@ -6070,112 +5633,19 @@ class EnphaseEVClient:
     def _coerce_lifetime_energy_value(value: object) -> float | None:
         """Normalize numeric lifetime-energy values into float samples."""
 
-        if isinstance(value, (int, float)):
-            try:
-                return float(value)
-            except Exception:  # noqa: BLE001
-                return None
-        if isinstance(value, str):
-            cleaned = value.strip()
-            if not cleaned:
-                return None
-            try:
-                return float(cleaned)
-            except Exception:  # noqa: BLE001
-                return None
-        return None
+        return api_parsers.coerce_lifetime_energy_value(value)
 
     @classmethod
     def _coerce_non_boolean_number(cls, value: object) -> float | None:
         """Normalize numeric values while rejecting JSON booleans."""
 
-        if isinstance(value, bool):
-            return None
-        return cls._coerce_lifetime_energy_value(value)
+        return api_parsers.coerce_non_boolean_number(value)
 
     @classmethod
     def _normalize_lifetime_energy_payload(cls, payload: object) -> dict | None:
         """Normalize site/HEMS lifetime-energy payloads into a common shape."""
 
-        data = payload
-        if isinstance(data, dict) and isinstance(data.get("data"), dict):
-            data = data.get("data")
-        if not isinstance(data, dict):
-            return None
-
-        array_fields = {
-            "production",
-            "consumption",
-            "solar_home",
-            "solar_grid",
-            "grid_home",
-            "import",
-            "export",
-            "charge",
-            "discharge",
-            "solar_battery",
-            "battery_home",
-            "battery_grid",
-            "grid_battery",
-            "evse",
-            "heatpump",
-            "water_heater",
-        }
-        array_field_aliases = {
-            "evse_charging": "evse",
-            "heat_pump": "heatpump",
-            "heat-pump": "heatpump",
-            "waterheater": "water_heater",
-            "water-heater": "water_heater",
-            "water_heater_consumption": "water_heater",
-        }
-        metadata_fields = {
-            "start_date",
-            "last_report_date",
-            "update_pending",
-            "system_id",
-        }
-        metadata_aliases = {
-            "startDate": "start_date",
-            "lastReportDate": "last_report_date",
-            "updatePending": "update_pending",
-            "systemId": "system_id",
-        }
-
-        normalized: dict[str, object] = {}
-        for key, value in data.items():
-            canonical_key = array_field_aliases.get(key, key)
-            if canonical_key in array_fields:
-                # Prefer canonical keys when both canonical and alias variants exist.
-                if (
-                    canonical_key != key
-                    and canonical_key in data
-                    and canonical_key in normalized
-                ):
-                    continue
-                if isinstance(value, list):
-                    normalized[canonical_key] = [
-                        cls._coerce_lifetime_energy_value(v) for v in value
-                    ]
-                else:
-                    normalized[canonical_key] = []
-                continue
-            if key in metadata_fields:
-                normalized[key] = value
-                continue
-            canonical_meta = metadata_aliases.get(key)
-            if canonical_meta and canonical_meta not in normalized:
-                normalized[canonical_meta] = value
-
-        interval_minutes = cls._coerce_lifetime_energy_value(
-            data.get("interval_minutes")
-            or data.get("interval")
-            or data.get("interval_min")
-            or data.get("intervalMinutes")
-        )
-        if interval_minutes is not None and interval_minutes > 0:
-            normalized["interval_minutes"] = interval_minutes
-        return normalized
+        return api_parsers.normalize_lifetime_energy_payload(payload)
 
     async def hems_consumption_lifetime(self) -> dict | None:
         """Return HEMS lifetime consumption buckets when available.
@@ -6218,88 +5688,19 @@ class EnphaseEVClient:
     @staticmethod
     def _clean_optional_text(value: object) -> str | None:
         """Return a trimmed string value when present."""
-        return helper_coerce_optional_text(value)
+        return api_parsers.clean_optional_text(value)
 
     @classmethod
     def _heatpump_sg_ready_mode_details(cls, value: object) -> dict[str, object]:
         """Map raw HEMS SG Ready mode labels to app-facing semantics."""
 
-        text = cls._clean_optional_text(value)
-        if text is None:
-            return {
-                "sg_ready_mode_label": None,
-                "sg_ready_active": None,
-                "sg_ready_contact_state": None,
-            }
-        normalized = text.upper()
-        if normalized == "MODE_2":
-            return {
-                "sg_ready_mode_label": "Normal",
-                "sg_ready_active": False,
-                "sg_ready_contact_state": "open",
-            }
-        if normalized == "MODE_3":
-            return {
-                "sg_ready_mode_label": "Recommended",
-                "sg_ready_active": True,
-                "sg_ready_contact_state": "closed",
-            }
-        return {
-            "sg_ready_mode_label": None,
-            "sg_ready_active": None,
-            "sg_ready_contact_state": None,
-        }
+        return api_parsers.heatpump_sg_ready_mode_details(value)
 
     @classmethod
     def _normalize_hems_heatpump_state_payload(cls, payload: object) -> dict | None:
         """Normalize HEMS heat-pump runtime state payloads."""
 
-        if not isinstance(payload, dict):
-            return None
-        data = payload.get("data")
-        if not isinstance(data, dict):
-            data = payload
-        device_uid = cls._clean_optional_text(
-            data.get("device_uid")
-            if data.get("device_uid") is not None
-            else data.get("device-uid")
-        )
-        heatpump_status = cls._clean_optional_text(
-            data.get("heatpump_status")
-            if data.get("heatpump_status") is not None
-            else data.get("heatpump-status")
-        )
-        sg_ready_mode_raw = cls._clean_optional_text(
-            data.get("sg_ready_mode")
-            if data.get("sg_ready_mode") is not None
-            else data.get("sg-ready-mode")
-        )
-        details = cls._heatpump_sg_ready_mode_details(sg_ready_mode_raw)
-        endpoint_type = cls._clean_optional_text(payload.get("type"))
-        endpoint_timestamp = payload.get("timestamp")
-        normalized: dict[str, object] = {
-            "type": endpoint_type,
-            "timestamp": endpoint_timestamp,
-            "endpoint_type": endpoint_type,
-            "endpoint_timestamp": endpoint_timestamp,
-            "device_uid": device_uid,
-            "heatpump_status": heatpump_status,
-            "sg_ready_mode_raw": sg_ready_mode_raw,
-            "sg_ready_mode_label": details.get("sg_ready_mode_label"),
-            "sg_ready_active": details.get("sg_ready_active"),
-            "sg_ready_contact_state": details.get("sg_ready_contact_state"),
-            "vpp_sgready_mode_override": cls._clean_optional_text(
-                data.get("vpp_sgready_mode_override")
-                if data.get("vpp_sgready_mode_override") is not None
-                else data.get("vpp-sgready-mode-override")
-            ),
-            "last_report_at": (
-                data.get("last_report_at")
-                if data.get("last_report_at") is not None
-                else data.get("last-report-at")
-            ),
-        }
-        return normalized
+        return api_parsers.normalize_hems_heatpump_state_payload(payload)
 
     @classmethod
     def _normalize_hems_daily_consumption_entry(
@@ -6307,104 +5708,19 @@ class EnphaseEVClient:
     ) -> dict[str, object] | None:
         """Normalize a HEMS daily-consumption device entry."""
 
-        if not isinstance(payload, dict):
-            return None
-        device_uid = cls._clean_optional_text(
-            payload.get("device_uid")
-            if payload.get("device_uid") is not None
-            else payload.get("device-uid")
-        )
-        device_name = cls._clean_optional_text(
-            payload.get("device_name")
-            if payload.get("device_name") is not None
-            else payload.get("device-name")
-        )
-        buckets: list[dict[str, object]] = []
-        raw_buckets = payload.get("consumption")
-        if isinstance(raw_buckets, list):
-            for item in raw_buckets:
-                if not isinstance(item, dict):
-                    continue
-                bucket: dict[str, object] = {
-                    "solar": cls._coerce_lifetime_energy_value(item.get("solar")),
-                    "battery": cls._coerce_lifetime_energy_value(item.get("battery")),
-                    "grid": cls._coerce_lifetime_energy_value(item.get("grid")),
-                    "details": [],
-                }
-                details = item.get("details")
-                if isinstance(details, list):
-                    bucket["details"] = [
-                        cls._coerce_lifetime_energy_value(detail) for detail in details
-                    ]
-                buckets.append(bucket)
-        return {
-            "device_uid": device_uid,
-            "device_name": device_name,
-            "consumption": buckets,
-        }
+        return api_parsers.normalize_hems_daily_consumption_entry(payload)
 
     @classmethod
     def _normalize_hems_energy_consumption_payload(cls, payload: object) -> dict | None:
         """Normalize HEMS daily energy-consumption payloads."""
 
-        if not isinstance(payload, dict):
-            return None
-        data = payload.get("data")
-        if not isinstance(data, dict):
-            data = payload
-
-        endpoint_type = cls._clean_optional_text(payload.get("type"))
-        endpoint_timestamp = payload.get("timestamp")
-        normalized: dict[str, object] = {
-            "type": endpoint_type,
-            "timestamp": endpoint_timestamp,
-            "endpoint_type": endpoint_type,
-            "endpoint_timestamp": endpoint_timestamp,
-            "data": {
-                "heat-pump": [],
-                "evse": [],
-                "water-heater": [],
-            },
-        }
-        families = normalized["data"]
-        assert isinstance(families, dict)
-        for family_key in ("heat-pump", "evse", "water-heater"):
-            raw_family = data.get(family_key)
-            if raw_family is None:
-                raw_family = data.get(family_key.replace("-", "_"))
-            if not isinstance(raw_family, list):
-                continue
-            entries: list[dict[str, object]] = []
-            for item in raw_family:
-                normalized_entry = cls._normalize_hems_daily_consumption_entry(item)
-                if normalized_entry is not None:
-                    entries.append(normalized_entry)
-            families[family_key] = entries
-        return normalized
+        return api_parsers.normalize_hems_energy_consumption_payload(payload)
 
     @classmethod
     def _normalize_pv_system_today_payload(cls, payload: object) -> dict | None:
         """Normalize site-today payloads used by heat-pump daily totals."""
 
-        if not isinstance(payload, dict):
-            return None
-        stats = payload.get("stats")
-        normalized_stats: list[dict[str, object]] = []
-        if isinstance(stats, list):
-            for item in stats:
-                if not isinstance(item, dict):
-                    continue
-                normalized_stat = dict(item)
-                for key in ("heatpump", "heat_pump", "heat-pump"):
-                    value = item.get(key)
-                    if value is None:
-                        continue
-                    normalized_stat["heatpump"] = value
-                    break
-                normalized_stats.append(normalized_stat)
-        normalized = dict(payload)
-        normalized["stats"] = normalized_stats
-        return normalized
+        return api_parsers.normalize_pv_system_today_payload(payload)
 
     async def hems_heatpump_state(
         self, device_uid: str, *, timezone: str | None = None
@@ -6539,78 +5855,7 @@ class EnphaseEVClient:
     def _normalize_hems_power_timeseries_payload(cls, payload: object) -> dict | None:
         """Normalize HEMS heat-pump power timeseries payloads."""
 
-        data = payload
-        if isinstance(data, dict) and isinstance(data.get("data"), dict):
-            data = data.get("data")
-        if not isinstance(data, dict):
-            return None
-
-        raw_values: object | None = None
-        fallback_non_list: object | None = None
-        for key in (
-            "heat_pump_consumption",
-            "heatpump_consumption",
-            "heat-pump-consumption",
-            "heatPumpConsumption",
-            "heatpumpConsumption",
-            "heat_pump",
-            "heat-pump",
-            "heatpump",
-        ):
-            value = data.get(key)
-            if value is None:
-                continue
-            if isinstance(value, list):
-                raw_values = value
-                break
-            if fallback_non_list is None:
-                fallback_non_list = value
-        if raw_values is None:
-            for key, value in data.items():
-                key_text = str(key).strip().lower()
-                normalized_key = "".join(ch for ch in key_text if ch.isalnum())
-                if "heatpump" not in normalized_key:
-                    continue
-                if "consumption" not in normalized_key and not normalized_key.endswith(
-                    "heatpump"
-                ):
-                    continue
-                if not isinstance(value, list):
-                    if fallback_non_list is None:
-                        fallback_non_list = value
-                    continue
-                raw_values = value
-                break
-        if raw_values is None:
-            raw_values = fallback_non_list
-        values: list[float | None]
-        if isinstance(raw_values, list):
-            values = [cls._coerce_lifetime_energy_value(item) for item in raw_values]
-        else:
-            values = []
-
-        normalized: dict[str, object] = {
-            "heat_pump_consumption": values,
-        }
-        device_uid = data.get("device_uid")
-        if device_uid is None:
-            device_uid = data.get("uid")
-        if device_uid is not None:
-            normalized["device_uid"] = device_uid
-        start_date = data.get("start_date")
-        if start_date is None:
-            start_date = data.get("startDate")
-        if start_date is not None:
-            normalized["start_date"] = start_date
-        interval_minutes = cls._coerce_lifetime_energy_value(
-            data.get("interval_minutes")
-            or data.get("interval")
-            or data.get("interval_min")
-            or data.get("intervalMinutes")
-        )
-        if interval_minutes is not None and interval_minutes > 0:
-            normalized["interval_minutes"] = interval_minutes
-        return normalized
+        return api_parsers.normalize_hems_power_timeseries_payload(payload)
 
     @staticmethod
     def _is_hems_invalid_date_error(err: aiohttp.ClientResponseError) -> bool:

--- a/custom_components/enphase_ev/api_models.py
+++ b/custom_components/enphase_ev/api_models.py
@@ -1,0 +1,43 @@
+"""Typed API boundary models for the Enphase EV client."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class AuthTokens:
+    """Container for Enlighten authentication state."""
+
+    cookie: str
+    session_id: str | None = None
+    access_token: str | None = None
+    token_expires_at: int | None = None
+    raw_cookies: dict[str, str] | None = None
+
+
+@dataclass(slots=True)
+class SiteInfo:
+    """Basic representation of an Enlighten site."""
+
+    site_id: str
+    name: str | None = None
+
+
+@dataclass(slots=True)
+class ChargerInfo:
+    """Metadata about a charger discovered for a site."""
+
+    serial: str
+    name: str | None = None
+
+
+@dataclass(slots=True, frozen=True)
+class TextResponse:
+    """Raw text response returned by browser-compatible endpoints."""
+
+    status: int
+    text: str
+    url: str
+    headers: dict[str, str]
+    location: str | None = None

--- a/custom_components/enphase_ev/api_parsers.py
+++ b/custom_components/enphase_ev/api_parsers.py
@@ -1,0 +1,1119 @@
+"""Payload parser and normalizer helpers for Enphase API endpoints."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+
+from .api_models import ChargerInfo, SiteInfo
+from .runtime_helpers import coerce_optional_text
+
+
+@dataclass(slots=True, frozen=True)
+class LatestPowerSample:
+    """Normalized latest power sample."""
+
+    value: float
+    units: str | None = None
+    precision: int | None = None
+    time: int | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the payload shape used by existing API consumers."""
+
+        payload: dict[str, object] = {"value": self.value}
+        if self.units is not None:
+            payload["units"] = self.units
+        if self.precision is not None:
+            payload["precision"] = self.precision
+        if self.time is not None:
+            payload["time"] = self.time
+        return payload
+
+
+@dataclass(slots=True, frozen=True)
+class EVSEDailyEnergyEntry:
+    """Normalized EVSE daily energy timeseries for one charger."""
+
+    serial: str
+    day_values_kwh: dict[str, float]
+    energy_kwh: float | None
+    current_value_kwh: float | None
+    metadata: dict[str, object]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the payload shape used by existing API consumers."""
+
+        return {
+            "serial": self.serial,
+            "day_values_kwh": self.day_values_kwh,
+            "energy_kwh": self.energy_kwh,
+            "current_value_kwh": self.current_value_kwh,
+            **self.metadata,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class EVSELifetimeEnergyEntry:
+    """Normalized EVSE lifetime energy sample for one charger."""
+
+    serial: str
+    energy_kwh: float
+    metadata: dict[str, object]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the payload shape used by existing API consumers."""
+
+        return {"serial": self.serial, "energy_kwh": self.energy_kwh, **self.metadata}
+
+
+@dataclass(slots=True, frozen=True)
+class HEMSHeatpumpState:
+    """Normalized HEMS heat pump runtime state."""
+
+    payload: dict[str, object]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the payload shape used by existing API consumers."""
+
+        return dict(self.payload)
+
+
+@dataclass(slots=True, frozen=True)
+class HEMSDailyConsumptionEntry:
+    """Normalized HEMS daily consumption entry for one device."""
+
+    device_uid: str | None
+    device_name: str | None
+    consumption: list[dict[str, object]]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the payload shape used by existing API consumers."""
+
+        return {
+            "device_uid": self.device_uid,
+            "device_name": self.device_name,
+            "consumption": self.consumption,
+        }
+
+
+def normalize_sites(payload: object) -> list[SiteInfo]:
+    """Normalize Enlighten site search payload variants."""
+
+    data = payload
+    if isinstance(data, dict):
+        for key in ("sites", "data", "items", "systems"):
+            value = data.get(key)
+            if isinstance(value, list):
+                data = value
+                break
+    if not isinstance(data, list):
+        return []
+
+    sites: dict[str, SiteInfo] = {}
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        site_id = (
+            item.get("site_id")
+            or item.get("siteId")
+            or item.get("id")
+            or item.get("system_id")
+        )
+        if site_id is None:
+            continue
+        site_id_text = str(site_id)
+        name = (
+            item.get("name")
+            or item.get("site_name")
+            or item.get("siteName")
+            or item.get("title")
+            or item.get("displayName")
+            or item.get("display_name")
+        )
+        name_text = str(name) if name else None
+        if site_id_text in sites:
+            if not sites[site_id_text].name and name_text:
+                sites[site_id_text].name = name_text
+            continue
+        sites[site_id_text] = SiteInfo(site_id=site_id_text, name=name_text or None)
+    return list(sites.values())
+
+
+def normalize_chargers(payload: object) -> list[ChargerInfo]:
+    """Normalize charger inventory payload variants."""
+
+    data = payload
+    if isinstance(data, dict):
+        nested = data.get("data")
+        if nested:
+            data = nested
+
+    if isinstance(data, dict):
+        for key in ("chargers", "evChargerData", "evses", "devices", "items"):
+            value = data.get(key)
+            if isinstance(value, list):
+                data = value
+                break
+    if not isinstance(data, list):
+        return []
+
+    chargers: list[ChargerInfo] = []
+    for item in data:
+        if not isinstance(item, dict):
+            continue
+        serial = (
+            item.get("serial")
+            or item.get("serialNumber")
+            or item.get("sn")
+            or item.get("id")
+        )
+        if not serial:
+            continue
+        serial_text = str(serial)
+        name = (
+            item.get("name")
+            or item.get("displayName")
+            or item.get("display_name")
+            or item.get("title")
+        )
+        name_text = str(name) if name else None
+        chargers.append(ChargerInfo(serial=serial_text, name=name_text or None))
+    return chargers
+
+
+def coerce_lifetime_energy_value(value: object) -> float | None:
+    """Normalize numeric lifetime-energy values into float samples."""
+
+    if isinstance(value, (int, float)):
+        try:
+            return float(value)
+        except Exception:  # noqa: BLE001
+            return None
+    if isinstance(value, str):
+        cleaned = value.strip()
+        if not cleaned:
+            return None
+        try:
+            return float(cleaned)
+        except Exception:  # noqa: BLE001
+            return None
+    return None
+
+
+def coerce_non_boolean_number(value: object) -> float | None:
+    """Normalize numeric values while rejecting JSON booleans."""
+
+    if isinstance(value, bool):
+        return None
+    return coerce_lifetime_energy_value(value)
+
+
+def parse_latest_power_payload(payload: object) -> LatestPowerSample | None:
+    """Parse app-api latest power payloads into a typed sample."""
+
+    data = payload
+    if isinstance(data, dict) and isinstance(data.get("data"), dict):
+        data = data.get("data")
+    if not isinstance(data, dict):
+        return None
+
+    latest = data.get("latest_power")
+    if not isinstance(latest, dict):
+        latest = data
+
+    value = coerce_non_boolean_number(latest.get("value"))
+    if value is None:
+        return None
+
+    units_text: str | None = None
+    units = latest.get("units")
+    if units is not None:
+        try:
+            normalized_units = str(units).strip()
+        except Exception:  # noqa: BLE001
+            normalized_units = ""
+        if normalized_units:
+            units_text = normalized_units
+
+    precision_int: int | None = None
+    precision = coerce_non_boolean_number(latest.get("precision"))
+    if precision is not None:
+        try:
+            precision_int = int(precision)
+        except Exception:  # noqa: BLE001
+            precision_int = None
+
+    sample_time_int: int | None = None
+    sample_time = latest.get("time")
+    if sample_time is not None:
+        sample_time_val = coerce_non_boolean_number(sample_time)
+        if sample_time_val is not None:
+            if sample_time_val > 10**12:
+                sample_time_val /= 1000.0
+            try:
+                sample_time_int = int(sample_time_val)
+            except Exception:  # noqa: BLE001
+                sample_time_int = None
+
+    return LatestPowerSample(
+        value=value,
+        units=units_text,
+        precision=precision_int,
+        time=sample_time_int,
+    )
+
+
+def normalize_latest_power_payload(payload: object) -> dict[str, object] | None:
+    """Normalize app-api latest power payloads into a common shape."""
+
+    sample = parse_latest_power_payload(payload)
+    return sample.to_dict() if sample is not None else None
+
+
+def normalize_lifetime_energy_payload(payload: object) -> dict | None:
+    """Normalize site/HEMS lifetime-energy payloads into a common shape."""
+
+    data = payload
+    if isinstance(data, dict) and isinstance(data.get("data"), dict):
+        data = data.get("data")
+    if not isinstance(data, dict):
+        return None
+
+    array_fields = {
+        "production",
+        "consumption",
+        "solar_home",
+        "solar_grid",
+        "grid_home",
+        "import",
+        "export",
+        "charge",
+        "discharge",
+        "solar_battery",
+        "battery_home",
+        "battery_grid",
+        "grid_battery",
+        "evse",
+        "heatpump",
+        "water_heater",
+    }
+    array_field_aliases = {
+        "evse_charging": "evse",
+        "heat_pump": "heatpump",
+        "heat-pump": "heatpump",
+        "waterheater": "water_heater",
+        "water-heater": "water_heater",
+        "water_heater_consumption": "water_heater",
+    }
+    metadata_fields = {
+        "start_date",
+        "last_report_date",
+        "update_pending",
+        "system_id",
+    }
+    metadata_aliases = {
+        "startDate": "start_date",
+        "lastReportDate": "last_report_date",
+        "updatePending": "update_pending",
+        "systemId": "system_id",
+    }
+
+    normalized: dict[str, object] = {}
+    for key, value in data.items():
+        canonical_key = array_field_aliases.get(key, key)
+        if canonical_key in array_fields:
+            if (
+                canonical_key != key
+                and canonical_key in data
+                and canonical_key in normalized
+            ):
+                continue
+            if isinstance(value, list):
+                normalized[canonical_key] = [
+                    coerce_lifetime_energy_value(v) for v in value
+                ]
+            else:
+                normalized[canonical_key] = []
+            continue
+        if key in metadata_fields:
+            normalized[key] = value
+            continue
+        canonical_meta = metadata_aliases.get(key)
+        if canonical_meta and canonical_meta not in normalized:
+            normalized[canonical_meta] = value
+
+    interval_minutes = coerce_lifetime_energy_value(
+        data.get("interval_minutes")
+        or data.get("interval")
+        or data.get("interval_min")
+        or data.get("intervalMinutes")
+    )
+    if interval_minutes is not None and interval_minutes > 0:
+        normalized["interval_minutes"] = interval_minutes
+    return normalized
+
+
+def normalize_evse_timeseries_serial(value: object) -> str | None:
+    """Return a normalized EVSE serial string."""
+
+    if value is None:
+        return None
+    try:
+        text = str(value).strip()
+    except Exception:  # noqa: BLE001
+        return None
+    return text or None
+
+
+def parse_evse_timeseries_date_key(value: object) -> str | None:
+    """Normalize a date-like EVSE timeseries key to YYYY-MM-DD."""
+
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.date().isoformat()
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, (int, float)):
+        try:
+            ts_val = float(value)
+            if ts_val > 10**12:
+                ts_val /= 1000.0
+            return datetime.fromtimestamp(ts_val, tz=timezone.utc).date().isoformat()
+        except Exception:  # noqa: BLE001
+            return None
+    if not isinstance(value, str):
+        return None
+    cleaned = value.strip()
+    if not cleaned:
+        return None
+    if len(cleaned) >= 10:
+        try:
+            return (
+                datetime.fromisoformat(cleaned.replace("Z", "+00:00"))
+                .date()
+                .isoformat()
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            datetime.strptime(cleaned[:10], "%Y-%m-%d")
+            return cleaned[:10]
+        except Exception:  # noqa: BLE001
+            pass
+    return None
+
+
+def coerce_evse_timeseries_energy(
+    value: object,
+    *,
+    key_hint: str | None = None,
+    unit_hint: object | None = None,
+) -> float | None:
+    """Normalize EVSE timeseries energy to kWh."""
+
+    numeric = coerce_lifetime_energy_value(value)
+    if numeric is None:
+        return None
+    try:
+        unit_text = str(unit_hint).strip().lower() if unit_hint is not None else ""
+    except Exception:  # noqa: BLE001
+        unit_text = ""
+    hint = (key_hint or "").lower()
+    if "wh" in hint and "kwh" not in hint:
+        return round(numeric / 1000.0, 6)
+    if unit_text in {"wh", "watt_hour", "watt-hours", "watt_hours"}:
+        return round(numeric / 1000.0, 6)
+    return round(numeric, 6)
+
+
+def normalize_evse_timeseries_metadata(payload: object) -> dict[str, object]:
+    """Normalize shared EVSE timeseries metadata."""
+
+    if not isinstance(payload, dict):
+        return {}
+    interval = coerce_lifetime_energy_value(
+        payload.get("interval_minutes")
+        or payload.get("interval")
+        or payload.get("interval_min")
+        or payload.get("intervalMinutes")
+    )
+    metadata: dict[str, object] = {}
+    if interval is not None and interval > 0:
+        metadata["interval_minutes"] = interval
+    last_report = (
+        payload.get("last_report_date")
+        or payload.get("lastReportDate")
+        or payload.get("last_reported_at")
+        or payload.get("lastReportedAt")
+    )
+    if last_report is not None:
+        metadata["last_report_date"] = last_report
+    return metadata
+
+
+def daily_values_from_mapping(
+    payload: dict[str, object],
+    *,
+    parse_date_key: Callable[[object], str | None] = parse_evse_timeseries_date_key,
+    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
+) -> tuple[dict[str, float], float | None]:
+    """Extract per-day EVSE values from a mapping payload."""
+
+    day_values: dict[str, float] = {}
+    current_value: float | None = None
+    unit_hint = payload.get("unit") or payload.get("source_unit")
+    for key, raw in payload.items():
+        day_key = parse_date_key(key)
+        if day_key is None:
+            continue
+        numeric = coerce_energy(raw, key_hint=str(key), unit_hint=unit_hint)
+        if numeric is None:
+            continue
+        day_values[day_key] = numeric
+    for key in (
+        "energy_kwh",
+        "value_kwh",
+        "daily_energy_kwh",
+        "daily_kwh",
+        "energy",
+        "value",
+        "energy_wh",
+        "daily_energy_wh",
+    ):
+        if key not in payload:
+            continue
+        current_value = coerce_energy(
+            payload.get(key), key_hint=key, unit_hint=unit_hint
+        )
+        break
+    return day_values, current_value
+
+
+def daily_values_from_sequence(
+    values: list[object],
+    *,
+    start_date_value: object | None = None,
+    unit_hint: object | None = None,
+    parse_date_key: Callable[[object], str | None] = parse_evse_timeseries_date_key,
+    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
+) -> tuple[dict[str, float], float | None]:
+    """Extract per-day EVSE values from a sequence payload."""
+
+    day_values: dict[str, float] = {}
+    current_value: float | None = None
+    start_day = parse_date_key(start_date_value)
+    start_dt = None
+    if start_day is not None:
+        try:
+            start_dt = datetime.fromisoformat(start_day)
+        except Exception:  # noqa: BLE001
+            start_dt = None
+    for idx, item in enumerate(values):
+        if isinstance(item, dict):
+            day_key = parse_date_key(
+                item.get("date")
+                or item.get("day")
+                or item.get("start_date")
+                or item.get("startDate")
+                or item.get("timestamp")
+                or item.get("time")
+            )
+            item_unit = item.get("unit") or unit_hint
+            for key in (
+                "energy_kwh",
+                "value_kwh",
+                "daily_energy_kwh",
+                "energy",
+                "value",
+                "energy_wh",
+                "daily_energy_wh",
+            ):
+                if key not in item:
+                    continue
+                numeric = coerce_energy(
+                    item.get(key), key_hint=key, unit_hint=item_unit
+                )
+                if numeric is None:
+                    continue
+                if day_key is not None:
+                    day_values[day_key] = numeric
+                else:
+                    current_value = numeric
+                break
+            continue
+        numeric = coerce_energy(item, unit_hint=unit_hint)
+        if numeric is None:
+            continue
+        if start_dt is not None:
+            day_values[(start_dt + timedelta(days=idx)).date().isoformat()] = numeric
+        else:
+            current_value = numeric
+    return day_values, current_value
+
+
+def parse_evse_daily_entry(
+    serial: str,
+    payload: object,
+    *,
+    base_metadata: dict[str, object] | None = None,
+    parse_date_key: Callable[[object], str | None] = parse_evse_timeseries_date_key,
+    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
+) -> EVSEDailyEnergyEntry | None:
+    """Parse one EVSE daily timeseries entry."""
+
+    metadata = dict(base_metadata or {})
+    day_values: dict[str, float] = {}
+    current_value: float | None = None
+    if isinstance(payload, dict):
+        metadata.update(normalize_evse_timeseries_metadata(payload))
+        record_serial = normalize_evse_timeseries_serial(
+            payload.get("serial")
+            or payload.get("serial_number")
+            or payload.get("device_serial")
+            or payload.get("charger_serial")
+            or payload.get("sn")
+        )
+        if record_serial and record_serial != serial:
+            serial = record_serial
+        nested = (
+            payload.get("days")
+            or payload.get("daily")
+            or payload.get("values")
+            or payload.get("series")
+            or payload.get("data")
+        )
+        if isinstance(nested, list):
+            day_values, current_value = daily_values_from_sequence(
+                nested,
+                start_date_value=payload.get("start_date") or payload.get("startDate"),
+                unit_hint=payload.get("unit") or payload.get("source_unit"),
+                parse_date_key=parse_date_key,
+                coerce_energy=coerce_energy,
+            )
+        elif isinstance(nested, dict):
+            day_values, current_value = daily_values_from_mapping(
+                nested,
+                parse_date_key=parse_date_key,
+                coerce_energy=coerce_energy,
+            )
+        else:
+            day_values, current_value = daily_values_from_mapping(
+                payload,
+                parse_date_key=parse_date_key,
+                coerce_energy=coerce_energy,
+            )
+    elif isinstance(payload, list):
+        day_values, current_value = daily_values_from_sequence(
+            payload,
+            parse_date_key=parse_date_key,
+            coerce_energy=coerce_energy,
+        )
+    else:
+        current_value = coerce_energy(payload)
+    if not day_values and current_value is None:
+        return None
+    current_day = max(day_values) if day_values else None
+    return EVSEDailyEnergyEntry(
+        serial=serial,
+        day_values_kwh=day_values,
+        energy_kwh=(
+            day_values.get(current_day) if current_day is not None else current_value
+        ),
+        current_value_kwh=current_value,
+        metadata=metadata,
+    )
+
+
+def normalize_evse_daily_entry(
+    serial: str,
+    payload: object,
+    *,
+    base_metadata: dict[str, object] | None = None,
+    parse_date_key: Callable[[object], str | None] = parse_evse_timeseries_date_key,
+    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
+) -> dict[str, object] | None:
+    """Normalize one EVSE daily timeseries entry."""
+
+    entry = parse_evse_daily_entry(
+        serial,
+        payload,
+        base_metadata=base_metadata,
+        parse_date_key=parse_date_key,
+        coerce_energy=coerce_energy,
+    )
+    return entry.to_dict() if entry is not None else None
+
+
+def parse_evse_lifetime_entry(
+    serial: str,
+    payload: object,
+    *,
+    base_metadata: dict[str, object] | None = None,
+    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
+) -> EVSELifetimeEnergyEntry | None:
+    """Parse one EVSE lifetime timeseries entry."""
+
+    metadata = dict(base_metadata or {})
+    energy_kwh: float | None = None
+    if isinstance(payload, dict):
+        metadata.update(normalize_evse_timeseries_metadata(payload))
+        record_serial = normalize_evse_timeseries_serial(
+            payload.get("serial")
+            or payload.get("serial_number")
+            or payload.get("device_serial")
+            or payload.get("charger_serial")
+            or payload.get("sn")
+        )
+        if record_serial and record_serial != serial:
+            serial = record_serial
+        unit_hint = payload.get("unit") or payload.get("source_unit")
+        for key in (
+            "energy_kwh",
+            "value_kwh",
+            "lifetime_energy_kwh",
+            "lifetime_kwh",
+            "total_kwh",
+            "energy_wh",
+            "lifetime_energy_wh",
+            "value_wh",
+            "energy",
+            "value",
+        ):
+            if key not in payload:
+                continue
+            energy_kwh = coerce_energy(
+                payload.get(key), key_hint=key, unit_hint=unit_hint
+            )
+            if energy_kwh is not None:
+                break
+        if energy_kwh is None:
+            values = (
+                payload.get("values") or payload.get("series") or payload.get("data")
+            )
+            if isinstance(values, list):
+                for item in reversed(values):
+                    if isinstance(item, dict):
+                        for key in (
+                            "energy_kwh",
+                            "value_kwh",
+                            "lifetime_energy_kwh",
+                            "energy_wh",
+                            "value_wh",
+                            "value",
+                        ):
+                            if key not in item:
+                                continue
+                            energy_kwh = coerce_energy(
+                                item.get(key),
+                                key_hint=key,
+                                unit_hint=item.get("unit") or unit_hint,
+                            )
+                            if energy_kwh is not None:
+                                break
+                        if energy_kwh is not None:
+                            break
+                    else:
+                        energy_kwh = coerce_energy(item, unit_hint=unit_hint)
+                        if energy_kwh is not None:
+                            break
+    else:
+        energy_kwh = coerce_energy(payload)
+    if energy_kwh is None:
+        return None
+    return EVSELifetimeEnergyEntry(
+        serial=serial,
+        energy_kwh=energy_kwh,
+        metadata=metadata,
+    )
+
+
+def normalize_evse_lifetime_entry(
+    serial: str,
+    payload: object,
+    *,
+    base_metadata: dict[str, object] | None = None,
+    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
+) -> dict[str, object] | None:
+    """Normalize one EVSE lifetime timeseries entry."""
+
+    entry = parse_evse_lifetime_entry(
+        serial,
+        payload,
+        base_metadata=base_metadata,
+        coerce_energy=coerce_energy,
+    )
+    return entry.to_dict() if entry is not None else None
+
+
+def normalize_evse_timeseries_payload(
+    payload: object,
+    *,
+    daily: bool,
+    parse_date_key: Callable[[object], str | None] = parse_evse_timeseries_date_key,
+    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
+) -> dict[str, dict[str, object]] | None:
+    """Normalize EVSE timeseries payloads keyed by charger serial."""
+
+    data = payload
+    if isinstance(data, dict) and isinstance(data.get("data"), (dict, list)):
+        data = data.get("data")
+    base_metadata = normalize_evse_timeseries_metadata(
+        payload if isinstance(payload, dict) else {}
+    )
+    if isinstance(data, dict):
+        candidates = (
+            data.get("results")
+            or data.get("chargers")
+            or data.get("devices")
+            or data.get("timeseries")
+        )
+        if isinstance(candidates, list):
+            data = candidates
+    normalized: dict[str, dict[str, object]] = {}
+    if isinstance(data, list):
+        for item in data:
+            if not isinstance(item, dict):
+                continue
+            serial = normalize_evse_timeseries_serial(
+                item.get("serial")
+                or item.get("serial_number")
+                or item.get("device_serial")
+                or item.get("charger_serial")
+                or item.get("sn")
+            )
+            if not serial:
+                continue
+            entry = (
+                normalize_evse_daily_entry(
+                    serial,
+                    item,
+                    base_metadata=base_metadata,
+                    parse_date_key=parse_date_key,
+                    coerce_energy=coerce_energy,
+                )
+                if daily
+                else normalize_evse_lifetime_entry(
+                    serial,
+                    item,
+                    base_metadata=base_metadata,
+                    coerce_energy=coerce_energy,
+                )
+            )
+            if entry is not None:
+                normalized[serial] = entry
+        return normalized
+    if not isinstance(data, dict):
+        return None
+    for key, value in data.items():
+        serial = normalize_evse_timeseries_serial(key)
+        if not serial:
+            continue
+        entry = (
+            normalize_evse_daily_entry(
+                serial,
+                value,
+                base_metadata=base_metadata,
+                parse_date_key=parse_date_key,
+                coerce_energy=coerce_energy,
+            )
+            if daily
+            else normalize_evse_lifetime_entry(
+                serial,
+                value,
+                base_metadata=base_metadata,
+                coerce_energy=coerce_energy,
+            )
+        )
+        if entry is None:
+            continue
+        normalized[serial] = entry
+    return normalized
+
+
+def clean_optional_text(value: object) -> str | None:
+    """Return a trimmed string value when present."""
+
+    return coerce_optional_text(value)
+
+
+def heatpump_sg_ready_mode_details(value: object) -> dict[str, object]:
+    """Map raw HEMS SG Ready mode labels to app-facing semantics."""
+
+    text = clean_optional_text(value)
+    if text is None:
+        return {
+            "sg_ready_mode_label": None,
+            "sg_ready_active": None,
+            "sg_ready_contact_state": None,
+        }
+    normalized = text.upper()
+    if normalized == "MODE_2":
+        return {
+            "sg_ready_mode_label": "Normal",
+            "sg_ready_active": False,
+            "sg_ready_contact_state": "open",
+        }
+    if normalized == "MODE_3":
+        return {
+            "sg_ready_mode_label": "Recommended",
+            "sg_ready_active": True,
+            "sg_ready_contact_state": "closed",
+        }
+    return {
+        "sg_ready_mode_label": None,
+        "sg_ready_active": None,
+        "sg_ready_contact_state": None,
+    }
+
+
+def parse_hems_heatpump_state_payload(payload: object) -> HEMSHeatpumpState | None:
+    """Parse HEMS heat-pump runtime state payloads."""
+
+    if not isinstance(payload, dict):
+        return None
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        data = payload
+    device_uid = clean_optional_text(
+        data.get("device_uid")
+        if data.get("device_uid") is not None
+        else data.get("device-uid")
+    )
+    heatpump_status = clean_optional_text(
+        data.get("heatpump_status")
+        if data.get("heatpump_status") is not None
+        else data.get("heatpump-status")
+    )
+    sg_ready_mode_raw = clean_optional_text(
+        data.get("sg_ready_mode")
+        if data.get("sg_ready_mode") is not None
+        else data.get("sg-ready-mode")
+    )
+    details = heatpump_sg_ready_mode_details(sg_ready_mode_raw)
+    endpoint_type = clean_optional_text(payload.get("type"))
+    endpoint_timestamp = payload.get("timestamp")
+    return HEMSHeatpumpState(
+        {
+            "type": endpoint_type,
+            "timestamp": endpoint_timestamp,
+            "endpoint_type": endpoint_type,
+            "endpoint_timestamp": endpoint_timestamp,
+            "device_uid": device_uid,
+            "heatpump_status": heatpump_status,
+            "sg_ready_mode_raw": sg_ready_mode_raw,
+            "sg_ready_mode_label": details.get("sg_ready_mode_label"),
+            "sg_ready_active": details.get("sg_ready_active"),
+            "sg_ready_contact_state": details.get("sg_ready_contact_state"),
+            "vpp_sgready_mode_override": clean_optional_text(
+                data.get("vpp_sgready_mode_override")
+                if data.get("vpp_sgready_mode_override") is not None
+                else data.get("vpp-sgready-mode-override")
+            ),
+            "last_report_at": (
+                data.get("last_report_at")
+                if data.get("last_report_at") is not None
+                else data.get("last-report-at")
+            ),
+        }
+    )
+
+
+def normalize_hems_heatpump_state_payload(payload: object) -> dict | None:
+    """Normalize HEMS heat-pump runtime state payloads."""
+
+    state = parse_hems_heatpump_state_payload(payload)
+    return state.to_dict() if state is not None else None
+
+
+def parse_hems_daily_consumption_entry(
+    payload: object,
+) -> HEMSDailyConsumptionEntry | None:
+    """Parse a HEMS daily-consumption device entry."""
+
+    if not isinstance(payload, dict):
+        return None
+    device_uid = clean_optional_text(
+        payload.get("device_uid")
+        if payload.get("device_uid") is not None
+        else payload.get("device-uid")
+    )
+    device_name = clean_optional_text(
+        payload.get("device_name")
+        if payload.get("device_name") is not None
+        else payload.get("device-name")
+    )
+    buckets: list[dict[str, object]] = []
+    raw_buckets = payload.get("consumption")
+    if isinstance(raw_buckets, list):
+        for item in raw_buckets:
+            if not isinstance(item, dict):
+                continue
+            bucket: dict[str, object] = {
+                "solar": coerce_lifetime_energy_value(item.get("solar")),
+                "battery": coerce_lifetime_energy_value(item.get("battery")),
+                "grid": coerce_lifetime_energy_value(item.get("grid")),
+                "details": [],
+            }
+            details = item.get("details")
+            if isinstance(details, list):
+                bucket["details"] = [
+                    coerce_lifetime_energy_value(detail) for detail in details
+                ]
+            buckets.append(bucket)
+    return HEMSDailyConsumptionEntry(
+        device_uid=device_uid,
+        device_name=device_name,
+        consumption=buckets,
+    )
+
+
+def normalize_hems_daily_consumption_entry(
+    payload: object,
+) -> dict[str, object] | None:
+    """Normalize a HEMS daily-consumption device entry."""
+
+    entry = parse_hems_daily_consumption_entry(payload)
+    return entry.to_dict() if entry is not None else None
+
+
+def normalize_hems_energy_consumption_payload(payload: object) -> dict | None:
+    """Normalize HEMS daily energy-consumption payloads."""
+
+    if not isinstance(payload, dict):
+        return None
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        data = payload
+
+    endpoint_type = clean_optional_text(payload.get("type"))
+    endpoint_timestamp = payload.get("timestamp")
+    normalized: dict[str, object] = {
+        "type": endpoint_type,
+        "timestamp": endpoint_timestamp,
+        "endpoint_type": endpoint_type,
+        "endpoint_timestamp": endpoint_timestamp,
+        "data": {
+            "heat-pump": [],
+            "evse": [],
+            "water-heater": [],
+        },
+    }
+    families = normalized["data"]
+    assert isinstance(families, dict)
+    for family_key in ("heat-pump", "evse", "water-heater"):
+        raw_family = data.get(family_key)
+        if raw_family is None:
+            raw_family = data.get(family_key.replace("-", "_"))
+        if not isinstance(raw_family, list):
+            continue
+        entries: list[dict[str, object]] = []
+        for item in raw_family:
+            normalized_entry = normalize_hems_daily_consumption_entry(item)
+            if normalized_entry is not None:
+                entries.append(normalized_entry)
+        families[family_key] = entries
+    return normalized
+
+
+def normalize_pv_system_today_payload(payload: object) -> dict | None:
+    """Normalize site-today payloads used by heat-pump daily totals."""
+
+    if not isinstance(payload, dict):
+        return None
+    stats = payload.get("stats")
+    normalized_stats: list[dict[str, object]] = []
+    if isinstance(stats, list):
+        for item in stats:
+            if not isinstance(item, dict):
+                continue
+            normalized_stat = dict(item)
+            for key in ("heatpump", "heat_pump", "heat-pump"):
+                value = item.get(key)
+                if value is None:
+                    continue
+                normalized_stat["heatpump"] = value
+                break
+            normalized_stats.append(normalized_stat)
+    normalized = dict(payload)
+    normalized["stats"] = normalized_stats
+    return normalized
+
+
+def normalize_hems_power_timeseries_payload(payload: object) -> dict | None:
+    """Normalize HEMS heat-pump power timeseries payloads."""
+
+    data = payload
+    if isinstance(data, dict) and isinstance(data.get("data"), dict):
+        data = data.get("data")
+    if not isinstance(data, dict):
+        return None
+
+    raw_values: object | None = None
+    fallback_non_list: object | None = None
+    for key in (
+        "heat_pump_consumption",
+        "heatpump_consumption",
+        "heat-pump-consumption",
+        "heatPumpConsumption",
+        "heatpumpConsumption",
+        "heat_pump",
+        "heat-pump",
+        "heatpump",
+    ):
+        value = data.get(key)
+        if value is None:
+            continue
+        if isinstance(value, list):
+            raw_values = value
+            break
+        if fallback_non_list is None:
+            fallback_non_list = value
+    if raw_values is None:
+        for key, value in data.items():
+            key_text = str(key).strip().lower()
+            normalized_key = "".join(ch for ch in key_text if ch.isalnum())
+            if "heatpump" not in normalized_key:
+                continue
+            if "consumption" not in normalized_key and not normalized_key.endswith(
+                "heatpump"
+            ):
+                continue
+            if not isinstance(value, list):
+                if fallback_non_list is None:
+                    fallback_non_list = value
+                continue
+            raw_values = value
+            break
+    if raw_values is None:
+        raw_values = fallback_non_list
+    values: list[float | None]
+    if isinstance(raw_values, list):
+        values = [coerce_lifetime_energy_value(item) for item in raw_values]
+    else:
+        values = []
+
+    normalized: dict[str, object] = {
+        "heat_pump_consumption": values,
+    }
+    device_uid = data.get("device_uid")
+    if device_uid is None:
+        device_uid = data.get("uid")
+    if device_uid is not None:
+        normalized["device_uid"] = device_uid
+    start_date = data.get("start_date")
+    if start_date is None:
+        start_date = data.get("startDate")
+    if start_date is not None:
+        normalized["start_date"] = start_date
+    interval_minutes = coerce_lifetime_energy_value(
+        data.get("interval_minutes")
+        or data.get("interval")
+        or data.get("interval_min")
+        or data.get("intervalMinutes")
+    )
+    if interval_minutes is not None and interval_minutes > 0:
+        normalized["interval_minutes"] = interval_minutes
+    return normalized

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -20,6 +20,18 @@ from .battery_schedule_editor import (
     battery_schedule_overlap_placeholders,
     battery_schedule_overlap_record,
 )
+from .battery_runtime_dry_contact import (
+    copy_dry_contact_settings_entry,
+    dry_contact_identity_candidates,
+    dry_contact_identity_map,
+    dry_contact_match_conflicts,
+    dry_contact_member_dedupe_key,
+    dry_contact_member_is_dry_contact,
+    dry_contact_settings_looks_like_entry,
+    match_dry_contact_settings,
+    normalize_dry_contact_schedule_windows,
+    parse_dry_contact_settings_payload,
+)
 from .const import (
     BATTERY_BACKUP_HISTORY_CACHE_TTL,
     BATTERY_BACKUP_HISTORY_FAILURE_CACHE_TTL,
@@ -196,284 +208,42 @@ class BatteryRuntime:
     def _copy_dry_contact_settings_entry(
         self, entry: dict[str, object]
     ) -> dict[str, object]:
-        copied: dict[str, object] = {}
-        for key, value in entry.items():
-            if isinstance(value, dict):
-                copied[key] = dict(value)
-            elif isinstance(value, list):
-                copied[key] = [
-                    dict(item) if isinstance(item, dict) else item for item in value
-                ]
-            else:
-                copied[key] = value
-        return copied
+        return copy_dry_contact_settings_entry(entry)
 
     def _dry_contact_settings_looks_like_entry(self, entry: object) -> bool:
-        if not isinstance(entry, dict):
-            return False
-        keys = (
-            "serial_number",
-            "serial",
-            "serialNumber",
-            "device_uid",
-            "device-uid",
-            "deviceUid",
-            "uid",
-            "contact_id",
-            "contactId",
-            "id",
-            "channel_type",
-            "channelType",
-            "meter_type",
-            "name",
-            "displayName",
-            "configuredName",
-            "overrideSupported",
-            "overrideActive",
-            "controlMode",
-            "pollingInterval",
-            "pollingIntervalSeconds",
-            "socThreshold",
-            "socThresholdMin",
-            "socThresholdMax",
-            "scheduleWindows",
-            "schedule_windows",
-            "schedule",
-            "schedules",
-            "windows",
-        )
-        return any(key in entry for key in keys)
+        return dry_contact_settings_looks_like_entry(entry)
 
     def _normalize_dry_contact_schedule_windows(
         self, windows: object
     ) -> list[dict[str, object]]:
-        if isinstance(windows, list):
-            candidates = [item for item in windows if isinstance(item, dict)]
-        elif isinstance(windows, dict):
-            candidates = [windows]
-        else:
-            return []
-        normalized_windows: list[dict[str, object]] = []
-        seen: set[tuple[str | None, str | None]] = set()
-        for item in candidates:
-            start = self._coerce_optional_text(
-                item.get("start")
-                if item.get("start") is not None
-                else (
-                    item.get("startTime")
-                    if item.get("startTime") is not None
-                    else (
-                        item.get("begin")
-                        if item.get("begin") is not None
-                        else (
-                            item.get("beginTime")
-                            if item.get("beginTime") is not None
-                            else (
-                                item.get("from")
-                                if item.get("from") is not None
-                                else item.get("windowStart")
-                            )
-                        )
-                    )
-                )
-            )
-            end = self._coerce_optional_text(
-                item.get("end")
-                if item.get("end") is not None
-                else (
-                    item.get("endTime")
-                    if item.get("endTime") is not None
-                    else (
-                        item.get("finish")
-                        if item.get("finish") is not None
-                        else (
-                            item.get("finishTime")
-                            if item.get("finishTime") is not None
-                            else (
-                                item.get("to")
-                                if item.get("to") is not None
-                                else item.get("windowEnd")
-                            )
-                        )
-                    )
-                )
-            )
-            if start is None and end is None:
-                continue
-            dedupe_key = (start, end)
-            if dedupe_key in seen:
-                continue
-            seen.add(dedupe_key)
-            normalized: dict[str, object] = {}
-            if start is not None:
-                normalized["start"] = start
-            if end is not None:
-                normalized["end"] = end
-            normalized_windows.append(normalized)
-        return normalized_windows
+        return normalize_dry_contact_schedule_windows(
+            windows, self._coerce_optional_text
+        )
 
     def _dry_contact_identity_candidates(
         self,
         value: dict[str, object],
     ) -> list[tuple[str, str]]:
-        candidates: list[tuple[str, str]] = []
-
-        def _add(identity_key: str, raw_value: object) -> None:
-            text = self._coerce_optional_text(raw_value)
-            if text is None:
-                return
-            candidates.append((identity_key, text.casefold()))
-
-        _add(
-            "serial_number",
-            (
-                value.get("serial_number")
-                if value.get("serial_number") is not None
-                else (
-                    value.get("serial")
-                    if value.get("serial") is not None
-                    else value.get("serialNumber")
-                )
-            ),
-        )
-        _add(
-            "device_uid",
-            (
-                value.get("device_uid")
-                if value.get("device_uid") is not None
-                else (
-                    value.get("device-uid")
-                    if value.get("device-uid") is not None
-                    else (
-                        value.get("deviceUid")
-                        if value.get("deviceUid") is not None
-                        else (
-                            value.get("iqer_uid")
-                            if value.get("iqer_uid") is not None
-                            else value.get("iqer-uid")
-                        )
-                    )
-                )
-            ),
-        )
-        _add("uid", value.get("uid"))
-        _add(
-            "contact_id",
-            (
-                value.get("contact_id")
-                if value.get("contact_id") is not None
-                else (
-                    value.get("contactId")
-                    if value.get("contactId") is not None
-                    else value.get("id")
-                )
-            ),
-        )
-        _add(
-            "channel_type",
-            (
-                value.get("channel_type")
-                if value.get("channel_type") is not None
-                else (
-                    value.get("channelType")
-                    if value.get("channelType") is not None
-                    else (
-                        value.get("meter_type")
-                        if value.get("meter_type") is not None
-                        else value.get("type")
-                    )
-                )
-            ),
-        )
-        _add(
-            "name",
-            (
-                value.get("configured_name")
-                if value.get("configured_name") is not None
-                else (
-                    value.get("display_name")
-                    if value.get("display_name") is not None
-                    else (
-                        value.get("name")
-                        if value.get("name") is not None
-                        else (
-                            value.get("displayName")
-                            if value.get("displayName") is not None
-                            else (
-                                value.get("configuredName")
-                                if value.get("configuredName") is not None
-                                else value.get("label")
-                            )
-                        )
-                    )
-                )
-            ),
-        )
-        return candidates
+        return dry_contact_identity_candidates(value, self._coerce_optional_text)
 
     def _dry_contact_identity_map(self, value: dict[str, object]) -> dict[str, str]:
-        return dict(self._dry_contact_identity_candidates(value))
+        return dry_contact_identity_map(value, self._coerce_optional_text)
 
     @staticmethod
     def _dry_contact_member_dedupe_key(
         identities: dict[str, str], index: int
     ) -> tuple[tuple[str, str], ...]:
-        for keys in (
-            ("device_uid", "contact_id"),
-            ("device_uid", "channel_type"),
-            ("uid", "contact_id"),
-            ("uid", "channel_type"),
-            ("contact_id", "channel_type"),
-            ("serial_number", "channel_type"),
-            ("serial_number", "contact_id"),
-            ("contact_id",),
-            ("channel_type",),
-            ("serial_number",),
-            ("device_uid",),
-            ("uid",),
-            ("name",),
-        ):
-            if all(identities.get(key) is not None for key in keys):
-                return tuple((key, identities[key]) for key in keys)
-        return (("idx", str(index)),)
+        return dry_contact_member_dedupe_key(identities, index)
 
     @staticmethod
     def _dry_contact_match_conflicts(
         member_identities: dict[str, str],
         entry_identities: dict[str, str],
     ) -> bool:
-        for key in (
-            "contact_id",
-            "channel_type",
-            "serial_number",
-            "device_uid",
-            "uid",
-        ):
-            member_value = member_identities.get(key)
-            entry_value = entry_identities.get(key)
-            if member_value is None or entry_value is None:
-                continue
-            if member_value != entry_value:
-                return True
-        return False
+        return dry_contact_match_conflicts(member_identities, entry_identities)
 
     def _dry_contact_member_is_dry_contact(self, member: object) -> bool:
-        if not isinstance(member, dict):
-            return False
-        for key in ("channel_type", "channelType", "meter_type", "type", "name"):
-            value = self._coerce_optional_text(member.get(key))
-            if value is None:
-                continue
-            compact = (
-                value.casefold().replace("-", "").replace("_", "").replace(" ", "")
-            )
-            if compact in {"nc1", "nc2", "no1", "no2"}:
-                return True
-            if "drycontact" in compact:
-                return True
-            if "relay" in compact and any(token in compact for token in ("nc", "no")):
-                return True
-        return False
+        return dry_contact_member_is_dry_contact(member, self._coerce_optional_text)
 
     def _dry_contact_members_for_settings(self) -> list[dict[str, object]]:
         members: list[dict[str, object]] = []
@@ -523,71 +293,11 @@ class BatteryRuntime:
         *,
         settings_entries: list[dict[str, object]],
     ) -> tuple[list[dict[str, object] | None], list[dict[str, object]]]:
-        members_list = [dict(member) for member in members if isinstance(member, dict)]
-        member_identity_maps = [
-            self._dry_contact_identity_map(member) for member in members_list
-        ]
-        index_by_key: dict[str, dict[str, list[int]]] = {
-            key: {}
-            for key in (
-                "contact_id",
-                "channel_type",
-                "serial_number",
-                "device_uid",
-                "uid",
-                "name",
-            )
-        }
-        for index, identities in enumerate(member_identity_maps):
-            for key, mapping in index_by_key.items():
-                value = identities.get(key)
-                if value is None:
-                    continue
-                mapping.setdefault(value, []).append(index)
-
-        entries = [
-            self._copy_dry_contact_settings_entry(entry)
-            for entry in settings_entries
-            if isinstance(entry, dict)
-        ]
-        matches: list[dict[str, object] | None] = [None] * len(members_list)
-        unmatched: list[dict[str, object]] = []
-        used_member_indexes: set[int] = set()
-
-        for entry in entries:
-            entry_identities = self._dry_contact_identity_map(entry)
-            matched_member_index: int | None = None
-            for key in (
-                "contact_id",
-                "channel_type",
-                "serial_number",
-                "device_uid",
-                "uid",
-                "name",
-            ):
-                value = entry_identities.get(key)
-                if value is None:
-                    continue
-                candidate_indexes = [
-                    index
-                    for index in index_by_key[key].get(value, [])
-                    if index not in used_member_indexes
-                ]
-                if len(candidate_indexes) != 1:
-                    continue
-                candidate_index = candidate_indexes[0]
-                if self._dry_contact_match_conflicts(
-                    member_identity_maps[candidate_index], entry_identities
-                ):
-                    continue
-                matched_member_index = candidate_index
-                break
-            if matched_member_index is None:
-                unmatched.append(entry)
-                continue
-            used_member_indexes.add(matched_member_index)
-            matches[matched_member_index] = entry
-        return matches, unmatched
+        return match_dry_contact_settings(
+            members,
+            settings_entries=settings_entries,
+            coerce_text=self._coerce_optional_text,
+        )
 
     def _current_schedule_window_from_coordinator(
         self,
@@ -3194,353 +2904,20 @@ class BatteryRuntime:
 
     def parse_dry_contact_settings_payload(self, payload: object) -> None:
         state = self.battery_state
-        state._dry_contact_settings_entries = []
-        state._dry_contact_unmatched_settings = []
-        if not isinstance(payload, dict):
-            state._dry_contact_settings_supported = False
-            return
-        data = payload.get("data")
-        if not isinstance(data, dict):
-            data = payload
-        raw_entries: list[dict[str, object]] = []
-        visited: set[int] = set()
-
-        def _visit(node: object, depth: int = 0) -> None:
-            if depth > 4:
-                return
-            if isinstance(node, dict):
-                node_id = id(node)
-                if node_id in visited:
-                    return
-                visited.add(node_id)
-                if self._dry_contact_settings_looks_like_entry(node):
-                    raw_entries.append(node)
-                for value in node.values():
-                    if isinstance(value, (dict, list)):
-                        _visit(value, depth + 1)
-            elif isinstance(node, list):
-                for item in node:
-                    if isinstance(item, (dict, list)):
-                        _visit(item, depth + 1)
-
-        _visit(data)
-        entries: list[dict[str, object]] = []
-        seen_signatures: set[tuple[object, ...]] = set()
-        for entry in raw_entries:
-            normalized: dict[str, object] = {}
-            serial_number = self._coerce_optional_text(
-                entry.get("serial_number")
-                if entry.get("serial_number") is not None
-                else (
-                    entry.get("serial")
-                    if entry.get("serial") is not None
-                    else (
-                        entry.get("serialNumber")
-                        if entry.get("serialNumber") is not None
-                        else entry.get("deviceSerial")
-                    )
-                )
-            )
-            if serial_number is not None:
-                normalized["serial_number"] = serial_number
-            device_uid = self._coerce_optional_text(
-                entry.get("device_uid")
-                if entry.get("device_uid") is not None
-                else (
-                    entry.get("device-uid")
-                    if entry.get("device-uid") is not None
-                    else (
-                        entry.get("deviceUid")
-                        if entry.get("deviceUid") is not None
-                        else (
-                            entry.get("iqer_uid")
-                            if entry.get("iqer_uid") is not None
-                            else entry.get("iqer-uid")
-                        )
-                    )
-                )
-            )
-            if device_uid is not None:
-                normalized["device_uid"] = device_uid
-            uid = self._coerce_optional_text(entry.get("uid"))
-            if uid is not None:
-                normalized["uid"] = uid
-            contact_id = self._coerce_optional_text(
-                entry.get("contact_id")
-                if entry.get("contact_id") is not None
-                else (
-                    entry.get("contactId")
-                    if entry.get("contactId") is not None
-                    else entry.get("id")
-                )
-            )
-            if contact_id is not None:
-                normalized["contact_id"] = contact_id
-            channel_type = self._coerce_optional_text(
-                entry.get("channel_type")
-                if entry.get("channel_type") is not None
-                else (
-                    entry.get("channelType")
-                    if entry.get("channelType") is not None
-                    else (
-                        entry.get("meter_type")
-                        if entry.get("meter_type") is not None
-                        else entry.get("type")
-                    )
-                )
-            )
-            if channel_type is not None:
-                normalized["channel_type"] = channel_type
-            configured_name = self._coerce_optional_text(
-                entry.get("configured_name")
-                if entry.get("configured_name") is not None
-                else (
-                    entry.get("configuredName")
-                    if entry.get("configuredName") is not None
-                    else (
-                        entry.get("display_name")
-                        if entry.get("display_name") is not None
-                        else (
-                            entry.get("displayName")
-                            if entry.get("displayName") is not None
-                            else (
-                                entry.get("name")
-                                if entry.get("name") is not None
-                                else entry.get("label")
-                            )
-                        )
-                    )
-                )
-            )
-            if configured_name is not None:
-                normalized["configured_name"] = configured_name
-            override_supported = self._coerce_optional_bool(
-                entry.get("override_supported")
-                if entry.get("override_supported") is not None
-                else (
-                    entry.get("overrideSupported")
-                    if entry.get("overrideSupported") is not None
-                    else (
-                        entry.get("isOverrideSupported")
-                        if entry.get("isOverrideSupported") is not None
-                        else (
-                            entry.get("supportsOverride")
-                            if entry.get("supportsOverride") is not None
-                            else (
-                                entry.get("allowOverride")
-                                if entry.get("allowOverride") is not None
-                                else entry.get("canOverride")
-                            )
-                        )
-                    )
-                )
-            )
-            if override_supported is not None:
-                normalized["override_supported"] = override_supported
-            override_active = self._coerce_optional_bool(
-                entry.get("override_active")
-                if entry.get("override_active") is not None
-                else (
-                    entry.get("overrideActive")
-                    if entry.get("overrideActive") is not None
-                    else (
-                        entry.get("override")
-                        if entry.get("override") is not None
-                        else (
-                            entry.get("isOverrideActive")
-                            if entry.get("isOverrideActive") is not None
-                            else entry.get("manualOverride")
-                        )
-                    )
-                )
-            )
-            if override_active is not None:
-                normalized["override_active"] = override_active
-            control_mode = self._coerce_optional_text(
-                entry.get("control_mode")
-                if entry.get("control_mode") is not None
-                else (
-                    entry.get("controlMode")
-                    if entry.get("controlMode") is not None
-                    else (
-                        entry.get("mode")
-                        if entry.get("mode") is not None
-                        else entry.get("operatingMode")
-                    )
-                )
-            )
-            if control_mode is not None:
-                normalized["control_mode"] = control_mode
-            polling_interval = self._coerce_optional_int(
-                entry.get("polling_interval_seconds")
-                if entry.get("polling_interval_seconds") is not None
-                else (
-                    entry.get("pollingIntervalSeconds")
-                    if entry.get("pollingIntervalSeconds") is not None
-                    else (
-                        entry.get("pollingInterval")
-                        if entry.get("pollingInterval") is not None
-                        else entry.get("polling_interval")
-                    )
-                )
-            )
-            if polling_interval is not None:
-                normalized["polling_interval_seconds"] = polling_interval
-            soc_threshold = self._coerce_optional_int(
-                entry.get("soc_threshold")
-                if entry.get("soc_threshold") is not None
-                else (
-                    entry.get("socThreshold")
-                    if entry.get("socThreshold") is not None
-                    else (
-                        entry.get("thresholdSoc")
-                        if entry.get("thresholdSoc") is not None
-                        else (
-                            entry.get("targetSoc")
-                            if entry.get("targetSoc") is not None
-                            else (
-                                entry.get("setPointSoc")
-                                if entry.get("setPointSoc") is not None
-                                else entry.get("soc")
-                            )
-                        )
-                    )
-                )
-            )
-            if soc_threshold is not None:
-                normalized["soc_threshold"] = soc_threshold
-            soc_threshold_min = self._coerce_optional_int(
-                entry.get("soc_threshold_min")
-                if entry.get("soc_threshold_min") is not None
-                else (
-                    entry.get("socThresholdMin")
-                    if entry.get("socThresholdMin") is not None
-                    else (
-                        entry.get("minimumSoc")
-                        if entry.get("minimumSoc") is not None
-                        else (
-                            entry.get("minSoc")
-                            if entry.get("minSoc") is not None
-                            else entry.get("minSocThreshold")
-                        )
-                    )
-                )
-            )
-            if soc_threshold_min is not None:
-                normalized["soc_threshold_min"] = soc_threshold_min
-            soc_threshold_max = self._coerce_optional_int(
-                entry.get("soc_threshold_max")
-                if entry.get("soc_threshold_max") is not None
-                else (
-                    entry.get("socThresholdMax")
-                    if entry.get("socThresholdMax") is not None
-                    else (
-                        entry.get("maximumSoc")
-                        if entry.get("maximumSoc") is not None
-                        else (
-                            entry.get("maxSoc")
-                            if entry.get("maxSoc") is not None
-                            else entry.get("maxSocThreshold")
-                        )
-                    )
-                )
-            )
-            if soc_threshold_max is not None:
-                normalized["soc_threshold_max"] = soc_threshold_max
-            schedule_windows = self._normalize_dry_contact_schedule_windows(
-                entry.get("schedule_windows")
-                if entry.get("schedule_windows") is not None
-                else (
-                    entry.get("scheduleWindows")
-                    if entry.get("scheduleWindows") is not None
-                    else (
-                        entry.get("schedule")
-                        if entry.get("schedule") is not None
-                        else (
-                            entry.get("schedules")
-                            if entry.get("schedules") is not None
-                            else (
-                                entry.get("windows")
-                                if entry.get("windows") is not None
-                                else entry.get("window")
-                            )
-                        )
-                    )
-                )
-            )
-            if not schedule_windows:
-                fallback_start = self._coerce_optional_text(
-                    entry.get("scheduleStart")
-                    if entry.get("scheduleStart") is not None
-                    else (
-                        entry.get("schedule_start")
-                        if entry.get("schedule_start") is not None
-                        else (
-                            entry.get("windowStart")
-                            if entry.get("windowStart") is not None
-                            else entry.get("startTime")
-                        )
-                    )
-                )
-                fallback_end = self._coerce_optional_text(
-                    entry.get("scheduleEnd")
-                    if entry.get("scheduleEnd") is not None
-                    else (
-                        entry.get("schedule_end")
-                        if entry.get("schedule_end") is not None
-                        else (
-                            entry.get("windowEnd")
-                            if entry.get("windowEnd") is not None
-                            else entry.get("endTime")
-                        )
-                    )
-                )
-                if fallback_start is not None or fallback_end is not None:
-                    schedule_window: dict[str, object] = {}
-                    if fallback_start is not None:
-                        schedule_window["start"] = fallback_start
-                    if fallback_end is not None:
-                        schedule_window["end"] = fallback_end
-                    schedule_windows = [schedule_window]
-            if schedule_windows:
-                normalized["schedule_windows"] = schedule_windows
-            if not normalized:
-                continue
-            signature = (
-                normalized.get("serial_number"),
-                normalized.get("device_uid"),
-                normalized.get("uid"),
-                normalized.get("contact_id"),
-                normalized.get("channel_type"),
-                normalized.get("configured_name"),
-                normalized.get("override_supported"),
-                normalized.get("override_active"),
-                normalized.get("control_mode"),
-                normalized.get("polling_interval_seconds"),
-                normalized.get("soc_threshold"),
-                normalized.get("soc_threshold_min"),
-                normalized.get("soc_threshold_max"),
-                tuple(
-                    (
-                        window.get("start") if isinstance(window, dict) else None,
-                        window.get("end") if isinstance(window, dict) else None,
-                    )
-                    for window in normalized.get("schedule_windows", [])
-                    if isinstance(window, dict)
-                ),
-            )
-            if signature in seen_signatures:
-                continue
-            seen_signatures.add(signature)
-            entries.append(normalized)
-        matches, unmatched = self._match_dry_contact_settings(
-            self._dry_contact_members_for_settings(),
-            settings_entries=entries,
+        result = parse_dry_contact_settings_payload(
+            payload,
+            members=(
+                self._dry_contact_members_for_settings()
+                if isinstance(payload, dict)
+                else []
+            ),
+            coerce_bool=self._coerce_optional_bool,
+            coerce_int=self._coerce_optional_int,
+            coerce_text=self._coerce_optional_text,
         )
-        _ = matches
-        state._dry_contact_settings_entries = entries
-        state._dry_contact_unmatched_settings = unmatched
-        state._dry_contact_settings_supported = True
+        state._dry_contact_settings_entries = result.entries
+        state._dry_contact_unmatched_settings = result.unmatched
+        state._dry_contact_settings_supported = result.supported
 
     def dry_contact_settings_matches(
         self,

--- a/custom_components/enphase_ev/battery_runtime_dry_contact.py
+++ b/custom_components/enphase_ev/battery_runtime_dry_contact.py
@@ -1,0 +1,563 @@
+"""Dry contact settings parsing helpers for battery runtime."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+CoerceBool = Callable[[object], bool | None]
+CoerceInt = Callable[[object], int | None]
+CoerceText = Callable[[object], str | None]
+
+
+@dataclass(frozen=True)
+class DryContactSettingsParseResult:
+    """Normalized dry contact settings payload result."""
+
+    entries: list[dict[str, object]]
+    unmatched: list[dict[str, object]]
+    supported: bool
+
+
+DRY_CONTACT_ENTRY_KEYS = (
+    "serial_number",
+    "serial",
+    "serialNumber",
+    "device_uid",
+    "device-uid",
+    "deviceUid",
+    "uid",
+    "contact_id",
+    "contactId",
+    "id",
+    "channel_type",
+    "channelType",
+    "meter_type",
+    "name",
+    "displayName",
+    "configuredName",
+    "overrideSupported",
+    "overrideActive",
+    "controlMode",
+    "pollingInterval",
+    "pollingIntervalSeconds",
+    "socThreshold",
+    "socThresholdMin",
+    "socThresholdMax",
+    "scheduleWindows",
+    "schedule_windows",
+    "schedule",
+    "schedules",
+    "windows",
+)
+
+
+def _first_present(source: dict[str, object], *keys: str) -> object:
+    """Return the first present, non-None value for a known set of aliases."""
+
+    for key in keys:
+        value = source.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def copy_dry_contact_settings_entry(entry: dict[str, object]) -> dict[str, object]:
+    """Return a shallow copy that also detaches nested dict/list containers."""
+
+    copied: dict[str, object] = {}
+    for key, value in entry.items():
+        if isinstance(value, dict):
+            copied[key] = dict(value)
+        elif isinstance(value, list):
+            copied[key] = [
+                dict(item) if isinstance(item, dict) else item for item in value
+            ]
+        else:
+            copied[key] = value
+    return copied
+
+
+def dry_contact_settings_looks_like_entry(entry: object) -> bool:
+    """Return whether a payload node resembles a dry-contact settings entry."""
+
+    return isinstance(entry, dict) and any(
+        key in entry for key in DRY_CONTACT_ENTRY_KEYS
+    )
+
+
+def normalize_dry_contact_schedule_windows(
+    windows: object, coerce_text: CoerceText
+) -> list[dict[str, object]]:
+    """Normalize dry-contact schedule windows from known payload aliases."""
+
+    if isinstance(windows, list):
+        candidates = [item for item in windows if isinstance(item, dict)]
+    elif isinstance(windows, dict):
+        candidates = [windows]
+    else:
+        return []
+    normalized_windows: list[dict[str, object]] = []
+    seen: set[tuple[str | None, str | None]] = set()
+    for item in candidates:
+        start = coerce_text(
+            _first_present(
+                item,
+                "start",
+                "startTime",
+                "begin",
+                "beginTime",
+                "from",
+                "windowStart",
+            )
+        )
+        end = coerce_text(
+            _first_present(
+                item,
+                "end",
+                "endTime",
+                "finish",
+                "finishTime",
+                "to",
+                "windowEnd",
+            )
+        )
+        if start is None and end is None:
+            continue
+        dedupe_key = (start, end)
+        if dedupe_key in seen:
+            continue
+        seen.add(dedupe_key)
+        normalized: dict[str, object] = {}
+        if start is not None:
+            normalized["start"] = start
+        if end is not None:
+            normalized["end"] = end
+        normalized_windows.append(normalized)
+    return normalized_windows
+
+
+def dry_contact_identity_candidates(
+    value: dict[str, object], coerce_text: CoerceText
+) -> list[tuple[str, str]]:
+    """Build normalized identity candidates from known dry-contact aliases."""
+
+    candidates: list[tuple[str, str]] = []
+
+    def _add(identity_key: str, raw_value: object) -> None:
+        text = coerce_text(raw_value)
+        if text is None:
+            return
+        candidates.append((identity_key, text.casefold()))
+
+    _add(
+        "serial_number",
+        _first_present(value, "serial_number", "serial", "serialNumber"),
+    )
+    _add(
+        "device_uid",
+        _first_present(
+            value, "device_uid", "device-uid", "deviceUid", "iqer_uid", "iqer-uid"
+        ),
+    )
+    _add("uid", value.get("uid"))
+    _add("contact_id", _first_present(value, "contact_id", "contactId", "id"))
+    _add(
+        "channel_type",
+        _first_present(value, "channel_type", "channelType", "meter_type", "type"),
+    )
+    _add(
+        "name",
+        _first_present(
+            value,
+            "configured_name",
+            "display_name",
+            "name",
+            "displayName",
+            "configuredName",
+            "label",
+        ),
+    )
+    return candidates
+
+
+def dry_contact_identity_map(
+    value: dict[str, object], coerce_text: CoerceText
+) -> dict[str, str]:
+    """Build a dry-contact identity map from known aliases."""
+
+    return dict(dry_contact_identity_candidates(value, coerce_text))
+
+
+def dry_contact_member_dedupe_key(
+    identities: dict[str, str], index: int
+) -> tuple[tuple[str, str], ...]:
+    """Return the most specific stable dedupe key for a dry-contact member."""
+
+    for keys in (
+        ("device_uid", "contact_id"),
+        ("device_uid", "channel_type"),
+        ("uid", "contact_id"),
+        ("uid", "channel_type"),
+        ("contact_id", "channel_type"),
+        ("serial_number", "channel_type"),
+        ("serial_number", "contact_id"),
+        ("contact_id",),
+        ("channel_type",),
+        ("serial_number",),
+        ("device_uid",),
+        ("uid",),
+        ("name",),
+    ):
+        if all(identities.get(key) is not None for key in keys):
+            return tuple((key, identities[key]) for key in keys)
+    return (("idx", str(index)),)
+
+
+def dry_contact_match_conflicts(
+    member_identities: dict[str, str],
+    entry_identities: dict[str, str],
+) -> bool:
+    """Return whether two partially matched dry-contact identities conflict."""
+
+    for key in (
+        "contact_id",
+        "channel_type",
+        "serial_number",
+        "device_uid",
+        "uid",
+    ):
+        member_value = member_identities.get(key)
+        entry_value = entry_identities.get(key)
+        if member_value is None or entry_value is None:
+            continue
+        if member_value != entry_value:
+            return True
+    return False
+
+
+def dry_contact_member_is_dry_contact(member: object, coerce_text: CoerceText) -> bool:
+    """Return whether an inventory member appears to be a dry-contact relay."""
+
+    if not isinstance(member, dict):
+        return False
+    for key in ("channel_type", "channelType", "meter_type", "type", "name"):
+        value = coerce_text(member.get(key))
+        if value is None:
+            continue
+        compact = value.casefold().replace("-", "").replace("_", "").replace(" ", "")
+        if compact in {"nc1", "nc2", "no1", "no2"}:
+            return True
+        if "drycontact" in compact:
+            return True
+        if "relay" in compact and any(token in compact for token in ("nc", "no")):
+            return True
+    return False
+
+
+def match_dry_contact_settings(
+    members: list[dict[str, object]],
+    *,
+    settings_entries: list[dict[str, object]],
+    coerce_text: CoerceText,
+) -> tuple[list[dict[str, object] | None], list[dict[str, object]]]:
+    """Match normalized dry-contact settings entries to inventory members."""
+
+    members_list = [dict(member) for member in members if isinstance(member, dict)]
+    member_identity_maps = [
+        dry_contact_identity_map(member, coerce_text) for member in members_list
+    ]
+    index_by_key: dict[str, dict[str, list[int]]] = {
+        key: {}
+        for key in (
+            "contact_id",
+            "channel_type",
+            "serial_number",
+            "device_uid",
+            "uid",
+            "name",
+        )
+    }
+    for index, identities in enumerate(member_identity_maps):
+        for key, mapping in index_by_key.items():
+            value = identities.get(key)
+            if value is None:
+                continue
+            mapping.setdefault(value, []).append(index)
+
+    entries = [
+        copy_dry_contact_settings_entry(entry)
+        for entry in settings_entries
+        if isinstance(entry, dict)
+    ]
+    matches: list[dict[str, object] | None] = [None] * len(members_list)
+    unmatched: list[dict[str, object]] = []
+    used_member_indexes: set[int] = set()
+
+    for entry in entries:
+        entry_identities = dry_contact_identity_map(entry, coerce_text)
+        matched_member_index: int | None = None
+        for key in (
+            "contact_id",
+            "channel_type",
+            "serial_number",
+            "device_uid",
+            "uid",
+            "name",
+        ):
+            value = entry_identities.get(key)
+            if value is None:
+                continue
+            candidate_indexes = [
+                index
+                for index in index_by_key[key].get(value, [])
+                if index not in used_member_indexes
+            ]
+            if len(candidate_indexes) != 1:
+                continue
+            candidate_index = candidate_indexes[0]
+            if dry_contact_match_conflicts(
+                member_identity_maps[candidate_index], entry_identities
+            ):
+                continue
+            matched_member_index = candidate_index
+            break
+        if matched_member_index is None:
+            unmatched.append(entry)
+            continue
+        used_member_indexes.add(matched_member_index)
+        matches[matched_member_index] = entry
+    return matches, unmatched
+
+
+def parse_dry_contact_settings_payload(
+    payload: object,
+    *,
+    members: list[dict[str, object]],
+    coerce_bool: CoerceBool,
+    coerce_int: CoerceInt,
+    coerce_text: CoerceText,
+) -> DryContactSettingsParseResult:
+    """Parse and normalize dry-contact settings from an Enphase payload."""
+
+    if not isinstance(payload, dict):
+        return DryContactSettingsParseResult([], [], False)
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        data = payload
+    raw_entries: list[dict[str, object]] = []
+    visited: set[int] = set()
+
+    def _visit(node: object, depth: int = 0) -> None:
+        if depth > 4:
+            return
+        if isinstance(node, dict):
+            node_id = id(node)
+            if node_id in visited:
+                return
+            visited.add(node_id)
+            if dry_contact_settings_looks_like_entry(node):
+                raw_entries.append(node)
+            for value in node.values():
+                if isinstance(value, (dict, list)):
+                    _visit(value, depth + 1)
+        elif isinstance(node, list):
+            for item in node:
+                if isinstance(item, (dict, list)):
+                    _visit(item, depth + 1)
+
+    _visit(data)
+    entries: list[dict[str, object]] = []
+    seen_signatures: set[tuple[object, ...]] = set()
+    for entry in raw_entries:
+        normalized = _normalize_dry_contact_settings_entry(
+            entry,
+            coerce_bool=coerce_bool,
+            coerce_int=coerce_int,
+            coerce_text=coerce_text,
+        )
+        if not normalized:
+            continue
+        signature = _dry_contact_settings_signature(normalized)
+        if signature in seen_signatures:
+            continue
+        seen_signatures.add(signature)
+        entries.append(normalized)
+    _matches, unmatched = match_dry_contact_settings(
+        members,
+        settings_entries=entries,
+        coerce_text=coerce_text,
+    )
+    return DryContactSettingsParseResult(entries, unmatched, True)
+
+
+def _normalize_dry_contact_settings_entry(
+    entry: dict[str, object],
+    *,
+    coerce_bool: CoerceBool,
+    coerce_int: CoerceInt,
+    coerce_text: CoerceText,
+) -> dict[str, object]:
+    normalized: dict[str, object] = {}
+
+    text_fields: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("serial_number", ("serial_number", "serial", "serialNumber", "deviceSerial")),
+        (
+            "device_uid",
+            ("device_uid", "device-uid", "deviceUid", "iqer_uid", "iqer-uid"),
+        ),
+        ("uid", ("uid",)),
+        ("contact_id", ("contact_id", "contactId", "id")),
+        ("channel_type", ("channel_type", "channelType", "meter_type", "type")),
+        (
+            "configured_name",
+            (
+                "configured_name",
+                "configuredName",
+                "display_name",
+                "displayName",
+                "name",
+                "label",
+            ),
+        ),
+        ("control_mode", ("control_mode", "controlMode", "mode", "operatingMode")),
+    )
+    for target_key, source_keys in text_fields:
+        value = coerce_text(_first_present(entry, *source_keys))
+        if value is not None:
+            normalized[target_key] = value
+
+    bool_fields: tuple[tuple[str, tuple[str, ...]], ...] = (
+        (
+            "override_supported",
+            (
+                "override_supported",
+                "overrideSupported",
+                "isOverrideSupported",
+                "supportsOverride",
+                "allowOverride",
+                "canOverride",
+            ),
+        ),
+        (
+            "override_active",
+            (
+                "override_active",
+                "overrideActive",
+                "override",
+                "isOverrideActive",
+                "manualOverride",
+            ),
+        ),
+    )
+    for target_key, source_keys in bool_fields:
+        value = coerce_bool(_first_present(entry, *source_keys))
+        if value is not None:
+            normalized[target_key] = value
+
+    int_fields: tuple[tuple[str, tuple[str, ...]], ...] = (
+        (
+            "polling_interval_seconds",
+            (
+                "polling_interval_seconds",
+                "pollingIntervalSeconds",
+                "pollingInterval",
+                "polling_interval",
+            ),
+        ),
+        (
+            "soc_threshold",
+            (
+                "soc_threshold",
+                "socThreshold",
+                "thresholdSoc",
+                "targetSoc",
+                "setPointSoc",
+                "soc",
+            ),
+        ),
+        (
+            "soc_threshold_min",
+            (
+                "soc_threshold_min",
+                "socThresholdMin",
+                "minimumSoc",
+                "minSoc",
+                "minSocThreshold",
+            ),
+        ),
+        (
+            "soc_threshold_max",
+            (
+                "soc_threshold_max",
+                "socThresholdMax",
+                "maximumSoc",
+                "maxSoc",
+                "maxSocThreshold",
+            ),
+        ),
+    )
+    for target_key, source_keys in int_fields:
+        value = coerce_int(_first_present(entry, *source_keys))
+        if value is not None:
+            normalized[target_key] = value
+
+    schedule_windows = normalize_dry_contact_schedule_windows(
+        _first_present(
+            entry,
+            "schedule_windows",
+            "scheduleWindows",
+            "schedule",
+            "schedules",
+            "windows",
+            "window",
+        ),
+        coerce_text,
+    )
+    if not schedule_windows:
+        fallback_start = coerce_text(
+            _first_present(
+                entry, "scheduleStart", "schedule_start", "windowStart", "startTime"
+            )
+        )
+        fallback_end = coerce_text(
+            _first_present(entry, "scheduleEnd", "schedule_end", "windowEnd", "endTime")
+        )
+        if fallback_start is not None or fallback_end is not None:
+            schedule_window: dict[str, object] = {}
+            if fallback_start is not None:
+                schedule_window["start"] = fallback_start
+            if fallback_end is not None:
+                schedule_window["end"] = fallback_end
+            schedule_windows = [schedule_window]
+    if schedule_windows:
+        normalized["schedule_windows"] = schedule_windows
+    return normalized
+
+
+def _dry_contact_settings_signature(
+    normalized: dict[str, object],
+) -> tuple[object, ...]:
+    return (
+        normalized.get("serial_number"),
+        normalized.get("device_uid"),
+        normalized.get("uid"),
+        normalized.get("contact_id"),
+        normalized.get("channel_type"),
+        normalized.get("configured_name"),
+        normalized.get("override_supported"),
+        normalized.get("override_active"),
+        normalized.get("control_mode"),
+        normalized.get("polling_interval_seconds"),
+        normalized.get("soc_threshold"),
+        normalized.get("soc_threshold_min"),
+        normalized.get("soc_threshold_max"),
+        tuple(
+            (
+                window.get("start") if isinstance(window, dict) else None,
+                window.get("end") if isinstance(window, dict) else None,
+            )
+            for window in normalized.get("schedule_windows", [])
+            if isinstance(window, dict)
+        ),
+    )

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -221,7 +221,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         self._type_keys_loaded = False
         self._inventory_unknown = False
         self._email: str | None = None
-        self._remember_password = True
+        self._remember_password = False
         self._password: str | None = None
         self._reconfigure_entry: ConfigEntry | None = None
         self._reauth_entry: ConfigEntry | None = None
@@ -977,7 +977,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         stored_remember_password = bool(
             self._reconfigure_entry.data.get(CONF_REMEMBER_PASSWORD)
         )
-        self._remember_password = True
+        self._remember_password = stored_remember_password
         self._site_only = bool(self._reconfigure_entry.data.get(CONF_SITE_ONLY, False))
         self._include_inverters = bool(
             self._reconfigure_entry.data.get(CONF_INCLUDE_INVERTERS, True)
@@ -1003,7 +1003,7 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         stored_remember_password = bool(
             self._reauth_entry.data.get(CONF_REMEMBER_PASSWORD)
         )
-        self._remember_password = True
+        self._remember_password = stored_remember_password
         self._site_only = bool(self._reauth_entry.data.get(CONF_SITE_ONLY, False))
         self._include_inverters = bool(
             self._reauth_entry.data.get(CONF_INCLUDE_INVERTERS, True)

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -244,6 +244,7 @@ class RefreshPipelineContext:
     fallback_data: dict[str, dict]
     first_refresh: bool
     status_used_stale: bool = False
+    fast_poll: bool = False
 
 
 class EnphaseCoordinator(DataUpdateCoordinator[dict]):
@@ -1136,6 +1137,18 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         if self._warmup_task is not None:
             self._warmup_task.cancel()
             self._warmup_task = None
+        for task in list(self._amp_restart_tasks.values()):
+            if task is not None and not task.done():
+                task.cancel()
+        self._amp_restart_tasks.clear()
+        if self._streaming_stop_task is not None:
+            if not self._streaming_stop_task.done():
+                self._streaming_stop_task.cancel()
+            self._streaming_stop_task = None
+        if self._auth_refresh_task is not None:
+            if not self._auth_refresh_task.done():
+                self._auth_refresh_task.cancel()
+            self._auth_refresh_task = None
         self.discovery_snapshot.cancel_pending_save()
         session_manager = getattr(self, "session_history", None)
         if session_manager is not None and hasattr(session_manager, "clear"):
@@ -2245,6 +2258,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         refresh_started_utc = dt_util.utcnow()
         if refresh_started_utc.tzinfo is None:
             refresh_started_utc = refresh_started_utc.replace(tzinfo=_tz.utc)
+        reset_request_count = getattr(self.client, "reset_request_count", None)
+        if callable(reset_request_count):
+            reset_request_count()
         fallback_data: dict[str, dict] = {}
         if isinstance(self.data, dict):
             try:
@@ -2405,6 +2421,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         phase_timings = context.phase_timings
         phase_timings["total_s"] = round(time.monotonic() - context.started_mono, 3)
         self._phase_timings = phase_timings.copy()
+        request_count = getattr(self.client, "request_count", None)
+        if isinstance(request_count, int):
+            self._last_refresh_cloud_calls = request_count
+            if context.fast_poll:
+                self._last_fast_refresh_cloud_calls = request_count
+            else:
+                self._last_steady_refresh_cloud_calls = request_count
         if context.first_refresh:
             self._bootstrap_phase_timings = phase_timings.copy()
         self._refresh_cached_topology()
@@ -3716,6 +3739,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._sync_desired_charging(out)
 
         polling_state = self._determine_polling_state(out)
+        context.fast_poll = bool(polling_state["want_fast"])
         summary_force = self.summary.prepare_refresh(
             want_fast=polling_state["want_fast"],
             target_interval=float(polling_state["target"]),

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -22,6 +22,7 @@ from .const import (
     ISSUE_SESSION_HISTORY_UNAVAILABLE,
     ISSUE_SITE_ENERGY_UNAVAILABLE,
 )
+from .coordinator_refresh_metrics import refresh_performance_summary
 from .log_redaction import redact_text
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -248,6 +249,15 @@ class CoordinatorDiagnostics:
             "rate_limit_hits": getattr(coord, "_rate_limit_hits", 0),
             "dns_errors": getattr(coord, "_dns_failures", 0),
             "phase_timings": coord.phase_timings,
+            "refresh_performance": refresh_performance_summary(
+                coord.phase_timings,
+                latency_ms=coord.latency_ms,
+                cloud_calls=getattr(coord, "_last_refresh_cloud_calls", None),
+                steady_cloud_calls=getattr(
+                    coord, "_last_steady_refresh_cloud_calls", None
+                ),
+                fast_cloud_calls=getattr(coord, "_last_fast_refresh_cloud_calls", None),
+            ),
             "bootstrap_phase_timings": coord.bootstrap_phase_timings,
             "warmup_phase_timings": coord.warmup_phase_timings,
             "warmup_in_progress": getattr(coord, "_warmup_in_progress", False),

--- a/custom_components/enphase_ev/coordinator_refresh_metrics.py
+++ b/custom_components/enphase_ev/coordinator_refresh_metrics.py
@@ -1,0 +1,64 @@
+"""Refresh performance diagnostics helpers."""
+
+from __future__ import annotations
+
+REFRESH_TOTAL_BUDGET_S = 30.0
+REFRESH_STAGE_BUDGET_S = 5.0
+
+
+def refresh_performance_summary(
+    phase_timings: dict[str, float],
+    *,
+    latency_ms: int | None = None,
+    cloud_calls: int | None = None,
+    steady_cloud_calls: int | None = None,
+    fast_cloud_calls: int | None = None,
+    total_budget_s: float = REFRESH_TOTAL_BUDGET_S,
+    stage_budget_s: float = REFRESH_STAGE_BUDGET_S,
+) -> dict[str, object]:
+    """Return a compact refresh timing budget summary."""
+
+    timings: dict[str, float] = {}
+    for key, value in (phase_timings or {}).items():
+        try:
+            timing = float(value)
+        except (TypeError, ValueError):
+            continue
+        if timing < 0:
+            continue
+        timings[str(key)] = round(timing, 3)
+
+    stage_timings = {key: value for key, value in timings.items() if key != "total_s"}
+    total_s = timings.get("total_s")
+    if total_s is None and latency_ms is not None:
+        try:
+            total_s = round(float(latency_ms) / 1000.0, 3)
+        except (TypeError, ValueError):
+            total_s = None
+
+    slowest_stage = None
+    slowest_stage_s = None
+    if stage_timings:
+        slowest_stage, slowest_stage_s = max(
+            stage_timings.items(), key=lambda item: item[1]
+        )
+
+    over_budget_stages = sorted(
+        key for key, value in stage_timings.items() if value > stage_budget_s
+    )
+
+    return {
+        "total_s": total_s,
+        "total_budget_s": total_budget_s,
+        "total_over_budget": (
+            bool(total_s > total_budget_s) if total_s is not None else False
+        ),
+        "timed_stage_count": len(stage_timings),
+        "stage_budget_s": stage_budget_s,
+        "over_budget_stages": over_budget_stages,
+        "slowest_stage": slowest_stage,
+        "slowest_stage_s": slowest_stage_s,
+        "cloud_calls": cloud_calls,
+        "steady_cloud_calls": steady_cloud_calls,
+        "fast_cloud_calls": fast_cloud_calls,
+    }

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -60,6 +60,7 @@ from .runtime_helpers import (
     inventory_type_available as _type_available,
     inventory_type_device_info as _type_device_info,
 )
+from . import sensor_battery_helpers as _battery_helpers
 from .evse_runtime import evse_power_is_actively_charging
 
 PARALLEL_UPDATES = 0
@@ -117,6 +118,11 @@ BATTERY_LED_STATUS_STATE_MAP: dict[int, str] = {
     16: "idle",
     17: "idle",
 }
+_battery_last_reported_members = _battery_helpers.battery_last_reported_members
+_battery_last_reported_snapshot = _battery_helpers.battery_last_reported_snapshot
+_battery_optional_bool = _battery_helpers.battery_optional_bool
+_battery_parse_timestamp = _battery_helpers.battery_parse_timestamp
+_battery_snapshot_last_reported = _battery_helpers.battery_snapshot_last_reported
 
 
 def _type_label(coord: EnphaseCoordinator, type_key: str) -> str | None:
@@ -3453,150 +3459,6 @@ class EnphaseInverterLifetimeEnergySensor(CoordinatorEntity, RestoreSensor):
             manufacturer="Enphase",
             name="IQ Microinverters",
         )
-
-
-def _battery_parse_timestamp(value: object) -> datetime | None:
-    if value in (None, ""):
-        return None
-    try:
-        if isinstance(value, datetime):
-            dt_value = value
-        else:
-            epoch_value: float | None = None
-            if isinstance(value, (int, float)):
-                epoch_value = float(value)
-            else:
-                text = str(value).strip()
-                if not text:
-                    return None
-                iso_text = text.replace("[UTC]", "")
-                if iso_text.endswith("Z"):
-                    iso_text = iso_text[:-1] + "+00:00"
-                try:
-                    dt_value = datetime.fromisoformat(iso_text)
-                    if dt_value.tzinfo is None:
-                        return dt_value.replace(tzinfo=timezone.utc)
-                    return dt_value.astimezone(timezone.utc)
-                except Exception:  # noqa: BLE001
-                    try:
-                        epoch_value = float(text.replace(",", ""))
-                    except Exception:  # noqa: BLE001
-                        return None
-            if (
-                epoch_value is None
-                or not math.isfinite(epoch_value)
-                or epoch_value <= 0
-            ):
-                return None
-            if epoch_value > 1_000_000_000_000:
-                epoch_value /= 1000.0
-            dt_value = datetime.fromtimestamp(epoch_value, tz=timezone.utc)
-        if dt_value.tzinfo is None:
-            return dt_value.replace(tzinfo=timezone.utc)
-        return dt_value.astimezone(timezone.utc)
-    except Exception:  # noqa: BLE001
-        return None
-
-
-def _battery_optional_bool(value: object) -> bool | None:
-    if value is None:
-        return None
-    if isinstance(value, bool):
-        return value
-    if isinstance(value, (int, float)):
-        return value != 0
-    if isinstance(value, str):
-        normalized = value.strip().lower()
-        if normalized in ("true", "1", "yes", "y", "on", "enabled"):
-            return True
-        if normalized in ("false", "0", "no", "n", "off", "disabled"):
-            return False
-    return None
-
-
-def _battery_snapshot_last_reported(snapshot: dict[str, object]) -> datetime | None:
-    # Battery status API reports storages[].last_report as epoch seconds.
-    for key in ("last_report", "last_reported", "last_reported_at", "lastReportedAt"):
-        parsed = _battery_parse_timestamp(snapshot.get(key))
-        if parsed is not None:
-            return parsed
-    return None
-
-
-def _battery_last_reported_members(
-    coord: EnphaseCoordinator,
-) -> list[dict[str, object]]:
-    payload = getattr(coord, "battery_status_payload", None)
-    storage_members: list[dict[str, object]] = []
-    if isinstance(payload, dict):
-        storages = payload.get("storages")
-        if isinstance(storages, list):
-            for item in storages:
-                if not isinstance(item, dict):
-                    continue
-                if _battery_optional_bool(item.get("excluded")) is True:
-                    continue
-                storage_members.append(dict(item))
-            return storage_members
-
-    iter_battery_serials = getattr(coord, "iter_battery_serials", None)
-    battery_storage = getattr(coord, "battery_storage", None)
-    serials = (
-        [serial for serial in iter_battery_serials() if serial]
-        if callable(iter_battery_serials)
-        else []
-    )
-    if not callable(battery_storage):
-        return [{"serial_number": serial} for serial in serials]
-    for serial in serials:
-        snapshot = battery_storage(serial)
-        if not isinstance(snapshot, dict):
-            storage_members.append({"serial_number": serial})
-            continue
-        storage_members.append(dict(snapshot))
-    return storage_members
-
-
-def _battery_last_reported_snapshot(coord: EnphaseCoordinator) -> dict[str, object]:
-    members = _battery_last_reported_members(coord)
-    latest_reported: datetime | None = None
-    latest_reported_device: dict[str, object] | None = None
-    without_last_report_count = 0
-    for snapshot in members:
-        last_reported = _battery_snapshot_last_reported(snapshot)
-        if last_reported is None:
-            without_last_report_count += 1
-            continue
-        if latest_reported is None or last_reported > latest_reported:
-            latest_reported = last_reported
-            serial = (
-                snapshot.get("serial_number")
-                or snapshot.get("identity")
-                or snapshot.get("battery_id")
-                or snapshot.get("id")
-            )
-            latest_reported_device = {
-                "serial_number": serial,
-                "name": snapshot.get("name"),
-                "status": (
-                    snapshot.get("statusText")
-                    if snapshot.get("statusText") is not None
-                    else (
-                        snapshot.get("status_text")
-                        if snapshot.get("status_text") is not None
-                        else snapshot.get("status")
-                    )
-                ),
-            }
-    return {
-        "total_batteries": len(members),
-        "without_last_report_count": without_last_report_count,
-        "latest_reported": latest_reported,
-        "latest_reported_utc": (
-            latest_reported.isoformat() if latest_reported is not None else None
-        ),
-        "latest_reported_device": latest_reported_device,
-    }
 
 
 class _EnphaseBatteryStorageBaseSensor(CoordinatorEntity, SensorEntity):

--- a/custom_components/enphase_ev/sensor_battery_helpers.py
+++ b/custom_components/enphase_ev/sensor_battery_helpers.py
@@ -1,0 +1,173 @@
+"""Battery sensor parsing helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import math
+from typing import Protocol
+
+
+class BatteryLastReportedCoordinator(Protocol):
+    """Coordinator surface needed to build battery last-reported snapshots."""
+
+    battery_status_payload: object
+
+    def iter_battery_serials(self) -> object: ...
+
+    def battery_storage(self, serial: str) -> object: ...
+
+
+def battery_parse_timestamp(value: object) -> datetime | None:
+    """Parse battery timestamp values into UTC datetimes."""
+
+    if value in (None, ""):
+        return None
+    try:
+        if isinstance(value, datetime):
+            dt_value = value
+        else:
+            epoch_value: float | None = None
+            if isinstance(value, (int, float)):
+                epoch_value = float(value)
+            else:
+                text = str(value).strip()
+                if not text:
+                    return None
+                iso_text = text.replace("[UTC]", "")
+                if iso_text.endswith("Z"):
+                    iso_text = iso_text[:-1] + "+00:00"
+                try:
+                    dt_value = datetime.fromisoformat(iso_text)
+                    if dt_value.tzinfo is None:
+                        return dt_value.replace(tzinfo=timezone.utc)
+                    return dt_value.astimezone(timezone.utc)
+                except Exception:  # noqa: BLE001
+                    try:
+                        epoch_value = float(text.replace(",", ""))
+                    except Exception:  # noqa: BLE001
+                        return None
+            if (
+                epoch_value is None
+                or not math.isfinite(epoch_value)
+                or epoch_value <= 0
+            ):
+                return None
+            if epoch_value > 1_000_000_000_000:
+                epoch_value /= 1000.0
+            dt_value = datetime.fromtimestamp(epoch_value, tz=timezone.utc)
+        if dt_value.tzinfo is None:
+            return dt_value.replace(tzinfo=timezone.utc)
+        return dt_value.astimezone(timezone.utc)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def battery_optional_bool(value: object) -> bool | None:
+    """Return a tolerant bool for battery payload fields."""
+
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in ("true", "1", "yes", "y", "on", "enabled"):
+            return True
+        if normalized in ("false", "0", "no", "n", "off", "disabled"):
+            return False
+    return None
+
+
+def battery_snapshot_last_reported(snapshot: dict[str, object]) -> datetime | None:
+    """Return the newest last-report timestamp carried by a battery snapshot."""
+
+    # Battery status API reports storages[].last_report as epoch seconds.
+    for key in ("last_report", "last_reported", "last_reported_at", "lastReportedAt"):
+        parsed = battery_parse_timestamp(snapshot.get(key))
+        if parsed is not None:
+            return parsed
+    return None
+
+
+def battery_last_reported_members(
+    coord: BatteryLastReportedCoordinator,
+) -> list[dict[str, object]]:
+    """Return battery members suitable for last-reported aggregation."""
+
+    payload = getattr(coord, "battery_status_payload", None)
+    storage_members: list[dict[str, object]] = []
+    if isinstance(payload, dict):
+        storages = payload.get("storages")
+        if isinstance(storages, list):
+            for item in storages:
+                if not isinstance(item, dict):
+                    continue
+                if battery_optional_bool(item.get("excluded")) is True:
+                    continue
+                storage_members.append(dict(item))
+            return storage_members
+
+    iter_battery_serials = getattr(coord, "iter_battery_serials", None)
+    battery_storage = getattr(coord, "battery_storage", None)
+    serials = (
+        [serial for serial in iter_battery_serials() if serial]
+        if callable(iter_battery_serials)
+        else []
+    )
+    if not callable(battery_storage):
+        return [{"serial_number": serial} for serial in serials]
+    for serial in serials:
+        snapshot = battery_storage(serial)
+        if not isinstance(snapshot, dict):
+            storage_members.append({"serial_number": serial})
+            continue
+        storage_members.append(dict(snapshot))
+    return storage_members
+
+
+def battery_last_reported_snapshot(
+    coord: BatteryLastReportedCoordinator,
+) -> dict[str, object]:
+    """Return an aggregate last-reported snapshot for site battery storage."""
+
+    members = battery_last_reported_members(coord)
+    latest_reported: datetime | None = None
+    latest_reported_device: dict[str, object] | None = None
+    without_last_report_count = 0
+    for snapshot in members:
+        last_reported = battery_snapshot_last_reported(snapshot)
+        if last_reported is None:
+            without_last_report_count += 1
+            continue
+        if latest_reported is None or last_reported > latest_reported:
+            latest_reported = last_reported
+            serial = (
+                snapshot.get("serial_number")
+                or snapshot.get("identity")
+                or snapshot.get("battery_id")
+                or snapshot.get("id")
+            )
+            latest_reported_device = {
+                "serial_number": serial,
+                "name": snapshot.get("name"),
+                "status": (
+                    snapshot.get("statusText")
+                    if snapshot.get("statusText") is not None
+                    else (
+                        snapshot.get("status_text")
+                        if snapshot.get("status_text") is not None
+                        else snapshot.get("status")
+                    )
+                ),
+            }
+    return {
+        "total_batteries": len(members),
+        "without_last_report_count": without_last_report_count,
+        "latest_reported": latest_reported,
+        "latest_reported_utc": (
+            latest_reported.isoformat() if latest_reported is not None else None
+        ),
+        "latest_reported_device": latest_reported_device,
+    }

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -118,8 +118,12 @@ def async_setup_services(
         return None
 
     async def _get_coordinator_for_sn(sn: str) -> EnphaseCoordinator | None:
-        for coord in iter_coordinators(hass):
-            if not coord.serials or sn in coord.serials or sn in (coord.data or {}):
+        for entry in hass.config_entries.async_entries(DOMAIN):
+            runtime_data = getattr(entry, "runtime_data", None)
+            if not isinstance(runtime_data, EnphaseRuntimeData):
+                continue
+            coord = runtime_data.coordinator
+            if sn in (coord.serials or set()) or sn in (coord.data or {}):
                 return coord
         return None
 
@@ -444,11 +448,6 @@ def async_setup_services(
 
     async def _resolve_site_ids_from_call(call: ServiceCall) -> set[str]:
         site_ids: set[str] = set()
-        config_entry_id = call.data.get("config_entry_id")
-        if config_entry_id:
-            coord = _get_coordinator_for_entry_id(str(config_entry_id))
-            if coord is not None:
-                site_ids.add(str(coord.site_id))
         for device_id in _extract_device_ids(call):
             site_id = await _resolve_site_id(device_id)
             if site_id:
@@ -487,53 +486,56 @@ def async_setup_services(
             translation_key="exceptions.grid_site_required",
         )
 
-    async def _svc_force_refresh(call: ServiceCall) -> None:
-        coord = await _resolve_single_site_coordinator(call)
-        await coord.async_request_refresh()
-
-    async def _svc_start(call: ServiceCall) -> None:
+    async def _resolve_charger_targets(
+        call: ServiceCall,
+    ) -> list[tuple[str, str, EnphaseCoordinator]]:
         device_ids = _extract_device_ids(call)
         if not device_ids:
-            return
-        connector_id = int(call.data.get("connector_id", 1))
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.grid_site_required",
+            )
+
+        targets: list[tuple[str, str, EnphaseCoordinator]] = []
         for device_id in device_ids:
             sn = await _resolve_sn(device_id)
             if not sn:
                 continue
             coord = await _get_coordinator_for_sn(sn)
-            if not coord:
-                continue
+            if coord is None:
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="exceptions.grid_site_required",
+                )
+            targets.append((device_id, sn, coord))
+
+        if not targets:
+            raise ServiceValidationError(
+                translation_domain=DOMAIN,
+                translation_key="exceptions.grid_site_required",
+            )
+        return targets
+
+    async def _svc_force_refresh(call: ServiceCall) -> None:
+        coord = await _resolve_single_site_coordinator(call)
+        await coord.async_request_refresh()
+
+    async def _svc_start(call: ServiceCall) -> None:
+        connector_id = int(call.data.get("connector_id", 1))
+        for _device_id, sn, coord in await _resolve_charger_targets(call):
             level = call.data.get("charging_level")
             await coord.async_start_charging(
                 sn, requested_amps=level, connector_id=connector_id
             )
 
     async def _svc_stop(call: ServiceCall) -> None:
-        device_ids = _extract_device_ids(call)
-        if not device_ids:
-            return
-        for device_id in device_ids:
-            sn = await _resolve_sn(device_id)
-            if not sn:
-                continue
-            coord = await _get_coordinator_for_sn(sn)
-            if not coord:
-                continue
+        for _device_id, sn, coord in await _resolve_charger_targets(call):
             await coord.async_stop_charging(sn)
 
     async def _svc_trigger(call: ServiceCall) -> dict[str, object]:
-        device_ids = _extract_device_ids(call)
-        if not device_ids:
-            return {}
         message = call.data["requested_message"]
         results: list[dict[str, object]] = []
-        for device_id in device_ids:
-            sn = await _resolve_sn(device_id)
-            if not sn:
-                continue
-            coord = await _get_coordinator_for_sn(sn)
-            if not coord:
-                continue
+        for device_id, sn, coord in await _resolve_charger_targets(call):
             reply = await coord.async_trigger_ocpp_message(sn, message)
             results.append(
                 {
@@ -572,26 +574,14 @@ def async_setup_services(
             ir.async_delete_issue(hass, DOMAIN, issue_id)
 
     async def _svc_start_stream(call: ServiceCall) -> None:
-        site_ids = await _resolve_site_ids_from_call(call)
-        coords = iter_coordinators(hass, site_ids=site_ids or None)
-        if not coords:
-            return
-        if not site_ids:
-            coords = coords[:1]
-        for coord in coords:
-            await coord.async_start_streaming(manual=True)
-            await coord.async_request_refresh()
+        coord = await _resolve_single_site_coordinator(call)
+        await coord.async_start_streaming(manual=True)
+        await coord.async_request_refresh()
 
     async def _svc_stop_stream(call: ServiceCall) -> None:
-        site_ids = await _resolve_site_ids_from_call(call)
-        coords = iter_coordinators(hass, site_ids=site_ids or None)
-        if not coords:
-            return
-        if not site_ids:
-            coords = coords[:1]
-        for coord in coords:
-            await coord.async_stop_streaming(manual=True)
-            await coord.async_request_refresh()
+        coord = await _resolve_single_site_coordinator(call)
+        await coord.async_stop_streaming(manual=True)
+        await coord.async_request_refresh()
 
     async def _svc_update_cfg_schedule(call: ServiceCall) -> None:
         coord = await _resolve_single_site_coordinator(call)
@@ -865,21 +855,13 @@ def async_setup_services(
         return result
 
     async def _svc_sync_schedules(call: ServiceCall) -> None:
-        device_ids = _extract_device_ids(call)
-        if device_ids:
-            for device_id in device_ids:
-                sn = await _resolve_sn(device_id)
-                if not sn:
-                    continue
-                coord = await _get_coordinator_for_sn(sn)
-                if not coord or not hasattr(coord, "schedule_sync"):
-                    continue
-                await coord.schedule_sync.async_refresh(reason="service", serials=[sn])
-            return
-
-        for coord in iter_coordinators(hass):
-            if hasattr(coord, "schedule_sync"):
-                await coord.schedule_sync.async_refresh(reason="service")
+        for _device_id, sn, coord in await _resolve_charger_targets(call):
+            if not hasattr(coord, "schedule_sync"):
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="exceptions.grid_site_required",
+                )
+            await coord.schedule_sync.async_refresh(reason="service", serials=[sn])
 
     hass.services.async_register(
         DOMAIN, "force_refresh", _svc_force_refresh, schema=FORCE_REFRESH_SCHEMA

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -134,6 +134,17 @@ def _make_token(payload: dict) -> str:
     return f"header.{payload_b64}.sig"
 
 
+def test_request_count_reset_and_snapshot() -> None:
+    client = _make_client()
+
+    client._request_count = 3  # noqa: SLF001
+    assert client.request_count == 3
+
+    client.reset_request_count()
+
+    assert client.request_count == 0
+
+
 def _make_optional_payload_error(endpoint: str) -> api.InvalidPayloadError:
     return api.InvalidPayloadError(
         "Invalid JSON response",

--- a/tests/components/enphase_ev/test_api_parsers.py
+++ b/tests/components/enphase_ev/test_api_parsers.py
@@ -1,0 +1,161 @@
+"""Tests for typed API parser helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.enphase_ev import api_parsers
+from custom_components.enphase_ev.api import EnphaseEVClient
+
+
+def test_discovery_parsers_return_typed_models() -> None:
+    """Discovery payloads normalize into API boundary model instances."""
+
+    sites = api_parsers.normalize_sites(
+        {"systems": [{"system_id": 123, "displayName": "Garage"}]}
+    )
+    chargers = api_parsers.normalize_chargers(
+        {"evChargerData": [{"serialNumber": "EV123", "display_name": "Driveway"}]}
+    )
+
+    assert [(site.site_id, site.name) for site in sites] == [("123", "Garage")]
+    assert [(charger.serial, charger.name) for charger in chargers] == [
+        ("EV123", "Driveway")
+    ]
+
+
+def test_discovery_parsers_preserve_legacy_field_priority() -> None:
+    """Parser extraction keeps the old field precedence for mixed payloads."""
+
+    sites = api_parsers.normalize_sites(
+        {
+            "sites": [
+                {
+                    "site_id": "123",
+                    "site_name": "Legacy Name",
+                    "title": "Title Name",
+                    "displayName": "Display Name",
+                }
+            ]
+        }
+    )
+    chargers = api_parsers.normalize_chargers(
+        {
+            "data": [{"serial": "DATA-SN", "name": "Data Charger"}],
+            "chargers": [{"serial": "TOP-SN", "name": "Top Charger"}],
+        }
+    )
+
+    assert [(site.site_id, site.name) for site in sites] == [("123", "Legacy Name")]
+    assert [(charger.serial, charger.name) for charger in chargers] == [
+        ("DATA-SN", "Data Charger")
+    ]
+
+
+def test_latest_power_parser_result_to_dict() -> None:
+    """Latest power parsing exposes a typed result before dict conversion."""
+
+    sample = api_parsers.parse_latest_power_payload(
+        {
+            "data": {
+                "latest_power": {
+                    "value": "752.5",
+                    "units": "W",
+                    "precision": "1",
+                    "time": "1773207600000",
+                }
+            }
+        }
+    )
+
+    assert sample is not None
+    assert sample.value == pytest.approx(752.5)
+    assert sample.to_dict() == {
+        "value": 752.5,
+        "units": "W",
+        "precision": 1,
+        "time": 1_773_207_600,
+    }
+
+
+def test_client_non_boolean_number_wrapper_delegates_to_parser() -> None:
+    """Compatibility wrapper keeps rejecting booleans while accepting numbers."""
+
+    assert EnphaseEVClient._coerce_non_boolean_number("12.5") == pytest.approx(12.5)
+    assert EnphaseEVClient._coerce_non_boolean_number(True) is None
+
+
+def test_evse_parser_result_objects_to_existing_payload_shapes() -> None:
+    """EVSE parsers use typed entries while preserving existing dict shapes."""
+
+    daily = api_parsers.parse_evse_daily_entry(
+        "EV123",
+        {
+            "days": [
+                {"date": "2026-03-10", "energy_wh": 1200},
+                {"date": "2026-03-11", "energy_kwh": "2.5"},
+            ],
+            "intervalMinutes": "1440",
+        },
+    )
+    lifetime = api_parsers.parse_evse_lifetime_entry(
+        "EV123",
+        {"lifetime_energy_wh": 45600, "lastReportDate": "2026-03-11"},
+    )
+
+    assert daily is not None
+    assert daily.to_dict() == {
+        "serial": "EV123",
+        "day_values_kwh": {
+            "2026-03-10": 1.2,
+            "2026-03-11": 2.5,
+        },
+        "energy_kwh": 2.5,
+        "current_value_kwh": None,
+        "interval_minutes": 1440.0,
+    }
+    assert lifetime is not None
+    assert lifetime.to_dict() == {
+        "serial": "EV123",
+        "energy_kwh": 45.6,
+        "last_report_date": "2026-03-11",
+    }
+
+
+def test_hems_parser_result_objects_to_existing_payload_shapes() -> None:
+    """HEMS parsers use typed entries while preserving existing dict shapes."""
+
+    state = api_parsers.parse_hems_heatpump_state_payload(
+        {
+            "type": "hems-heatpump-details",
+            "timestamp": "2026-03-20T08:19:17Z",
+            "data": {
+                "device-uid": "HP-1",
+                "heatpump-status": "RUNNING",
+                "sg-ready-mode": "MODE_3",
+            },
+        }
+    )
+    entry = api_parsers.parse_hems_daily_consumption_entry(
+        {
+            "device-uid": "HP-1",
+            "device-name": "Heat Pump",
+            "consumption": [{"solar": "1.0", "grid": "2.5", "details": [3, "bad"]}],
+        }
+    )
+
+    assert state is not None
+    assert state.to_dict()["sg_ready_mode_label"] == "Recommended"
+    assert entry is not None
+    assert entry.to_dict() == {
+        "device_uid": "HP-1",
+        "device_name": "Heat Pump",
+        "consumption": [
+            {
+                "solar": 1.0,
+                "battery": None,
+                "grid": 2.5,
+                "details": [3.0, None],
+            }
+        ],
+    }

--- a/tests/components/enphase_ev/test_battery_runtime_dry_contact_helpers.py
+++ b/tests/components/enphase_ev/test_battery_runtime_dry_contact_helpers.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from custom_components.enphase_ev.battery_runtime_dry_contact import (
+    dry_contact_member_is_dry_contact,
+    match_dry_contact_settings,
+    parse_dry_contact_settings_payload,
+)
+
+
+def _coerce_bool(value: object) -> bool | None:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "off"}:
+            return False
+    return None
+
+
+def _coerce_int(value: object) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _coerce_text(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def test_parse_dry_contact_settings_payload_normalizes_aliases_and_unmatched() -> None:
+    members = [
+        {
+            "serial_number": "envoy-1",
+            "device_uid": "uid-1",
+            "contact_id": "1",
+            "channel_type": "nc1",
+        }
+    ]
+
+    result = parse_dry_contact_settings_payload(
+        {
+            "data": {
+                "settings": [
+                    {
+                        "serialNumber": "envoy-1",
+                        "deviceUid": "uid-1",
+                        "contactId": "1",
+                        "channelType": "NC1",
+                        "configuredName": "Load shed",
+                        "overrideSupported": "true",
+                        "overrideActive": "false",
+                        "pollingIntervalSeconds": "30",
+                        "socThreshold": "25",
+                        "socThresholdMin": "10",
+                        "socThresholdMax": "90",
+                        "scheduleWindows": [
+                            {"startTime": "01:00", "endTime": "02:00"},
+                            {"startTime": "01:00", "endTime": "02:00"},
+                        ],
+                    },
+                    {
+                        "serial": "envoy-2",
+                        "contactId": "2",
+                        "scheduleStart": "03:00",
+                        "scheduleEnd": "04:00",
+                    },
+                ]
+            }
+        },
+        members=members,
+        coerce_bool=_coerce_bool,
+        coerce_int=_coerce_int,
+        coerce_text=_coerce_text,
+    )
+
+    assert result.supported is True
+    assert result.entries == [
+        {
+            "serial_number": "envoy-1",
+            "device_uid": "uid-1",
+            "contact_id": "1",
+            "channel_type": "NC1",
+            "configured_name": "Load shed",
+            "override_supported": True,
+            "override_active": False,
+            "polling_interval_seconds": 30,
+            "soc_threshold": 25,
+            "soc_threshold_min": 10,
+            "soc_threshold_max": 90,
+            "schedule_windows": [{"start": "01:00", "end": "02:00"}],
+        },
+        {
+            "serial_number": "envoy-2",
+            "contact_id": "2",
+            "schedule_windows": [{"start": "03:00", "end": "04:00"}],
+        },
+    ]
+    assert result.unmatched == [
+        {
+            "serial_number": "envoy-2",
+            "contact_id": "2",
+            "schedule_windows": [{"start": "03:00", "end": "04:00"}],
+        }
+    ]
+
+
+def test_parse_dry_contact_settings_payload_invalid_is_unsupported() -> None:
+    result = parse_dry_contact_settings_payload(
+        ["bad"],
+        members=[],
+        coerce_bool=_coerce_bool,
+        coerce_int=_coerce_int,
+        coerce_text=_coerce_text,
+    )
+
+    assert result.supported is False
+    assert result.entries == []
+    assert result.unmatched == []
+
+
+def test_dry_contact_matching_copies_results_and_detects_relays() -> None:
+    members = [
+        {"serial_number": "envoy-1", "channel_type": "NO1"},
+        {"serial_number": "envoy-2", "name": "Aux relay NC2"},
+    ]
+    settings = [{"serial_number": "envoy-1", "channel_type": "NO1"}]
+
+    matches, unmatched = match_dry_contact_settings(
+        members, settings_entries=settings, coerce_text=_coerce_text
+    )
+    settings[0]["channel_type"] = "changed"
+
+    assert matches == [{"serial_number": "envoy-1", "channel_type": "NO1"}, None]
+    assert unmatched == []
+    assert dry_contact_member_is_dry_contact(members[0], _coerce_text) is True
+    assert dry_contact_member_is_dry_contact(members[1], _coerce_text) is True

--- a/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
+++ b/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
@@ -2210,7 +2210,8 @@ async def test_battery_schedule_services_cover_failure_paths(
     coord.async_start_streaming = AsyncMock()
     await start_stream(SimpleNamespace(data={"config_entry_id": config_entry.entry_id}))
     coord.async_start_streaming.assert_awaited_once()
-    await start_stream(SimpleNamespace(data={"config_entry_id": "missing-entry"}))
+    with pytest.raises(ServiceValidationError):
+        await start_stream(SimpleNamespace(data={"config_entry_id": "missing-entry"}))
 
     with pytest.raises(ServiceValidationError, match="must be different"):
         await add_schedule(

--- a/tests/components/enphase_ev/test_config_flow_coverage.py
+++ b/tests/components/enphase_ev/test_config_flow_coverage.py
@@ -642,7 +642,7 @@ async def test_site_step_prefills_selected_site(hass) -> None:
 
 
 @pytest.mark.asyncio
-async def test_user_step_remember_password_defaults_enabled(hass) -> None:
+async def test_user_step_remember_password_defaults_disabled(hass) -> None:
     flow = _make_flow(hass)
 
     result = await flow.async_step_user()
@@ -655,7 +655,7 @@ async def test_user_step_remember_password_defaults_enabled(hass) -> None:
         if isinstance(item, VolOptional) and item.schema == CONF_REMEMBER_PASSWORD
     )
     default = key.default() if callable(key.default) else key.default
-    assert default is True
+    assert default is False
 
 
 @pytest.mark.asyncio
@@ -1235,7 +1235,7 @@ async def test_finalize_login_entry_reauth_updates_entry(hass) -> None:
 
 
 @pytest.mark.asyncio
-async def test_reconfigure_step_remember_password_defaults_enabled(hass) -> None:
+async def test_reconfigure_step_remember_password_preserves_opt_out(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1262,11 +1262,11 @@ async def test_reconfigure_step_remember_password_defaults_enabled(hass) -> None
         if isinstance(item, VolOptional) and item.schema == CONF_REMEMBER_PASSWORD
     )
     default = key.default() if callable(key.default) else key.default
-    assert default is True
+    assert default is False
 
 
 @pytest.mark.asyncio
-async def test_reauth_step_remember_password_defaults_enabled(hass) -> None:
+async def test_reauth_step_remember_password_preserves_opt_out(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -1293,7 +1293,7 @@ async def test_reauth_step_remember_password_defaults_enabled(hass) -> None:
         if isinstance(item, VolOptional) and item.schema == CONF_REMEMBER_PASSWORD
     )
     default = key.default() if callable(key.default) else key.default
-    assert default is True
+    assert default is False
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -35,6 +35,9 @@ from custom_components.enphase_ev.evse_runtime import (
     FAST_TOGGLE_POLL_HOLD_S,
     ChargeModeResolution,
 )
+from custom_components.enphase_ev.coordinator_refresh_metrics import (
+    refresh_performance_summary,
+)
 from custom_components.enphase_ev.session_history import (
     SESSION_CACHE_STATE_UNAVAILABLE,
     SessionCacheEntry,
@@ -1811,6 +1814,9 @@ def test_collect_site_metrics_and_placeholders(hass, monkeypatch):
     coord._dns_failures = 0
     coord._last_error = "unauthorized"
     coord._phase_timings = {"status_s": 0.5}
+    coord._last_refresh_cloud_calls = 3
+    coord._last_steady_refresh_cloud_calls = 3
+    coord._last_fast_refresh_cloud_calls = 7
     coord._session_history_cache_ttl = 300
     coord._hems_devices_using_stale = True
     coord._hems_devices_last_success_mono = time.monotonic() - 12
@@ -1822,6 +1828,19 @@ def test_collect_site_metrics_and_placeholders(hass, monkeypatch):
     assert metrics["last_success"] == now.isoformat()
     assert metrics["backoff_active"] is True
     assert metrics["phase_timings"] == {"status_s": 0.5}
+    assert metrics["refresh_performance"] == {
+        "total_s": 0.123,
+        "total_budget_s": 30.0,
+        "total_over_budget": False,
+        "timed_stage_count": 1,
+        "stage_budget_s": 5.0,
+        "over_budget_stages": [],
+        "slowest_stage": "status_s",
+        "slowest_stage_s": 0.5,
+        "cloud_calls": 3,
+        "steady_cloud_calls": 3,
+        "fast_cloud_calls": 7,
+    }
     assert metrics["hems_devices_data_stale"] is True
     assert metrics["hems_devices_last_success_utc"] == now.isoformat()
     assert metrics["hems_devices_last_success_age_s"] >= 0
@@ -1833,6 +1852,31 @@ def test_collect_site_metrics_and_placeholders(hass, monkeypatch):
     assert placeholders["last_status"] == "503"
 
 
+def test_refresh_pipeline_records_cloud_call_counts(hass, monkeypatch) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    client = SimpleNamespace(request_count=99)
+
+    def reset_request_count() -> None:
+        client.request_count = 0
+
+    client.reset_request_count = reset_request_count
+    coord.client = client
+
+    context = coord._start_refresh_pipeline()  # noqa: SLF001
+    assert client.request_count == 0
+    client.request_count = 4
+    coord._finish_refresh_pipeline(context)  # noqa: SLF001
+    assert coord._last_refresh_cloud_calls == 4  # noqa: SLF001
+    assert coord._last_steady_refresh_cloud_calls == 4  # noqa: SLF001
+
+    context = coord._start_refresh_pipeline()  # noqa: SLF001
+    context.fast_poll = True
+    client.request_count = 6
+    coord._finish_refresh_pipeline(context)  # noqa: SLF001
+    assert coord._last_refresh_cloud_calls == 6  # noqa: SLF001
+    assert coord._last_fast_refresh_cloud_calls == 6  # noqa: SLF001
+
+
 def test_collect_site_metrics_skips_negative_hems_age(hass, monkeypatch):
     coord = _make_coordinator(hass, monkeypatch)
     coord._hems_devices_last_success_mono = time.monotonic() + 5  # noqa: SLF001
@@ -1840,6 +1884,28 @@ def test_collect_site_metrics_skips_negative_hems_age(hass, monkeypatch):
     metrics = coord.collect_site_metrics()
 
     assert "hems_devices_last_success_age_s" not in metrics
+
+
+def test_refresh_performance_summary_flags_budget_and_bad_timings() -> None:
+    summary = refresh_performance_summary(
+        {"total_s": 31, "status_s": 6, "ignored": -1, "bad": "nope"},  # type: ignore[dict-item]
+        latency_ms=120,
+    )
+
+    assert summary == {
+        "total_s": 31.0,
+        "total_budget_s": 30.0,
+        "total_over_budget": True,
+        "timed_stage_count": 1,
+        "stage_budget_s": 5.0,
+        "over_budget_stages": ["status_s"],
+        "slowest_stage": "status_s",
+        "slowest_stage_s": 6.0,
+        "cloud_calls": None,
+        "steady_cloud_calls": None,
+        "fast_cloud_calls": None,
+    }
+    assert refresh_performance_summary({}, latency_ms="bad")["total_s"] is None  # type: ignore[arg-type]
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -1174,6 +1174,94 @@ async def test_async_unload_entry_stops_schedule_sync(
     assert config_entry.runtime_data is None
 
 
+class _RecordingTask:
+    def __init__(self, *, done: bool = False) -> None:
+        self._done = done
+        self.cancelled = False
+
+    def done(self) -> bool:
+        return self._done
+
+    def cancel(self) -> None:
+        self.cancelled = True
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_cancels_background_lifecycle_tasks(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    warmup_task = _RecordingTask()
+    session_task = _RecordingTask()
+    amp_task = _RecordingTask()
+    completed_amp_task = _RecordingTask(done=True)
+    stream_stop_task = _RecordingTask()
+    auth_refresh_task = _RecordingTask()
+    schedule_sync = SimpleNamespace(async_stop=AsyncMock())
+    session_history = SimpleNamespace(_enrichment_tasks={session_task})
+
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    def _clear_session_history() -> None:
+        for task in list(session_history._enrichment_tasks):
+            task.cancel()
+        session_history._enrichment_tasks.clear()
+
+    session_history.clear = Mock(side_effect=_clear_session_history)
+
+    class CleanupCoordinator:
+        cleanup_runtime_state = EnphaseCoordinator.cleanup_runtime_state
+
+        def __init__(self) -> None:
+            self._warmup_task = warmup_task
+            self._amp_restart_tasks = {
+                "EV123": amp_task,
+                "EV456": completed_amp_task,
+            }
+            self._streaming_stop_task = stream_stop_task
+            self._auth_refresh_task = auth_refresh_task
+            self.discovery_snapshot = SimpleNamespace(cancel_pending_save=Mock())
+            self.session_history = session_history
+            self._session_history_cache_shim = {("EV123", "2026-04-24"): (1.0, [])}
+            self._topology_listeners = [Mock()]
+            self.schedule_sync = schedule_sync
+            self.evse_runtime = SimpleNamespace(
+                prune_runtime_caches=Mock(),
+            )
+
+        def _prune_runtime_caches(self, *, active_serials, keep_day_keys) -> None:
+            self.evse_runtime.prune_runtime_caches(
+                active_serials=active_serials,
+                keep_day_keys=keep_day_keys,
+            )
+
+    coord = CleanupCoordinator()
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    unload = AsyncMock(return_value=True)
+    monkeypatch.setattr(hass.config_entries, "async_forward_entry_unload", unload)
+
+    assert await async_unload_entry(hass, config_entry)
+
+    schedule_sync.async_stop.assert_awaited_once()
+    assert warmup_task.cancelled
+    assert session_task.cancelled
+    assert amp_task.cancelled
+    assert not completed_amp_task.cancelled
+    assert stream_stop_task.cancelled
+    assert auth_refresh_task.cancelled
+    assert coord._warmup_task is None
+    assert coord._amp_restart_tasks == {}
+    assert coord._streaming_stop_task is None
+    assert coord._auth_refresh_task is None
+    assert coord._session_history_cache_shim == {}
+    assert coord._topology_listeners == []
+    session_history.clear.assert_called_once_with()
+    coord.discovery_snapshot.cancel_pending_save.assert_called_once_with()
+    coord.evse_runtime.prune_runtime_caches.assert_called_once_with(
+        active_serials=(), keep_day_keys=()
+    )
+    assert config_entry.runtime_data is None
+
+
 @pytest.mark.asyncio
 async def test_async_unload_entry_does_not_cleanup_when_unload_fails(
     hass: HomeAssistant, config_entry, monkeypatch
@@ -1492,11 +1580,16 @@ async def test_registered_services_cover_branches(
     svc_update_cfg = registered[(DOMAIN, "update_cfg_schedule")]["handler"]
     update_cfg_schema = registered[(DOMAIN, "update_cfg_schedule")]["schema"]
 
-    await svc_start(SimpleNamespace(data={}))
-    await svc_stop(SimpleNamespace(data={}))
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    with pytest.raises(ServiceValidationError):
+        await svc_start(SimpleNamespace(data={}))
+    with pytest.raises(ServiceValidationError):
+        await svc_stop(SimpleNamespace(data={}))
 
     fake_service_helper.calls = 0
-    assert await svc_trigger(SimpleNamespace(data={})) == {}
+    with pytest.raises(ServiceValidationError):
+        await svc_trigger(SimpleNamespace(data={"requested_message": "status"}))
 
     with pytest.raises(vol.Invalid):
         update_cfg_schema({"site_id": site_id})
@@ -1505,23 +1598,25 @@ async def test_registered_services_cover_branches(
         "limit": 75,
     }
 
-    await svc_start(SimpleNamespace(data={"device_id": [lonely_device.id]}))
-    await svc_stop(SimpleNamespace(data={"device_id": lonely_device.id}))
-    empty_trigger = await svc_trigger(
-        SimpleNamespace(
-            data={"device_id": lonely_device.id, "requested_message": "status"}
+    with pytest.raises(ServiceValidationError):
+        await svc_start(SimpleNamespace(data={"device_id": [lonely_device.id]}))
+    with pytest.raises(ServiceValidationError):
+        await svc_stop(SimpleNamespace(data={"device_id": lonely_device.id}))
+    with pytest.raises(ServiceValidationError):
+        await svc_trigger(
+            SimpleNamespace(
+                data={"device_id": lonely_device.id, "requested_message": "status"}
+            )
         )
-    )
-    assert empty_trigger == {"results": []}
 
     await svc_sync(
-        SimpleNamespace(
-            data={"device_id": [charger_two.id, site_device.id, lonely_device.id]}
-        )
+        SimpleNamespace(data={"device_id": [charger_two.id, site_device.id]})
     )
     assert call(reason="service", serials=[second_serial]) in (
         coord_primary.schedule_sync.async_refresh.await_args_list
     )
+    with pytest.raises(ServiceValidationError):
+        await svc_sync(SimpleNamespace(data={"device_id": [lonely_device.id]}))
     await svc_request_grid_otp(SimpleNamespace(data={"site_id": site_id}))
     coord_primary.async_request_grid_toggle_otp.assert_awaited_once()
     coord_primary.async_request_refresh.assert_awaited()
@@ -1588,27 +1683,32 @@ async def test_registered_services_cover_branches(
 
     await svc_start_stream(SimpleNamespace(data={"site_id": site_id}))
     await svc_start_stream(SimpleNamespace(data={"device_id": [charger_one.id]}))
-    await svc_start_stream(SimpleNamespace(data={}))
+    with pytest.raises(ServiceValidationError):
+        await svc_start_stream(SimpleNamespace(data={}))
     coord_primary.async_start_streaming.assert_awaited()
     assert coord_other.async_start_streaming.await_count == 0
     assert coord_primary._streaming is True
 
     await svc_stop_stream(SimpleNamespace(data={"site_id": site_id}))
     await svc_stop_stream(SimpleNamespace(data={"device_id": [charger_one.id]}))
-    await svc_stop_stream(SimpleNamespace(data={}))
+    with pytest.raises(ServiceValidationError):
+        await svc_stop_stream(SimpleNamespace(data={}))
     coord_primary.async_stop_streaming.assert_awaited()
     assert coord_other.async_stop_streaming.await_count == 0
     assert coord_primary._streaming is False
 
     fake_service_helper.calls = 0
-    await svc_sync(SimpleNamespace(data={}))
-    assert coord_primary.schedule_sync.async_refresh.await_count >= 2
+    with pytest.raises(ServiceValidationError):
+        await svc_sync(SimpleNamespace(data={}))
+    assert coord_primary.schedule_sync.async_refresh.await_count >= 1
 
     entry_one.runtime_data = None
     entry_two.runtime_data = None
     entry_three.runtime_data = None
-    await svc_start_stream(SimpleNamespace(data={"site_id": "missing"}))
-    await svc_stop_stream(SimpleNamespace(data={"site_id": "missing"}))
+    with pytest.raises(ServiceValidationError):
+        await svc_start_stream(SimpleNamespace(data={"site_id": "missing"}))
+    with pytest.raises(ServiceValidationError):
+        await svc_stop_stream(SimpleNamespace(data={"site_id": "missing"}))
 
     supports_response = registered[(DOMAIN, "trigger_message")]["kwargs"][
         "supports_response"
@@ -1617,8 +1717,6 @@ async def test_registered_services_cover_branches(
 
     assert supports_response is SupportsResponse.OPTIONAL
     assert fake_service_helper.calls >= 3
-
-    from custom_components.enphase_ev.coordinator import ServiceValidationError
 
     with pytest.raises(ServiceValidationError):
         await svc_request_grid_otp(SimpleNamespace(data={}))
@@ -1696,7 +1794,8 @@ async def test_service_helper_resolve_functions_cover_none_branches(
                 return value
         raise AssertionError(f"helper {target} not found")
 
-    resolve_sn = _extract_helper(svc_start, "_resolve_sn")
+    resolve_targets = _extract_helper(svc_start, "_resolve_charger_targets")
+    resolve_sn = _extract_helper(resolve_targets, "_resolve_sn")
     resolve_site = _extract_helper(svc_clear, "_resolve_site_id")
 
     dev_reg = dr.async_get(hass)
@@ -1754,7 +1853,10 @@ async def test_service_helper_resolve_functions_cover_none_branches(
     )
     assert await resolve_site(child_with_type_parent.id) == "TYPED"
 
-    await svc_stop(SimpleNamespace(data={}))
+    from custom_components.enphase_ev.coordinator import ServiceValidationError
+
+    with pytest.raises(ServiceValidationError):
+        await svc_stop(SimpleNamespace(data={}))
 
 
 def test_init_module_reload_executes_module_code() -> None:

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -13,6 +13,9 @@ from homeassistant.const import UnitOfEnergy
 
 from custom_components.enphase_ev import sensor as sensor_mod
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
+from custom_components.enphase_ev.sensor_battery_helpers import (
+    battery_last_reported_snapshot,
+)
 
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
 
@@ -4113,15 +4116,49 @@ def test_gateway_helpers_cover_edge_paths(coordinator_factory) -> None:
     assert sensor_mod._gateway_parse_timestamp(float("inf")) is None
     assert sensor_mod._battery_parse_timestamp(0) is None
     assert sensor_mod._battery_parse_timestamp("1e20") is None
+    assert sensor_mod._battery_parse_timestamp(" ") is None
+    assert sensor_mod._battery_parse_timestamp("not-a-timestamp") is None
+    assert sensor_mod._battery_parse_timestamp("2026-02-15T08:31:33") == datetime(
+        2026, 2, 15, 8, 31, 33, tzinfo=timezone.utc
+    )
     parsed_epoch = sensor_mod._battery_parse_timestamp(1_771_144_293_000)
     assert parsed_epoch == datetime(2026, 2, 15, 8, 31, 33, tzinfo=timezone.utc)
     parsed_battery_naive = sensor_mod._battery_parse_timestamp(
         datetime(2026, 2, 15, 8, 31, 33)
     )
     assert parsed_battery_naive == datetime(2026, 2, 15, 8, 31, 33, tzinfo=timezone.utc)
+    assert sensor_mod._battery_optional_bool(True) is True
     assert sensor_mod._battery_optional_bool(1) is True
     assert sensor_mod._battery_optional_bool("disabled") is False
     assert sensor_mod._battery_optional_bool("maybe") is None
+    assert sensor_mod._battery_last_reported_members(
+        SimpleNamespace(
+            battery_status_payload=None,
+            iter_battery_serials=lambda: ["BAT-3"],
+        )
+    ) == [{"serial_number": "BAT-3"}]
+    snapshot_from_storage = battery_last_reported_snapshot(
+        SimpleNamespace(
+            battery_status_payload=None,
+            iter_battery_serials=lambda: ["BAT-1", "BAT-2"],
+            battery_storage=lambda serial: (
+                {
+                    "serial_number": serial,
+                    "name": f"Battery {serial[-1]}",
+                    "last_reported_at": "2026-02-15T08:31:33Z",
+                }
+                if serial == "BAT-1"
+                else "bad"
+            ),
+        )
+    )
+    assert snapshot_from_storage["total_batteries"] == 2
+    assert snapshot_from_storage["without_last_report_count"] == 1
+    assert snapshot_from_storage["latest_reported_device"] == {
+        "serial_number": "BAT-1",
+        "name": "Battery 1",
+        "status": None,
+    }
     assert sensor_mod._EnphaseBatteryStorageBaseSensor._parse_timestamp(
         "2026-02-15T08:31:33Z"
     ) == datetime(2026, 2, 15, 8, 31, 33, tzinfo=timezone.utc)

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
+from homeassistant.helpers import device_registry as dr
+
+from custom_components.enphase_ev.const import CONF_SITE_ID, CONF_SITE_ONLY, DOMAIN
+from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
+from custom_components.enphase_ev.services import async_setup_services
+
+
+def _register_service_handlers(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> dict[tuple[str, str], object]:
+    registered: dict[tuple[str, str], object] = {}
+
+    def fake_register(self, domain, service, handler, schema=None, **kwargs):
+        registered[(domain, service)] = handler
+
+    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
+    async_setup_services(hass)
+    return registered
+
+
+def _fake_service_coordinator(*, site_id: str, serials: set[str]):
+    return SimpleNamespace(
+        site_id=site_id,
+        serials=serials,
+        data={serial: {"sn": serial} for serial in serials},
+        async_start_charging=AsyncMock(return_value={"status": "ok"}),
+        async_stop_charging=AsyncMock(return_value=None),
+        async_trigger_ocpp_message=AsyncMock(return_value={"status": "accepted"}),
+        async_start_streaming=AsyncMock(return_value=None),
+        async_stop_streaming=AsyncMock(return_value=None),
+        async_request_refresh=AsyncMock(return_value=None),
+        schedule_sync=SimpleNamespace(async_refresh=AsyncMock(return_value=None)),
+    )
+
+
+@pytest.mark.asyncio
+async def test_services_route_evse_targets_to_owning_entry_with_site_only_entry(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Service calls must not route EVSE work to a site-only config entry."""
+
+    handlers = _register_service_handlers(hass, monkeypatch)
+
+    site_only_coord = _fake_service_coordinator(site_id="site-only", serials=set())
+    evse_coord = _fake_service_coordinator(site_id="evse-site", serials={"EVSE123"})
+
+    site_only_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "site-only", CONF_SITE_ONLY: True},
+        title="Site Only",
+        unique_id="site-only",
+    )
+    site_only_entry.add_to_hass(hass)
+    site_only_entry.runtime_data = EnphaseRuntimeData(coordinator=site_only_coord)
+
+    evse_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "evse-site", CONF_SITE_ONLY: False},
+        title="EVSE Site",
+        unique_id="evse-site",
+    )
+    evse_entry.add_to_hass(hass)
+    evse_entry.runtime_data = EnphaseRuntimeData(coordinator=evse_coord)
+
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=site_only_entry.entry_id,
+        identifiers={(DOMAIN, "site:site-only")},
+        manufacturer="Enphase",
+        name="Site Only Device",
+    )
+    device_registry.async_get_or_create(
+        config_entry_id=evse_entry.entry_id,
+        identifiers={(DOMAIN, "site:evse-site")},
+        manufacturer="Enphase",
+        name="EVSE Site Device",
+    )
+    charger = device_registry.async_get_or_create(
+        config_entry_id=evse_entry.entry_id,
+        identifiers={(DOMAIN, "EVSE123")},
+        manufacturer="Enphase",
+        name="Garage Charger",
+        via_device=(DOMAIN, "site:evse-site"),
+    )
+
+    await handlers[(DOMAIN, "start_charging")](
+        SimpleNamespace(
+            data={
+                "device_id": [charger.id],
+                "charging_level": 24,
+                "connector_id": 2,
+            }
+        )
+    )
+    evse_coord.async_start_charging.assert_awaited_once_with(
+        "EVSE123", requested_amps=24, connector_id=2
+    )
+    site_only_coord.async_start_charging.assert_not_awaited()
+
+    await handlers[(DOMAIN, "stop_charging")](
+        SimpleNamespace(data={"device_id": [charger.id]})
+    )
+    evse_coord.async_stop_charging.assert_awaited_once_with("EVSE123")
+    site_only_coord.async_stop_charging.assert_not_awaited()
+
+    trigger_result = await handlers[(DOMAIN, "trigger_message")](
+        SimpleNamespace(
+            data={"device_id": [charger.id], "requested_message": "MeterValues"}
+        )
+    )
+    assert trigger_result == {
+        "results": [
+            {
+                "device_id": charger.id,
+                "serial": "EVSE123",
+                "site_id": "evse-site",
+                "response": {"status": "accepted"},
+            }
+        ]
+    }
+    evse_coord.async_trigger_ocpp_message.assert_awaited_once_with(
+        "EVSE123", "MeterValues"
+    )
+    site_only_coord.async_trigger_ocpp_message.assert_not_awaited()
+
+    await handlers[(DOMAIN, "start_live_stream")](
+        SimpleNamespace(data={"device_id": [charger.id]})
+    )
+    evse_coord.async_start_streaming.assert_awaited_once_with(manual=True)
+    site_only_coord.async_start_streaming.assert_not_awaited()
+
+    await handlers[(DOMAIN, "stop_live_stream")](
+        SimpleNamespace(data={"device_id": [charger.id]})
+    )
+    evse_coord.async_stop_streaming.assert_awaited_once_with(manual=True)
+    site_only_coord.async_stop_streaming.assert_not_awaited()
+
+    await handlers[(DOMAIN, "sync_schedules")](
+        SimpleNamespace(data={"device_id": [charger.id]})
+    )
+    evse_coord.schedule_sync.async_refresh.assert_awaited_once_with(
+        reason="service", serials=["EVSE123"]
+    )
+    site_only_coord.schedule_sync.async_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_targeted_services_raise_without_target_or_owner(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Targeted services should fail instead of silently doing nothing."""
+
+    handlers = _register_service_handlers(hass, monkeypatch)
+    coord = _fake_service_coordinator(site_id="evse-site", serials={"EVSE123"})
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "evse-site", CONF_SITE_ONLY: False},
+        title="EVSE Site",
+        unique_id="evse-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    device_registry = dr.async_get(hass)
+    site_device = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "site:evse-site")},
+        manufacturer="Enphase",
+        name="EVSE Site Device",
+    )
+    orphan_charger = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "ORPHAN123")},
+        manufacturer="Enphase",
+        name="Orphan Charger",
+    )
+
+    no_target_calls = (
+        ("start_charging", {}),
+        ("stop_charging", {}),
+        ("trigger_message", {"requested_message": "MeterValues"}),
+        ("start_live_stream", {}),
+        ("stop_live_stream", {}),
+        ("sync_schedules", {}),
+    )
+    for service, data in no_target_calls:
+        with pytest.raises(ServiceValidationError):
+            await handlers[(DOMAIN, service)](SimpleNamespace(data=data))
+
+    charger_target_calls = (
+        ("start_charging", {"device_id": [site_device.id]}),
+        ("stop_charging", {"device_id": [site_device.id]}),
+        (
+            "trigger_message",
+            {"device_id": [site_device.id], "requested_message": "MeterValues"},
+        ),
+        ("sync_schedules", {"device_id": [site_device.id]}),
+    )
+    for service, data in charger_target_calls:
+        with pytest.raises(ServiceValidationError):
+            await handlers[(DOMAIN, service)](SimpleNamespace(data=data))
+
+    owner_required_calls = (
+        ("start_charging", {"device_id": [orphan_charger.id]}),
+        ("stop_charging", {"device_id": [orphan_charger.id]}),
+        (
+            "trigger_message",
+            {"device_id": [orphan_charger.id], "requested_message": "MeterValues"},
+        ),
+        ("sync_schedules", {"device_id": [orphan_charger.id]}),
+    )
+    for service, data in owner_required_calls:
+        with pytest.raises(ServiceValidationError):
+            await handlers[(DOMAIN, service)](SimpleNamespace(data=data))
+
+    coord.async_start_charging.assert_not_awaited()
+    coord.async_stop_charging.assert_not_awaited()
+    coord.async_trigger_ocpp_message.assert_not_awaited()
+    coord.async_start_streaming.assert_not_awaited()
+    coord.async_stop_streaming.assert_not_awaited()
+    coord.schedule_sync.async_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_sync_schedules_raises_when_owner_has_no_schedule_sync(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Schedule sync service should fail loudly when the coordinator cannot sync."""
+
+    handlers = _register_service_handlers(hass, monkeypatch)
+    coord = _fake_service_coordinator(site_id="evse-site", serials={"EVSE123"})
+    delattr(coord, "schedule_sync")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "evse-site", CONF_SITE_ONLY: False},
+        title="EVSE Site",
+        unique_id="evse-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    device_registry = dr.async_get(hass)
+    charger = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "EVSE123")},
+        manufacturer="Enphase",
+        name="Garage Charger",
+    )
+
+    with pytest.raises(ServiceValidationError):
+        await handlers[(DOMAIN, "sync_schedules")](
+            SimpleNamespace(data={"device_id": [charger.id]})
+        )


### PR DESCRIPTION
## Summary

Split large Enphase integration modules into focused parser/helper modules, add typed API payload models, tighten service target/coordinator validation, and expose refresh performance diagnostics. The change also preserves password-storage opt-out during reauth/reconfigure and expands regression coverage for unload cleanup, parser precedence, multi-entry service routing, and service validation behavior.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/api_models.py,custom_components/enphase_ev/api_parsers.py,custom_components/enphase_ev/battery_runtime.py,custom_components/enphase_ev/battery_runtime_dry_contact.py,custom_components/enphase_ev/config_flow.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/coordinator_refresh_metrics.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/sensor_battery_helpers.py,custom_components/enphase_ev/services.py --fail-under=100"
```

Additional runtime sanity validation:

```bash
docker compose -f devtools/docker/docker-compose.yml up -d ha-runtime
```

Validated the copied local Home Assistant dev config with the configured Enphase account: integration loaded, devices/entities/services registered, diagnostics generated with refresh performance and redacted secrets, safe services succeeded (`force_refresh`, `validate_schedule`, `sync_schedules`, `start_live_stream`, `stop_live_stream`, `clear_reauth_issue`), local editor entity writes succeeded, and destructive service guard paths failed loudly instead of silently no-oping.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Home Assistant REST service calls that intentionally raise `ServiceValidationError` return non-2xx responses through the runtime API; the validation behavior is covered by unit tests and was sanity-checked against the local runtime. I did not execute destructive live writes such as start/stop charging, grid mode changes, OTP requests, or creating/deleting real schedules.