### PR TITLE
Smooth idle heat pump power

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Bounded the `Current Production Power` live-sample cache so stale values are not reused indefinitely when the latest-power endpoint stops returning valid samples.
+- Smoothed idle heat-pump power over existing low-load energy samples so whole-Wh cloud readings no longer flicker between `0 W` and standby load, while exposing the raw short-window value in diagnostics.
 
 ### 🔧 Improvements
 - Clarified the Enphase authentication-block repair message and added a manual stored-credential reauthentication service for trying one immediate unblock attempt.

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -5993,6 +5993,22 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         return self.heatpump_runtime.heatpump_power_source
 
     @property
+    def heatpump_power_raw_w(self) -> float | None:
+        return self.heatpump_runtime.heatpump_power_raw_w
+
+    @property
+    def heatpump_power_window_seconds(self) -> float | None:
+        return self.heatpump_runtime.heatpump_power_window_seconds
+
+    @property
+    def heatpump_power_validation(self) -> str | None:
+        return self.heatpump_runtime.heatpump_power_validation
+
+    @property
+    def heatpump_power_smoothed(self) -> bool:
+        return self.heatpump_runtime.heatpump_power_smoothed
+
+    @property
     def heatpump_power_using_stale(self) -> bool:
         return self.heatpump_runtime.heatpump_power_using_stale
 

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -53,6 +53,8 @@ _LOGGER = logging.getLogger(__name__)
 _HEATPUMP_IDLE_POWER_MAX_W = 20.0
 _HEATPUMP_POWER_DEFAULT_WINDOW_S = 300.0
 _HEATPUMP_POWER_MIN_DELTA_WH = 0.5
+_HEATPUMP_IDLE_SMOOTHING_MIN_WINDOW_S = 15 * 60.0
+_HEATPUMP_IDLE_SMOOTHING_MAX_WINDOW_S = 30 * 60.0
 
 
 class HeatpumpRuntime:
@@ -234,6 +236,10 @@ class HeatpumpRuntime:
         self._heatpump_power_start_utc = None
         self._heatpump_power_device_uid = None
         self._heatpump_power_source = None
+        self._heatpump_power_raw_w = None
+        self._heatpump_power_window_seconds = None
+        self._heatpump_power_validation = None
+        self._heatpump_power_smoothed = False
         self._heatpump_power_using_stale = False
         self._heatpump_power_last_error = error
         return False
@@ -242,6 +248,10 @@ class HeatpumpRuntime:
         for attr in attrs:
             value = getattr(self, attr, None)
             if isinstance(value, bool):
+                if value:
+                    return True
+                continue
+            if attr == "_heatpump_power_sample_history" and isinstance(value, list):
                 if value:
                     return True
                 continue
@@ -974,6 +984,143 @@ class HeatpumpRuntime:
             return None
         return raw.replace("-", "_").replace(" ", "_").upper()
 
