### PR TITLE
Redact site IDs from logs and diagnostics

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -1927,10 +1927,11 @@ class EnphaseEVClient:
         previous = self._payload_failure_log_state.pop(endpoint_key, None)
         if previous is None:
             return
+        endpoint_safe = redact_text(endpoint_key, site_ids=(self._site,))
         _LOGGER.info(
             "Payload recovered for site %s endpoint %s",
             redact_site_id(self._site),
-            endpoint_key,
+            endpoint_safe,
         )
 
     def _log_invalid_payload(self, err: InvalidPayloadError) -> None:
@@ -1942,12 +1943,13 @@ class EnphaseEVClient:
         self._payload_failure_log_state[endpoint_key] = signature
         if previous is not None:
             return
+        endpoint_safe = redact_text(endpoint_key, site_ids=(self._site,))
         _LOGGER.warning(
             "Invalid payload for site %s endpoint %s "
             "(status=%s, content_type=%s, failure_kind=%s, decode_error=%s, "
             "body_length=%s, body_sha256=%s, preview=%s)",
             redact_site_id(self._site),
-            endpoint_key,
+            endpoint_safe,
             signature.status,
             signature.content_type or "<missing>",
             signature.failure_kind or "<unknown>",
@@ -3634,8 +3636,7 @@ class EnphaseEVClient:
             _LOGGER.warning("Failed to acquire XSRF token", exc_info=True)
             return None
 
-    @staticmethod
-    def _redact_headers(headers: dict[str, str]) -> dict[str, str]:
+    def _redact_headers(self, headers: dict[str, str]) -> dict[str, str]:
         """Return a copy of headers with sensitive values masked."""
 
         redacted: dict[str, str] = {}
@@ -3650,7 +3651,7 @@ class EnphaseEVClient:
             }:
                 redacted[key] = "[redacted]"
             else:
-                redacted[key] = value
+                redacted[key] = redact_text(value, site_ids=(self._site,))
         return redacted
 
     @staticmethod
@@ -3952,6 +3953,9 @@ class EnphaseEVClient:
         )
         attempt = 0
         request_label = _request_label(method, url)
+        safe_request_label = redact_text(
+            request_label, site_ids=(self._site,), max_length=256
+        )
         endpoint = ""
         try:
             endpoint = URL(url).path
@@ -3978,28 +3982,28 @@ class EnphaseEVClient:
                             method, url, headers=base_headers, **kwargs
                         ) as r:
                             if r.status == 401:
-                                self._last_unauthorized_request = request_label
+                                self._last_unauthorized_request = safe_request_label
                                 if self._reauth_cb and attempt == 0:
                                     _LOGGER.debug(
                                         "Received 401 for %s; attempting stored-credential refresh",
-                                        request_label,
+                                        safe_request_label,
                                     )
                                     attempt += 1
                                     reauth_ok = await self._reauth_cb()
                                     if reauth_ok:
                                         _LOGGER.debug(
                                             "Stored-credential refresh succeeded for %s; retrying request",
-                                            request_label,
+                                            safe_request_label,
                                         )
                                         continue
                                     _LOGGER.debug(
                                         "Stored-credential refresh failed for %s",
-                                        request_label,
+                                        safe_request_label,
                                     )
                                 else:
                                     _LOGGER.debug(
                                         "Received 401 for %s with no stored-credential refresh available",
-                                        request_label,
+                                        safe_request_label,
                                     )
                                 raise Unauthorized()
                             if r.status in (204, 205):
@@ -4077,7 +4081,7 @@ class EnphaseEVClient:
                                         "attempt_id=%s attempt_changes=%s header_flags=%s "
                                         "cookie_names=%s headers=%s response=%s",
                                         family,
-                                        request_label,
+                                        safe_request_label,
                                         r.status,
                                         params_summary,
                                         payload_summary,
@@ -4124,10 +4128,10 @@ class EnphaseEVClient:
                                     endpoint=endpoint or None,
                                     payload=body_text,
                                 ):
-                                    self._last_unauthorized_request = request_label
+                                    self._last_unauthorized_request = safe_request_label
                                     raise self._login_wall_unauthorized(
                                         endpoint=endpoint or None,
-                                        request_label=request_label,
+                                        request_label=safe_request_label,
                                         status=status or None,
                                         content_type=content_type or None,
                                         payload=body_text,
@@ -4181,6 +4185,9 @@ class EnphaseEVClient:
         extra_headers = kwargs.pop("headers", None)
         attempt = 0
         request_label = _request_label(method, url)
+        safe_request_label = redact_text(
+            request_label, site_ids=(self._site,), max_length=256
+        )
         endpoint = ""
         try:
             endpoint = URL(url).path
@@ -4205,7 +4212,7 @@ class EnphaseEVClient:
                         method, url, headers=base_headers, **kwargs
                     ) as r:
                         if r.status == 401:
-                            self._last_unauthorized_request = request_label
+                            self._last_unauthorized_request = safe_request_label
                             if self._reauth_cb and attempt == 0:
                                 attempt += 1
                                 if await self._reauth_cb():
@@ -4216,10 +4223,10 @@ class EnphaseEVClient:
                             if _is_enphase_login_wall(
                                 endpoint=endpoint or None, payload=text
                             ):
