### PR TITLE
Handle scheduler login wall auth blocks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Seed AC Battery status and last-reported data from the battery status endpoint when the dedicated AC Battery devices page does not return parsed rows.
 - Routed IQ EV Charger device services through the target device's owning site or config entry so multi-site installs do not send start, stop, trigger, or schedule-sync requests to the wrong site when another entry has no discovered serials yet.
 - Kept the "Store password for automatic reauthentication" checkbox aligned with the existing entry setting during reconfigure and reauthentication flows instead of defaulting back to storing newly entered passwords.
+- Treated scheduler login-wall responses as authentication failures so Enphase auth blocks are detected during schedule sync instead of being logged as ordinary schedule fetch errors.
 - Rejected charger and site services with a clear validation error when no target or owning coordinator can be resolved.
 - Cancelled pending EV charger amp-restart and live-stream stop tasks during config entry unload so stale tasks cannot call the cloud client after reload or removal.
 

--- a/custom_components/enphase_ev/schedule_sync.py
+++ b/custom_components/enphase_ev/schedule_sync.py
@@ -24,7 +24,7 @@ from homeassistant.helpers.event import (
 from homeassistant.setup import async_setup_component
 from homeassistant.util import dt as dt_util
 
-from .api import SchedulerUnavailable
+from .api import EnphaseLoginWallUnauthorized, SchedulerUnavailable
 from .const import (
     DEFAULT_SCHEDULE_SYNC_ENABLED,
     DOMAIN,
@@ -165,6 +165,20 @@ class ScheduleSync:
         )
         if callable(note_unavailable):
             note_unavailable(err)
+
+    def _note_login_wall_unauthorized(self, err: EnphaseLoginWallUnauthorized) -> None:
+        """Let the coordinator activate its auth-block path from scheduler calls."""
+
+        self._last_error = redact_text(
+            err,
+            site_ids=(getattr(self._coordinator, "site_id", None),),
+        )
+        self._last_status = "auth_failed"
+        activate = getattr(
+            self._coordinator, "_activate_auth_block_from_login_wall", None
+        )
+        if callable(activate) and activate(err):
+            self._last_status = "auth_blocked"
 
     async def _disable_support(self) -> None:
         if self._disabled_cleanup_done:
@@ -315,6 +329,9 @@ class ScheduleSync:
                 sn, slot_states=slot_states
             )
             self._mark_scheduler_available()
+        except EnphaseLoginWallUnauthorized as err:
+            self._note_login_wall_unauthorized(err)
+            return
         except SchedulerUnavailable as err:
             self._last_error = redact_text(
                 err,
@@ -417,6 +434,7 @@ class ScheduleSync:
                 else self._coordinator.iter_serials()
             )
             unique_serials = [sn for sn in dict.fromkeys(serial_list) if sn]
+            success = True
             if unique_serials:
                 semaphore = asyncio.Semaphore(SYNC_REFRESH_CONCURRENCY)
 
@@ -429,10 +447,25 @@ class ScheduleSync:
                 results = await asyncio.gather(
                     *(_fetch_one(sn) for sn in unique_serials)
                 )
-                for sn, response, err in results:
-                    self._apply_sync_serial_result(sn, response, err)
+                auth_result = next(
+                    (
+                        result
+                        for result in results
+                        if isinstance(result[2], EnphaseLoginWallUnauthorized)
+                    ),
+                    None,
+                )
+                success = auth_result is None and all(
+                    result[2] is None for result in results
+                )
+                if auth_result is not None:
+                    self._apply_sync_serial_result(*auth_result)
+                else:
+                    for sn, response, err in results:
+                        self._apply_sync_serial_result(sn, response, err)
             self._last_sync = dt_util.utcnow()
-            self._last_status = f"ok:{reason}"
+            if success:
+                self._last_status = f"ok:{reason}"
 
     async def _patch_slot(
         self, sn: str, slot_id: str, slot_patch: dict[str, Any]
@@ -450,6 +483,9 @@ class ScheduleSync:
                 sn, slot_id, slot_patch
             )
             self._mark_scheduler_available()