+    def _heatpump_power_history(self) -> list[dict[str, object]]:
+        history = getattr(self, "_heatpump_power_sample_history", None)
+        if isinstance(history, list):
+            return history
+        self._heatpump_power_sample_history = []
+        return self._heatpump_power_sample_history
+
+    @staticmethod
+    def _heatpump_power_history_sample_time(entry: object) -> datetime | None:
+        if not isinstance(entry, dict):
+            return None
+        value = entry.get("sample_utc")
+        return value if isinstance(value, datetime) else None
+
+    def _record_heatpump_power_history_sample(self, snapshot: object) -> None:
+        if not isinstance(snapshot, dict):
+            return
+        energy_wh = coerce_optional_float(snapshot.get("split_daily_energy_wh"))
+        sample_utc = parse_inverter_last_report(
+            snapshot.get("split_endpoint_timestamp")
+        )
+        if energy_wh is None or sample_utc is None:
+            return
+        device_uid = coerce_optional_text(snapshot.get("split_device_uid"))
+        day_key = coerce_optional_text(snapshot.get("day_key"))
+        timezone_name = coerce_optional_text(snapshot.get("timezone"))
+        cutoff = sample_utc - timedelta(seconds=_HEATPUMP_IDLE_SMOOTHING_MAX_WINDOW_S)
+        history = self._heatpump_power_history()
+        retained: list[dict[str, object]] = []
+        for entry in history:
+            entry_ts = self._heatpump_power_history_sample_time(entry)
+            if entry_ts is None or entry_ts < cutoff:
+                continue
+            if (
+                coerce_optional_text(entry.get("device_uid")) == device_uid
+                and coerce_optional_text(entry.get("day_key")) == day_key
+                and coerce_optional_text(entry.get("timezone")) == timezone_name
+                and entry_ts == sample_utc
+            ):
+                continue
+            retained.append(entry)
+        retained.append(
+            {
+                "device_uid": device_uid,
+                "day_key": day_key,
+                "timezone": timezone_name,
+                "energy_wh": energy_wh,
+                "sample_utc": sample_utc,
+            }
+        )
+        retained.sort(
+            key=lambda entry: self._heatpump_power_history_sample_time(entry)
+            or datetime.min.replace(tzinfo=_tz.utc)
+        )
+        history[:] = retained
+
+    def _heatpump_idle_smoothed_power(
+        self,
+        snapshot: dict[str, object],
+        *,
+        current_energy_wh: float,
+        current_sample_utc: datetime,
+        raw_value_w: float | None,
+        raw_validation: str,
+    ) -> dict[str, object] | None:
+        if raw_value_w is None or raw_value_w > 0:
+            return None
+        if raw_validation not in {
+            "accepted_idle_zero",
+            "accepted_idle_repeated_sample",
+        }:
+            return None
+        device_uid = coerce_optional_text(snapshot.get("split_device_uid"))
+        day_key = coerce_optional_text(snapshot.get("day_key"))
+        timezone_name = coerce_optional_text(snapshot.get("timezone"))
+        history = self._heatpump_power_history()
+        candidates: list[tuple[datetime, float]] = []
+        for entry in history:
+            sample_utc = self._heatpump_power_history_sample_time(entry)
+            if sample_utc is None:
+                continue
+            age_s = (current_sample_utc - sample_utc).total_seconds()
+            if not (
+                _HEATPUMP_IDLE_SMOOTHING_MIN_WINDOW_S
+                <= age_s
+                <= _HEATPUMP_IDLE_SMOOTHING_MAX_WINDOW_S
+            ):
+                continue
+            if coerce_optional_text(entry.get("device_uid")) != device_uid:
+                continue
+            if coerce_optional_text(entry.get("day_key")) != day_key:
+                continue
+            if coerce_optional_text(entry.get("timezone")) != timezone_name:
+                continue
+            energy_wh = coerce_optional_float(entry.get("energy_wh"))
+            if energy_wh is None or energy_wh > current_energy_wh:
+                continue
+            candidates.append((sample_utc, energy_wh))
+        for start_utc, start_energy_wh in sorted(candidates, key=lambda item: item[0]):
+            last_energy_wh = start_energy_wh
+            monotonic = True
+            for entry in history:
+                sample_utc = self._heatpump_power_history_sample_time(entry)
+                if sample_utc is None or not (
+                    start_utc < sample_utc < current_sample_utc
+                ):
+                    continue
+                if coerce_optional_text(entry.get("device_uid")) != device_uid:
+                    continue
+                if coerce_optional_text(entry.get("day_key")) != day_key:
+                    continue
+                if coerce_optional_text(entry.get("timezone")) != timezone_name:
+                    continue
+                energy_wh = coerce_optional_float(entry.get("energy_wh"))
+                if energy_wh is None:
+                    continue
+                if energy_wh < last_energy_wh or energy_wh > current_energy_wh:
+                    monotonic = False
+                    break
+                last_energy_wh = energy_wh
+            if not monotonic:
+                continue
+            window_s = (current_sample_utc - start_utc).total_seconds()
+            delta_wh = current_energy_wh - start_energy_wh
+            if delta_wh <= _HEATPUMP_POWER_MIN_DELTA_WH:
+                continue
+            value_w = (delta_wh * 3600.0) / window_s
+            if value_w > _HEATPUMP_IDLE_POWER_MAX_W:
+                continue
+            return {
+                "accepted_value_w": value_w,
+                "window_seconds": window_s,
+                "series_start_utc": start_utc,
+                "validation": "smoothed_idle_delta",
+            }
+        return None
+
     def _heatpump_power_summary_from_daily_snapshot(
         self,
         snapshot: object,
@@ -1077,6 +1224,39 @@ class HeatpumpRuntime:
                         if is_idle:
                             validation = "accepted_idle_delta"
 
+        raw_value = accepted_value
+        raw_window_s = window_s
+        raw_validation = validation
+        display_window_s = window_s
+        display_validation = validation
+        smoothed = False
+        if (
+            is_idle
+            and not rejected
+            and current_energy_wh is not None
+            and current_sample_utc is not None
+        ):
+            smoothed_summary = self._heatpump_idle_smoothed_power(
+                snapshot,
+                current_energy_wh=current_energy_wh,
+                current_sample_utc=current_sample_utc,
+                raw_value_w=raw_value,
+                raw_validation=raw_validation,
+            )
+            if smoothed_summary is not None:
+                accepted_value = coerce_optional_float(
+                    smoothed_summary.get("accepted_value_w")
+                )
+                display_window_s = coerce_optional_float(
+                    smoothed_summary.get("window_seconds")
+                )
+                smoothed_start = smoothed_summary.get("series_start_utc")
+                if isinstance(smoothed_start, datetime):
+                    series_start_utc = smoothed_start
+                display_validation = str(smoothed_summary["validation"])
+                validation = display_validation
+                smoothed = True
+
         summary: dict[str, object] = {
             "requested_device_ref": (
                 self._debug_truncate_identifier(device_uid) if device_uid else None
@@ -1103,10 +1283,17 @@ class HeatpumpRuntime:
             "accepted_value_w": (
                 round(accepted_value, 3) if accepted_value is not None else None
             ),
+            "raw_value_w": round(raw_value, 3) if raw_value is not None else None,
             "previous_detail_value": (
                 round(previous_energy_wh, 3) if previous_energy_wh is not None else None
             ),
             "window_seconds": round(window_s, 3) if window_s is not None else None,
+            "raw_window_seconds": (
+                round(raw_window_s, 3) if raw_window_s is not None else None
+            ),
+            "power_window_seconds": (
+                round(display_window_s, 3) if display_window_s is not None else None
+            ),
             "daily_energy_wh": snapshot.get("daily_energy_wh"),
             "split_daily_energy_wh": snapshot.get("split_daily_energy_wh"),
             "daily_solar_wh": snapshot.get("daily_solar_wh"),
@@ -1114,6 +1301,9 @@ class HeatpumpRuntime:
             "daily_grid_wh": snapshot.get("daily_grid_wh"),
             "runtime_mode": runtime_mode,
             "validation": validation,
+            "raw_validation": raw_validation,
+            "power_validation": display_validation,
+            "smoothed": smoothed,
             "rejected": rejected,
             "series_start_utc": (
                 series_start_utc.isoformat() if series_start_utc is not None else None
@@ -1802,6 +1992,11 @@ class HeatpumpRuntime:
             self._heatpump_power_last_error = None
             self._heatpump_power_last_success_mono = None
             self._heatpump_power_last_success_utc = None
+            self._heatpump_power_raw_w = None
+            self._heatpump_power_window_seconds = None
+            self._heatpump_power_validation = None
+            self._heatpump_power_smoothed = False
+            self._heatpump_power_sample_history = []
             self._heatpump_power_using_stale = False
             self._heatpump_power_selection_marker = None
             return
@@ -2007,6 +2202,16 @@ class HeatpumpRuntime:
             if device_uid
             else "hems_energy_consumption_delta"
         )
+        self._heatpump_power_raw_w = coerce_optional_float(
+            power_summary.get("raw_value_w")
+        )
+        self._heatpump_power_window_seconds = coerce_optional_float(
+            power_summary.get("power_window_seconds")
+        )
+        self._heatpump_power_validation = coerce_optional_text(
+            power_summary.get("power_validation")
+        )
+        self._heatpump_power_smoothed = bool(power_summary.get("smoothed"))
         self._heatpump_power_cache_until = getattr(
             self, "_heatpump_daily_consumption_cache_until", None
         ) or (now + HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL)
@@ -2023,6 +2228,7 @@ class HeatpumpRuntime:
         )
         self._heatpump_mark_known_present()
         self._heatpump_power_selection_marker = marker if device_uid else None
+        self._record_heatpump_power_history_sample(snapshot)
         power_snapshot["selected_payload"] = dict(power_summary)
         power_snapshot["selected_source"] = (
             f"hems_energy_consumption_delta:{self._debug_truncate_identifier(device_uid)}"
@@ -2060,6 +2266,11 @@ class HeatpumpRuntime:
                 "_heatpump_power_start_utc",
                 "_heatpump_power_device_uid",
                 "_heatpump_power_source",
+                "_heatpump_power_raw_w",
+                "_heatpump_power_window_seconds",
+                "_heatpump_power_validation",
+                "_heatpump_power_smoothed",
+                "_heatpump_power_sample_history",
                 "_heatpump_power_snapshot",
                 "_heatpump_power_cache_until",
                 "_heatpump_power_backoff_until",
@@ -2328,6 +2539,47 @@ class HeatpumpRuntime:
         except Exception:
             return None
         return text or None
+
+    @property
+    def heatpump_power_raw_w(self) -> float | None:
+        value = getattr(self, "_heatpump_power_raw_w", None)
+        if value is None:
+            return None
+        try:
+            numeric = float(value)
+        except Exception:
+            return None
+        if numeric != numeric or numeric in (float("inf"), float("-inf")):
+            return None
+        return numeric
+
+    @property
+    def heatpump_power_window_seconds(self) -> float | None:
+        value = getattr(self, "_heatpump_power_window_seconds", None)
+        if value is None:
+            return None
+        try:
+            numeric = float(value)
+        except Exception:
+            return None
+        if numeric != numeric or numeric in (float("inf"), float("-inf")):
+            return None
+        return numeric
+
+    @property
+    def heatpump_power_validation(self) -> str | None:
+        value = getattr(self, "_heatpump_power_validation", None)
+        if value is None:
+            return None
+        try:
+            text = str(value).strip()
+        except Exception:
+            return None
+        return text or None
+
+    @property
+    def heatpump_power_smoothed(self) -> bool:
+        return bool(getattr(self, "_heatpump_power_smoothed", False))
 
     @property
     def heatpump_power_using_stale(self) -> bool:

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -7960,6 +7960,10 @@ class EnphaseHeatPumpPowerSensor(_SiteBaseEntity):
             ),
             "device_uid": self._coord.heatpump_power_device_uid,
             "source": self._coord.heatpump_power_source,
+            "raw_power_w": self._coord.heatpump_power_raw_w,
+            "power_window_seconds": self._coord.heatpump_power_window_seconds,
+            "power_validation": self._coord.heatpump_power_validation,
+            "smoothed": self._coord.heatpump_power_smoothed,
             "using_stale": bool(
                 getattr(self._coord, "heatpump_power_using_stale", False)
             ),

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -240,6 +240,13 @@ class HeatpumpState:
     _heatpump_power_start_utc: datetime | None = None
     _heatpump_power_device_uid: str | None = None
     _heatpump_power_source: str | None = None
+    _heatpump_power_raw_w: float | None = None
+    _heatpump_power_window_seconds: float | None = None
+    _heatpump_power_validation: str | None = None
+    _heatpump_power_smoothed: bool = False
+    _heatpump_power_sample_history: list[dict[str, object]] = field(
+        default_factory=list
+    )
     _heatpump_power_cache_until: float | None = None
     _heatpump_power_backoff_until: float | None = None
     _heatpump_power_last_error: str | None = None

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1061,11 +1061,27 @@ def test_heatpump_power_properties_handle_invalid_internal_values(
     coord._heatpump_power_w = float("inf")  # noqa: SLF001
     assert coord.heatpump_power_w is None
 
+    coord._heatpump_power_raw_w = BadFloat()  # noqa: SLF001
+    assert coord.heatpump_power_raw_w is None
+    coord._heatpump_power_raw_w = float("nan")  # noqa: SLF001
+    assert coord.heatpump_power_raw_w is None
+    coord._heatpump_power_raw_w = float("inf")  # noqa: SLF001
+    assert coord.heatpump_power_raw_w is None
+
+    coord._heatpump_power_window_seconds = BadFloat()  # noqa: SLF001
+    assert coord.heatpump_power_window_seconds is None
+    coord._heatpump_power_window_seconds = float("nan")  # noqa: SLF001
+    assert coord.heatpump_power_window_seconds is None
+    coord._heatpump_power_window_seconds = float("inf")  # noqa: SLF001
+    assert coord.heatpump_power_window_seconds is None
+
     coord._heatpump_power_device_uid = BadStr()  # noqa: SLF001
     coord._heatpump_power_source = BadStr()  # noqa: SLF001
+    coord._heatpump_power_validation = BadStr()  # noqa: SLF001
     coord._heatpump_power_last_error = BadStr()  # noqa: SLF001
     assert coord.heatpump_power_device_uid is None
     assert coord.heatpump_power_source is None
+    assert coord.heatpump_power_validation is None
     assert coord.heatpump_power_last_error is None
 
 

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -240,6 +240,426 @@ def test_heatpump_power_summary_covers_idle_delta_edge_paths(
     assert summary["validation"] == expected_validation
 
 
+def test_heatpump_power_summary_smooths_idle_zero_from_history(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_power_sample_history = [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 105.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 15, tzinfo=timezone.utc),
+        },
+    ]
+    runtime._heatpump_daily_consumption_previous = (
+        _heatpump_daily_snapshot(  # noqa: SLF001
+            energy_wh=105.0,
+            timestamp="2026-04-02T00:15:00Z",
+        )
+    )
+
+    summary = runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=105.0,
+            timestamp="2026-04-02T00:20:00Z",
+        ),
+        runtime_snapshot={"heatpump_status": "IDLE"},
+    )
+
+    assert summary is not None
+    assert summary["raw_value_w"] == pytest.approx(0.0)
+    assert summary["raw_validation"] == "accepted_idle_zero"
+    assert summary["accepted_value_w"] == pytest.approx(15.0)
+    assert summary["power_window_seconds"] == pytest.approx(1200.0)
+    assert summary["power_validation"] == "smoothed_idle_delta"
+    assert summary["smoothed"] is True
+
+
+def test_heatpump_power_summary_does_not_smooth_non_idle_zero(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_power_sample_history = [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        }
+    ]
+    runtime._heatpump_daily_consumption_previous = (
+        _heatpump_daily_snapshot(  # noqa: SLF001
+            energy_wh=105.0,
+            timestamp="2026-04-02T00:15:00Z",
+        )
+    )
+
+    summary = runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=105.0,
+            timestamp="2026-04-02T00:20:00Z",
+        ),
+        runtime_snapshot={"heatpump_status": "RUNNING"},
+    )
+
+    assert summary is not None
+    assert summary["accepted_value_w"] == pytest.approx(0.0)
+    assert summary["power_validation"] == "accepted_zero_delta"
+    assert summary["smoothed"] is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_heatpump_power_smooths_idle_zero_from_recorded_history(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._devices_inventory_payload = {"curr_date_site": "2026-04-02"}  # noqa: SLF001
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [
+                    {
+                        "device_type": "HEAT_PUMP",
+                        "device_uid": "HP-1",
+                        "statusText": "Normal",
+                    }
+                ],
+            }
+        },
+        ["heatpump"],
+    )
+    coord.client.hems_heatpump_state = AsyncMock(
+        return_value={"device_uid": "HP-1", "heatpump_status": "IDLE"}
+    )
+    coord.client.pv_system_today = AsyncMock(
+        side_effect=[
+            _site_today_payload(100.0, timestamp="2026-04-02T00:00:00Z"),
+            _site_today_payload(105.0, timestamp="2026-04-02T00:15:00Z"),
+            _site_today_payload(105.0, timestamp="2026-04-02T00:20:00Z"),
+        ]
+    )
+    coord.client.hems_energy_consumption = AsyncMock(
+        side_effect=[
+            {
+                "type": "hems-device-details",
+                "timestamp": "2026-04-02T00:00:00Z",
+                "data": {
+                    "heat-pump": [
+                        {
+                            "device_uid": "HP-1",
+                            "device_name": "Waermepumpe",
+                            "consumption": [{"details": [100.0]}],
+                        }
+                    ]
+                },
+            },
+            {
+                "type": "hems-device-details",
+                "timestamp": "2026-04-02T00:15:00Z",
+                "data": {
+                    "heat-pump": [
+                        {
+                            "device_uid": "HP-1",
+                            "device_name": "Waermepumpe",
+                            "consumption": [{"details": [105.0]}],
+                        }
+                    ]
+                },
+            },
+            {
+                "type": "hems-device-details",
+                "timestamp": "2026-04-02T00:20:00Z",
+                "data": {
+                    "heat-pump": [
+                        {
+                            "device_uid": "HP-1",
+                            "device_name": "Waermepumpe",
+                            "consumption": [{"details": [105.0]}],
+                        }
+                    ]
+                },
+            },
+        ]
+    )
+
+    await coord.heatpump_runtime._async_refresh_heatpump_power(  # noqa: SLF001
+        force=True
+    )
+    assert coord.heatpump_power_w == pytest.approx(0.0)
+    assert coord.heatpump_power_validation == "accepted_idle_seeded"
+
+    await coord.heatpump_runtime._async_refresh_heatpump_power(  # noqa: SLF001
+        force=True
+    )
+    assert coord.heatpump_power_w == pytest.approx(20.0)
+    assert coord.heatpump_power_smoothed is False
+
+    await coord.heatpump_runtime._async_refresh_heatpump_power(  # noqa: SLF001
+        force=True
+    )
+
+    assert coord.client.hems_energy_consumption.await_count == 3
+    assert coord.heatpump_power_w == pytest.approx(15.0)
+    assert coord.heatpump_power_raw_w == pytest.approx(0.0)
+    assert coord.heatpump_power_window_seconds == pytest.approx(1200.0)
+    assert coord.heatpump_power_validation == "smoothed_idle_delta"
+    assert coord.heatpump_power_smoothed is True
+    assert coord.heatpump_power_start_utc == datetime(
+        2026, 4, 2, 0, 0, tzinfo=timezone.utc
+    )
+    power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
+        "power_snapshot"
+    ]
+    assert power_snapshot["selected_payload"]["raw_validation"] == (
+        "accepted_idle_zero"
+    )
+    assert power_snapshot["selected_payload"]["smoothed"] is True
+
+
+def test_heatpump_power_history_helpers_cover_guard_paths(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_power_sample_history = "bad-history"  # type: ignore[assignment]  # noqa: SLF001
+    assert runtime._heatpump_power_history() == []  # noqa: SLF001
+    assert runtime._heatpump_power_history_sample_time(None) is None  # noqa: SLF001
+
+    runtime._record_heatpump_power_history_sample(None)  # noqa: SLF001
+    runtime._record_heatpump_power_history_sample(  # noqa: SLF001
+        {"split_daily_energy_wh": None, "split_endpoint_timestamp": None}
+    )
+    assert runtime._heatpump_power_sample_history == []  # noqa: SLF001
+
+    runtime._heatpump_power_sample_history = [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 90.0,
+            "sample_utc": datetime(2026, 4, 1, 23, 0, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 99.0,
+            "sample_utc": "bad-time",
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 101.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 5, tzinfo=timezone.utc),
+        },
+    ]
+
+    runtime._record_heatpump_power_history_sample(  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=105.0,
+            timestamp="2026-04-02T00:05:00Z",
+        )
+    )
+
+    assert runtime._heatpump_power_sample_history == [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 105.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 5, tzinfo=timezone.utc),
+        },
+    ]
+
+
+def test_heatpump_idle_smoothing_rejects_invalid_history(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    current_sample_utc = datetime(2026, 4, 2, 0, 20, tzinfo=timezone.utc)
+    snapshot = _heatpump_daily_snapshot(
+        energy_wh=105.0,
+        timestamp="2026-04-02T00:20:00Z",
+    )
+    runtime._heatpump_power_sample_history = [  # noqa: SLF001
+        {"sample_utc": "bad-time"},
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 90.0,
+            "sample_utc": datetime(2026, 4, 1, 23, 40, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "OTHER",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-01",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "Europe/Berlin",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": None,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "OTHER",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 101.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 5, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-01",
+            "timezone": "UTC",
+            "energy_wh": 101.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 6, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "Europe/Berlin",
+            "energy_wh": 101.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 7, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": None,
+            "sample_utc": datetime(2026, 4, 2, 0, 8, tzinfo=timezone.utc),
+        },
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 106.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 10, tzinfo=timezone.utc),
+        },
+    ]
+
+    assert (
+        runtime._heatpump_idle_smoothed_power(  # noqa: SLF001
+            snapshot,
+            current_energy_wh=105.0,
+            current_sample_utc=current_sample_utc,
+            raw_value_w=1.0,
+            raw_validation="accepted_idle_delta",
+        )
+        is None
+    )
+    assert (
+        runtime._heatpump_idle_smoothed_power(  # noqa: SLF001
+            snapshot,
+            current_energy_wh=105.0,
+            current_sample_utc=current_sample_utc,
+            raw_value_w=0.0,
+            raw_validation="accepted_idle_seeded",
+        )
+        is None
+    )
+    assert (
+        runtime._heatpump_idle_smoothed_power(  # noqa: SLF001
+            snapshot,
+            current_energy_wh=105.0,
+            current_sample_utc=current_sample_utc,
+            raw_value_w=0.0,
+            raw_validation="accepted_idle_zero",
+        )
+        is None
+    )
+
+    runtime._heatpump_power_sample_history = [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 104.8,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        }
+    ]
+    assert (
+        runtime._heatpump_idle_smoothed_power(  # noqa: SLF001
+            snapshot,
+            current_energy_wh=105.0,
+            current_sample_utc=current_sample_utc,
+            raw_value_w=0.0,
+            raw_validation="accepted_idle_zero",
+        )
+        is None
+    )
+
+    runtime._heatpump_power_sample_history = [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 80.0,
+            "sample_utc": datetime(2026, 4, 2, 0, 0, tzinfo=timezone.utc),
+        }
+    ]
+    assert (
+        runtime._heatpump_idle_smoothed_power(  # noqa: SLF001
+            snapshot,
+            current_energy_wh=105.0,
+            current_sample_utc=current_sample_utc,
+            raw_value_w=0.0,
+            raw_validation="accepted_idle_zero",
+        )
+        is None
+    )
+
+
 @pytest.mark.asyncio
 async def test_heatpump_runtime_diagnostics_refreshes_power_snapshot(
     coordinator_factory,
@@ -2273,6 +2693,19 @@ def test_heatpump_cleanup_due_treats_true_bool_as_cleanup_needed(
 
     assert (
         runtime._heatpump_cleanup_due("_heatpump_known_present") is True
+    )  # noqa: SLF001
+
+    runtime._heatpump_power_sample_history = [  # noqa: SLF001
+        {
+            "device_uid": "HP-1",
+            "day_key": "2026-04-02",
+            "timezone": "UTC",
+            "energy_wh": 100.0,
+            "sample_utc": datetime(2026, 4, 2, tzinfo=timezone.utc),
+        }
+    ]
+    assert (
+        runtime._heatpump_cleanup_due("_heatpump_power_sample_history") is True
     )  # noqa: SLF001
 
 

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -2001,6 +2001,10 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
     )  # noqa: SLF001
     coord._heatpump_power_device_uid = "HP-1"  # noqa: SLF001
     coord._heatpump_power_source = "hems_energy_consumption_delta:HP-1"  # noqa: SLF001
+    coord._heatpump_power_raw_w = 0.0  # noqa: SLF001
+    coord._heatpump_power_window_seconds = 1200.0  # noqa: SLF001
+    coord._heatpump_power_validation = "smoothed_idle_delta"  # noqa: SLF001
+    coord._heatpump_power_smoothed = True  # noqa: SLF001
     coord._heatpump_power_last_error = None  # noqa: SLF001
     coord.heatpump_runtime._heatpump_power_last_success_utc = datetime(  # noqa: SLF001
         2026, 2, 27, 9, 16, tzinfo=timezone.utc
@@ -2083,6 +2087,10 @@ def test_heatpump_diagnostic_sensors_expose_inventory_and_power(
     power_attrs = power_sensor.extra_state_attributes
     assert power_attrs["device_uid"] == "HP-1"
     assert power_attrs["source"] == "hems_energy_consumption_delta:HP-1"
+    assert power_attrs["raw_power_w"] == pytest.approx(0.0)
+    assert power_attrs["power_window_seconds"] == pytest.approx(1200.0)
+    assert power_attrs["power_validation"] == "smoothed_idle_delta"
+    assert power_attrs["smoothed"] is True
     assert "using_stale" in power_attrs
     assert "last_success_utc" in power_attrs
 


### PR DESCRIPTION
## Summary

Smooth idle heat-pump power by averaging existing low-load HEMS energy samples over a 15-30 minute window when the raw short-window delta is zero or tiny. This avoids whole-Wh cloud readings flickering between `0 W` and standby load without adding extra Enphase refreshes.

The heat-pump power sensor now exposes `raw_power_w`, `power_window_seconds`, `power_validation`, and `smoothed` attributes so diagnostics can distinguish the displayed smoothed value from the raw short-window value.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/heatpump_runtime.py custom_components/enphase_ev/sensor.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_heatpump_runtime.py tests/components/enphase_ev/test_sensor_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_heatpump_runtime.py -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/heatpump_runtime.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/state_models.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
```

`pre_commit` did not run hooks in Docker because this Codex worktree has a `.git` file pointing to a host gitdir path that is not mounted inside the container: `fatal: not a git repository: /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git/worktrees/ha-enphase-ev-charger13`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No screenshots. The change uses existing successful heat-pump energy samples only; it does not add Enphase cloud calls or alter refresh cadence.