-                                self._last_unauthorized_request = request_label
+                                self._last_unauthorized_request = safe_request_label
                                 raise self._login_wall_unauthorized(
                                     endpoint=endpoint or None,
-                                    request_label=request_label,
+                                    request_label=safe_request_label,
                                     status=int(r.status),
                                     content_type=r.headers.get("Content-Type"),
                                     payload=text,
@@ -4252,10 +4259,10 @@ class EnphaseEVClient:
                         if _is_enphase_login_wall(
                             endpoint=endpoint or None, payload=text
                         ):
-                            self._last_unauthorized_request = request_label
+                            self._last_unauthorized_request = safe_request_label
                             raise self._login_wall_unauthorized(
                                 endpoint=endpoint or None,
-                                request_label=request_label,
+                                request_label=safe_request_label,
                                 status=int(r.status),
                                 content_type=r.headers.get("Content-Type"),
                                 payload=text,

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -1297,14 +1297,14 @@ class BatteryRuntime:
                 _LOGGER.debug(
                     "Ignoring CFG schedule validation failure on site %s: %s",
                     redact_site_id(self.coordinator.site_id),
-                    redact_text(err),
+                    redact_text(err, site_ids=(self.coordinator.site_id,)),
                 )
             return
         except Exception as err:  # noqa: BLE001 - validation preflight is optional
             _LOGGER.debug(
                 "Ignoring CFG schedule validation exception on site %s: %s",
                 redact_site_id(self.coordinator.site_id),
-                redact_text(err),
+                redact_text(err, site_ids=(self.coordinator.site_id,)),
             )
             return
         if not isinstance(result, dict):

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -420,7 +420,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             elif fast_opt is not None:
                 interval = max(interval, fast_interval)
         self._configured_slow_poll_interval = interval
-        self.summary = SummaryStore(lambda: self.client, logger=_LOGGER)
+        self.summary = SummaryStore(
+            lambda: self.client,
+            site_id_getter=lambda: self.site_id,
+            logger=_LOGGER,
+        )
         self.energy = EnergyManager(
             client_provider=lambda: self.client,
             site_id=self.site_id,
@@ -430,6 +434,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self.evse_timeseries = EVSETimeseriesManager(
             hass,
             lambda: self.client,
+            site_id_getter=lambda: self.site_id,
             logger=_LOGGER,
         )
         self._session_history_interval_min = DEFAULT_SESSION_HISTORY_INTERVAL_MIN
@@ -471,6 +476,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             concurrency=SESSION_HISTORY_CONCURRENCY,
             data_supplier=lambda: self.data,
             publish_callback=self.async_set_updated_data,
+            site_id_getter=lambda: self.site_id,
             logger=_LOGGER,
         )
         self.evse_runtime = EvseRuntime(self)
@@ -519,6 +525,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             manager = EVSETimeseriesManager(
                 self.__dict__.get("hass"),
                 lambda: self.__dict__.get("client"),
+                site_id_getter=lambda: getattr(self, "site_id", None),
                 logger=_LOGGER,
             )
             self.__dict__["evse_timeseries"] = manager

--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -8,9 +8,10 @@ from typing import Any
 from homeassistant.components.diagnostics import async_redact_data
 from homeassistant.helpers import device_registry as dr
 
-from .const import CONF_EMAIL, DOMAIN
+from .const import CONF_EMAIL, CONF_SITE_ID, DOMAIN
 from .device_types import parse_type_identifier
 from .energy import SiteEnergyFlow
+from .log_redaction import redact_text
 from .runtime_data import get_runtime_data
 
 DIAGNOSTIC_CAPTURE_ERRORS = (RuntimeError, TypeError, ValueError, AttributeError)
@@ -102,10 +103,76 @@ DIAGNOSTIC_IDENTIFIER_KEYS = [
 DIAGNOSTICS_REDACT_KEYS = [*TO_REDACT, *DIAGNOSTIC_IDENTIFIER_KEYS]
 
 
-def _redact_diagnostics_payload(payload: dict[str, Any]) -> dict[str, Any]:
+def _normalize_site_ids(values: list[Any]) -> tuple[str, ...]:
+    """Return normalized site IDs to redact from embedded diagnostics strings."""
+
+    site_ids: list[str] = []
+    for value in values:
+        if value is None:
+            continue
+        try:
+            text = str(value).strip()
+        except Exception:  # noqa: BLE001
+            continue
+        if text and text not in site_ids:
+            site_ids.append(text)
+    return tuple(site_ids)
+
+
+def _value_matches_site_id(value: Any, site_ids: tuple[str, ...]) -> bool:
+    """Return true when a scalar diagnostics value exactly matches a site ID."""
+
+    if not site_ids or isinstance(value, bool):
+        return False
+    try:
+        text = str(value).strip()
+    except Exception:  # noqa: BLE001
+        return False
+    if text in site_ids:
+        return True
+    if isinstance(value, float) and value.is_integer():
+        return str(int(value)) in site_ids
+    return False
+
+
+def _redact_embedded_diagnostics_text(value: Any, site_ids: tuple[str, ...]) -> Any:
+    """Redact site IDs embedded in otherwise non-sensitive diagnostics strings."""
+
+    if isinstance(value, dict):
+        redacted: dict[Any, Any] = {}
+        for key, child_value in value.items():
+            if isinstance(key, str):
+                safe_key = redact_text(key, site_ids=site_ids, max_length=512)
+            elif _value_matches_site_id(key, site_ids):
+                safe_key = "[site]"
+            else:
+                safe_key = key
+            redacted[safe_key] = _redact_embedded_diagnostics_text(
+                child_value, site_ids
+            )
+        return redacted
+    if isinstance(value, list):
+        return [_redact_embedded_diagnostics_text(item, site_ids) for item in value]
+    if isinstance(value, tuple):
+        return tuple(
+            _redact_embedded_diagnostics_text(item, site_ids) for item in value
+        )
+    if isinstance(value, str):
+        return redact_text(value, site_ids=site_ids, max_length=4096)
+    if _value_matches_site_id(value, site_ids):
+        return "[site]"
+    return value
+
+
+def _redact_diagnostics_payload(
+    payload: dict[str, Any],
+    *,
+    site_ids: tuple[str, ...] = (),
+) -> dict[str, Any]:
     """Return a redacted diagnostics payload safe for external sharing."""
 
-    return async_redact_data(payload, DIAGNOSTICS_REDACT_KEYS)
+    redacted = async_redact_data(payload, DIAGNOSTICS_REDACT_KEYS)
+    return _redact_embedded_diagnostics_text(redacted, site_ids)
 
 
 def _text(value: Any) -> str | None:
@@ -364,6 +431,7 @@ def _ac_battery_status_summary_for_diagnostics(summary: Any) -> dict[str, Any]:
 async def async_get_config_entry_diagnostics(hass, entry):
     """Return diagnostics for a config entry."""
 
+    site_ids = _normalize_site_ids([entry.data.get(CONF_SITE_ID)])
     data = async_redact_data(dict(entry.data), TO_REDACT)
     options = dict(getattr(entry, "options", {}) or {})
 
@@ -375,7 +443,7 @@ async def async_get_config_entry_diagnostics(hass, entry):
     try:
         coord = get_runtime_data(entry).coordinator
     except RuntimeError:
-        return diag
+        return _redact_diagnostics_payload(diag, site_ids=site_ids)
 
     try:
         upd = (
@@ -390,6 +458,13 @@ async def async_get_config_entry_diagnostics(hass, entry):
         metrics: dict[str, Any] = coord.collect_site_metrics()
     except DIAGNOSTIC_CAPTURE_ERRORS:
         metrics = {}
+    site_ids = _normalize_site_ids(
+        [
+            *site_ids,
+            getattr(coord, "site_id", None),
+            metrics.get("site_id") if isinstance(metrics, dict) else None,
+        ]
+    )
 
     try:
         last_modes = coord.charge_mode_cache_snapshot()
@@ -573,11 +648,12 @@ async def async_get_config_entry_diagnostics(hass, entry):
             "cache_age_s": cache_age,
         }
 
-    return _redact_diagnostics_payload(diag)
+    return _redact_diagnostics_payload(diag, site_ids=site_ids)
 
 
 async def async_get_device_diagnostics(hass, entry, device):
     """Return diagnostics for a device."""
+    site_ids = _normalize_site_ids([entry.data.get(CONF_SITE_ID)])
     dev_reg = dr.async_get(hass)
     dev = dev_reg.async_get(device.id)
     if not dev:
@@ -595,6 +671,7 @@ async def async_get_device_diagnostics(hass, entry, device):
             parsed = parse_type_identifier(ident_text)
             if parsed:
                 type_site_id, type_key = parsed
+                site_ids = _normalize_site_ids([*site_ids, type_site_id])
             continue
         sn = ident_text
         break
@@ -767,7 +844,7 @@ async def async_get_device_diagnostics(hass, entry, device):
                     runtime_payload = {}
                 if isinstance(runtime_payload, dict) and runtime_payload:
                     payload["heatpump_runtime"] = runtime_payload
-        return _redact_diagnostics_payload(payload)
+        return _redact_diagnostics_payload(payload, site_ids=site_ids)
     if not sn:
         return {"error": "serial_not_resolved"}
     coord = None
@@ -776,4 +853,7 @@ async def async_get_device_diagnostics(hass, entry, device):
     except RuntimeError:
         pass
     snapshot = (coord.data or {}).get(sn) if coord else None
-    return _redact_diagnostics_payload({"serial": sn, "snapshot": snapshot or {}})
+    return _redact_diagnostics_payload(
+        {"serial": sn, "snapshot": snapshot or {}},
+        site_ids=site_ids,
+    )

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -911,7 +911,10 @@ class EvseRuntime:
             response = await coord.client.start_live_stream()
         except Exception as err:  # noqa: BLE001
             if not was_active:
-                _LOGGER.debug("Live stream start failed: %s", redact_text(err))
+                _LOGGER.debug(
+                    "Live stream start failed: %s",
+                    redact_text(err, site_ids=(coord.site_id,)),
+                )
                 return
         else:
             start_ok = self.streaming_response_ok(response)
@@ -942,7 +945,10 @@ class EvseRuntime:
         try:
             await coord.client.stop_live_stream()
         except Exception as err:  # noqa: BLE001
-            _LOGGER.debug("Live stream stop failed: %s", redact_text(err))
+            _LOGGER.debug(
+                "Live stream stop failed: %s",
+                redact_text(err, site_ids=(coord.site_id,)),
+            )
         self.clear_streaming_state()
 
     def schedule_stream_stop(self, *, force: bool = False) -> None:
@@ -956,7 +962,10 @@ class EvseRuntime:
                 try:
                     await coord.client.stop_live_stream()
                 except Exception as err:  # noqa: BLE001
-                    _LOGGER.debug("Live stream stop failed: %s", redact_text(err))
+                    _LOGGER.debug(
+                        "Live stream stop failed: %s",
+                        redact_text(err, site_ids=(coord.site_id,)),
+                    )
                 self.clear_streaming_state()
             else:
                 await coord.async_stop_streaming()

--- a/custom_components/enphase_ev/evse_timeseries.py
+++ b/custom_components/enphase_ev/evse_timeseries.py
@@ -29,12 +29,14 @@ class EVSETimeseriesManager:
         client_provider: Callable[[], object],
         *,
         logger: logging.Logger | None = None,
+        site_id_getter: Callable[[], object] | None = None,
         cache_ttl: float = EVSE_TIMESERIES_CACHE_TTL,
         failure_backoff: float = EVSE_TIMESERIES_FAILURE_BACKOFF_S,
     ) -> None:
         self._hass = hass
         self._client_provider = client_provider
         self._logger = logger or _LOGGER
+        self._site_id_getter = site_id_getter
         self._cache_ttl = max(60.0, float(cache_ttl or 0))
         self._failure_backoff = max(60.0, float(failure_backoff or 0))
         self._daily_cache: dict[str, tuple[float, dict[str, dict[str, object]]]] = {}
@@ -61,6 +63,18 @@ class EVSETimeseriesManager:
                 "last_payload_signature": None,
             },
         }
