### PR TITLE
Document integration architecture and code intent

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,7 @@ docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "p
 ## Documentation and Changelog
 
 - Update `README.md` when behaviour, options, or supported features change. Include new configuration parameters using the recommended `configuration_basic` formatting when appropriate.
+- For codebase orientation, see [`docs/architecture.md`](docs/architecture.md) and [`docs/glossary.md`](docs/glossary.md).
 - Record user-facing changes in `CHANGELOG.md` under an `Unreleased` entry (or add a new version section when preparing a release).
 
 ## Tests

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -1,3 +1,5 @@
+"""Set up Enphase EV config entries, services, devices, and registry migrations."""
+
 from __future__ import annotations
 
 import asyncio
@@ -157,6 +159,8 @@ async def _async_update_listener(
 ) -> None:
     runtime_data = getattr(entry, "runtime_data", None)
     if isinstance(runtime_data, EnphaseRuntimeData) and runtime_data.skip_reload_once:
+        # Reauth and reconfigure update the entry data themselves, so skip the
+        # reload Home Assistant would normally trigger from the options listener.
         runtime_data.skip_reload_once = False
         return
     if getattr(entry, "disabled_by", None) is not None:
@@ -208,6 +212,7 @@ def _sync_type_devices(
     entry: EnphaseConfigEntry, coord, dev_reg, site_id: object
 ) -> dict[str, object]:
     """Create or update type devices from coordinator inventory."""
+
     inventory_view = coord.inventory_view
     type_devices: dict[str, object] = {}
     type_devices_by_identifier: dict[tuple[str, str], object] = {}
