### PR TITLE
Remove redundant defensive code

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -5919,10 +5919,7 @@ class EnphaseEVClient:
 
         if err.status != 422:
             return False
-        try:
-            text = str(err.message or "").lower()
-        except Exception:  # noqa: BLE001 - defensive casting
-            text = ""
+        text = str(err.message or "").lower()
         return any(
             token in text
             for token in (

--- a/custom_components/enphase_ev/api_parsers.py
+++ b/custom_components/enphase_ev/api_parsers.py
@@ -990,19 +990,18 @@ def normalize_hems_energy_consumption_payload(payload: object) -> dict | None:
 
     endpoint_type = clean_optional_text(payload.get("type"))
     endpoint_timestamp = payload.get("timestamp")
+    families: dict[str, object] = {
+        "heat-pump": [],
+        "evse": [],
+        "water-heater": [],
+    }
     normalized: dict[str, object] = {
         "type": endpoint_type,
         "timestamp": endpoint_timestamp,
         "endpoint_type": endpoint_type,
         "endpoint_timestamp": endpoint_timestamp,
-        "data": {
-            "heat-pump": [],
-            "evse": [],
-            "water-heater": [],
-        },
+        "data": families,
     }
-    families = normalized["data"]
-    assert isinstance(families, dict)
     for family_key in ("heat-pump", "evse", "water-heater"):
         raw_family = data.get(family_key)
         if raw_family is None:

--- a/custom_components/enphase_ev/energy.py
+++ b/custom_components/enphase_ev/energy.py
@@ -84,13 +84,9 @@ class EnergyManager:
 
     def _site_energy_cache_age(self) -> float | None:
         """Return the age of the cached site energy payload."""
-        cache_ts = getattr(self, "_site_energy_cache_ts", None)
-        if cache_ts is None:
+        if self._site_energy_cache_ts is None:
             return None
-        try:
-            return time.monotonic() - cache_ts
-        except Exception:
-            return None
+        return time.monotonic() - self._site_energy_cache_ts
 
     @property
     def site_energy_cache_age(self) -> float | None:
@@ -111,10 +107,6 @@ class EnergyManager:
     def site_energy_refresh_due(self, *, force: bool = False) -> bool:
         """Return True when the site-energy cache should be refreshed."""
 
-        if not hasattr(self, "_site_energy_cache_ts"):
-            self._site_energy_cache_ts = None
-        if not hasattr(self, "_site_energy_cache_ttl"):
-            self._site_energy_cache_ttl = SITE_ENERGY_CACHE_TTL
         force_refresh = force or self._site_energy_force_refresh
         if self._service_backoff_active():
             return False
@@ -256,15 +248,8 @@ class EnergyManager:
         minutes = self._coerce_energy_value(interval_raw)
         if minutes is None or minutes <= 0:
             minutes = SITE_ENERGY_DEFAULT_INTERVAL_MIN
-        try:
-            minutes_float = float(minutes)
-            hours = minutes_float / 60.0
-        except Exception:  # noqa: BLE001
-            minutes_float = SITE_ENERGY_DEFAULT_INTERVAL_MIN
-            hours = minutes_float / 60.0
-        if hours <= 0:
-            minutes_float = SITE_ENERGY_DEFAULT_INTERVAL_MIN
-            hours = minutes_float / 60.0
+        minutes_float = float(minutes)
+        hours = minutes_float / 60.0
         return hours, minutes_float
 
     def _sum_energy_buckets(
@@ -511,10 +496,7 @@ class EnergyManager:
                 return
             if total_wh == 0 and not allow_zero:
                 return
-            try:
-                total_kwh = round(total_wh / 1000.0, 3)
-            except Exception:  # noqa: BLE001
-                return
+            total_kwh = round(total_wh / 1000.0, 3)
             prev_entry = prev.get(flow)
             prev_value = None
             prev_reset_at = None
@@ -848,10 +830,6 @@ class EnergyManager:
 
     async def _async_refresh_site_energy(self, *, force: bool = False) -> None:
         """Refresh lifetime energy cache with TTL enforcement."""
-        if not hasattr(self, "_site_energy_cache_ts"):
-            self._site_energy_cache_ts = None
-        if not hasattr(self, "_site_energy_cache_ttl"):
-            self._site_energy_cache_ttl = SITE_ENERGY_CACHE_TTL
         force_refresh = force or self._site_energy_force_refresh
         self._site_energy_force_refresh = False
         now_mono = time.monotonic()

--- a/custom_components/enphase_ev/log_redaction.py
+++ b/custom_components/enphase_ev/log_redaction.py
@@ -38,13 +38,7 @@ def redact_identifier(value: object) -> str:
 def redact_site_id(value: object) -> str:
     """Return a stable site marker for logs."""
 
-    if value is None:
-        return "[site]"
-    try:
-        text = str(value).strip()
-    except Exception:  # noqa: BLE001
-        return "[site]"
-    return "[site]" if text else "[site]"
+    return "[site]"
 
 
 def _key_kind(key: object) -> str:

--- a/custom_components/enphase_ev/parsing_helpers.py
+++ b/custom_components/enphase_ev/parsing_helpers.py
@@ -211,8 +211,6 @@ def parse_inverter_last_report(value: object) -> datetime | None:
                 epoch_value = float(text)
             except Exception:
                 return None
-    if epoch_value is None:
-        return None
     if epoch_value > 1_000_000_000_000:
         epoch_value /= 1000.0
     try:

--- a/custom_components/enphase_ev/refresh_plan.py
+++ b/custom_components/enphase_ev/refresh_plan.py
@@ -455,29 +455,10 @@ def _plan_from_stages(*stages: RefreshStage | None) -> RefreshPlan:
     return RefreshPlan(stages=filtered)
 
 
-def _refresh_due(
-    target: object,
-    predicate_name: str,
-    *,
-    fallback_due: Callable[[], bool] | None = None,
-    **kwargs: object,
-) -> bool:
-    predicate = getattr(target, predicate_name, None)
-    if callable(predicate):
-        return bool(predicate(**kwargs))
-    if fallback_due is None:
-        return False
-    return bool(fallback_due())
-
-
 def _heatpump_power_covers_dependency_refreshes(runtime: object) -> bool:
-    has_type = getattr(runtime, "has_type", None)
-    if callable(has_type):
-        try:
-            if not bool(has_type("heatpump")):
-                return False
-        except Exception:
-            return False
+    has_type = getattr(runtime, "has_type")
+    if not bool(has_type("heatpump")):
+        return False
     client = getattr(runtime, "client", None)
     if getattr(client, "hems_site_supported", None) is not True:
         return False
@@ -718,12 +699,7 @@ def build_post_session_followup_plan(
         return post_session_followup_plan(day_local_default)
     parallel: list[RefreshTask] = []
     evse_timeseries = getattr(owner, "evse_timeseries")
-    if _refresh_due(
-        evse_timeseries,
-        "refresh_due",
-        day_local=day_local_default,
-        fallback_due=lambda: callable(getattr(evse_timeseries, "async_refresh", None)),
-    ):
+    if evse_timeseries.refresh_due(day_local=day_local_default):
         parallel.append(
             callback_task(
                 "evse_timeseries_s",
@@ -734,13 +710,7 @@ def build_post_session_followup_plan(
             )
         )
     energy = getattr(owner, "energy")
-    if _refresh_due(
-        energy,
-        "site_energy_refresh_due",
-        fallback_due=lambda: callable(
-            getattr(energy, "_async_refresh_site_energy", None)
-        ),
-    ):
+    if energy.site_energy_refresh_due():
         parallel.append(
             callback_task(
                 "site_energy_s",
@@ -749,11 +719,7 @@ def build_post_session_followup_plan(
             )
         )
     inventory = getattr(owner, "inventory_runtime")
-    if _refresh_due(
-        inventory,
-        "inverters_refresh_due",
-        fallback_due=lambda: callable(getattr(owner, "_async_refresh_inverters", None)),
-    ):
+    if inventory.inverters_refresh_due():
         parallel.append(
             method_task("inverters_s", "inverters", "_async_refresh_inverters")
         )

--- a/custom_components/enphase_ev/refresh_runner.py
+++ b/custom_components/enphase_ev/refresh_runner.py
@@ -34,15 +34,6 @@ _SKIPPABLE_REFRESH_ERRORS = (
 )
 
 
-def _unpack_refresh_call(
-    call: BoundRefreshCall | tuple[str, str, Callable[[], object]],
-) -> tuple[str, str, Callable[[], object], str | None]:
-    if len(call) == 3:
-        timing_key, log_label, callback_factory = call
-        return timing_key, log_label, callback_factory, None
-    return call
-
-
 class RefreshRunner:
     """Execute refresh plans and startup warmup on behalf of the coordinator."""
 
@@ -98,7 +89,7 @@ class RefreshRunner:
         self,
         phase_timings: dict[str, float],
         *,
-        calls: tuple[BoundRefreshCall | tuple[str, str, Callable[[], object]], ...],
+        calls: tuple[BoundRefreshCall, ...],
         stage_key: str | None = None,
         defer_topology: bool = False,
     ) -> None:
@@ -117,9 +108,7 @@ class RefreshRunner:
                         endpoint_family=endpoint_family,
                     )
                 )
-                for timing_key, log_label, callback_factory, endpoint_family in (
-                    _unpack_refresh_call(call) for call in calls
-                )
+                for timing_key, log_label, callback_factory, endpoint_family in calls
             ]
             results = await asyncio.gather(*tasks)
         except (asyncio.CancelledError, Exception):
@@ -143,7 +132,7 @@ class RefreshRunner:
         self,
         phase_timings: dict[str, float],
         *,
-        calls: tuple[BoundRefreshCall | tuple[str, str, Callable[[], object]], ...],
+        calls: tuple[BoundRefreshCall, ...],
         stage_key: str | None = None,
         defer_topology: bool = False,
     ) -> None:
@@ -152,9 +141,7 @@ class RefreshRunner:
 
         group_started = time.monotonic()
         try:
-            for timing_key, log_label, callback_factory, endpoint_family in (
-                _unpack_refresh_call(call) for call in calls
-            ):
+            for timing_key, log_label, callback_factory, endpoint_family in calls:
                 key, duration = await self.async_run_refresh_call(
                     timing_key,
                     log_label,
@@ -174,12 +161,8 @@ class RefreshRunner:
         self,
         phase_timings: dict[str, float],
         *,
-        parallel_calls: tuple[
-            BoundRefreshCall | tuple[str, str, Callable[[], object]], ...
-        ] = (),
-        ordered_calls: tuple[
-            BoundRefreshCall | tuple[str, str, Callable[[], object]], ...
-        ] = (),
+        parallel_calls: tuple[BoundRefreshCall, ...] = (),
+        ordered_calls: tuple[BoundRefreshCall, ...] = (),
         stage_key: str | None = None,
         defer_topology: bool = False,
     ) -> None:

--- a/custom_components/enphase_ev/runtime_helpers.py
+++ b/custom_components/enphase_ev/runtime_helpers.py
@@ -53,21 +53,14 @@ def coerce_optional_text(value: object) -> str | None:
 def iso_or_none(value: datetime | None) -> str | None:
     if value is None:
         return None
-    try:
-        return value.isoformat()
-    except Exception:  # noqa: BLE001
-        return None
+    return value.isoformat()
 
 
 def monotonic_deadline_to_utc_iso(target_mono: float) -> str | None:
     now_mono = time.monotonic()
-    try:
-        target_value = float(target_mono)
-    except Exception:  # noqa: BLE001
+    if target_mono <= 0 or target_mono <= now_mono:
         return None
-    if target_value <= 0 or target_value <= now_mono:
-        return None
-    delta_seconds = target_value - now_mono
+    delta_seconds = target_mono - now_mono
     return iso_or_none(dt_util.utcnow() + timedelta(seconds=delta_seconds))
 
 

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -966,11 +966,6 @@ def async_setup_services(
 
     async def _svc_sync_schedules(call: ServiceCall) -> None:
         for _device_id, sn, coord in await _resolve_charger_targets(call):
-            if not hasattr(coord, "schedule_sync"):
-                raise ServiceValidationError(
-                    translation_domain=DOMAIN,
-                    translation_key="exceptions.grid_site_required",
-                )
             await coord.schedule_sync.async_refresh(reason="service", serials=[sn])
 
     hass.services.async_register(
@@ -981,11 +976,10 @@ def async_setup_services(
     )
     hass.services.async_register(DOMAIN, "stop_charging", _svc_stop, schema=STOP_SCHEMA)
 
-    trigger_register_kwargs: dict[str, object] = {"schema": TRIGGER_SCHEMA}
-    try:
-        trigger_register_kwargs["supports_response"] = supports_response.OPTIONAL
-    except AttributeError:
-        trigger_register_kwargs["supports_response"] = supports_response
+    trigger_register_kwargs: dict[str, object] = {
+        "schema": TRIGGER_SCHEMA,
+        "supports_response": supports_response.OPTIONAL,
+    }
     hass.services.async_register(
         DOMAIN, "trigger_message", _svc_trigger, **trigger_register_kwargs
     )
@@ -1016,11 +1010,10 @@ def async_setup_services(
     hass.services.async_register(
         DOMAIN, "delete_schedule", _svc_delete_schedule, schema=DELETE_SCHEDULE_SCHEMA
     )
-    validate_register_kwargs: dict[str, object] = {"schema": VALIDATE_SCHEDULE_SCHEMA}
-    try:
-        validate_register_kwargs["supports_response"] = supports_response.OPTIONAL
-    except AttributeError:
-        validate_register_kwargs["supports_response"] = supports_response
+    validate_register_kwargs: dict[str, object] = {
+        "schema": VALIDATE_SCHEDULE_SCHEMA,
+        "supports_response": supports_response.OPTIONAL,
+    }
     hass.services.async_register(
         DOMAIN, "validate_schedule", _svc_validate_schedule, **validate_register_kwargs
     )

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -8096,18 +8096,6 @@ async def test_hems_power_timeseries_success_logs_redacted_response_summary(
     assert "'latest_non_null_value': 0.0" in caplog.text
 
 
-def test_is_hems_invalid_date_error_handles_unstringable_message() -> None:
-    class _BadString:
-        def __str__(self) -> str:
-            raise RuntimeError("boom")
-
-    class _Err:
-        status = 422
-        message = _BadString()
-
-    assert api.EnphaseEVClient._is_hems_invalid_date_error(_Err()) is False
-
-
 @pytest.mark.asyncio
 async def test_hems_power_timeseries_non_date_422_reraises(monkeypatch) -> None:
     client = _make_client()

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -1412,6 +1412,7 @@ def _prepare_minimal_success_update(coord, sn: str) -> None:
         invalidate=lambda: None,
     )
     coord.evse_timeseries = SimpleNamespace(
+        refresh_due=MagicMock(return_value=True),
         async_refresh=AsyncMock(),
         merge_charger_payloads=MagicMock(),
         diagnostics=lambda: {},

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1084,7 +1084,7 @@ async def test_refresh_runner_helpers_cover_stage_and_topology_paths(
         phase_timings,
         stage_key="ordered",
         defer_topology=True,
-        calls=(("first_s", "first", AsyncMock(return_value=None)),),
+        calls=(("first_s", "first", AsyncMock(return_value=None), None),),
     )
 
     assert "first_s" in phase_timings

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -14,7 +14,6 @@ from custom_components.enphase_ev.refresh_plan import (
     FOLLOWUP_PLAN,
     HEATPUMP_FOLLOWUP_PLAN,
     SITE_ONLY_FOLLOWUP_PLAN,
-    _refresh_due,
     bind_refresh_stage,
     bind_refresh_plan,
     build_followup_plan,
@@ -506,10 +505,6 @@ def test_dynamic_followup_plan_skips_up_to_date_tasks() -> None:
     assert build_followup_plan(owner).stages == ()
 
 
-def test_refresh_due_returns_false_without_predicate_or_fallback() -> None:
-    assert _refresh_due(object(), "missing_predicate") is False
-
-
 def test_dynamic_followup_plan_selects_due_subset() -> None:
     owner = _RefreshOwner()
     owner.battery_runtime.battery_backup_history_refresh_due = lambda: False
@@ -680,24 +675,6 @@ def test_dynamic_heatpump_followup_includes_cleanup_when_hems_support_unknown() 
     ]
 
 
-def test_dynamic_heatpump_followup_includes_cleanup_when_has_type_raises() -> None:
-    owner = _RefreshOwner()
-
-    def _boom(_key: str) -> bool:
-        raise RuntimeError("bad has_type")
-
-    owner.heatpump_runtime.has_type = _boom
-
-    plan = build_heatpump_followup_plan(owner)
-
-    assert len(plan.stages) == 1
-    assert [task.timing_key for task in plan.stages[0].ordered_tasks] == [
-        "heatpump_runtime_s",
-        "heatpump_daily_s",
-        "heatpump_power_s",
-    ]
-
-
 def test_dynamic_post_session_followup_only_includes_due_tasks() -> None:
     owner = _RefreshOwner()
     owner.energy.site_energy_refresh_due = MagicMock(return_value=False)
@@ -759,8 +736,8 @@ async def test_coordinator_run_refresh_calls_tracks_stage_and_topology_batch(
     await coord.refresh_runner.async_run_refresh_calls(
         phase_timings,
         calls=(
-            ("first_s", "first", lambda: None),
-            ("second_s", "second", lambda: None),
+            ("first_s", "first", lambda: None, None),
+            ("second_s", "second", lambda: None, None),
         ),
         stage_key="refresh",
         defer_topology=True,
@@ -808,8 +785,8 @@ async def test_coordinator_run_refresh_calls_drains_siblings_before_batch_end(
         await coord.refresh_runner.async_run_refresh_calls(
             {},
             calls=(
-                ("slow_s", "slow", _slow),
-                ("fail_s", "fail", _fail),
+                ("slow_s", "slow", _slow, None),
+                ("fail_s", "fail", _fail, None),
             ),
             defer_topology=True,
         )

--- a/tests/components/enphase_ev/test_evse_firmware.py
+++ b/tests/components/enphase_ev/test_evse_firmware.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 from datetime import datetime
-from types import SimpleNamespace
 
 import pytest
 from homeassistant.util import dt as dt_util
@@ -154,7 +153,6 @@ def test_normalize_details_and_helpers_cover_edge_cases() -> None:
     assert _iso_or_none(None) is None
     assert _mono_to_utc_iso(0) is None
     assert _mono_to_utc_iso(-1) is None
-    assert _mono_to_utc_iso(SimpleNamespace()) is None  # type: ignore[arg-type]
     assert _text(" value ") == "value"
     assert _text(None) is None
 
@@ -163,9 +161,3 @@ def test_normalize_details_and_helpers_cover_edge_cases() -> None:
             raise ValueError("boom")
 
     assert _text(_BadStr()) is None
-
-    class _BadDatetime:
-        def isoformat(self) -> str:
-            raise ValueError("boom")
-
-    assert _iso_or_none(_BadDatetime()) is None  # type: ignore[arg-type]

--- a/tests/components/enphase_ev/test_firmware_catalog.py
+++ b/tests/components/enphase_ev/test_firmware_catalog.py
@@ -473,12 +473,6 @@ def test_helper_edge_branches() -> None:
     assert firmware_catalog._catalog_generated_at({"generated_at": _BadStr()}) is None
 
     assert firmware_catalog._iso_or_none(None) is None
-
-    class _BadDatetime:
-        def isoformat(self):
-            raise ValueError("boom")
-
-    assert firmware_catalog._iso_or_none(_BadDatetime()) is None  # type: ignore[arg-type]
     assert firmware_catalog._mono_to_utc_iso(time.monotonic() - 1) is None
     assert firmware_catalog._mono_to_utc_iso(time.monotonic() + 1) is not None
     assert firmware_catalog._parse_iso_datetime("") is None

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -1276,17 +1276,6 @@ def test_heatpump_runtime_type_helpers_cover_guard_paths(coordinator_factory) ->
     ]  # noqa: SLF001
 
 
-def test_parse_inverter_last_report_handles_none_epoch_value(monkeypatch) -> None:
-    monkeypatch.setattr(
-        parsing_helpers_mod,
-        "float",
-        lambda _value: None,
-        raising=False,
-    )
-
-    assert parse_inverter_last_report(1711843200) is None
-
-
 @pytest.mark.asyncio
 async def test_refresh_heatpump_power_tracks_latest_valid_sample(
     coordinator_factory,

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -2225,30 +2225,6 @@ async def test_device_service_routing_helper_guard_paths(
     )
 
 
-def test_register_services_supports_response_fallback(
-    hass: HomeAssistant, monkeypatch
-) -> None:
-    """Service setup should honor an explicit supports_response fallback."""
-    registered: dict[tuple[str, str], dict[str, object]] = {}
-
-    def fake_register(self, domain, service, handler, schema=None, **kwargs):
-        registered[(domain, service)] = {
-            "handler": handler,
-            "schema": schema,
-            "kwargs": kwargs,
-        }
-
-    monkeypatch.setattr(hass.services.__class__, "async_register", fake_register)
-
-    fallback = SimpleNamespace()
-    async_setup_services(hass, supports_response=fallback)
-
-    assert (
-        registered[(DOMAIN, "trigger_message")]["kwargs"]["supports_response"]
-        is fallback
-    )
-
-
 def test_init_module_importable() -> None:
     import importlib
 

--- a/tests/components/enphase_ev/test_log_redaction.py
+++ b/tests/components/enphase_ev/test_log_redaction.py
@@ -15,7 +15,6 @@ def test_identifier_helpers_redact_values() -> None:
     assert redact_identifier("ABCD") == "A...D"
     assert redact_identifier(None) == "[redacted]"
     assert redact_site_id("123456789") == "[site]"
-    assert redact_site_id(None) == "[site]"
 
 
 def test_redact_text_scrubs_common_sensitive_values() -> None:
@@ -48,7 +47,6 @@ def test_identifier_helpers_cover_bad_string_inputs() -> None:
             raise ValueError("boom")
 
     assert truncate_identifier(_BadStr()) is None
-    assert redact_site_id(_BadStr()) == "[site]"
 
 
 def test_redact_text_covers_key_kinds_and_truncation() -> None:

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -229,35 +229,3 @@ async def test_targeted_services_raise_without_target_or_owner(
     coord.async_start_streaming.assert_not_awaited()
     coord.async_stop_streaming.assert_not_awaited()
     coord.schedule_sync.async_refresh.assert_not_awaited()
-
-
-@pytest.mark.asyncio
-async def test_sync_schedules_raises_when_owner_has_no_schedule_sync(
-    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Schedule sync service should fail loudly when the coordinator cannot sync."""
-
-    handlers = _register_service_handlers(hass, monkeypatch)
-    coord = _fake_service_coordinator(site_id="evse-site", serials={"EVSE123"})
-    delattr(coord, "schedule_sync")
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={CONF_SITE_ID: "evse-site", CONF_SITE_ONLY: False},
-        title="EVSE Site",
-        unique_id="evse-site",
-    )
-    entry.add_to_hass(hass)
-    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
-
-    device_registry = dr.async_get(hass)
-    charger = device_registry.async_get_or_create(
-        config_entry_id=entry.entry_id,
-        identifiers={(DOMAIN, "EVSE123")},
-        manufacturer="Enphase",
-        name="Garage Charger",
-    )
-
-    with pytest.raises(ServiceValidationError):
-        await handlers[(DOMAIN, "sync_schedules")](
-            SimpleNamespace(data={"device_id": [charger.id]})
-        )

--- a/tests/components/enphase_ev/test_site_energy.py
+++ b/tests/components/enphase_ev/test_site_energy.py
@@ -13,7 +13,6 @@ from homeassistant.const import UnitOfPower
 from custom_components.enphase_ev import energy as energy_mod
 from custom_components.enphase_ev.api import SiteEnergyUnavailable
 from custom_components.enphase_ev.energy import (
-    SITE_ENERGY_CACHE_TTL,
     LifetimeGuardState,
     SiteEnergyFlow,
 )
@@ -73,19 +72,15 @@ def test_site_energy_aggregation_with_fallbacks(coordinator_factory) -> None:
     assert meta["interval_minutes"] == pytest.approx(60.0)
 
 
-def test_site_energy_refresh_due_initializes_attrs_and_respects_backoff(
+def test_site_energy_refresh_due_respects_backoff(
     coordinator_factory, monkeypatch
 ) -> None:
     coord = coordinator_factory()
     manager = coord.energy
-    del manager._site_energy_cache_ts
-    del manager._site_energy_cache_ttl
     manager._service_backoff_until = 150.0  # noqa: SLF001
     monkeypatch.setattr(energy_mod.time, "monotonic", lambda: 100.0)
 
     assert manager.site_energy_refresh_due() is False
-    assert manager._site_energy_cache_ts is None  # noqa: SLF001
-    assert manager._site_energy_cache_ttl == SITE_ENERGY_CACHE_TTL  # noqa: SLF001
 
 
 def test_site_energy_refresh_due_skips_when_cache_is_fresh(
@@ -230,11 +225,11 @@ def test_apply_lifetime_guard_holds_small_backward_jitter(
 
 def test_site_energy_cache_age_and_invalidate(coordinator_factory, monkeypatch) -> None:
     coord = coordinator_factory()
-    coord.energy._site_energy_cache_ts = "bad"  # type: ignore[assignment]
+    coord.energy._site_energy_cache_ts = 90.0
     monkeypatch.setattr(
         "custom_components.enphase_ev.energy.time.monotonic", lambda: 100.0
     )
-    assert coord.energy._site_energy_cache_age() is None  # noqa: SLF001
+    assert coord.energy._site_energy_cache_age() == pytest.approx(10.0)  # noqa: SLF001
     coord.energy._invalidate_site_energy_cache()  # noqa: SLF001
     assert coord.energy._site_energy_cache_ts is None
 
@@ -453,9 +448,7 @@ def test_site_energy_default_interval_applied(coordinator_factory) -> None:
     assert meta["interval_minutes"] == pytest.approx(5.0)
 
 
-def test_site_energy_interval_hours_edge_cases(
-    monkeypatch, coordinator_factory
-) -> None:
+def test_site_energy_interval_hours_edge_cases(coordinator_factory) -> None:
     coord = coordinator_factory()
     # Non-dict payload falls back to default interval
     hours, minutes = coord.energy._site_energy_interval_hours(None)  # noqa: SLF001
@@ -468,63 +461,11 @@ def test_site_energy_interval_hours_edge_cases(
     assert minutes == pytest.approx(10.0)
     assert hours == pytest.approx(10.0 / 60.0)
 
-    class BoomFloat:
-        def __le__(self, _other):
-            return False
-
-        def __float__(self):
-            raise ValueError("boom")
-
-    # Force float conversion error branch
-    monkeypatch.setattr(coord.energy, "_coerce_energy_value", lambda _v: BoomFloat())
     hours, minutes = coord.energy._site_energy_interval_hours(
-        {"interval_minutes": "bad"}
+        {"interval_minutes": 0}
     )  # noqa: SLF001
     assert minutes == pytest.approx(5.0)
     assert hours == pytest.approx(5.0 / 60.0)
-
-    class WeirdZero(float):
-        def __le__(self, other):
-            return False
-
-    # Bypass initial <=0 check to hit hours<=0 fallback
-    monkeypatch.setattr(coord.energy, "_coerce_energy_value", lambda _v: WeirdZero(0.0))
-    hours, minutes = coord.energy._site_energy_interval_hours(
-        {"interval_minutes": WeirdZero(0.0)}
-    )  # noqa: SLF001
-    assert minutes == pytest.approx(5.0)
-    assert hours == pytest.approx(5.0 / 60.0)
-
-
-def test_site_energy_store_round_failure(monkeypatch, coordinator_factory):
-    coord = coordinator_factory()
-    call_count = 0
-    real_round = round
-
-    def boom_round(val, ndigits=None):
-        nonlocal call_count
-        call_count += 1
-        if call_count == 1:
-            raise ValueError("round boom")
-        return real_round(val, ndigits) if ndigits is not None else real_round(val)
-
-    monkeypatch.setattr("builtins.round", boom_round)
-    flows, _meta = coord.energy._aggregate_site_energy(
-        {"production": [1000]}
-    )  # noqa: SLF001
-    assert flows == {}
-
-
-@pytest.mark.asyncio
-async def test_async_refresh_site_energy_handles_missing_attrs(
-    monkeypatch, coordinator_factory
-):
-    coord = coordinator_factory()
-    coord.client.lifetime_energy = AsyncMock(return_value=None)
-    delattr(coord.energy, "_site_energy_cache_ts")
-    delattr(coord.energy, "_site_energy_cache_ttl")
-    await coord.energy._async_refresh_site_energy()  # noqa: SLF001
-    assert coord.energy._site_energy_cache_ts is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Remove redundant defensive branches and coverage-padding tests that only exercised impossible or unsupported internal states. This keeps the production contracts tighter for typed runtime helpers, refresh planning, service registration, site-energy parsing, and selected API parser helpers while preserving 100% targeted coverage for the touched modules.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/api.py custom_components/enphase_ev/api_parsers.py custom_components/enphase_ev/energy.py custom_components/enphase_ev/log_redaction.py custom_components/enphase_ev/parsing_helpers.py custom_components/enphase_ev/refresh_plan.py custom_components/enphase_ev/refresh_runner.py custom_components/enphase_ev/runtime_helpers.py custom_components/enphase_ev/services.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_evse_firmware.py tests/components/enphase_ev/test_firmware_catalog.py tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_log_redaction.py tests/components/enphase_ev/test_services.py tests/components/enphase_ev/test_site_energy.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/api_parsers.py custom_components/enphase_ev/energy.py custom_components/enphase_ev/log_redaction.py custom_components/enphase_ev/parsing_helpers.py custom_components/enphase_ev/refresh_plan.py custom_components/enphase_ev/refresh_runner.py custom_components/enphase_ev/runtime_helpers.py custom_components/enphase_ev/services.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_evse_firmware.py tests/components/enphase_ev/test_firmware_catalog.py tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_log_redaction.py tests/components/enphase_ev/test_services.py tests/components/enphase_ev/test_site_energy.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/api.py custom_components/enphase_ev/api_parsers.py custom_components/enphase_ev/energy.py custom_components/enphase_ev/log_redaction.py custom_components/enphase_ev/parsing_helpers.py custom_components/enphase_ev/refresh_plan.py custom_components/enphase_ev/refresh_runner.py custom_components/enphase_ev/runtime_helpers.py custom_components/enphase_ev/services.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_evse_firmware.py tests/components/enphase_ev/test_firmware_catalog.py tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_init_module.py tests/components/enphase_ev/test_log_redaction.py tests/components/enphase_ev/test_services.py tests/components/enphase_ev/test_site_energy.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_log_redaction.py tests/components/enphase_ev/test_evse_firmware.py tests/components/enphase_ev/test_firmware_catalog.py tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_site_energy.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_services.py tests/components/enphase_ev/test_init_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/api_parsers.py,custom_components/enphase_ev/energy.py,custom_components/enphase_ev/log_redaction.py,custom_components/enphase_ev/parsing_helpers.py,custom_components/enphase_ev/refresh_plan.py,custom_components/enphase_ev/refresh_runner.py,custom_components/enphase_ev/runtime_helpers.py,custom_components/enphase_ev/services.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
```

Additional validation:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_additional_coverage.py::test_async_update_data_merges_evse_timeseries"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
```

Notes:

- Full targeted coverage passed with `2912 passed` and 100% coverage for all touched source modules.
- `pre-commit run --all-files` could not run inside Docker because the mounted worktree points Git at an unmounted host worktree path, causing `fatal: not a git repository`.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots. This is an internal refactor/test cleanup with no user-facing strings or behavior changes intended.