+
+    def _site_ids(self) -> tuple[object, ...]:
+        if self._site_id_getter is None:
+            return ()
+        try:
+            site_id = self._site_id_getter()
+        except Exception:  # noqa: BLE001
+            return ()
+        return (site_id,) if site_id else ()
+
+    def _redact_error(self, err: object) -> str:
+        return redact_text(err, site_ids=self._site_ids())
 
     @property
     def cache_ttl(self) -> float:
@@ -205,7 +219,7 @@ class EVSETimeseriesManager:
         using_stale: bool = False,
     ) -> None:
         state = self._endpoint_state_for(endpoint)
-        reason = redact_text(err) if err else "EVSE timeseries unavailable"
+        reason = self._redact_error(err) if err else "EVSE timeseries unavailable"
         state["available"] = False
         state["using_stale"] = using_stale
         state["failures"] = int(state.get("failures", 0) or 0) + 1

--- a/custom_components/enphase_ev/log_redaction.py
+++ b/custom_components/enphase_ev/log_redaction.py
@@ -9,7 +9,25 @@ _EMAIL_RE = re.compile(r"(?i)\b[A-Z0-9._%+\-]+@[A-Z0-9.\-]+\.[A-Z]{2,}\b")
 _IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
 _MAC_RE = re.compile(r"(?i)\b(?:[0-9A-F]{2}[:-]){5}[0-9A-F]{2}\b")
 _DEBUG_KV_RE = re.compile(
-    r"(?P<key>[A-Za-z][A-Za-z0-9_\-]*)(?P<sep>\s*[=:]\s*)(?P<value>[^,\s)]+)"
+    r"(?P<key>[A-Za-z][A-Za-z0-9_\-]*)(?P<sep>\s*[=:]\s*)(?P<value>[^,&\s)]+)"
+)
+_SITE_URL_PATH_RE = re.compile(
+    r"(?P<prefix>/(?:systems|sites|hems|app-api|fwDetails)/)"
+    r"(?P<site>\d+)(?=$|[/?#\s])"
+    r"|(?P<service_prefix>/service/(?:enho_historical_events_ms"
+    r"|batteryConfig/api/v1/(?:siteSettings|profile|batterySettings)"
+    r"|batteryConfig/api/v1/batterySettings/acceptDisclaimer"
+    r"|batteryConfig/api/v1/(?:acceptDisclaimer|cancel/profile)"
+    r"|batteryConfig/api/v1/stormGuard(?:/toggle)?"
+    r"|batteryConfig/api/v1/battery/sites)/)"
+    r"(?P<service_site>\d+)(?=$|[/?#\s])"
+    r"|(?P<evse_prefix>/evse_controller/(?:api/v[12]/)?)"
+    r"(?P<evse_site>\d+)(?=$|[/?#\s])"
+    r"|(?P<scheduler_prefix>/service/evse_scheduler/api/v1/[^/]+/"
+    r"charging-mode/(?:GREEN_CHARGING/|SCHEDULED_CHARGING/)?)"
+    r"(?P<scheduler_site>\d+)(?=$|[/?#\s])"
+    r"|(?P<pv_settings_prefix>/pv/settings/)"
+    r"(?P<pv_settings_site>\d+)(?=$|[/?#\s])"
 )
 
 