@@ -217,6 +222,8 @@ def _sync_type_devices(
         if is_dry_contact_type_key(type_key) or (
             normalized in _TYPE_DEVICE_KEYS_WITH_DIRECT_CHILD_DEVICES
         ):
+            # Dry-contact and EV charger members get concrete child devices, so
+            # adding another aggregate type device would duplicate the hierarchy.
             continue
         ident = inventory_view.type_identifier(type_key)
         if ident is None:
@@ -491,6 +498,8 @@ def _migrate_cloud_entity_unique_ids(
     entry_id = getattr(entry, "entry_id", None)
     migrated = 0
     removed = 0
+    # Keep entity IDs stable for users while moving old unique IDs to the
+    # site-scoped naming convention used by current cloud sensors.
     rename_specs = (
         (
             "sensor",

--- a/custom_components/enphase_ev/ac_battery_runtime.py
+++ b/custom_components/enphase_ev/ac_battery_runtime.py
@@ -1,3 +1,5 @@
+"""Parse and refresh Enphase AC Battery device state."""
+
 from __future__ import annotations
 
 import re
@@ -11,6 +13,8 @@ from homeassistant.util import dt as dt_util
 from .const import DOMAIN
 from .service_validation import raise_translated_service_validation
 
+# Enphase exposes AC Battery controls through an HTML page rather than the JSON
+# endpoints used for most battery data.
 _AC_BATTERY_TABLE_RE = re.compile(
     r"<table[^>]*id=['\"]ac_batteries['\"][^>]*>(?P<table>.*?)</table>",
     re.IGNORECASE | re.DOTALL,
@@ -265,6 +269,8 @@ class AcBatteryRuntime:
             if not key:
                 continue
 
+            # The sleep link CSS class is the stable signal; the label can vary
+            # with localization or minor Enlighten page copy changes.
             sleep_match = _AC_BATTERY_SLEEP_CONTROL_RE.search(row_text)
             sleep_class = (
                 sleep_match.group("class").strip().lower() if sleep_match else None
@@ -506,11 +512,15 @@ class AcBatteryRuntime:
             }
         )
         if isinstance(redacted, dict):
+            # These payload copies feed diagnostics, so identifiers must stay
+            # redacted even though the source page was HTML.
             state._ac_battery_devices_payload = redacted
             state._ac_battery_devices_html_payload = redacted
         else:
             state._ac_battery_devices_payload = {"value": redacted}
             state._ac_battery_devices_html_payload = {"value": redacted}
+        # The AC Battery page is slow-changing and expensive enough to keep on
+        # its own short-lived cache separate from endpoint-family backoff.
         state._ac_battery_devices_cache_until = now + 300.0
         coord._note_endpoint_family_success(family, success_ttl_s=300.0)
 

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -1,3 +1,11 @@
+"""Client and authentication helpers for Enphase Enlighten cloud endpoints.
+
+This module intentionally keeps the HTTP boundary in one place. Enphase exposes
+several browser-backed services with different header, cookie, token, and XSRF
+expectations, so the client normalizes those variants before coordinator and
+entity code consume the data.
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -54,6 +62,9 @@ _BATTERY_CONFIG_VARIANT_LEAN = "official_web_lean"
 _BATTERY_CONFIG_VARIANT_COOKIE_EAUTH = "cookie_eauth_compatible"
 _BATTERY_CONFIG_VARIANT_MIXED = "mixed_auth_compatible"
 _ENLIGHTEN_READ_CONCURRENCY_LIMIT = 2
+# Enlighten web pages and XHR endpoints share service capacity with the mobile
+# app. A module-level limiter keeps parallel refresh helpers from creating a
+# burst of browser-like reads during one Home Assistant update cycle.
 _enlighten_read_semaphore: asyncio.Semaphore | None = None
 
 
@@ -368,6 +379,8 @@ def _redact_debug_json_body(
 ) -> Any:
     """Return a JSON-safe payload with common identifiers redacted."""
 
+    # Invalid payload previews are copied into diagnostics and repair context,
+    # so redact before truncating to avoid exposing short tokens or site IDs.
     normalized_site_ids: set[str] = set()
     for site_id in site_ids or ():
         try:
@@ -2316,6 +2329,9 @@ class EnphaseEVClient:
     ) -> dict[str, str | None]:
         """Return headers for BatteryConfig read/write calls."""
 
+        # BatteryConfig is backed by the first-party battery profile web app,
+        # not the regular Enlighten XHR surface, so these headers intentionally
+        # mimic that origin and user agent instead of reusing the base headers.
         headers: dict[str, str | None] = {
             "Accept": "application/json, text/plain, */*",
             "Origin": "https://battery-profile-ui.enphaseenergy.com",
@@ -2613,6 +2629,10 @@ class EnphaseEVClient:
     ) -> list[_BatteryConfigWriteAttempt]:
         """Return ordered write attempts for a BatteryConfig endpoint family."""
 
+        # Captured BatteryConfig traffic differs by region, firmware, and
+        # whether the site supports MQTT-backed writes. Keep these variants
+        # explicit so a successful shape can be cached without hiding why the
+        # fallback exists.
         attempts: list[_BatteryConfigWriteAttempt]
         body = json_body if isinstance(json_body, dict) else None
         has_source = isinstance(params, dict) and "source" in params
@@ -3319,6 +3339,9 @@ class EnphaseEVClient:
                 seen_signatures.add(signature)
 
                 try:
+                    # Some cookie-compatible writes must reuse the XSRF token
+                    # captured with the original browser session; refreshing it
+                    # first can turn a working request into a 403.
                     if not (
                         attempt.prefer_existing_xsrf
                         and self._battery_config_cookie_header_xsrf_token() is not None

--- a/custom_components/enphase_ev/api_parsers.py
+++ b/custom_components/enphase_ev/api_parsers.py
@@ -103,6 +103,8 @@ def normalize_sites(payload: object) -> list[SiteInfo]:
 
     data = payload
     if isinstance(data, dict):
+        # Enlighten account search has returned each of these wrapper keys in
+        # different browser and API flows.
         for key in ("sites", "data", "items", "systems"):
             value = data.get(key)
             if isinstance(value, list):
@@ -151,6 +153,8 @@ def normalize_chargers(payload: object) -> list[ChargerInfo]:
             data = nested
 
     if isinstance(data, dict):
+        # Charger discovery may come from EVSE-specific or generic inventory
+        # routes, so accept both naming families.
         for key in ("chargers", "evChargerData", "evses", "devices", "items"):
             value = data.get(key)
             if isinstance(value, list):
@@ -251,6 +255,7 @@ def parse_latest_power_payload(payload: object) -> LatestPowerSample | None:
         sample_time_val = coerce_non_boolean_number(sample_time)
         if sample_time_val is not None:
             if sample_time_val > 10**12:
+                # Some app-api payloads report milliseconds instead of seconds.
                 sample_time_val /= 1000.0
             try:
                 sample_time_int = int(sample_time_val)
@@ -300,6 +305,8 @@ def normalize_lifetime_energy_payload(payload: object) -> dict | None:
         "water_heater",
     }
     array_field_aliases = {
+        # HEMS and site-energy payloads use slightly different names for the
+        # same flows depending on endpoint family.
         "evse_charging": "evse",
         "heat_pump": "heatpump",
         "heat-pump": "heatpump",
@@ -380,6 +387,7 @@ def parse_evse_timeseries_date_key(value: object) -> str | None:
         try:
             ts_val = float(value)
             if ts_val > 10**12:
+                # Timeseries keys have appeared as Unix milliseconds.
                 ts_val /= 1000.0
             return datetime.fromtimestamp(ts_val, tz=timezone.utc).date().isoformat()
         except Exception:  # noqa: BLE001

--- a/custom_components/enphase_ev/auth_refresh_runtime.py
+++ b/custom_components/enphase_ev/auth_refresh_runtime.py
@@ -1,12 +1,4 @@
-"""Stored-credential Enlighten token refresh.
-
-``AuthRefreshRuntime.attempt_auto_refresh`` uses this class's own methods
-(``auth_refresh_recent_success_active``, ``auth_refresh_rejected_active``,
-``async_run_auto_refresh``, ``clear_auth_refresh_task``) so behavior stays in one
-place; tests typically patch ``custom_components.enphase_ev.auth_refresh_runtime``
-(``async_authenticate``, ``async_get_clientsession``) or the runtime instance on
-the coordinator.
-"""
+"""Refresh Enlighten tokens from stored credentials with cooldown safeguards."""
 
 from __future__ import annotations
 
@@ -71,6 +63,8 @@ class AuthRefreshRuntime:
 
         task = getattr(coord, "_auth_refresh_task", None)
         if task is not None and not task.done():
+            # Concurrent 401 handlers share the same refresh attempt so Enphase
+            # does not see a burst of password logins.
             return await asyncio.shield(task)
 
         async with coord._refresh_lock:
@@ -123,6 +117,8 @@ class AuthRefreshRuntime:
         if coord._auth_refresh_rejected_count >= int(
             AUTH_REFRESH_REJECTED_SUSPEND_THRESHOLD
         ):
+            # Repeated credential rejections are treated as durable auth
+            # failures and suspended longer than transient service errors.
             coord._auth_refresh_rejected_until = None
             coord._auth_refresh_rejected_ends_utc = None
             try:

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -1,3 +1,5 @@
+"""Coordinate Enphase battery controls, schedules, caches, and diagnostics."""
+
 from __future__ import annotations
 
 import asyncio
@@ -358,6 +360,8 @@ class BatteryRuntime:
             return None
         profile = _LIVE_BATTERY_MODE_PROFILE_ALIASES.get(normalized)
         if profile == "cost_savings":
+            # Enphase can report both Cost Savings and AI Optimization as the
+            # same live savings mode, so preserve the selected profile when known.
             for attr in ("_battery_pending_profile", "_battery_profile"):
                 candidate = getattr(self.battery_state, attr, None)
                 if candidate in {"cost_savings", "ai_optimisation"}:
@@ -657,6 +661,9 @@ class BatteryRuntime:
         if pending_age is None:
             return
         if pending_age >= self._backend_not_pending_clear_grace_seconds():
+            # The backend may briefly report no pending task before the updated
+            # settings are reflected, so pending state is cleared only after a
+            # poll-sized grace window.
             self.clear_battery_pending()
 
     def effective_profile_matches_pending(self) -> bool:
@@ -994,6 +1001,8 @@ class BatteryRuntime:
                     redact_text(err, site_ids=(coord.site_id,)),
                 )
             else:
+                # The raw permission payload can contain site identifiers and is
+                # retained for diagnostics only after coordinator redaction.
                 redacted_payload = coord.redact_battery_payload(payload)
                 if isinstance(redacted_payload, dict):
                     state._battery_site_settings_payload = redacted_payload

--- a/custom_components/enphase_ev/battery_schedule_editor.py
+++ b/custom_components/enphase_ev/battery_schedule_editor.py
@@ -1,3 +1,5 @@
+"""Keep battery schedule editor form state in sync with BatteryConfig payloads."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -101,6 +103,8 @@ def _weekly_schedule_segments(
         if start_minutes < end_minutes:
             segments.append((offset + start_minutes, offset + end_minutes))
             continue
+        # Cross-midnight schedules occupy the selected day and the following
+        # day's early window.
         segments.append((offset + start_minutes, offset + _DAY_MINUTES))
         next_day_offset = (day % 7) * _DAY_MINUTES
         segments.append((next_day_offset, next_day_offset + end_minutes))
@@ -288,6 +292,8 @@ def battery_schedule_inventory(
     normalized: list[BatteryScheduleRecord] = []
 
     if isinstance(payload, dict):
+        # BatteryConfig exposes each schedule family separately; normalize them
+        # into one list for editor controls.
         for schedule_type in ("cfg", "dtg", "rbd"):
             family_payload = payload.get(schedule_type)
             if not isinstance(family_payload, dict):
@@ -344,6 +350,8 @@ def battery_schedule_inventory(
     if normalized:
         return normalized
 
+    # Fall back to coordinator scalar fields populated by older BatteryConfig
+    # responses so existing schedule entities remain usable.
     fallback_specs = (
         (
             "cfg",
@@ -434,6 +442,8 @@ class BatteryScheduleEditorManager:
         for schedule in self.schedules:
             label = raw_labels[schedule.schedule_id]
             if counts[label] > 1:
+                # Multiple battery schedule families can share the same time
+                # window, so include a short ID only for ambiguous labels.
                 labels[schedule.schedule_id] = f"{label} [{schedule.schedule_id[:8]}]"
             else:
                 labels[schedule.schedule_id] = label

--- a/custom_components/enphase_ev/button.py
+++ b/custom_components/enphase_ev/button.py
@@ -1,3 +1,5 @@
+"""Button entities for Enphase charger and battery service actions."""
+
 from __future__ import annotations
 
 from homeassistant.components.button import ButtonEntity
@@ -177,6 +179,8 @@ async def async_setup_entry(
         if not inventory_ready:
             return
 
+        # Prune only after inventory is ready so a transient discovery miss does
+        # not remove user-customized entity registry entries.
         active_charger_unique_ids = set()
         for sn in current_serials:
             active_charger_unique_ids.update(

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -1,3 +1,5 @@
+"""Handle Enphase Enlighten authentication, discovery, and options flows."""
+
 from __future__ import annotations
 import logging
 import re
@@ -257,6 +259,8 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 self._remember_password = remember
                 self._password = password if remember else None
                 if isinstance(err.tokens, AuthTokens) and err.tokens.raw_cookies:
+                    # Enphase MFA validation depends on cookies from the first
+                    # login response, not just the OTP entered on the next form.
                     self._start_mfa(err.tokens)
                     return await self.async_step_mfa()
                 errors["base"] = "mfa_required"
@@ -424,6 +428,8 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             return {"base": "unknown"}
 
         self._mfa_tokens = updated
+        # Enphase can temporarily block repeated OTP sends, so the flow keeps a
+        # local delay even when the backend response does not expose one.
         self._mfa_resend_available_at = time.monotonic() + MFA_RESEND_DELAY_SECONDS
         return {}
 
@@ -581,6 +587,8 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             CONF_INCLUDE_INVERTERS: bool(include_inverters),
             CONF_SELECTED_TYPE_KEYS: list(dict.fromkeys(selected_type_keys)),
         }
+        # Stored credentials are optional and only retained when the user opted
+        # in; cookies/tokens are still needed for normal cloud refreshes.
         prior_heatpump_discovery_handled = bool(
             self._reconfigure_entry
             and self._reconfigure_entry.data.get(CONF_HEATPUMP_DISCOVERY_HANDLED, False)

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1,3 +1,11 @@
+"""Coordinate Enphase cloud refreshes and expose normalized integration state.
+
+The coordinator owns polling cadence, auth refresh, endpoint health, runtime
+managers, and diagnostics state for one Home Assistant config entry. Entity
+platforms should read normalized state from here instead of calling the cloud
+client directly.
+"""
+
 from __future__ import annotations
 
 import asyncio
@@ -165,6 +173,9 @@ HEMS_DEVICES_STALE_AFTER_S = 90.0
 # HEMS heat-pump status/power can lag the Enphase app by only a few seconds.
 # Keep these caches short so we do not hold stale or empty telemetry for minutes.
 HEMS_DEVICES_CACHE_TTL = 15.0
+# Session history can arrive after real-time charging state changes. These
+# windows keep recent context available without letting old sessions override
+# live charger telemetry.
 SESSION_HISTORY_ACTIVE_SOFT_TTL_S = 120.0
 SESSION_HISTORY_RECENT_STOP_SOFT_TTL_S = 300.0
 SESSION_HISTORY_IDLE_HARD_TTL_GRACE_S = 300.0
@@ -4590,6 +4601,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return self._scheduler_backoff_active()
 
     def _scheduler_backoff_delay(self) -> float:
+        # Scheduler outages are usually service-side and transient. Tie the
+        # retry floor to the slow poll interval so repair issues remain visible
+        # without hammering the optional scheduler service.
         slow_floor = float(self._slow_interval_floor())
         backoff_multiplier = 2 ** min(self._scheduler_failures - 1, 3)
         return max(30.0, min(600.0, slow_floor * backoff_multiplier))
@@ -4676,6 +4690,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return bool(backoff_until and time.monotonic() < backoff_until)
 
     def _auth_settings_backoff_delay(self) -> float:
+        # Auth settings share the EVSE control plane, so use the same bounded
+        # exponential shape as scheduler backoff when the optional endpoint is
+        # unavailable.
         slow_floor = float(self._slow_interval_floor())
         backoff_multiplier = 2 ** min(self._auth_settings_failures - 1, 3)
         return max(30.0, min(600.0, slow_floor * backoff_multiplier))
@@ -6186,6 +6203,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self.backoff_ends_utc = None
 
         async def _resume(_now: datetime) -> None:
+            # Home Assistant should recover from cloud throttling on its own;
+            # the timer clears diagnostic state and triggers one refresh when
+            # the backoff window ends.
             self._backoff_cancel = None
             self._backoff_until = None
             self.backoff_ends_utc = None

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -1,3 +1,5 @@
+"""Collect coordinator diagnostics and synchronize Home Assistant repair issues."""
+
 from __future__ import annotations
 
 import time
@@ -48,6 +50,8 @@ class CoordinatorDiagnostics:
     ) -> None:
         coord = self.coordinator
         metrics, base_placeholders = self.issue_context()
+        # Repair issues store the current diagnostic snapshot so users can share
+        # actionable context without enabling debug logging first.
         issue_placeholders = dict(base_placeholders)
         if placeholders:
             issue_placeholders.update(placeholders)
@@ -139,6 +143,8 @@ class CoordinatorDiagnostics:
             if type_key is not None and not _type_available_for_entities(type_key):
                 return False
             if coord.last_success_utc is not None:
+                # Site diagnostic entities remain useful with stale data after a
+                # prior successful refresh.
                 return True
             return _coordinator_available()
 

--- a/custom_components/enphase_ev/current_power_runtime.py
+++ b/custom_components/enphase_ev/current_power_runtime.py
@@ -1,3 +1,5 @@
+"""Fetch and normalize Enphase current-power samples."""
+
 from __future__ import annotations
 
 import logging
@@ -104,6 +106,8 @@ class CurrentPowerRuntime:
             try:
                 sample_seconds = float(sample_time)
                 if sample_seconds > 10**12:
+                    # The app API has returned both seconds and milliseconds
+                    # for this field across deployments.
                     sample_seconds /= 1000.0
                 sampled_at = datetime.fromtimestamp(sample_seconds, tz=_tz.utc)
             except Exception:  # noqa: BLE001

--- a/custom_components/enphase_ev/device_types.py
+++ b/custom_components/enphase_ev/device_types.py
@@ -1,3 +1,5 @@
+"""Normalize Enphase inventory type names and device members."""
+
 from __future__ import annotations
 
 import re
@@ -7,6 +9,8 @@ from typing import Any
 from .const import DOMAIN
 
 _TYPE_ALIAS_TOKEN_MAP: dict[str, str] = {
+    # Inventory labels vary between Enlighten pages, API families, and legacy
+    # product names; normalize aliases before entity/device decisions.
     "envoy": "envoy",
     "gateway": "envoy",
     "iqgateway": "envoy",
@@ -195,6 +199,7 @@ def member_is_retired(member: object) -> bool:
     retired_flag = member.get("isRetired")
     if retired_flag is True:
         return True
+    # Some inventory payloads omit ``isRetired`` and only expose lifecycle text.
     for key in ("status", "statusText", "status_text"):
         value = member.get(key)
         if value is None:

--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -1,3 +1,5 @@
+"""Build redacted Home Assistant diagnostics for Enphase config entries/devices."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -28,6 +30,8 @@ TO_REDACT = [
 ]
 
 DIAGNOSTIC_IDENTIFIER_KEYS = [
+    # Enphase diagnostics often include nested raw payloads. Redact broad key
+    # families so future payload additions are safe by default.
     "site",
     "site_id",
     "site_name",
@@ -358,6 +362,8 @@ def _ac_battery_status_summary_for_diagnostics(summary: Any) -> dict[str, Any]:
 
 
 async def async_get_config_entry_diagnostics(hass, entry):
+    """Return diagnostics for a config entry."""
+
     data = async_redact_data(dict(entry.data), TO_REDACT)
     options = dict(getattr(entry, "options", {}) or {})
 
@@ -436,6 +442,8 @@ async def async_get_config_entry_diagnostics(hass, entry):
             coord, "async_ensure_system_dashboard_diagnostics", None
         )
         if callable(ensure_system_dashboard):
+            # Device diagnostics may need optional dashboard payloads that are
+            # not fetched during every normal coordinator refresh.
             await ensure_system_dashboard()
     except DIAGNOSTIC_CAPTURE_ERRORS:
         pass
@@ -614,6 +622,8 @@ async def async_get_device_diagnostics(hass, entry, device):
             "count": (bucket.get("count", 0) if isinstance(bucket, dict) else 0),
             "devices": (bucket.get("devices", []) if isinstance(bucket, dict) else []),
         }
+        # Type diagnostics summarize groups of devices, while serial diagnostics
+        # below expose one charger snapshot.
         if isinstance(bucket, dict):
             for key, value in bucket.items():
                 if key in payload or key == "devices":

--- a/custom_components/enphase_ev/evse_feature_flags_runtime.py
+++ b/custom_components/enphase_ev/evse_feature_flags_runtime.py
@@ -1,3 +1,5 @@
+"""Fetch and cache EVSE feature flags used to gate charger capabilities."""
+
 from __future__ import annotations
 
 import logging
@@ -177,6 +179,8 @@ class EvseFeatureFlagsRuntime:
                 return
         fetcher = getattr(coord.client, "evse_feature_flags", None)
         if not callable(fetcher):
+            # Older client versions do not expose feature flags, so cached state
+            # must clear.
             coord._evse_feature_flags_payload = None
             coord._evse_site_feature_flags = {}
             coord._evse_feature_flags_by_serial = {}
@@ -189,6 +193,7 @@ class EvseFeatureFlagsRuntime:
                 "EVSE feature flags fetch failed: %s",
                 redact_text(err, site_ids=(coord.site_id,)),
             )
+            # Failed flag discovery should not hammer the management endpoint.
             coord._evse_feature_flags_cache_until = (
                 now + EVSE_FEATURE_FLAGS_FAILURE_BACKOFF_S
             )

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -1,3 +1,5 @@
+"""Manage EVSE runtime state, polling, and charger control side effects."""
+
 from __future__ import annotations
 
 import asyncio
@@ -38,6 +40,7 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Enphase scheduler/config endpoints are relatively slow and may rate-limit bursts.
 GREEN_BATTERY_CACHE_TTL = 300.0
 AUTH_SETTINGS_CACHE_TTL = 300.0
 CHARGE_MODE_CACHE_TTL = 300.0
@@ -452,6 +455,7 @@ class EvseRuntime:
                 )
                 continue
             last_attempt = coord._auto_resume_attempts.get(sn_str)
+            # A suspended EVSE can report unchanged state for more than one poll.
             if last_attempt is not None and (now - last_attempt) < 120:
                 continue
             coord._auto_resume_attempts[sn_str] = now
@@ -716,6 +720,8 @@ class EvseRuntime:
                 and err.status == 500
                 and "invalid charge level" in str(err.message or "").lower()
             ):
+                # Some chargers reject starts with a charge level when no explicit
+                # setpoint was requested, but accept the same command without it.
                 result = await coord.client.start_charging(
                     sn_str,
                     amps,
@@ -793,6 +799,7 @@ class EvseRuntime:
             delay_s = AMP_RESTART_DELAY_S
         fast_seconds = max(60, int(delay_s) if delay_s else 60)
         stop_hold = max(90.0, delay_s)
+        # The Enphase app applies amp changes by restarting the active session.
         try:
             await coord.async_stop_charging(
                 sn_str,
@@ -1024,6 +1031,7 @@ class EvseRuntime:
                 slow_floor = max(slow_floor, int(coord.update_interval.total_seconds()))
             except Exception:
                 pass
+        # Home Assistant's coordinator interval remains the lower bound for slow mode.
         _, slow_floor = normalize_poll_intervals(fast_floor, slow_floor)
         return slow_floor
 
@@ -1221,6 +1229,8 @@ class EvseRuntime:
         if cached and (now - cached[4] < AUTH_SETTINGS_CACHE_TTL):
             return cached[0], cached[1], cached[2], cached[3]
         if coord._auth_settings_backoff_active():
+            # Unsupported auth endpoints are treated as transient so older
+            # installs keep working.
             if cached:
                 return cached[0], cached[1], cached[2], cached[3]
             return None

--- a/custom_components/enphase_ev/evse_schedule_editor.py
+++ b/custom_components/enphase_ev/evse_schedule_editor.py
@@ -1,3 +1,5 @@
+"""Keep EVSE schedule editor form state in sync with scheduler slots."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass, field
@@ -203,6 +205,8 @@ def evse_schedule_inventory(
             continue
         schedule_type = str(slot.get("scheduleType") or "CUSTOM").strip().upper()
         if schedule_type == "OFF_PEAK":
+            # Off-peak schedules are backend-managed and not editable through the
+            # custom schedule form.
             continue
         start_time = slot.get("startTime")
         end_time = slot.get("endTime")
@@ -261,6 +265,8 @@ class EvseScheduleEditorManager:
         for schedule in schedules:
             label = raw_labels[schedule.slot_id]
             if counts[label] > 1:
+                # Duplicate windows are common, so include a short slot suffix
+                # only when the label would otherwise collide.
                 labels[schedule.slot_id] = f"{label} [{schedule.slot_id[-6:]}]"
             else:
                 labels[schedule.slot_id] = label
@@ -468,6 +474,7 @@ class EvseScheduleEditorManager:
         if schedule_sync is not None and existing_id:
             existing_slot = schedule_sync.get_slot(sn, existing_id)
         slot: dict[str, Any] = dict(existing_slot or {})
+        # Start from the existing slot so scheduler-owned fields survive edits.
         slot["id"] = existing_id or f"{self.coordinator.site_id}:{sn}:{uuid.uuid4()}"
         slot["startTime"] = form.start_time
         slot["endTime"] = form.end_time

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -1,3 +1,5 @@
+"""Coordinate HEMS heat-pump runtime refreshes and diagnostics snapshots."""
+
 from __future__ import annotations
 
 import inspect
@@ -47,6 +49,7 @@ if TYPE_CHECKING:  # pragma: no cover
 
 _LOGGER = logging.getLogger(__name__)
 
+# The power endpoints report cumulative buckets, so derived watts need a delta window.
 _HEATPUMP_IDLE_POWER_MAX_W = 20.0
 _HEATPUMP_POWER_DEFAULT_WINDOW_S = 300.0
 _HEATPUMP_POWER_MIN_DELTA_WH = 0.5
@@ -316,6 +319,8 @@ class HeatpumpRuntime:
         """Capture optional live/detail payloads used by heat-pump runtime views."""
 
         if not self.has_type("heatpump"):
+            # Home Assistant keeps entities registered after discovery, so clear runtime
+            # payloads without treating a missing inventory type as an unload event.
             self._heatpump_runtime_diagnostics_cache_until = None
             self._show_livestream_payload = None
             self._heatpump_events_payloads = []
@@ -382,6 +387,7 @@ class HeatpumpRuntime:
                     redact_text(err, site_ids=(self.site_id,)) or err.__class__.__name__
                 )
             else:
+                # Diagnostics may include account-scoped battery data from shared APIs.
                 redacted_payload = self._redact_battery_payload(payload)
                 if isinstance(redacted_payload, dict):
                     self._show_livestream_payload = redacted_payload
@@ -424,6 +430,8 @@ class HeatpumpRuntime:
                             or err.__class__.__name__
                         )
                     else:
+                        # Event payloads can include opaque device links and
+                        # identifiers.
                         redacted_payload = self._redact_battery_payload(payload)
                         if redacted_payload is None:
                             payload_entry["payload"] = None
@@ -527,6 +535,7 @@ class HeatpumpRuntime:
 
         await self._async_refresh_hems_support_preflight(force=force)
         if getattr(self.client, "hems_site_supported", None) is False:
+            # Enphase returns HEMS-only runtime data for supported sites only.
             self._heatpump_mark_runtime_state_stale(
                 now=now,
                 error="HEMS runtime endpoint unavailable for this site",
@@ -561,6 +570,7 @@ class HeatpumpRuntime:
         except Exception as err:  # noqa: BLE001
             error = redact_text(err, site_ids=(self.site_id,)) or err.__class__.__name__
             self._heatpump_mark_runtime_state_stale(now=now, error=error)
+            # Backoff preserves recent snapshots while the cloud endpoint is unhealthy.
             self._heatpump_runtime_state_backoff_until = (
                 now + HEATPUMP_RUNTIME_STATE_FAILURE_BACKOFF_S
             )
@@ -1257,6 +1267,8 @@ class HeatpumpRuntime:
                 and previous_snapshot.get("day_key") == marker[0]
                 and previous_snapshot.get("timezone") == marker[1]
             )
+            # Site-level totals remain useful when the optional split endpoint
+            # fails.
             used_stale_split = same_day and self._heatpump_mark_daily_split_stale(
                 now=now,
                 error=split_error,
@@ -1410,6 +1422,7 @@ class HeatpumpRuntime:
                 return completed_sample
             if completed_sample is None:
                 return open_sample
+            # The newest bucket is often provisional until Enphase closes the interval.
             if _is_provisional_open_bucket(open_sample[1], completed_sample[1]):
                 return completed_sample
             return open_sample

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -1,3 +1,5 @@
+"""Maintain Enphase inventory topology and diagnostics payload caches."""
+
 from __future__ import annotations
 
 import asyncio
@@ -55,6 +57,7 @@ _LOGGER = logging.getLogger(__name__)
 DEVICES_INVENTORY_CACHE_TTL = 300.0
 HEMS_DEVICES_STALE_AFTER_S = 90.0
 HEMS_DEVICES_CACHE_TTL = 15.0
+# System-dashboard detail calls are fan-out requests against the same cloud service.
 SYSTEM_DASHBOARD_DETAIL_CONCURRENCY = 3
 SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES: tuple[str, ...] = (
     "envoys",
@@ -485,6 +488,7 @@ class InventoryRuntime:
     @callback
     def _refresh_cached_topology(self) -> bool:
         if self._topology_refresh_suppressed > 0:
+            # Batch refreshes coalesce Home Assistant entity-registry notifications.
             self._topology_refresh_pending = True
             return False
         try:
@@ -785,6 +789,7 @@ class InventoryRuntime:
             if data.get("hems-devices") is not None
             else data.get("hems_devices")
         )
+        # The HEMS endpoint has appeared with both hyphenated and underscored keys.
         if not isinstance(hems_devices, dict):
             return []
         return [hems_devices]
@@ -1843,6 +1848,8 @@ class InventoryRuntime:
                     _hems_devices_cache_until=now + HEMS_DEVICES_CACHE_TTL,
                 )
             elif stale_allowed:
+                # A short stale window avoids removing heat-pump entities during
+                # cloud blips.
                 self._update_shared_state(
                     _hems_devices_payload=previous_payload,
                     _hems_devices_using_stale=True,
@@ -2050,6 +2057,8 @@ class InventoryRuntime:
             _system_dashboard_devices_details_raw=details_raw,
         )
         if isinstance(tree_raw, dict):
+            # Raw dashboard payloads are kept separately; diagnostics only
+            # exposes redacted copies.
             redacted_tree = self._redact_battery_payload(tree_raw)
             tree_payload_out = (
                 redacted_tree if isinstance(redacted_tree, dict) else None

--- a/custom_components/enphase_ev/inventory_view.py
+++ b/custom_components/enphase_ev/inventory_view.py
@@ -1,3 +1,5 @@
+"""Expose inventory-derived type visibility and Home Assistant device metadata."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Iterable
@@ -100,12 +102,15 @@ class InventoryView:
 
     def has_type_for_entities(self, type_key: object) -> bool:  # pragma: no cover
         """Return whether a type should gate entity creation/availability."""
+
         normalized = normalize_type_key(type_key)
         if not normalized:
             return False
         if not self._type_is_selected(normalized):
             return False
         if not getattr(self.coordinator, "_devices_inventory_ready", False):
+            # During startup, keep selected entities available until inventory
+            # proves the type absent.
             return True
         if self.has_type(normalized):
             return True
@@ -185,6 +190,8 @@ class InventoryView:
             return type_identifier(self.site_id, normalized)
         if normalized not in {"encharge", "ac_battery"}:
             return None
+        # Battery controls can be discovered through BatteryConfig before the
+        # generic devices inventory exposes a concrete member bucket.
         if not self.has_type_for_entities(normalized):
             return None
         return type_identifier(self.site_id, normalized)

--- a/custom_components/enphase_ev/log_redaction.py
+++ b/custom_components/enphase_ev/log_redaction.py
@@ -1,3 +1,5 @@
+"""Redact Enphase identifiers and credentials before logging."""
+
 from __future__ import annotations
 
 import re
@@ -52,6 +54,7 @@ def _key_kind(key: object) -> str:
     if compact in {"site", "siteid", "sitename"}:
         return "site"
     if compact in {"entityid"}:
+        # Entity IDs are user-visible Home Assistant names, not Enphase secrets.
         return "text"
     if any(
         token in compact
@@ -120,6 +123,8 @@ def redact_text(
 ) -> str:
     """Return compact text with common Enphase identifiers removed."""
 
+    # Apply caller-provided replacements before generic regex passes so exact
+    # site IDs and serials are removed even when they are embedded in URLs.
     try:
         text = " ".join(str(value or "").split()).strip()
     except Exception:  # noqa: BLE001

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -1,3 +1,5 @@
+"""Number entities for Enphase current limits and battery schedule settings."""
+
 from __future__ import annotations
 
 from collections.abc import Callable
@@ -40,6 +42,7 @@ def _battery_write_access_confirmed(coord: EnphaseCoordinator) -> bool:
         return True
     if confirmed is not None:
         return bool(confirmed)
+    # Battery write access starts unknown until BatteryConfig permissions load.
     return False
 
 
@@ -187,6 +190,8 @@ async def async_setup_entry(
         if not inventory_ready:
             return
 
+        # Registry cleanup waits for inventory so numbers are not removed while
+        # optional BatteryConfig endpoints are still warming up.
         active_charger_unique_ids = {
             _charger_number_unique_id(sn) for sn in current_serials
         }

--- a/custom_components/enphase_ev/parsing_helpers.py
+++ b/custom_components/enphase_ev/parsing_helpers.py
@@ -1,3 +1,5 @@
+"""Parse mixed Enphase scalar values into normalized integration state."""
+
 from __future__ import annotations
 
 from datetime import datetime
@@ -104,6 +106,8 @@ def heatpump_status_bucket(value: object) -> str:
     if text is None:
         return "unknown"
     normalized = text.lower().replace("-", "_").replace(" ", "_")
+    # HEMS heat-pump status strings are not normalized across lifecycle and
+    # operational fields, so bucket by semantic tokens.
     if any(token in normalized for token in ("fault", "error", "critical")):
         return "error"
     if "warn" in normalized:
@@ -200,6 +204,8 @@ def parse_inverter_last_report(value: object) -> datetime | None:
         if not text:
             return None
         if text.endswith("[UTC]"):
+            # Inverter inventory sometimes appends a literal timezone marker
+            # that Python's ISO parser does not accept.
             text = text[:-5]
         if text.endswith("Z"):
             text = text[:-1] + "+00:00"

--- a/custom_components/enphase_ev/payload_debug.py
+++ b/custom_components/enphase_ev/payload_debug.py
@@ -1,4 +1,4 @@
-"""Shared debug helpers for payload shape logging (coordinator, inventory, EVSE)."""
+"""Summarize payload shapes for debug logs without including raw payload data."""
 
 from __future__ import annotations
 
@@ -38,6 +38,8 @@ def debug_field_keys(members: object) -> list[str]:
 def debug_payload_shape(payload: object) -> dict[str, Any]:
     """Return a payload-shape summary suitable for debug logging."""
 
+    # Shape summaries help diagnose Enphase payload drift while avoiding values
+    # that can contain account, site, or device identifiers.
     if isinstance(payload, dict):
         shape: dict[str, Any] = {
             "kind": "dict",

--- a/custom_components/enphase_ev/refresh_runner.py
+++ b/custom_components/enphase_ev/refresh_runner.py
@@ -1,3 +1,5 @@
+"""Run coordinator refresh stages while isolating optional endpoint failures."""
+
 from __future__ import annotations
 
 import asyncio
@@ -26,6 +28,8 @@ if TYPE_CHECKING:
 
 _LOGGER = logging.getLogger(__name__)
 
+# Optional Enphase endpoint families should not fail the whole coordinator
+# refresh when their data can be marked stale and retried later.
 _SKIPPABLE_REFRESH_ERRORS = (
     aiohttp.ClientError,
     asyncio.TimeoutError,

--- a/custom_components/enphase_ev/runtime_data.py
+++ b/custom_components/enphase_ev/runtime_data.py
@@ -1,3 +1,5 @@
+"""Define runtime objects stored on Home Assistant config entries."""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -41,6 +43,7 @@ def get_runtime_data(entry: EnphaseConfigEntry) -> EnphaseRuntimeData:
     if isinstance(runtime_data, EnphaseRuntimeData):
         return runtime_data
 
+    # Home Assistant only populates runtime_data while the config entry is loaded.
     raise RuntimeError(f"Missing runtime data for entry {entry.entry_id}")
 
 
@@ -59,6 +62,7 @@ def iter_coordinators(
         site_id = str(getattr(coord, "site_id", ""))
         if site_ids and site_id not in site_ids:
             continue
+        # Multiple entries can reference the same Enphase site during reload workflows.
         if site_id in seen:
             continue
         seen.add(site_id)

--- a/custom_components/enphase_ev/runtime_helpers.py
+++ b/custom_components/enphase_ev/runtime_helpers.py
@@ -1,3 +1,5 @@
+"""Provide shared coercion, diagnostics, and time helpers for runtimes."""
+
 from __future__ import annotations
 
 import time
@@ -161,6 +163,8 @@ def resolve_site_local_current_date(
         else None
     )
     if inventory_payload is not None:
+        # Enphase inventory payloads sometimes include the site's current date
+        # directly.
         direct = normalize_iso_date(inventory_payload.get("curr_date_site"))
         if direct:
             return direct
@@ -187,6 +191,8 @@ def resolve_site_local_current_date(
 
 
 def redact_battery_payload(value: object) -> object:
+    """Return a diagnostics-safe copy of nested Enphase payload data."""
+
     sensitive = {
         "email",
         "authorization",

--- a/custom_components/enphase_ev/schedule.py
+++ b/custom_components/enphase_ev/schedule.py
@@ -1,9 +1,12 @@
+"""Normalize EVSE schedule slot payloads before scheduler writes."""
+
 from __future__ import annotations
 
 from datetime import time
 from typing import Any
 
 SLOT_PATCH_FIELDS = (
+    # Preserve scheduler-owned fields that the Enphase API expects on PATCH.
     "id",
     "startTime",
     "endTime",
@@ -53,6 +56,8 @@ def _coerce_int(value: Any) -> Any:
 
 
 def normalize_slot_payload(slot: dict[str, Any]) -> dict[str, Any]:
+    """Return the subset of a schedule slot safe to send back to Enphase."""
+
     sanitized: dict[str, Any] = {
         key: slot.get(key) for key in SLOT_PATCH_FIELDS if key in slot
     }
@@ -72,6 +77,7 @@ def normalize_slot_payload(slot: dict[str, Any]) -> dict[str, Any]:
 
     days = sanitized.get("days")
     if isinstance(days, list):
+        # Enphase indexes days from Monday=1 through Sunday=7.
         normalized_days = []
         for day in days:
             try:

--- a/custom_components/enphase_ev/schedule_sync.py
+++ b/custom_components/enphase_ev/schedule_sync.py
@@ -1,3 +1,5 @@
+"""Synchronize Enphase EVSE schedules into Home Assistant schedule helpers."""
+
 from __future__ import annotations
 
 import asyncio
@@ -37,11 +39,14 @@ _LOGGER = logging.getLogger(__name__)
 
 SYNC_INTERVAL = timedelta(minutes=5)
 SYNC_REFRESH_CONCURRENCY = 3
+# Scheduler writes often return before reads reflect the new slot state.
 PATCH_REFRESH_DELAY_S = 1.0
 SYNC_CAPTURE_ERRORS = (RuntimeError, TypeError, ValueError, AttributeError)
 
 
 class ScheduleSync:
+    """Mirror Enphase scheduler slots into Home Assistant helper entities."""
+
     def __init__(self, hass: HomeAssistant, coordinator, config_entry=None) -> None:
         self.hass = hass
         self._coordinator = coordinator
@@ -195,6 +200,8 @@ class ScheduleSync:
     async def _remove_all_helpers(self) -> None:
         collection = await self._ensure_storage_collection()
         ent_reg = er.async_get(self.hass)
+        # Remove both entity-registry and storage-collection records because
+        # schedule helpers persist independently of the integration entities.
         slot_keys: set[tuple[str, str]] = {
             (serial, slot_id)
             for serial, slots in self._slot_cache.items()
@@ -426,6 +433,8 @@ class ScheduleSync:
             self._last_status = "missing_bearer"
             return
         if self._lock.locked():
+            # Coordinator updates can arrive while an interval refresh is still
+            # running; the next scheduled tick will catch up.
             return
         async with self._lock:
             serial_list = (
@@ -667,6 +676,8 @@ class ScheduleSync:
             return
         server_timestamp = self._meta_cache.get(sn)
         if not server_timestamp:
+            # Collection writes need the server timestamp as optimistic
+            # concurrency metadata.
             await self.async_refresh(reason="replace_prepare", serials=[sn])
             server_timestamp = self._meta_cache.get(sn)
         payload_slots: list[dict[str, Any]] = []

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -1,3 +1,5 @@
+"""Select entities for Enphase charge modes and schedule editors."""
+
 from __future__ import annotations
 
 import asyncio
@@ -85,6 +87,8 @@ def _smart_charging_context(coord: EnphaseCoordinator, sn: str | None = None) ->
 
 def _solar_mode(coord: EnphaseCoordinator, sn: str | None = None) -> tuple[str, str]:
     if _smart_charging_context(coord, sn):
+        # The Enphase UI can present the same solar option as Smart Charging
+        # when battery profile preferences are active.
         return "SMART_CHARGING", charge_mode_label("SMART_CHARGING", hass=coord.hass)
     return "GREEN_CHARGING", charge_mode_label("GREEN_CHARGING", hass=coord.hass)
 
@@ -240,6 +244,8 @@ async def async_setup_entry(
             battery_schedule_editor_added = False
         if not inventory_ready:
             return
+        # Site-level selects are dynamic because BatteryConfig permissions and
+        # AC Battery support are learned after setup.
         prune_managed_entities(
             ent_reg,
             entry.entry_id,
@@ -702,13 +708,15 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
                 code == "iqevc_sch_10031"
                 or (display and "No Schedules enabled" in display)
             ):
+                # Scheduler returns this opaque code when Scheduled Charging is
+                # selected before any schedule is enabled.
                 raise ServiceValidationError(
                     "Enable at least one schedule before selecting Scheduled charging.",
                     translation_domain=DOMAIN,
                     translation_key="exceptions.schedule_required",
                 )
             raise
-        # Update cache immediately to reflect in UI, then refresh
+        # Update cache immediately to reflect in UI while the scheduler catches up.
         self._coord.set_charge_mode_cache(self._sn, mode)
         await self._coord.async_request_refresh()
 

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -1,3 +1,10 @@
+"""Sensor entities for Enphase charger, battery, gateway, and site telemetry.
+
+The module maps normalized coordinator snapshots into Home Assistant sensors,
+including restore-state fallbacks for cumulative energy and cloud diagnostic
+entities that surface optional endpoint health without exposing credentials.
+"""
+
 from __future__ import annotations
 
 from dataclasses import dataclass
@@ -1689,7 +1696,9 @@ class EnphaseEnergyTodaySensor(EnphaseBaseEntity, SensorEntity, RestoreEntity):
             self._last_context_source = "realtime"
             return realtime
         if history and history.get("energy_kwh") is not None:
-            # When idle, prefer the richer session history payload.
+            # Session history is richer than the live status payload once the
+            # charger is idle, especially for authorization and final energy
+            # metadata that can arrive after charging stops.
             self._last_context_source = "history"
             return history
         if realtime and realtime_nonzero:
@@ -5329,6 +5338,8 @@ class _SiteBaseEntity(CoordinatorEntity, SensorEntity):
         self, *, include_last_success: bool = True
     ) -> dict[str, object]:
         attrs: dict[str, object] = {}
+        # These attributes are intentionally sanitized by the coordinator
+        # before they become visible on diagnostic sensors.
         if include_last_success and self._coord.last_success_utc:
             attrs["last_success_utc"] = self._coord.last_success_utc.isoformat()
         if self._coord.last_failure_utc:

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -1,3 +1,5 @@
+"""Switch entities for Enphase charger, battery, and schedule controls."""
+
 from __future__ import annotations
 
 import logging
@@ -62,6 +64,8 @@ def _set_evse_toggle_pending(
 ) -> None:
     """Record a short-lived optimistic EVSE toggle target."""
 
+    # EVSE control endpoints can acknowledge before the status endpoint reflects
+    # the new value, so switches expose the requested target briefly.
     pending = getattr(coord, attr_name, None)
     if not isinstance(pending, dict):
         pending = {}
@@ -165,6 +169,9 @@ def _switch_entity_id_migrations(coord: EnphaseCoordinator) -> dict[str, str]:
 
 def _migrate_storm_guard_evse_entity_id(current_entity_id: str) -> str | None:
     """Return canonical EVSE storm guard entity_id preserving numeric suffixes."""
+
+    # Home Assistant may append numeric suffixes after entity collisions; keep
+    # those user-visible IDs stable during the spelling migration.
     base_entity_id = current_entity_id
     numeric_suffix = ""
     base, _, suffix = current_entity_id.rpartition("_")

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,136 @@
+# Architecture
+
+This document is a contributor map for the Enphase Energy integration. It explains where behavior lives and how the main pieces interact. For domain terms, see the [glossary](glossary.md).
+
+## Runtime Shape
+
+Each Home Assistant config entry owns one `EnphaseCoordinator`. The coordinator is the integration boundary for entities: platforms read normalized state from the coordinator and call coordinator/service helpers for writes. Entities should not call the cloud client directly unless a local helper already establishes that pattern.
+
+```mermaid
+flowchart TD
+    A["Config flow"] --> B["Config entry data/options"]
+    B --> C["async_setup_entry"]
+    C --> D["EnphaseCoordinator"]
+    D --> E["EnphaseEVClient"]
+    D --> F["Runtime managers"]
+    D --> G["InventoryView"]
+    D --> H["Entity platforms"]
+    E --> I["Enphase cloud endpoints"]
+    F --> D
+    G --> H
+    H --> J["Home Assistant entities"]
+    D --> K["Diagnostics and repairs"]
+```
+
+## Setup And Authentication
+
+`config_flow.py` handles user login, MFA, site selection, device-category selection, reconfigure, and reauth entry updates. It stores the tokens and cookies needed for refreshes in the config entry. The password is stored only when the user opts into remembered credentials so the integration can attempt automatic token refresh.
+
+`__init__.py` handles config entry setup and unload. It creates the coordinator, starts schedule sync and platform setup, registers services, and keeps the Home Assistant device and entity registries aligned with current inventory. Registry cleanup is intentionally conservative and waits for inventory readiness so transient cloud discovery failures do not remove user-customized entities.
+
+## Coordinator And Refresh Flow
+
+`coordinator.py` owns polling cadence, auth refresh coordination, endpoint health, backoff state, runtime managers, and normalized integration state. `refresh_plan.py` defines which endpoint families are refreshed in each phase. `refresh_runner.py` executes those plans and isolates optional endpoint failures so one unhealthy Enphase service does not fail the whole coordinator refresh.
+
+```mermaid
+sequenceDiagram
+    participant HA as Home Assistant
+    participant Coord as EnphaseCoordinator
+    participant Runner as RefreshRunner
+    participant Client as EnphaseEVClient
+    participant Runtime as Runtime managers
+
+    HA->>Coord: async_refresh
+    Coord->>Runner: run refresh plan
+    Runner->>Client: fetch endpoint families
+    Client-->>Runner: raw payloads or typed errors
+    Runner->>Runtime: update family state
+    Runtime-->>Coord: normalized snapshots
+    Coord-->>HA: coordinator data update
+```
+
+The coordinator distinguishes core failures from optional endpoint failures:
+
+- Auth failures can trigger Home Assistant reauth or an auth-block repair issue.
+- Rate limits and cloud outages enter bounded backoff and expose diagnostic sensors.
+- Optional endpoint failures mark that family stale, preserve recent useful data where safe, and report repairs when needed.
+
+## Cloud Client
+
+`api.py` is the HTTP boundary. It handles Enlighten login, MFA, credential refresh helpers, request headers, response parsing, invalid payload signatures, and endpoint-specific compatibility paths.
+
+Several Enphase surfaces behave like browser-backed applications rather than stable public APIs:
+
+- Enlighten pages and XHR endpoints need browser-like headers and cookies.
+- BatteryConfig has multiple auth/header/XSRF shapes depending on site, region, and firmware.
+- Scheduler and EVSE control endpoints can accept writes before read endpoints reflect the new state.
+- Some optional endpoints return HTML, login pages, or non-JSON success responses.
+
+Keep new endpoint handling inside `api.py` or narrow parser/helper modules so coordinator and entity code remain normalized.
+
+## Runtime Managers
+
+Runtime managers keep endpoint-family behavior out of the main coordinator:
+
+- `battery_runtime.py` handles BatteryConfig controls, profile state, schedules, pending writes, and battery diagnostics payloads.
+- `evse_runtime.py` handles charger commands, fast polling, streaming, charge-mode cache, auth settings, and EVSE control side effects.
+- `inventory_runtime.py` handles topology, type buckets, HEMS inventory, and system-dashboard payloads.
+- `heatpump_runtime.py` handles HEMS heat-pump runtime state, daily consumption, and diagnostics snapshots.
+- `current_power_runtime.py`, `evse_feature_flags_runtime.py`, `auth_refresh_runtime.py`, and `ac_battery_runtime.py` handle smaller endpoint families.
+
+These managers should own cache lifetimes, stale data decisions, and endpoint-specific parsing for their family. The coordinator should expose their normalized state through properties and helper methods.
+
+## Inventory And Entity Gating
+
+`inventory_runtime.py` builds type buckets from cloud inventory. `inventory_view.py` is the read-facing layer used by entity platforms to decide whether a type should exist or be available. `device_types.py` normalizes Enphase product labels into canonical type keys.
+
+Entity platforms under `sensor.py`, `binary_sensor.py`, `button.py`, `number.py`, `select.py`, `switch.py`, `time.py`, `calendar.py`, and `update.py` create Home Assistant entities from coordinator state. Platform setup usually follows this pattern:
+
+1. Add site-level entities that are supported by selected inventory types and permissions.
+2. Add charger or device entities for discovered serials/type members.
+3. Wait for inventory readiness before pruning managed entity registry entries.
+4. Use optimistic coordinator caches only when Enphase writes are known to settle asynchronously.
+
+## Diagnostics, Redaction, And Repairs
+
+`diagnostics.py` builds Home Assistant config-entry and device diagnostics. `coordinator_diagnostics.py` builds coordinator health snapshots and manages repair issues. `log_redaction.py` and `runtime_helpers.redact_battery_payload` are the shared redaction helpers.
+
+Diagnostics may include raw or near-raw Enphase payloads after redaction. Any new diagnostics payload should be reviewed for:
+
+- Tokens, cookies, credentials, emails, user IDs, and auth headers.
+- Site IDs, serials, device UIDs, MAC addresses, IP addresses, hostnames, URLs, and modem/SIM identifiers.
+- Nested payloads where future fields may add identifiers.
+
+When in doubt, redact broadly and expose counts, status summaries, field names, or shape summaries instead of raw values.
+
+## Schedule Editing And Sync
+
+EVSE schedules use Home Assistant schedule helpers through `schedule_sync.py`. The sync layer mirrors Enphase scheduler slots into helper entities and pushes helper changes back to Enphase. It keeps server timestamps as optimistic concurrency metadata and refreshes shortly after writes because scheduler reads can lag writes.
+
+Battery schedule editing is separate and lives in `battery_schedule_editor.py`. It normalizes BatteryConfig schedule families (`cfg`, `dtg`, `rbd`) into one editor model while preserving schedule type, days, limits, and fallback state from coordinator scalar fields.
+
+`schedule.py` normalizes EVSE slot payloads before scheduler writes. Preserve unknown or scheduler-owned fields unless there is a specific reason to drop them; Enphase PATCH endpoints often expect more than the fields directly edited by the UI.
+
+## Adding New Behavior
+
+Use this starting-point map:
+
+- New cloud endpoint: start in `api.py`, then add a parser/helper if payload normalization is non-trivial.
+- New endpoint family state: add or extend a runtime manager, then expose normalized coordinator properties.
+- New entity: add the entity in the relevant platform and gate it through `InventoryView` or existing coordinator capability flags.
+- New diagnostic payload: add redaction first, then add summaries or payload copies.
+- New user-facing string: update `strings.json`, every locale file under `translations/`, and translation tests when applicable.
+- New control action: route through coordinator/runtime helpers, translate validation failures, and update optimistic caches only when the Enphase read-after-write behavior requires it.
+
+## Testing Pointers
+
+Keep tests close to the changed behavior under `tests/components/enphase_ev/`.
+
+- Coordinator refresh and endpoint health: `test_coordinator_*.py`, `test_rate_limit_and_switch_kick.py`, `test_latency_and_connectivity.py`.
+- API client and parsers: `test_api_*.py`, `test_session_history_parsers.py`, `test_evse_timeseries.py`, `test_site_energy.py`.
+- Entity setup and cleanup: `test_entity_*.py`, `test_device_info.py`, `test_inventory_runtime.py`.
+- Battery controls and schedules: `test_battery_*.py`, `test_battery_schedule_editor_parity.py`.
+- EVSE controls and schedules: `test_evse_*.py`, `test_select_charge_mode.py`, `test_schedule_sync.py`.
+- Diagnostics and redaction: `test_diagnostics*.py`, `test_log_redaction.py`, `test_payload_debug.py`.
+
+Use the pinned Docker commands from `CONTRIBUTING.md` for validation.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,143 @@
+# Glossary
+
+This glossary explains project and Enphase terms used in code, diagnostics, issues, and tests.
+
+## Home Assistant Terms
+
+**Config entry**  
+The Home Assistant record created when a user adds the integration. It stores setup data, options, and runtime objects while loaded.
+
+**Coordinator**  
+The `EnphaseCoordinator` instance for one config entry. It owns refreshes, normalized state, endpoint health, runtime managers, and diagnostic state.
+
+**Entity**  
+A Home Assistant object exposed by the integration, such as a sensor, switch, button, select, number, time, calendar, binary sensor, or update entity.
+
+**Entity registry**  
+Home Assistant's persistent registry for entity IDs, unique IDs, disabled state, and user customizations.
+
+**Device registry**  
+Home Assistant's persistent registry for physical or logical devices. This integration creates type devices, charger devices, and site-related device groupings.
+
+**Reauth**  
+Home Assistant's flow for asking the user to authenticate again when stored credentials or tokens stop working.
+
+**Repair issue**  
+A Home Assistant issue registry entry shown to users when the integration detects actionable problems such as auth blocks, optional service outages, or persistent cloud failures.
+
+**Runtime data**  
+Objects attached to a loaded config entry. This integration stores the coordinator and editor managers there so platforms can share one runtime state.
+
+## Enphase Product Terms
+
+**Enlighten**  
+The Enphase cloud application used by the integration for authentication, site discovery, telemetry, and controls.
+
+**Site**  
+An Enphase system associated with an account. The site ID is the primary integration identity and should be treated as sensitive in diagnostics and logs.
+
+**IQ Gateway / Envoy**  
+The gateway device that reports site telemetry and bridges many Enphase system components to Enlighten.
+
+**System Controller / Enpower**  
+The Enphase controller used for backup and grid-control capabilities on supported battery sites. Some older payloads expose it as `enpower`.
+
+**IQ Battery / Encharge**  
+The current Enphase battery family. Code often uses the legacy product key `encharge` because that is how many cloud payloads identify battery devices.
+
+**AC Battery**  
+An older Enphase battery family with separate control and telemetry paths. Some AC Battery data is exposed through HTML pages rather than JSON endpoints.
+
+**IQ EV Charger / EVSE**  
+The Enphase EV charger family. EVSE means electric vehicle supply equipment and is the common API term for charger devices.
+
+**Microinverter**  
+An Enphase inverter attached to solar panels. The integration exposes inventory, connectivity, and lifetime production data when available.
+
+**HEMS**  
+Home Energy Management System. In this integration, HEMS endpoints provide extra inventory and energy channels such as heat-pump runtime and consumption data.
+
+**Heat pump**  
+A HEMS-supported load type. Heat-pump entities may come from dedicated HEMS inventory and runtime endpoints rather than generic site inventory alone.
+
+**Dry contact**  
+Relay-style auxiliary contacts exposed by some Enphase systems. These are treated as concrete child devices rather than aggregate inventory type devices.
+
+## API And Data Terms
+
+**BatteryConfig**  
+The Enphase battery profile web application and its backing API. It controls battery profile, reserve, schedule, Storm Guard, and grid-related settings on supported sites.
+
+**Scheduler**  
+The Enphase EVSE schedule service. It controls charger schedule slots and charge-mode behavior.
+
+**Auth settings**  
+EVSE configuration data that controls charger authentication features such as app authorization and RFID support.
+
+**Bearer token**  
+A JWT-like token sent in an `Authorization: Bearer ...` header. Some Enphase endpoints derive this from cookies, while others use the stored access token.
+
+**e-auth token**  
+An Enlighten auth token header or value used by several Enphase cloud endpoints.
+
+**Cookie auth**  
+Requests authenticated with the browser session cookie captured during login. Some BatteryConfig paths require cookie and XSRF values that match the original browser session.
+
+**XSRF token**  
+A cross-site request forgery token required by BatteryConfig writes. It may be delivered through headers, cookies, or an existing stored cookie depending on site and endpoint.
+
+**Login wall**  
+An HTML login page returned by Enlighten where JSON was expected. The integration treats this as an auth failure instead of a normal payload parse error.
+
+**Optional endpoint**  
+An Enphase endpoint family that enhances the integration but should not break the whole config entry when unavailable. Examples include scheduler details, HEMS runtime payloads, system-dashboard details, and some diagnostics-only payloads.
+
+**Endpoint family**  
+A group of related cloud calls tracked together for cache, stale data, diagnostics, and backoff decisions.
+
+**Payload shape**  
+The structure of a JSON or HTML response, such as wrapper keys, field names, nested lists, and status fields. Shape summaries are used for diagnostics without logging raw identifiers.
+
+**Stale data**  
+Previously fetched data reused after an optional endpoint fails. Stale data is used only where it is safer than removing entities or hiding recent context during a cloud blip.
+
+**Backoff**  
+A delay before retrying a failing endpoint family. Backoff protects Enphase services and prevents repeated user-facing failures during outages or rate limiting.
+
+## Integration Terms
+
+**Type key**  
+A canonical inventory category such as `envoy`, `encharge`, `ac_battery`, `iqevse`, `heatpump`, `microinverter`, or `dry_contact`.
+
+**Type bucket**  
+The normalized inventory group for one type key. It contains count, label, member devices, and selected metadata.
+
+**Inventory view**  
+The `InventoryView` helper used by entity platforms to decide whether a device type should be created or available.
+
+**Runtime manager**  
+A class that owns one endpoint family or feature area, such as battery runtime, EVSE runtime, inventory runtime, heat-pump runtime, or auth-refresh runtime.
+
+**Optimistic cache**  
+A short-lived local value used after a successful write when Enphase read endpoints lag behind write acknowledgements.
+
+**Selected type keys**  
+The device categories the user enabled during onboarding or reconfigure. They gate which entity groups are created.
+
+**Site-only mode**  
+A configuration where no EV charger serials are selected, but site-level telemetry and selected device-category entities can still be used.
+
+**Schedule slot**  
+An EVSE scheduler record with an ID, start/end time, days, charge limit, enabled flag, and scheduler-owned metadata.
+
+**Battery schedule family**  
+One BatteryConfig schedule group: `cfg` for charge from grid, `dtg` for discharge to grid, or `rbd` for restricted battery discharge.
+
+**Storm Guard**  
+An Enphase battery feature that changes behavior for storm preparation. The integration exposes controls only when the site reports support.
+
+**Grid control**  
+Battery settings that control charge from grid, discharge to grid, and related schedule behavior.
+
+**Diagnostics-safe**  
+Data that has been redacted enough to share in GitHub issues or support discussions without exposing credentials, account identifiers, site IDs, serials, network details, or opaque private links.


### PR DESCRIPTION
## Summary

Add contributor-facing architecture and glossary documentation, and improve code readability with PEP 257 module docstrings plus targeted comments around non-obvious Enphase and Home Assistant behavior.

This change is documentation-only. It focuses on explaining integration structure, auth and endpoint quirks, diagnostics redaction, runtime manager responsibilities, entity gating, and schedule sync behavior.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/ac_battery_runtime.py custom_components/enphase_ev/api.py custom_components/enphase_ev/auth_refresh_runtime.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/current_power_runtime.py custom_components/enphase_ev/evse_feature_flags_runtime.py custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/heatpump_runtime.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/refresh_runner.py custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/runtime_helpers.py custom_components/enphase_ev/sensor.py && black --check custom_components/enphase_ev/ac_battery_runtime.py custom_components/enphase_ev/api.py custom_components/enphase_ev/auth_refresh_runtime.py custom_components/enphase_ev/battery_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/current_power_runtime.py custom_components/enphase_ev/evse_feature_flags_runtime.py custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/heatpump_runtime.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/refresh_runner.py custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/runtime_helpers.py custom_components/enphase_ev/sensor.py"

docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/__init__.py custom_components/enphase_ev/config_flow.py custom_components/enphase_ev/button.py custom_components/enphase_ev/number.py custom_components/enphase_ev/select.py custom_components/enphase_ev/switch.py custom_components/enphase_ev/diagnostics.py custom_components/enphase_ev/coordinator_diagnostics.py custom_components/enphase_ev/log_redaction.py custom_components/enphase_ev/payload_debug.py custom_components/enphase_ev/api_parsers.py custom_components/enphase_ev/parsing_helpers.py custom_components/enphase_ev/device_types.py custom_components/enphase_ev/inventory_view.py custom_components/enphase_ev/schedule.py custom_components/enphase_ev/schedule_sync.py custom_components/enphase_ev/evse_schedule_editor.py custom_components/enphase_ev/battery_schedule_editor.py && black --check custom_components/enphase_ev/__init__.py custom_components/enphase_ev/config_flow.py custom_components/enphase_ev/button.py custom_components/enphase_ev/number.py custom_components/enphase_ev/select.py custom_components/enphase_ev/switch.py custom_components/enphase_ev/diagnostics.py custom_components/enphase_ev/coordinator_diagnostics.py custom_components/enphase_ev/log_redaction.py custom_components/enphase_ev/payload_debug.py custom_components/enphase_ev/api_parsers.py custom_components/enphase_ev/parsing_helpers.py custom_components/enphase_ev/device_types.py custom_components/enphase_ev/inventory_view.py custom_components/enphase_ev/schedule.py custom_components/enphase_ev/schedule_sync.py custom_components/enphase_ev/evse_schedule_editor.py custom_components/enphase_ev/battery_schedule_editor.py"

git diff --check -- docs/architecture.md docs/glossary.md CONTRIBUTING.md

docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run codespell --files docs/architecture.md docs/glossary.md CONTRIBUTING.md"

docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files && python scripts/validate_quality_scale.py"
```

No pytest run: comments/docstrings and contributor docs only; no runtime behavior changed.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Documentation-only contributor/readability change. No diagnostics or screenshots required.