### PR TITLE
[codex] Preserve manual reauth success response

### DIFF
--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -21,7 +21,7 @@ from .battery_schedule_editor import (
 )
 from .const import DOMAIN, ISSUE_AUTH_BLOCKED, ISSUE_REAUTH_REQUIRED
 from .device_types import parse_type_identifier
-from .log_redaction import redact_site_id
+from .log_redaction import redact_site_id, redact_text
 from .parsing_helpers import coerce_optional_bool
 from .runtime_data import EnphaseRuntimeData, iter_coordinators
 from .service_validation import raise_translated_service_validation
@@ -710,7 +710,14 @@ def async_setup_services(
         if success.retry_after_seconds is not None:
             response["retry_after_seconds"] = success.retry_after_seconds
         if success.success:
-            await coord.async_request_refresh()
+            try:
+                await coord.async_request_refresh()
+            except Exception as err:  # noqa: BLE001
+                _LOGGER.debug(
+                    "Manual reauthentication succeeded for site %s but the follow-up refresh failed: %s",
+                    redact_site_id(site_id),
+                    redact_text(err),
+                )
         return response
 
     async def _svc_start_stream(call: ServiceCall) -> None:

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -330,3 +331,33 @@ async def test_try_reauth_now_reports_manual_retry_cooldown(
     coord.async_start_streaming.assert_not_awaited()
     coord.async_stop_streaming.assert_not_awaited()
     coord.schedule_sync.async_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_try_reauth_now_still_returns_success_when_refresh_fails(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """A follow-up refresh failure should not hide a successful reauth."""
+
+    handlers = _register_service_handlers(hass, monkeypatch)
+    coord = _fake_service_coordinator(site_id="evse-site", serials={"EVSE123"})
+    coord.async_request_refresh.side_effect = RuntimeError("refresh boom")
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "evse-site", CONF_SITE_ONLY: False},
+        title="EVSE Site",
+        unique_id="evse-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    with caplog.at_level(logging.DEBUG):
+        result = await handlers[(DOMAIN, "try_reauth_now")](
+            SimpleNamespace(data={"site_id": "evse-site"})
+        )
+
+    assert result == {"site_id": "evse-site", "success": True, "reason": None}
+    coord.async_try_reauth_now.assert_awaited_once_with()
+    coord.async_request_refresh.assert_awaited_once_with()
+    assert "Manual reauthentication succeeded for site [site]" in caplog.text
+    assert "refresh boom" in caplog.text

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -335,7 +335,9 @@ async def test_try_reauth_now_reports_manual_retry_cooldown(
 
 @pytest.mark.asyncio
 async def test_try_reauth_now_still_returns_success_when_refresh_fails(
-    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """A follow-up refresh failure should not hide a successful reauth."""
 


### PR DESCRIPTION
## Summary

- preserve a successful `try_reauth_now` service response even when the follow-up coordinator refresh raises
- log the refresh failure instead of surfacing it as a service failure
- add regression coverage for the success-plus-refresh-failure path

## Testing

- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_services.py -k 'try_reauth_now'"`