@@ -102,6 +120,18 @@ def _redact_kv_match(match: re.Match[str]) -> str:
     return f"{key}{sep}{safe_value}"
 
 
+def _redact_site_path_match(match: re.Match[str]) -> str:
+    prefix = (
+        match.group("prefix")
+        or match.group("service_prefix")
+        or match.group("evse_prefix")
+        or match.group("scheduler_prefix")
+        or match.group("pv_settings_prefix")
+        or ""
+    )
+    return f"{prefix}[site]"
+
+
 def _normalize_iterable(values: Iterable[object] | None) -> list[str]:
     normalized: list[str] = []
     for value in values or ():
@@ -138,6 +168,7 @@ def redact_text(
     for site_id in _normalize_iterable(site_ids):
         text = text.replace(site_id, "[site]")
 
+    text = _SITE_URL_PATH_RE.sub(_redact_site_path_match, text)
     text = _EMAIL_RE.sub("[redacted]", text)
     text = _IPV4_RE.sub("[redacted]", text)
     text = _MAC_RE.sub("[redacted]", text)

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -21,6 +21,7 @@ from .battery_schedule_editor import (
 )
 from .const import DOMAIN, ISSUE_AUTH_BLOCKED, ISSUE_REAUTH_REQUIRED
 from .device_types import parse_type_identifier
+from .log_redaction import redact_site_id
 from .parsing_helpers import coerce_optional_bool
 from .runtime_data import EnphaseRuntimeData, iter_coordinators
 from .service_validation import raise_translated_service_validation
@@ -392,9 +393,10 @@ def async_setup_services(
             result = await validator(schedule_type)
         except aiohttp.ClientResponseError as err:
             if err.status in {403, 404}:
+                site_id = getattr(coord, "site_id", None)
                 _LOGGER.debug(
                     "Ignoring battery schedule preflight failure for site %s (%s %s)",
-                    getattr(coord, "site_id", "unknown"),
+                    redact_site_id(site_id),
                     err.status,
                     str(schedule_type).upper(),
                 )

--- a/custom_components/enphase_ev/session_history.py
+++ b/custom_components/enphase_ev/session_history.py
@@ -68,6 +68,7 @@ class SessionHistoryManager:
         concurrency: int = SESSION_HISTORY_CONCURRENCY,
         data_supplier: Callable[[], dict[str, dict] | None] | None = None,
         publish_callback: Callable[[dict[str, dict]], None] | None = None,
+        site_id_getter: Callable[[], object] | None = None,
         logger: logging.Logger | None = None,
     ) -> None:
         self._hass = hass
@@ -88,6 +89,7 @@ class SessionHistoryManager:
         self._enrichment_tasks: set[asyncio.Task[None]] = set()
         self._data_supplier = data_supplier
         self._publish_callback = publish_callback
+        self._site_id_getter = site_id_getter
         self._logger = logger or _LOGGER
         self._fetch_override: (
             Callable[[str, datetime | None], Awaitable[list[dict]]] | None
@@ -100,6 +102,18 @@ class SessionHistoryManager:
         self._service_backoff_ends_utc: datetime | None = None
         self._service_using_stale = False
         self._service_last_payload_signature: dict[str, object] | None = None
+
+    def _site_ids(self) -> tuple[object, ...]:
+        if self._site_id_getter is None:
+            return ()
+        try:
+            site_id = self._site_id_getter()
+        except Exception:  # noqa: BLE001
+            return ()
+        return (site_id,) if site_id else ()
+
+    def _redact_error(self, err: object) -> str:
+        return redact_text(err, site_ids=self._site_ids())
 
     @property
     def cache_ttl(self) -> float:
@@ -195,7 +209,7 @@ class SessionHistoryManager:
         *,
         using_stale: bool = False,
     ) -> None:
-        reason = redact_text(err) if err else ""
+        reason = self._redact_error(err) if err else ""
         if not reason:
             reason = "Session history unavailable"
         self._service_available = False
@@ -222,11 +236,10 @@ class SessionHistoryManager:
         except Exception:
             return None
 
-    @staticmethod
-    def _entry_error_text(err: Exception | str | None) -> str | None:
+    def _entry_error_text(self, err: Exception | str | None) -> str | None:
         if err is None:
             return None
-        reason = redact_text(err)
+        reason = self._redact_error(err)
         if reason:
             return reason
         if isinstance(err, str):
@@ -419,19 +432,23 @@ class SessionHistoryManager:
                         )
                 except asyncio.CancelledError as err:
                     self._logger.debug(
-                        "Session history enrichment cancelled for %s: %s", sn, err
+                        "Session history enrichment cancelled for %s: %s",
+                        sn,
+                        self._redact_error(err),
                     )
                     return sn, None
                 except Unauthorized as err:
                     self._logger.debug(
                         "Session history unauthorized for %s during enrichment: %s",
                         sn,
-                        err,
+                        self._redact_error(err),
                     )
                     return sn, None
                 except Exception as err:  # noqa: BLE001
                     self._logger.debug(
-                        "Session history enrichment failed for %s: %s", sn, err
+                        "Session history enrichment failed for %s: %s",
+                        sn,
+                        self._redact_error(err),
                     )
                     return sn, None
                 return sn, sessions
@@ -442,7 +459,8 @@ class SessionHistoryManager:
         for response in responses:
             if isinstance(response, Exception):
                 self._logger.debug(
-                    "Session history enrichment task error: %s", response
+                    "Session history enrichment task error: %s",
+                    self._redact_error(response),
                 )
                 continue
             sn, sessions = response