+        except EnphaseLoginWallUnauthorized as err:
+            self._note_login_wall_unauthorized(err)
+            return
         except SchedulerUnavailable as err:
             self._last_error = redact_text(
                 err,
@@ -567,6 +603,9 @@ class ScheduleSync:
     ) -> None:
         if err is None:
             self._mark_scheduler_available()
+        elif isinstance(err, EnphaseLoginWallUnauthorized):
+            self._note_login_wall_unauthorized(err)
+            return
         elif isinstance(err, SchedulerUnavailable):
             self._last_error = redact_text(
                 err,

--- a/tests/components/enphase_ev/test_schedule_sync.py
+++ b/tests/components/enphase_ev/test_schedule_sync.py
@@ -23,7 +23,10 @@ from pytest_homeassistant_custom_component.common import (
     MockConfigEntry,
 )
 
-from custom_components.enphase_ev.api import SchedulerUnavailable
+from custom_components.enphase_ev.api import (
+    EnphaseLoginWallUnauthorized,
+    SchedulerUnavailable,
+)
 from custom_components.enphase_ev.const import DOMAIN, OPT_SCHEDULE_SYNC_ENABLED
 from custom_components.enphase_ev import schedule_sync as schedule_sync_mod
 from custom_components.enphase_ev.schedule_sync import ScheduleSync
@@ -276,6 +279,53 @@ async def test_async_set_slot_enabled_handles_scheduler_unavailable(hass) -> Non
 
 
 @pytest.mark.asyncio
+async def test_async_set_slot_enabled_activates_auth_block_on_login_wall(
+    hass,
+) -> None:
+    payload = {
+        "meta": {"serverTimeStamp": "2025-01-01T00:00:00.000+00:00"},
+        "config": {},
+        "slots": [],
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"site_id": RANDOM_SITE_ID},
+        options={OPT_SCHEDULE_SYNC_ENABLED: True},
+    )
+    sync, client = await _setup_sync(hass, entry, payload)
+    coord = sync._coordinator
+    err = EnphaseLoginWallUnauthorized(
+        endpoint="/service/evse_scheduler/test/states",
+        request_label="PATCH scheduler states",
+        status=200,
+        content_type="application/json; charset=utf-8",
+    )
+    coord._activate_auth_block_from_login_wall = MagicMock(
+        return_value=True
+    )  # noqa: SLF001
+    sync._slot_cache = {
+        RANDOM_SERIAL: {
+            "slot-1": {
+                "id": "slot-1",
+                "scheduleType": "CUSTOM",
+                "enabled": True,
+                "startTime": "08:00",
+                "endTime": "09:00",
+            }
+        }
+    }
+    client.patch_schedule_states = AsyncMock(side_effect=err)
+
+    await sync.async_set_slot_enabled(RANDOM_SERIAL, "slot-1", False)
+
+    assert sync._last_status == "auth_blocked"
+    assert "Enphase login wall returned HTML" in sync._last_error
+    coord._activate_auth_block_from_login_wall.assert_called_once_with(
+        err
+    )  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_patch_slot_respects_scheduler_backoff(hass) -> None:
     payload = {
         "meta": {"serverTimeStamp": "2025-01-01T00:00:00.000+00:00"},
@@ -343,6 +393,49 @@ async def test_patch_slot_handles_scheduler_unavailable(hass) -> None:
 
 
 @pytest.mark.asyncio
+async def test_patch_slot_activates_auth_block_on_login_wall(hass) -> None:
+    payload = {
+        "meta": {"serverTimeStamp": "2025-01-01T00:00:00.000+00:00"},
+        "config": {},
+        "slots": [],
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"site_id": RANDOM_SITE_ID},
+        options={OPT_SCHEDULE_SYNC_ENABLED: True},
+    )
+    sync, client = await _setup_sync(hass, entry, payload)
+    coord = sync._coordinator
+    err = EnphaseLoginWallUnauthorized(
+        endpoint="/service/evse_scheduler/test/slot",
+        request_label="PATCH scheduler slot",
+        status=200,
+        content_type="application/json; charset=utf-8",
+    )
+    coord._activate_auth_block_from_login_wall = MagicMock(
+        return_value=True
+    )  # noqa: SLF001
+    client.patch_schedule = AsyncMock(side_effect=err)
+    sync._slot_cache = {
+        RANDOM_SERIAL: {
+            "slot-1": {
+                "id": "slot-1",
+                "scheduleType": "CUSTOM",
+                "startTime": "08:00",
+                "endTime": "09:00",
+            }
+        }
+    }
+
+    await sync._patch_slot(RANDOM_SERIAL, "slot-1", {"startTime": "09:00"})
+
+    assert sync._last_status == "auth_blocked"
+    coord._activate_auth_block_from_login_wall.assert_called_once_with(
+        err
+    )  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_patch_slot_marks_scheduler_available(hass) -> None:
     payload = {
         "meta": {"serverTimeStamp": "2025-01-01T00:00:00.000+00:00"},
@@ -396,6 +489,74 @@ async def test_sync_serial_handles_scheduler_unavailable(hass) -> None:
     assert sync._last_status == "scheduler_unavailable"
     assert sync._last_error == "down"
     coord._note_scheduler_unavailable.assert_called_once()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_sync_serial_activates_auth_block_on_login_wall(hass) -> None:
+    payload = {
+        "meta": {"serverTimeStamp": "2025-01-01T00:00:00.000+00:00"},
+        "config": {},
+        "slots": [],
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"site_id": RANDOM_SITE_ID},
+        options={OPT_SCHEDULE_SYNC_ENABLED: True},
+    )
+    sync, client = await _setup_sync(hass, entry, payload)
+    coord = sync._coordinator
+    err = EnphaseLoginWallUnauthorized(
+        endpoint="/service/evse_scheduler/test/schedules",
+        request_label="GET scheduler schedules",
+        status=200,
+        content_type="application/json; charset=utf-8",
+    )
+    coord._activate_auth_block_from_login_wall = MagicMock(
+        return_value=True
+    )  # noqa: SLF001
+    client.get_schedules = AsyncMock(side_effect=err)
+
+    await sync._sync_serial(RANDOM_SERIAL)
+
+    assert sync._last_status == "auth_blocked"
+    assert "Enphase login wall returned HTML" in sync._last_error
+    coord._activate_auth_block_from_login_wall.assert_called_once_with(
+        err
+    )  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_preserves_auth_block_status_on_login_wall(hass) -> None:
+    payload = {
+        "meta": {"serverTimeStamp": "2025-01-01T00:00:00.000+00:00"},
+        "config": {},
+        "slots": [],
+    }
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={"site_id": RANDOM_SITE_ID},
+        options={OPT_SCHEDULE_SYNC_ENABLED: True},
+    )
+    sync, client = await _setup_sync(hass, entry, payload)
+    coord = sync._coordinator
+    err = EnphaseLoginWallUnauthorized(
+        endpoint="/service/evse_scheduler/test/schedules",
+        request_label="GET scheduler schedules",
+        status=200,
+        content_type="application/json; charset=utf-8",
+    )
+    coord._activate_auth_block_from_login_wall = MagicMock(
+        return_value=True
+    )  # noqa: SLF001
+    client.get_schedules = AsyncMock(side_effect=err)
+
+    await sync.async_refresh(reason="startup", serials=[RANDOM_SERIAL])
+
+    assert sync._last_status == "auth_blocked"
+    assert sync._last_sync is not None
+    coord._activate_auth_block_from_login_wall.assert_called_once_with(
+        err
+    )  # noqa: SLF001
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Treat Enphase scheduler login-wall responses as authentication failures so schedule sync participates in the `#528` auth-block handling instead of only logging scheduler fetch or patch errors.

This preserves `auth_failed` / `auth_blocked` scheduler diagnostics during refresh, prevents a later successful scheduler result from overwriting an auth-block status, and activates the coordinator auth-block path from scheduler reads and writes.

## Related Issues

Related to #528.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/schedule_sync.py tests/components/enphase_ev/test_schedule_sync.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_schedule_sync.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/schedule_sync.py tests/components/enphase_ev/test_schedule_sync.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev/test_schedule_sync.py -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/schedule_sync.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james:/Users/james ha-dev bash -lc "python3 -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This follows up the auth-block work for #528. The latest logs showed scheduler sync receiving the Enphase login wall shortly after stored credentials were rejected, before the main coordinator path activated the long auth block.

No translation changes were needed; this uses existing auth-block repair behavior and diagnostics fields.