@@ -554,7 +572,9 @@ class SessionHistoryManager:
                 await self._async_refresh_filter_criteria(criteria_fetcher)
             except SessionHistoryUnavailable as err:
                 self._logger.debug(
-                    "Session history criteria unavailable for %s: %s", sn, err
+                    "Session history criteria unavailable for %s: %s",
+                    sn,
+                    self._redact_error(err),
                 )
                 if cached and cached.has_valid_cache:
                     self._note_service_unavailable(err, using_stale=True)
@@ -565,7 +585,9 @@ class SessionHistoryManager:
                 return []
             except Unauthorized as err:
                 self._logger.debug(
-                    "Session history criteria unauthorized for %s: %s", sn, err
+                    "Session history criteria unauthorized for %s: %s",
+                    sn,
+                    self._redact_error(err),
                 )
                 self._set_unavailable_entry(sn, day_key, now_mono, err)
                 return []
@@ -574,7 +596,7 @@ class SessionHistoryManager:
                     "Session history criteria error for %s: %s (%s)",
                     sn,
                     err.status,
-                    err.message,
+                    self._redact_error(err.message),
                 )
                 if err.status in (500, 502, 503, 504, 550):
                     self._block_until[sn] = now_mono + self._failure_backoff
@@ -582,7 +604,9 @@ class SessionHistoryManager:
                 return []
             except Exception as err:  # noqa: BLE001
                 self._logger.debug(
-                    "Session history criteria failed for %s: %s", sn, err
+                    "Session history criteria failed for %s: %s",
+                    sn,
+                    self._redact_error(err),
                 )
                 if cached and cached.has_valid_cache:
                     self._note_service_unavailable(err, using_stale=True)
@@ -624,7 +648,7 @@ class SessionHistoryManager:
                 "Session history unavailable for %s on %s: %s",
                 sn,
                 api_day,
-                err,
+                self._redact_error(err),
             )
             if cached and cached.has_valid_cache:
                 self._note_service_unavailable(err, using_stale=True)
@@ -638,7 +662,7 @@ class SessionHistoryManager:
                 "Session history unauthorized for %s on %s: %s",
                 sn,
                 api_day,
-                err,
+                self._redact_error(err),
             )
             self._set_unavailable_entry(sn, day_key, now_mono, err)
             return []
@@ -648,7 +672,7 @@ class SessionHistoryManager:
                 sn,
                 api_day,
                 err.status,
-                err.message,
+                self._redact_error(err.message),
             )
             if err.status in (500, 502, 503, 504, 550):
                 self._block_until[sn] = now_mono + self._failure_backoff
@@ -656,7 +680,10 @@ class SessionHistoryManager:
             return []
         except Exception as err:  # noqa: BLE001
             self._logger.debug(
-                "Session history fetch failed for %s on %s: %s", sn, api_day, err
+                "Session history fetch failed for %s on %s: %s",
+                sn,
+                api_day,
+                self._redact_error(err),
             )
             if cached and cached.has_valid_cache:
                 self._note_service_unavailable(err, using_stale=True)

--- a/custom_components/enphase_ev/summary.py
+++ b/custom_components/enphase_ev/summary.py
@@ -30,9 +30,11 @@ class SummaryStore:
         self,
         client_getter: Callable[[], Any],
         *,
+        site_id_getter: Callable[[], object] | None = None,
         logger: logging.Logger | None = None,
     ) -> None:
         self._client_getter = client_getter
+        self._site_id_getter = site_id_getter
         self._logger = logger or _LOGGER
         self._cache: tuple[float, list[dict], float] | None = None
         self._ttl: float = SUMMARY_IDLE_TTL
@@ -49,6 +51,20 @@ class SummaryStore:
             "backoff_ends_utc": None,
             "last_payload_signature": None,
         }
+
+    def _site_ids(self, client: Any | None = None) -> tuple[object, ...]:
+        site_ids: list[object] = []
+        if self._site_id_getter is not None:
+            try:
+                site_ids.append(self._site_id_getter())
+            except Exception:  # noqa: BLE001
+                pass
+        if client is not None:
+            site_ids.append(getattr(client, "_site", None))
+        return tuple(site_id for site_id in site_ids if site_id)
+
+    def _redact_error(self, err: object, client: Any | None = None) -> str:
+        return redact_text(err, site_ids=self._site_ids(client))
 
     @property
     def ttl(self) -> float:
@@ -158,7 +174,7 @@ class SummaryStore:
                 delay = self._failure_backoff_delay(err, failures)
                 self._state["available"] = False
                 self._state["last_failure_utc"] = dt_util.utcnow()
-                self._state["last_error"] = redact_text(err)
+                self._state["last_error"] = self._redact_error(err, client)
                 self._state["failures"] = failures
                 self._state["backoff_until"] = time.monotonic() + delay
                 try:
@@ -176,11 +192,14 @@ class SummaryStore:
                     self._state["using_stale"] = True
                     self._logger.debug(
                         "Summary v2 fetch failed; reusing cache: %s",
-                        redact_text(err),
+                        self._redact_error(err, client),
                     )
                     return cached[1]
                 self._state["using_stale"] = False
-                self._logger.debug("Summary v2 fetch failed: %s", redact_text(err))
+                self._logger.debug(
+                    "Summary v2 fetch failed: %s",
+                    self._redact_error(err, client),
+                )
                 return []
 
             summary_list = self._as_list(summary)

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -1043,8 +1043,9 @@ def test_redact_headers_masks_sensitive_fields() -> None:
         "X-CSRF-Token": "csrf",
         "X-XSRF-Token": "xsrf",
         "Username": "123456",
+        "Referer": "https://enlighten.enphaseenergy.com/pv/systems/SITE/summary",
     }
-    redacted = api.EnphaseEVClient._redact_headers(headers)
+    redacted = _make_client(MagicMock())._redact_headers(headers)
     assert redacted["Cookie"] == "[redacted]"
     assert redacted["Authorization"] == "[redacted]"
     assert redacted["e-auth-token"] == "[redacted]"
@@ -1052,6 +1053,7 @@ def test_redact_headers_masks_sensitive_fields() -> None:
     assert redacted["X-XSRF-Token"] == "[redacted]"
     assert redacted["Username"] == "[redacted]"
     assert redacted["X-Test"] == "value"
+    assert redacted["Referer"].endswith("/pv/systems/[site]/summary")
 
 
 def test_truncate_debug_identifier_branches() -> None:
@@ -1825,7 +1827,8 @@ async def test_json_logs_batteryconfig_write_failure_details(caplog) -> None:
 
     assert (
         "BatteryConfig write failed for PUT "
-        "/service/batteryConfig/api/v1/batterySettings/SITE: status=403" in caplog.text
+        "/service/batteryConfig/api/v1/batterySettings/[site]: status=403"
+        in caplog.text
     )
     assert "payload={'scheduleType': None, 'json_keys': ['veryLowSoc']}" in caplog.text
     assert "cookie_names=['bp-xsrf-token', 'other', 'session']" in caplog.text
@@ -1846,6 +1849,8 @@ async def test_json_logs_batteryconfig_write_failure_details(caplog) -> None:
     assert "'X-CSRF-Token': '[redacted]'" in caplog.text
     assert "'X-XSRF-Token': '[redacted]'" in caplog.text
     assert "'Username': '[redacted]'" in caplog.text
+    assert "/pv/systems/SITE/summary" not in caplog.text
+    assert "/pv/systems/[site]/summary" in caplog.text
     assert "secret-auth" not in caplog.text
     assert "secret-eauth" not in caplog.text
     assert "secret-xsrf" not in caplog.text
@@ -2089,7 +2094,7 @@ async def test_json_invalid_payload_logs_redacted_evse_status_body(
         == '{"site":"[site]","email":"[redacted]","serial":"SERI...5678"}'
     )
     assert (
-        "Invalid payload for site [site] endpoint /service/evse_controller/SITE/ev_chargers/status"
+        "Invalid payload for site [site] endpoint /service/evse_controller/[site]/ev_chargers/status"
         in caplog.text
     )
     assert "application/json; charset=utf-8" in caplog.text
@@ -2137,11 +2142,11 @@ async def test_json_invalid_payload_logs_once_and_recovery_logs_once(
     ]
     assert len(warning_messages) == 1
     assert (
-        "Invalid payload for site [site] endpoint /service/evse_controller/SITE/ev_chargers/status"
+        "Invalid payload for site [site] endpoint /service/evse_controller/[site]/ev_chargers/status"
         in warning_messages[0]
     )
     assert info_messages == [
-        "Payload recovered for site [site] endpoint /service/evse_controller/SITE/ev_chargers/status"
+        "Payload recovered for site [site] endpoint /service/evse_controller/[site]/ev_chargers/status"
     ]
 
 

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -121,6 +122,42 @@ def test_gateway_diagnostics_helper_branches() -> None:
     assert diagnostics._microinverter_summary({})["connectivity"] is None
     assert diagnostics._battery_status_summary_for_diagnostics(None) == {}
     assert diagnostics._ac_battery_status_summary_for_diagnostics(None) == {}
+
+
+def test_diagnostics_redacts_numeric_site_ids_in_nested_payloads() -> None:
+    class BadStr:
+        def __str__(self) -> str:
+            raise ValueError("boom")
+
+    payload = {
+        "payload": {
+            "id": 3381244,
+            3381244: {"status": "raw"},
+            42: "other",
+            "ids": [3381244, 3381244.0, 42, True, BadStr()],
+            "nested": {"value": "/systems/3381244/devices"},
+        }
+    }
+
+    redacted = diagnostics._redact_diagnostics_payload(  # noqa: SLF001
+        payload,
+        site_ids=("3381244",),
+    )
+
+    assert redacted["payload"]["id"] == "[site]"
+    assert redacted["payload"]["[site]"] == {"status": "raw"}
+    assert 3381244 not in redacted["payload"]
+    assert redacted["payload"][42] == "other"
+    assert redacted["payload"]["ids"][:2] == ["[site]", "[site]"]
+    assert redacted["payload"]["ids"][2] == 42
+    assert redacted["payload"]["ids"][3] is True
+    assert isinstance(redacted["payload"]["ids"][4], BadStr)
+    assert redacted["payload"]["nested"]["value"] == "/systems/[site]/devices"
+    assert diagnostics._normalize_site_ids(
+        [None, "3381244", 3381244, BadStr()]
+    ) == (  # noqa: SLF001
+        "3381244",
+    )
 
 
 class DummyClient(SimpleNamespace):
@@ -558,7 +595,7 @@ class DummyCoordinator(SimpleNamespace):
             "network_errors": self._network_errors,
             "http_errors": self._http_errors,
             "last_error": self._last_error,
-            "last_failure_endpoint": "/service/evse_controller/[site]/ev_chargers/status",
+            "last_failure_endpoint": f"/service/evse_controller/{self.site_id}/ev_chargers/status",
             "payload_using_stale": True,
             "payload_failure_kind": "json_decode",
             "payload_health": self.payload_health_diagnostics(),
@@ -605,7 +642,7 @@ class DummyCoordinator(SimpleNamespace):
                 "last_error": "Invalid JSON response",
                 "last_success_age_s": 12.5,
                 "last_payload_signature": {
-                    "endpoint": "/service/evse_controller/[site]/ev_chargers/status",
+                    "endpoint": f"/service/evse_controller/{self.site_id}/ev_chargers/status",
                     "failure_kind": "json_decode",
                     "body_preview_redacted": '{"site":"[site]","serial":"SERI...5678"}',
                 },
@@ -736,6 +773,7 @@ async def test_config_entry_diagnostics_includes_coordinator(
         ]
         == "/service/evse_controller/[site]/ev_chargers/status"
     )
+    assert RANDOM_SITE_ID not in json.dumps(diag, default=str)
     assert (
         diag["coordinator"]["payload_health"]["status"]["last_payload_signature"][
             "body_preview_redacted"

--- a/tests/components/enphase_ev/test_evse_timeseries.py
+++ b/tests/components/enphase_ev/test_evse_timeseries.py
@@ -67,16 +67,24 @@ async def test_evse_timeseries_manager_retains_cache_on_unavailable(hass) -> Non
             return_value={"EV-1": {"energy_kwh": 10.0}}
         ),
     )
-    manager = EVSETimeseriesManager(hass, lambda: client)
+    manager = EVSETimeseriesManager(
+        hass,
+        lambda: client,
+        site_id_getter=lambda: "3381244",
+    )
     day_local = datetime(2026, 3, 11, 12, 0, 0, tzinfo=timezone.utc)
 
     await manager.async_refresh(day_local=day_local)
 
     client.evse_timeseries_daily_energy = AsyncMock(
-        side_effect=EVSETimeseriesUnavailable("daily down")
+        side_effect=EVSETimeseriesUnavailable(
+            "GET /service/timeseries/evse/timeseries/daily_energy?site_id=3381244&source=evse"
+        )
     )
     client.evse_timeseries_lifetime_energy = AsyncMock(
-        side_effect=EVSETimeseriesUnavailable("lifetime down")
+        side_effect=EVSETimeseriesUnavailable(
+            "GET /service/timeseries/evse/timeseries/lifetime_energy?site_id=3381244&source=evse"
+        )
     )
 
     await manager.async_refresh(day_local=day_local, force=True)
@@ -89,9 +97,25 @@ async def test_evse_timeseries_manager_retains_cache_on_unavailable(hass) -> Non
     diagnostics = manager.diagnostics()
     assert diagnostics["available"] is False
     assert diagnostics["failures"] == 2
-    assert diagnostics["last_error"] == "daily down"
-    assert diagnostics["daily"]["last_error"] == "daily down"
-    assert diagnostics["lifetime"]["last_error"] == "lifetime down"
+    assert "3381244" not in str(diagnostics["last_error"])
+    assert "3381244" not in str(diagnostics["daily"]["last_error"])
+    assert "3381244" not in str(diagnostics["lifetime"]["last_error"])
+    assert "site_id=[site]&source=evse" in str(diagnostics["daily"]["last_error"])
+    assert "site_id=[site]&source=evse" in str(diagnostics["lifetime"]["last_error"])
+
+
+def test_evse_timeseries_redaction_ignores_site_getter_errors(hass) -> None:
+    def bad_site_id():
+        raise RuntimeError("bad site")
+
+    manager = EVSETimeseriesManager(hass, lambda: None, site_id_getter=bad_site_id)
+
+    assert (
+        manager._redact_error(
+            "GET /service/timeseries/evse/timeseries/daily_energy"
+        )  # noqa: SLF001
+        == "GET /service/timeseries/evse/timeseries/daily_energy"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_helper_modules.py
+++ b/tests/components/enphase_ev/test_helper_modules.py
@@ -468,6 +468,32 @@ async def test_summary_store_caches_and_handles_errors() -> None:
 
 
 @pytest.mark.asyncio
+async def test_summary_store_redacts_configured_site_from_errors() -> None:
+    client = _DummySummaryClient()
+    client.summary_v2 = AsyncMock(
+        side_effect=RuntimeError(
+            "GET /service/evse_controller/api/v2/3381244/ev_chargers/summary"
+        )
+    )
+    store = SummaryStore(lambda: client, site_id_getter=lambda: "3381244")
+
+    assert await store.async_fetch(force=True) == []
+
+    last_error = store.diagnostics()["last_error"]
+    assert "3381244" not in str(last_error)
+    assert "/api/v2/[site]/ev_chargers/summary" in str(last_error)
+
+
+def test_summary_store_redaction_ignores_site_getter_errors() -> None:
+    def bad_site_id():
+        raise RuntimeError("bad site")
+
+    store = SummaryStore(lambda: None, site_id_getter=bad_site_id)
+
+    assert store._redact_error("summary failed") == "summary failed"  # noqa: SLF001
+
+
+@pytest.mark.asyncio
 async def test_summary_store_records_invalid_payload_stale_diagnostics() -> None:
     client = _DummySummaryClient()
     store = SummaryStore(lambda: client)
@@ -993,8 +1019,27 @@ def test_session_history_cache_state_counts_handles_legacy_and_invalid_entries(
 
 
 def test_session_history_entry_error_text_handles_empty_values() -> None:
-    assert SessionHistoryManager._entry_error_text(None) is None  # noqa: SLF001
-    assert SessionHistoryManager._entry_error_text("   ") is None  # noqa: SLF001
+    manager = SessionHistoryManager(
+        MagicMock(config=MagicMock(time_zone="UTC"), async_create_task=MagicMock()),
+        lambda: None,
+        cache_ttl=10,
+    )
+    assert manager._entry_error_text(None) is None  # noqa: SLF001
+    assert manager._entry_error_text("   ") is None  # noqa: SLF001
+
+
+def test_session_history_redaction_ignores_site_getter_errors(hass) -> None:
+    def bad_site_id():
+        raise RuntimeError("bad site")
+
+    manager = SessionHistoryManager(
+        hass,
+        lambda: None,
+        cache_ttl=10,
+        site_id_getter=bad_site_id,
+    )
+
+    assert manager._redact_error("history failed") == "history failed"  # noqa: SLF001
 
 
 def _make_request_info() -> RequestInfo:

--- a/tests/components/enphase_ev/test_log_redaction.py
+++ b/tests/components/enphase_ev/test_log_redaction.py
@@ -19,7 +19,7 @@ def test_identifier_helpers_redact_values() -> None:
 
 def test_redact_text_scrubs_common_sensitive_values() -> None:
     text = (
-        "site_id=12345 serialNumber=SERIAL-12345678 uid=DEVICE-UID-9999 "
+        "site_id=12345&source=evse serialNumber=SERIAL-12345678 uid=DEVICE-UID-9999 "
         "email=user@example.com ip=10.0.0.2 mac=AA:BB:CC:DD:EE:FF plain 12345"
     )
 
@@ -36,9 +36,49 @@ def test_redact_text_scrubs_common_sensitive_values() -> None:
     assert "10.0.0.2" not in redacted
     assert "AA:BB:CC:DD:EE:FF" not in redacted
     assert "site_id=[site]" in redacted
+    assert "source=evse" in redacted
     assert "serialNumber=SERI...5678" in redacted
     assert "uid=DEVI...9999" in redacted
     assert redacted.count("[redacted]") >= 3
+
+
+def test_redact_text_scrubs_site_ids_from_enphase_url_paths() -> None:
+    text = (
+        "GET /systems/3381244/hems_power_timeseries "
+        "GET /service/system_dashboard/api_internal/dashboard/sites/3381244/devices-tree "
+        "GET /app-api/3381244/devices.json "
+        "GET /service/evse_controller/api/v2/3381244/ev_chargers/summary "
+        "GET /service/enho_historical_events_ms/3381244/filter_criteria "
+        "GET /service/batteryConfig/api/v1/siteSettings/3381244 "
+        "POST /service/batteryConfig/api/v1/batterySettings/acceptDisclaimer/3381244 "
+        "PUT /service/batteryConfig/api/v1/battery/sites/3381244/schedules "
+        "POST /service/batteryConfig/api/v1/stormGuard/toggle/3381244 "
+        "POST /service/batteryConfig/api/v1/cancel/profile/3381244 "
+        "PUT /service/evse_controller/api/v1/3381244/ev_chargers/EV1/ev_charger_config "
+        "POST /service/evse_scheduler/api/v1/iqevc/charging-mode/3381244/EV1/preference "
+        "PUT /service/evse_scheduler/api/v1/iqevc/charging-mode/GREEN_CHARGING/3381244/EV1/settings "
+        "PATCH /service/evse_scheduler/api/v1/iqevc/charging-mode/SCHEDULED_CHARGING/3381244/EV1/schedules "
+        "POST /pv/settings/3381244/battery_status.json"
+    )
+
+    redacted = redact_text(text, max_length=2000)
+
+    assert "3381244" not in redacted
+    assert "/systems/[site]/hems_power_timeseries" in redacted
+    assert "/sites/[site]/devices-tree" in redacted
+    assert "/app-api/[site]/devices.json" in redacted
+    assert "/evse_controller/api/v2/[site]/ev_chargers/summary" in redacted
+    assert "/enho_historical_events_ms/[site]/filter_criteria" in redacted
+    assert "/siteSettings/[site]" in redacted
+    assert "/batterySettings/acceptDisclaimer/[site]" in redacted
+    assert "/battery/sites/[site]/schedules" in redacted
+    assert "/stormGuard/toggle/[site]" in redacted
+    assert "/cancel/profile/[site]" in redacted
+    assert "/evse_controller/api/v1/[site]/ev_chargers/EV1" in redacted
+    assert "/charging-mode/[site]/EV1/preference" in redacted
+    assert "/charging-mode/GREEN_CHARGING/[site]/EV1/settings" in redacted
+    assert "/charging-mode/SCHEDULED_CHARGING/[site]/EV1/schedules" in redacted
+    assert "/pv/settings/[site]/battery_status.json" in redacted
 
 
 def test_identifier_helpers_cover_bad_string_inputs() -> None:

--- a/tests/components/enphase_ev/test_session_history_additional.py
+++ b/tests/components/enphase_ev/test_session_history_additional.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import logging
 import time
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -162,11 +163,14 @@ async def test_fetch_sessions_handles_paging(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_fetch_sessions_criteria_unavailable(monkeypatch):
+async def test_fetch_sessions_criteria_unavailable(monkeypatch, caplog):
     hass = _make_hass()
+    caplog.set_level(logging.DEBUG, logger=sh_mod._LOGGER.name)
 
     async def fake_criteria(**_kwargs):
-        raise SessionHistoryUnavailable("down")
+        raise SessionHistoryUnavailable(
+            "GET /service/enho_historical_events_ms/3381244/filter_criteria"
+        )
 
     client = SimpleNamespace(
         session_history_filter_criteria=fake_criteria,
@@ -176,6 +180,7 @@ async def test_fetch_sessions_criteria_unavailable(monkeypatch):
         hass,
         client_getter=lambda: client,
         cache_ttl=60,
+        site_id_getter=lambda: "3381244",
     )
     now = datetime(2025, 1, 5, tzinfo=timezone.utc)
     monkeypatch.setattr(sh_mod.dt_util, "now", lambda: now)
@@ -184,9 +189,16 @@ async def test_fetch_sessions_criteria_unavailable(monkeypatch):
     result = await manager._async_fetch_sessions_today("SN", day_local=now)
     assert result == []
     assert manager.service_available is False
+    assert "3381244" not in str(manager.service_last_error)
+    assert "3381244" not in caplog.text
+    assert "/enho_historical_events_ms/[site]/filter_criteria" in caplog.text
+    assert "/enho_historical_events_ms/[site]/filter_criteria" in str(
+        manager.service_last_error
+    )
     entry = manager._cache[("SN", now.strftime("%Y-%m-%d"))]
     assert entry.state == sh_mod.SESSION_CACHE_STATE_UNAVAILABLE
     assert entry.has_valid_cache is False
+    assert "3381244" not in str(entry.last_error)
 
 
 @pytest.mark.asyncio
@@ -249,15 +261,21 @@ async def test_fetch_sessions_criteria_http_error(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_fetch_sessions_marks_service_unavailable(monkeypatch):
+async def test_fetch_sessions_marks_service_unavailable(monkeypatch, caplog):
     hass = _make_hass()
+    caplog.set_level(logging.DEBUG, logger=sh_mod._LOGGER.name)
     client = SimpleNamespace(
-        session_history=AsyncMock(side_effect=SessionHistoryUnavailable("down"))
+        session_history=AsyncMock(
+            side_effect=SessionHistoryUnavailable(
+                "POST /service/enho_historical_events_ms/3381244/sessions/SN/history"
+            )
+        )
     )
     manager = sh_mod.SessionHistoryManager(
         hass,
         client_getter=lambda: client,
         cache_ttl=60,
+        site_id_getter=lambda: "3381244",
     )
     now = datetime(2025, 1, 3, tzinfo=timezone.utc)
     monkeypatch.setattr(sh_mod.dt_util, "now", lambda: now)
@@ -268,6 +286,9 @@ async def test_fetch_sessions_marks_service_unavailable(monkeypatch):
     assert manager.service_available is False
     assert manager.service_backoff_active is True
     assert manager.service_last_error
+    assert "3381244" not in str(manager.service_last_error)
+    assert "3381244" not in caplog.text
+    assert "/enho_historical_events_ms/[site]/sessions/SN/history" in caplog.text
     entry = manager._cache[("SN", now.strftime("%Y-%m-%d"))]
     assert entry.state == sh_mod.SESSION_CACHE_STATE_UNAVAILABLE
     assert entry.has_valid_cache is False


### PR DESCRIPTION
## Summary

Redacts Enphase site IDs from log and diagnostic paths where raw endpoint strings can surface. Expands shared log redaction for site-scoped URL families, wires known site IDs into summary/session-history/EVSE timeseries helper errors, redacts embedded diagnostics strings and numeric site-id values/keys, and hardens API/header/payload logging.

## Related Issues

Review feedback: site ID redaction gaps in session-history, diagnostics, and battery accept-disclaimer paths.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/log_redaction.py custom_components/enphase_ev/session_history.py tests/components/enphase_ev/test_log_redaction.py tests/components/enphase_ev/test_session_history_additional.py && pytest -q tests/components/enphase_ev/test_log_redaction.py tests/components/enphase_ev/test_session_history_additional.py tests/components/enphase_ev/test_diagnostics.py tests/components/enphase_ev/test_helper_modules.py tests/components/enphase_ev/test_evse_timeseries.py && ruff check ."

docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/log_redaction.py,custom_components/enphase_ev/diagnostics.py,custom_components/enphase_ev/summary.py,custom_components/enphase_ev/session_history.py,custom_components/enphase_ev/evse_timeseries.py --fail-under=100"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Diagnostics now redact configured site IDs when embedded in strings, numeric values, and numeric keys.
- Session-history debug logging now uses the shared redactor before emitting exception text.
