### PR TITLE
Add read-only site tariff sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
-- None
+- Added read-only site tariff sensors for next billing date, import rate values, and export rate values, attached to the IQ Gateway device when available.
+- Tariff sensors now refresh with normal sensor polling and keep their last known values while the Enphase tariff backend is degraded.
 
 ### 🐛 Bug fixes
 - Bounded the `Current Production Power` live-sample cache so stale values are not reused indefinitely when the latest-power endpoint stops returning valid samples.

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 - Advisory firmware update entities for gateway and EV charger devices with locale-aware release-note links
 - Heat-pump runtime status, connectivity, SG-Ready mode, power, and current-day consumption details sourced from HEMS endpoints
 - Site and battery energy telemetry, including derived grid-import, grid-export, and battery power sensors for Home Assistant Energy Dashboard use
+- Read-only site tariff visibility for next billing date, import rate values, and export rate values when Enphase exposes tariff data; tariff values refresh with normal sensor polling and retain the last known values while the tariff backend is unavailable
 - Health diagnostics, service-availability tracking, and actionable repair issues
 - Detailed diagnostic and inventory entities remain available but are disabled by default when they are mainly useful for troubleshooting
 - Broad localization support across all user-facing integration strings

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2365,6 +2365,24 @@ class EnphaseEVClient:
                 headers["X-XSRF-Token"] = xsrf
         return headers
 
+    def _tariff_headers(self) -> dict[str, str | None]:
+        """Return headers for tariff microservice read calls."""
+
+        token, user_id = self._battery_config_auth_context()
+        headers: dict[str, str | None] = {
+            "Accept": "application/json, text/javascript, */*; q=0.01",
+            "Cookie": self._cookie or None,
+            "e-auth-token": token,
+            "Requestid": str(uuid.uuid4()),
+            "X-Requested-With": "XMLHttpRequest",
+        }
+        if user_id:
+            headers["Username"] = user_id
+        xsrf = self._xsrf_token()
+        if xsrf:
+            headers["x-xsrf-token"] = xsrf
+        return headers
+
     def _battery_config_cookie_eauth_headers(
         self,
         *,
@@ -4912,6 +4930,34 @@ class EnphaseEVClient:
         url = f"{BASE_URL}/service/batteryConfig/api/v1/siteSettings/{self._site}"
         params = self._battery_config_params()
         return await self._battery_config_request("GET", url, params=params)
+
+    async def site_tariff_billing_details(self) -> dict:
+        """Return site tariff billing-cycle details."""
+
+        url = (
+            f"{BASE_URL}/service/tariff/tariff-ms/systems/{self._site}/billing-details"
+        )
+        return await self._json("GET", url, headers=self._tariff_headers())
+
+    async def site_tariff(self) -> dict:
+        """Return site import/export tariff configuration."""
+
+        url = f"{BASE_URL}/service/tariff/tariff-ms/systems/{self._site}/tariff"
+        return await self._json(
+            "GET",
+            url,
+            params={"include-site-details": "true"},
+            headers=self._tariff_headers(),
+        )
+
+    async def site_tariff_bundle(self) -> tuple[dict, dict]:
+        """Return billing details and tariff configuration for the site."""
+
+        billing, tariff = await asyncio.gather(
+            self.site_tariff_billing_details(),
+            self.site_tariff(),
+        )
+        return billing, tariff
 
     async def battery_profile_details(self, *, locale: str | None = None) -> dict:
         """Return BatteryConfig profile details for system + EVSE settings."""

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -149,6 +149,7 @@ from .refresh_plan import (
     build_site_only_followup_plan,
 )
 from .refresh_runner import RefreshRunner
+from .tariff import TariffRuntime
 from .service_validation import raise_translated_service_validation
 from .state_models import (
     BatteryControlCapability,
@@ -219,6 +220,7 @@ COORDINATOR_RUNTIME_CLASSES: dict[str, type] = {
     "current_power_runtime": CurrentPowerRuntime,
     "auth_refresh_runtime": AuthRefreshRuntime,
     "evse_feature_flags_runtime": EvseFeatureFlagsRuntime,
+    "tariff_runtime": TariffRuntime,
 }
 
 
@@ -493,6 +495,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._ensure_coordinator_runtime("current_power_runtime")
         self._ensure_coordinator_runtime("auth_refresh_runtime")
         self._ensure_coordinator_runtime("evse_feature_flags_runtime")
+        self._ensure_coordinator_runtime("tariff_runtime")
         self.inventory_runtime = InventoryRuntime(self)
         self.discovery_snapshot = DiscoverySnapshotManager(self)
         self.inventory_view = InventoryView(self)
@@ -652,6 +655,15 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 success_ttl_s=60.0,
                 failure_backoff_schedule_s=(300.0, 900.0, 1800.0, 3600.0),
                 max_backoff_s=3600.0,
+                support_state_on_success=True,
+            ),
+            "tariff": EndpointFamilyPolicy(
+                success_ttl_s=None,
+                stale_after_s=86400.0,
+                failure_backoff_schedule_s=(60.0, 60.0, 60.0, 60.0),
+                max_backoff_s=60.0,
+                optional=True,
+                suppress_after_failures=3,
                 support_state_on_success=True,
             ),
             "inventory_topology": EndpointFamilyPolicy(
@@ -2333,7 +2345,16 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self.discovery_snapshot.sync_site_energy_discovery_state()
         self._sync_site_energy_issue()
         phase_timings["site_energy_s"] = round(time.monotonic() - site_energy_start, 3)
-        if not context.first_refresh:
+        if context.first_refresh:
+            timing_key, duration = await self.refresh_runner.async_run_refresh_call(
+                "tariff_s",
+                "tariff",
+                lambda: self.tariff_runtime.async_refresh(force=True),
+                endpoint_family="tariff",
+            )
+            if duration is not None:
+                phase_timings[timing_key] = duration
+        else:
             followup_plan = build_site_only_followup_plan(
                 self,
                 force_full=self.endpoint_manual_bypass_active(),
@@ -2382,7 +2403,16 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self,
         context: RefreshPipelineContext,
     ) -> None:
-        if not context.first_refresh:
+        if context.first_refresh:
+            timing_key, duration = await self.refresh_runner.async_run_refresh_call(
+                "tariff_s",
+                "tariff",
+                lambda: self.tariff_runtime.async_refresh(force=True),
+                endpoint_family="tariff",
+            )
+            if duration is not None:
+                context.phase_timings[timing_key] = duration
+        else:
             followup_plan = build_followup_plan(
                 self,
                 force_full=self.endpoint_manual_bypass_active(),

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -26,6 +26,7 @@ from .const import (
 )
 from .coordinator_refresh_metrics import refresh_performance_summary
 from .log_redaction import redact_text
+from .tariff import TARIFF_ENDPOINT_FAMILY
 
 if TYPE_CHECKING:  # pragma: no cover
     from .coordinator import EnphaseCoordinator
@@ -230,6 +231,26 @@ class CoordinatorDiagnostics:
             battery_status_summary.get("site_available_power_kw")
         )
         ac_battery_power = _parsed_float(ac_battery_status_summary.get("power_w"))
+        endpoint_family_health = self.endpoint_family_health_diagnostics()
+        tariff_health = endpoint_family_health.get(TARIFF_ENDPOINT_FAMILY)
+        tariff_service_status = "unknown"
+        tariff_available = None
+        tariff_failures = None
+        tariff_last_error = None
+        tariff_backoff_active = None
+        tariff_backoff_ends_utc = None
+        if isinstance(tariff_health, dict):
+            tariff_failures = int(tariff_health.get("consecutive_failures") or 0)
+            tariff_last_error = tariff_health.get("last_error")
+            tariff_backoff_active = bool(tariff_health.get("cooldown_active"))
+            tariff_backoff_ends_utc = tariff_health.get("next_retry_utc")
+            tariff_degraded = (
+                tariff_backoff_active
+                or tariff_failures > 0
+                or bool(tariff_health.get("suppressed"))
+            )
+            tariff_service_status = "degraded" if tariff_degraded else "available"
+            tariff_available = not tariff_degraded
 
         metrics: dict[str, object] = {
             "site_id": coord.site_id,
@@ -271,7 +292,13 @@ class CoordinatorDiagnostics:
             "type_device_keys": type_keys,
             "type_device_counts": type_counts,
             "payload_health": self.payload_health_diagnostics(),
-            "endpoint_family_health": self.endpoint_family_health_diagnostics(),
+            "endpoint_family_health": endpoint_family_health,
+            "tariff_available": tariff_available,
+            "tariff_service_status": tariff_service_status,
+            "tariff_failures": tariff_failures,
+            "tariff_last_error": tariff_last_error,
+            "tariff_backoff_active": tariff_backoff_active,
+            "tariff_backoff_ends_utc": tariff_backoff_ends_utc,
             "auth_refresh_suspended_active": coord._auth_refresh_suspended_active(),
             "auth_refresh_suspended_until": _iso(
                 getattr(coord, "_auth_refresh_suspended_until_utc", None)
@@ -823,6 +850,21 @@ class CoordinatorDiagnostics:
 
         if evse_timeseries is not None:
             metrics["evse_timeseries"] = evse_timeseries.diagnostics()
+
+        degraded_services = [
+            service
+            for service, available_key in (
+                ("scheduler", "scheduler_available"),
+                ("auth_settings", "auth_settings_available"),
+                ("session_history", "session_history_available"),
+                ("site_energy", "site_energy_available"),
+                ("evse_timeseries", "evse_timeseries_available"),
+            )
+            if metrics.get(available_key) is False
+        ]
+        if tariff_service_status == "degraded":
+            degraded_services.append(TARIFF_ENDPOINT_FAMILY)
+        metrics["degraded_services"] = degraded_services
 
         firmware_catalog_manager = getattr(coord, "firmware_catalog_manager", None)
         status_snapshot = getattr(firmware_catalog_manager, "status_snapshot", None)

--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -557,6 +557,15 @@ async def async_get_config_entry_diagnostics(
     except DIAGNOSTIC_CAPTURE_ERRORS:
         scheduler = {}
 
+    tariff: dict[str, Any] = {}
+    tariff_runtime = getattr(coord, "tariff_runtime", None)
+    tariff_diagnostics = getattr(tariff_runtime, "diagnostics", None)
+    if callable(tariff_diagnostics):
+        try:
+            tariff = tariff_diagnostics()
+        except DIAGNOSTIC_CAPTURE_ERRORS:
+            tariff = {}
+
     firmware_catalog: dict[str, Any] = {}
     firmware_catalog_manager = getattr(coord, "firmware_catalog_manager", None)
     status_snapshot = getattr(firmware_catalog_manager, "status_snapshot", None)
@@ -590,6 +599,7 @@ async def async_get_config_entry_diagnostics(
         "system_dashboard": system_dashboard,
         "heatpump_runtime": heatpump_runtime,
         "scheduler": scheduler,
+        "tariff": tariff,
         "firmware_catalog": firmware_catalog or None,
     }
 

--- a/custom_components/enphase_ev/icons.json
+++ b/custom_components/enphase_ev/icons.json
@@ -609,6 +609,75 @@
       "gateway_last_reported": {
         "default": "mdi:clock-outline"
       },
+      "tariff_billing_cycle": {
+        "default": "mdi:calendar-month",
+        "state_attributes": {
+          "start_date": {
+            "default": "mdi:calendar-start"
+          },
+          "billing_frequency": {
+            "default": "mdi:calendar-sync"
+          },
+          "billing_interval_value": {
+            "default": "mdi:counter"
+          },
+          "billing_cycle": {
+            "default": "mdi:calendar-sync"
+          },
+          "last_refresh_utc": {
+            "default": "mdi:clock-outline"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "default": "mdi:cash-minus",
+        "state_attributes": {
+          "rate_structure": {
+            "default": "mdi:format-list-bulleted-type"
+          },
+          "variation_type": {
+            "default": "mdi:tune-variant"
+          },
+          "source": {
+            "default": "mdi:source-branch"
+          },
+          "currency": {
+            "default": "mdi:currency-usd"
+          },
+          "seasons": {
+            "default": "mdi:calendar-range"
+          },
+          "last_refresh_utc": {
+            "default": "mdi:clock-outline"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "default": "mdi:cash-plus",
+        "state_attributes": {
+          "rate_structure": {
+            "default": "mdi:format-list-bulleted-type"
+          },
+          "variation_type": {
+            "default": "mdi:tune-variant"
+          },
+          "source": {
+            "default": "mdi:source-branch"
+          },
+          "currency": {
+            "default": "mdi:currency-usd"
+          },
+          "export_plan": {
+            "default": "mdi:solar-power-variant"
+          },
+          "seasons": {
+            "default": "mdi:calendar-range"
+          },
+          "last_refresh_utc": {
+            "default": "mdi:clock-outline"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "default": "mdi:solar-power-variant",
         "state": {

--- a/custom_components/enphase_ev/refresh_plan.py
+++ b/custom_components/enphase_ev/refresh_plan.py
@@ -14,6 +14,7 @@ REFRESH_TASK_ENDPOINT_FAMILIES: dict[str, str] = {
     "battery_schedules_s": "battery_schedules",
     "storm_guard_s": "storm_guard",
     "storm_alert_s": "storm_alert",
+    "tariff_s": "tariff",
     "grid_control_check_s": "grid_control_check",
     "dry_contact_settings_s": "dry_contact_settings",
     "battery_status_s": "battery_status",
@@ -265,6 +266,12 @@ SITE_ONLY_FOLLOWUP_STAGE = RefreshStage(
             "storm_guard_s", "storm guard", "_async_refresh_storm_guard_profile"
         ),
         method_task("storm_alert_s", "storm alert", "_async_refresh_storm_alert"),
+        object_method_task(
+            "tariff_s",
+            "tariff",
+            "tariff_runtime",
+            "async_refresh",
+        ),
         object_method_task(
             "grid_control_check_s",
             "grid control",
@@ -566,6 +573,16 @@ def build_followup_plan(owner: object, *, force_full: bool = False) -> RefreshPl
                 "storm_alert_s",
                 "storm alert",
                 "_async_refresh_storm_alert",
+            )
+        )
+    tariff = getattr(owner, "tariff_runtime")
+    if tariff.refresh_due():
+        parallel.append(
+            object_method_task(
+                "tariff_s",
+                "tariff",
+                "tariff_runtime",
+                "async_refresh",
             )
         )
     if battery.grid_control_check_refresh_due():

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -67,6 +67,7 @@ from .runtime_helpers import (
     inventory_type_available as _type_available,
     inventory_type_device_info as _type_device_info,
 )
+from .tariff import next_billing_date, tariff_rate_sensor_specs
 from . import sensor_battery_helpers as _battery_helpers
 from .evse_runtime import evse_power_is_actively_charging
 
@@ -256,6 +257,17 @@ def _battery_schedule_inventory_supported(coord: EnphaseCoordinator) -> bool:
     )
 
 
+def _tariff_data_available(coord: EnphaseCoordinator) -> bool:
+    return any(
+        getattr(coord, attr, None) is not None
+        for attr in (
+            "tariff_billing",
+            "tariff_import_rate",
+            "tariff_export_rate",
+        )
+    )
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: EnphaseConfigEntry,
@@ -355,6 +367,49 @@ async def async_setup_entry(
             return
         ent_reg.async_remove(entity_id)
         known_type_keys.discard(type_key)
+
+    def _site_sensor_entity_registered(key: str) -> bool:
+        get_entity_id = getattr(ent_reg, "async_get_entity_id", None)
+        if not callable(get_entity_id):
+            return False
+        return get_entity_id("sensor", DOMAIN, _site_sensor_unique_id(key)) is not None
+
+    def _entity_registry_values():
+        entities = getattr(ent_reg, "entities", None)
+        values = getattr(entities, "values", None)
+        if callable(values):
+            return values()
+        return ()
+
+    @callback
+    def _async_remove_site_sensor_entities_with_prefix(
+        prefix: str,
+        current_keys: set[str],
+    ) -> None:
+        for key in list(known_site_entity_keys):
+            if key.startswith(prefix) and key not in current_keys:
+                _async_remove_site_sensor_entity(key)
+        unique_prefix = _site_sensor_unique_id(prefix)
+        for reg_entry in list(_entity_registry_values()):
+            entry_domain = getattr(reg_entry, "domain", None)
+            if entry_domain is None:
+                entry_domain = reg_entry.entity_id.partition(".")[0]
+            if entry_domain != "sensor":
+                continue
+            entry_platform = getattr(reg_entry, "platform", None)
+            if entry_platform is not None and entry_platform != DOMAIN:
+                continue
+            entry_config_id = getattr(reg_entry, "config_entry_id", None)
+            if entry_config_id is not None and entry_config_id != entry.entry_id:
+                continue
+            unique_id = _gateway_clean_text(getattr(reg_entry, "unique_id", None))
+            if not unique_id or not unique_id.startswith(unique_prefix):
+                continue
+            key = unique_id[len(f"{DOMAIN}_site_{coord.site_id}_") :]
+            if key in current_keys:
+                continue
+            ent_reg.async_remove(reg_entry.entity_id)
+            known_site_entity_keys.discard(key)
 
     @callback
     def _async_prune_dry_contact_type_inventory_entities() -> None:
@@ -741,6 +796,86 @@ async def async_setup_entry(
                 _add_site_entity(
                     "system_profile_status", EnphaseSystemProfileStatusSensor(coord)
                 )
+        tariff_billing = getattr(coord, "tariff_billing", None)
+        if (
+            tariff_billing is not None
+            or "tariff_billing_cycle" in known_site_entity_keys
+            or _site_sensor_entity_registered("tariff_billing_cycle")
+        ):
+            _add_site_entity("tariff_billing_cycle", EnphaseTariffBillingSensor(coord))
+        tariff_import_rate = getattr(coord, "tariff_import_rate", None)
+        tariff_export_rate = getattr(coord, "tariff_export_rate", None)
+        tariff_rates_refresh_seen = (
+            getattr(coord, "tariff_rates_last_refresh_utc", None) is not None
+        )
+        import_rate_specs = tariff_rate_sensor_specs(
+            tariff_import_rate,
+        )
+        if import_rate_specs:
+            current_import_keys = {
+                f"tariff_import_rate_{spec['key']}" for spec in import_rate_specs
+            }
+            _async_remove_site_sensor_entity("tariff_import_rate")
+            _async_remove_site_sensor_entities_with_prefix(
+                "tariff_import_rate_",
+                current_import_keys,
+            )
+            for spec in import_rate_specs:
+                key = f"tariff_import_rate_{spec['key']}"
+                _add_site_entity(
+                    key, EnphaseTariffRateValueSensor(coord, spec, is_import=True)
+                )
+        elif (
+            tariff_import_rate is not None
+            or "tariff_import_rate" in known_site_entity_keys
+            or _site_sensor_entity_registered("tariff_import_rate")
+        ):
+            if tariff_import_rate is not None:
+                _async_remove_site_sensor_entities_with_prefix(
+                    "tariff_import_rate_",
+                    set(),
+                )
+            _add_site_entity("tariff_import_rate", EnphaseTariffRateSensor(coord, True))
+        elif tariff_rates_refresh_seen:
+            _async_remove_site_sensor_entities_with_prefix(
+                "tariff_import_rate_",
+                set(),
+            )
+        export_rate_specs = tariff_rate_sensor_specs(
+            tariff_export_rate,
+        )
+        if export_rate_specs:
+            current_export_keys = {
+                f"tariff_export_rate_{spec['key']}" for spec in export_rate_specs
+            }
+            _async_remove_site_sensor_entity("tariff_export_rate")
+            _async_remove_site_sensor_entities_with_prefix(
+                "tariff_export_rate_",
+                current_export_keys,
+            )
+            for spec in export_rate_specs:
+                key = f"tariff_export_rate_{spec['key']}"
+                _add_site_entity(
+                    key, EnphaseTariffRateValueSensor(coord, spec, is_import=False)
+                )
+        elif (
+            tariff_export_rate is not None
+            or "tariff_export_rate" in known_site_entity_keys
+            or _site_sensor_entity_registered("tariff_export_rate")
+        ):
+            if tariff_export_rate is not None:
+                _async_remove_site_sensor_entities_with_prefix(
+                    "tariff_export_rate_",
+                    set(),
+                )
+            _add_site_entity(
+                "tariff_export_rate", EnphaseTariffRateSensor(coord, False)
+            )
+        elif tariff_rates_refresh_seen:
+            _async_remove_site_sensor_entities_with_prefix(
+                "tariff_export_rate_",
+                set(),
+            )
 
         for record in router_records:
             router_key = str(record.get("key", "")).strip()
@@ -1265,10 +1400,14 @@ async def async_setup_entry(
             last_inverter_serial_set = current_inverter_serials
 
     add_topology_listener = getattr(coord, "async_add_topology_listener", None)
-    if not callable(add_topology_listener):
+    has_topology_listener = callable(add_topology_listener)
+    if not has_topology_listener:
         add_topology_listener = getattr(coord, "async_add_listener", None)
     if callable(add_topology_listener):
         entry.async_on_unload(add_topology_listener(_async_sync_topology))
+    add_coordinator_listener = getattr(coord, "async_add_listener", None)
+    if has_topology_listener and callable(add_coordinator_listener):
+        entry.async_on_unload(add_coordinator_listener(_async_sync_topology))
     _async_prune_historical_charger_sensor_entities()
     _async_prune_removed_site_entities()
     _async_sync_topology()
@@ -8304,6 +8443,178 @@ class EnphaseBatteryLastReportedSensor(_SiteBaseEntity):
             "without_last_report_count": snapshot.get("without_last_report_count"),
             "total_batteries": snapshot.get("total_batteries"),
         }
+
+
+class _EnphaseTariffBaseSensor(_SiteBaseEntity):
+    _unrecorded_attributes = _SiteBaseEntity._unrecorded_attributes.union(
+        {
+            "seasons",
+            "last_refresh_utc",
+        }
+    )
+
+    @property
+    def available(self) -> bool:
+        return bool(_tariff_data_available(self._coord) and super().available)
+
+    @property
+    def device_info(self):
+        info = _type_device_info(self._coord, "envoy")
+        if info is not None:
+            return info
+        info = _type_device_info(self._coord, "cloud")
+        if info is not None:
+            return info
+        return _cloud_device_info(self._coord.site_id)
+
+    def _last_refresh_attr(self) -> dict[str, object]:
+        last_refresh = getattr(self._coord, "tariff_last_refresh_utc", None)
+        if isinstance(last_refresh, datetime):
+            return {"last_refresh_utc": last_refresh.isoformat()}
+        return {}
+
+
+class EnphaseTariffBillingSensor(_EnphaseTariffBaseSensor):
+    _attr_translation_key = "tariff_billing_cycle"
+    _attr_device_class = SensorDeviceClass.DATE
+    _attr_icon = "mdi:calendar-month"
+
+    def __init__(self, coord: EnphaseCoordinator):
+        super().__init__(
+            coord, "tariff_billing_cycle", "Next Billing Date", type_key=None
+        )
+
+    def _snapshot(self):
+        return getattr(self._coord, "tariff_billing", None)
+
+    @property
+    def available(self) -> bool:
+        snapshot = self._snapshot()
+        return (
+            snapshot is not None
+            and next_billing_date(snapshot) is not None
+            and super().available
+        )
+
+    @property
+    def native_value(self):
+        snapshot = self._snapshot()
+        if snapshot is None:
+            return None
+        return next_billing_date(snapshot)
+
+    @property
+    def extra_state_attributes(self):
+        snapshot = self._snapshot()
+        if snapshot is None:
+            return {}
+        attrs = dict(snapshot.attributes)
+        attrs.update(self._last_refresh_attr())
+        return attrs
+
+
+class EnphaseTariffRateSensor(_EnphaseTariffBaseSensor):
+    def __init__(self, coord: EnphaseCoordinator, is_import: bool):
+        self._is_import = is_import
+        key = "tariff_import_rate" if is_import else "tariff_export_rate"
+        name = "Import Rate" if is_import else "Export Rate"
+        self._attr_translation_key = key
+        self._attr_icon = "mdi:cash-minus" if is_import else "mdi:cash-plus"
+        super().__init__(coord, key, name, type_key=None)
+
+    def _snapshot(self):
+        attr = "tariff_import_rate" if self._is_import else "tariff_export_rate"
+        return getattr(self._coord, attr, None)
+
+    @property
+    def available(self) -> bool:
+        return self._snapshot() is not None and super().available
+
+    @property
+    def native_value(self):
+        snapshot = self._snapshot()
+        return getattr(snapshot, "state", None)
+
+    @property
+    def extra_state_attributes(self):
+        snapshot = self._snapshot()
+        if snapshot is None:
+            return {}
+        attrs = dict(snapshot.attributes)
+        attrs.update(self._last_refresh_attr())
+        return attrs
+
+
+class EnphaseTariffRateValueSensor(_EnphaseTariffBaseSensor):
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 4
+
+    def __init__(self, coord: EnphaseCoordinator, spec: dict, *, is_import: bool):
+        self._is_import = is_import
+        self._rate_prefix = "tariff_import_rate" if is_import else "tariff_export_rate"
+        self._rate_attr = "tariff_import_rate" if is_import else "tariff_export_rate"
+        label_prefix = "Import Rate" if is_import else "Export Rate"
+        self._attr_icon = "mdi:cash-minus" if is_import else "mdi:cash-plus"
+
+        self._detail_key = str(spec.get("key") or "rate")
+        detail_name = str(
+            spec.get("name") or self._detail_key.replace("_", " ").title()
+        )
+        name = f"{label_prefix} {detail_name}"
+        self._attr_translation_key = f"{self._rate_prefix}_value"
+        self._attr_translation_placeholders = {"detail": detail_name}
+        super().__init__(
+            coord,
+            f"{self._rate_prefix}_{self._detail_key}",
+            name,
+            type_key=None,
+        )
+
+    def _spec(self):
+        for spec in tariff_rate_sensor_specs(
+            getattr(self._coord, self._rate_attr, None)
+        ):
+            if spec.get("key") == self._detail_key:
+                return spec
+        return None
+
+    @property
+    def available(self) -> bool:
+        return self._spec() is not None and super().available
+
+    @property
+    def native_value(self):
+        spec = self._spec()
+        if spec is None:
+            return None
+        return spec.get("state")
+
+    @property
+    def native_unit_of_measurement(self):
+        spec = self._spec()
+        if spec is None:
+            return None
+        hass = getattr(self, "hass", None)
+        currency = _gateway_clean_text(
+            getattr(getattr(hass, "config", None), "currency", None)
+        )
+        if currency is not None:
+            return f"{currency}/{UnitOfEnergy.KILO_WATT_HOUR}"
+        return spec.get("unit")
+
+    @property
+    def extra_state_attributes(self):
+        spec = self._spec()
+        if spec is None:
+            return {}
+        attrs = dict(spec.get("attributes") or {})
+        attrs.update(self._last_refresh_attr())
+        return attrs
+
+
+class EnphaseTariffExportRateValueSensor(EnphaseTariffRateValueSensor):
+    def __init__(self, coord: EnphaseCoordinator, spec: dict):
+        super().__init__(coord, spec, is_import=False)
 
 
 class EnphaseAcBatteryOverallStatusSensor(_SiteBaseEntity):

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -1177,6 +1177,208 @@
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
       },
+      "tariff_billing_cycle": {
+        "name": "Next Billing Date",
+        "state_attributes": {
+          "start_date": {
+            "name": "Start Date"
+          },
+          "billing_frequency": {
+            "name": "Billing Frequency"
+          },
+          "billing_interval_value": {
+            "name": "Billing Interval Value"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Billing Cycle"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Microinverter Connectivity Status"
       },

--- a/custom_components/enphase_ev/system_health.py
+++ b/custom_components/enphase_ev/system_health.py
@@ -74,6 +74,13 @@ async def system_health_info(hass: HomeAssistant):
         "site_energy_failures": primary.get("site_energy_failures"),
         "site_energy_backoff_active": primary.get("site_energy_backoff_active"),
         "site_energy_backoff_ends_utc": primary.get("site_energy_backoff_ends_utc"),
+        "tariff_available": primary.get("tariff_available"),
+        "tariff_service_status": primary.get("tariff_service_status"),
+        "tariff_last_error": primary.get("tariff_last_error"),
+        "tariff_failures": primary.get("tariff_failures"),
+        "tariff_backoff_active": primary.get("tariff_backoff_active"),
+        "tariff_backoff_ends_utc": primary.get("tariff_backoff_ends_utc"),
+        "degraded_services": primary.get("degraded_services", []),
         "firmware_catalog_last_fetch_utc": primary.get(
             "firmware_catalog_last_fetch_utc"
         ),

--- a/custom_components/enphase_ev/tariff.py
+++ b/custom_components/enphase_ev/tariff.py
@@ -1,0 +1,589 @@
+"""Read-only tariff parsing and refresh helpers for Enphase sites."""
+
+from __future__ import annotations
+
+import calendar
+from dataclasses import dataclass
+from datetime import date, timedelta
+import re
+from typing import TYPE_CHECKING
+
+import aiohttp
+from homeassistant.util import dt as dt_util
+
+from .api import InvalidPayloadError, OptionalEndpointUnavailable
+
+if TYPE_CHECKING:
+    from .coordinator import EnphaseCoordinator
+
+TARIFF_ENDPOINT_FAMILY = "tariff"
+_EXPORT_RATE_KEY_RE = re.compile(r"[^a-z0-9]+")
+
+
+@dataclass(slots=True, frozen=True)
+class TariffBillingSnapshot:
+    """Normalized billing-cycle metadata."""
+
+    start_date: str | None
+    billing_frequency: str | None
+    billing_interval_value: int | None
+    billing_cycle: str | None
+
+    @property
+    def state(self) -> str | None:
+        """Return the concise billing-cycle label."""
+
+        return self.billing_cycle
+
+    @property
+    def attributes(self) -> dict[str, object]:
+        """Return Home Assistant state attributes."""
+
+        return {
+            "start_date": self.start_date,
+            "billing_frequency": self.billing_frequency,
+            "billing_interval_value": self.billing_interval_value,
+            "billing_cycle": self.billing_cycle,
+        }
+
+
+@dataclass(slots=True, frozen=True)
+class TariffRateSnapshot:
+    """Normalized tariff branch metadata."""
+
+    state: str | None
+    rate_structure: str | None
+    variation_type: str | None
+    source: str | None
+    currency: str | None
+    export_plan: str | None
+    seasons: tuple[dict[str, object], ...]
+
+    @property
+    def attributes(self) -> dict[str, object]:
+        """Return Home Assistant state attributes."""
+
+        attrs: dict[str, object] = {
+            "rate_structure": self.rate_structure,
+            "variation_type": self.variation_type,
+            "source": self.source,
+            "currency": self.currency,
+            "seasons": [dict(season) for season in self.seasons],
+        }
+        if self.export_plan is not None:
+            attrs["export_plan"] = self.export_plan
+        return attrs
+
+
+def _clean_text(value: object) -> str | None:
+    if value is None:
+        return None
+    try:
+        text = str(value).strip()
+    except Exception:
+        return None
+    return text or None
+
+
+def _int_or_none(value: object) -> int | None:
+    if value in (None, ""):
+        return None
+    try:
+        return int(float(str(value).strip()))
+    except (TypeError, ValueError):
+        return None
+
+
+def _rate_structure_label(value: object) -> str | None:
+    type_id = (_clean_text(value) or "").lower()
+    return {
+        "flat": "Flat",
+        "tou": "Time of use",
+        "tiered": "Tiered",
+    }.get(type_id, _clean_text(value))
+
+
+def _variation_label(value: object) -> str | None:
+    type_kind = (_clean_text(value) or "").lower()
+    return {
+        "single": "Single",
+        "seasonal": "Seasonal",
+        "weekends": "Weekdays and weekends",
+        "seasonal-and-weekends": "Seasonal weekdays and weekends",
+    }.get(type_kind, _clean_text(value))
+
+
+def _minutes_to_hhmm(value: object) -> str | None:
+    minutes = _int_or_none(value)
+    if minutes is None:
+        return None
+    minutes %= 24 * 60
+    return f"{minutes // 60:02d}:{minutes % 60:02d}"
+
+
+def _normalize_days(values: object) -> list[int]:
+    if not isinstance(values, list):
+        return []
+    days: list[int] = []
+    for value in values:
+        day = _int_or_none(value)
+        if day is not None:
+            days.append(day)
+    return days
+
+
+def _normalize_period(period: object) -> dict[str, object] | None:
+    if not isinstance(period, dict):
+        return None
+    normalized: dict[str, object] = {
+        "id": _clean_text(period.get("id")),
+        "type": _clean_text(period.get("type")),
+        "rate": _clean_text(period.get("rate")),
+        "start_time": _minutes_to_hhmm(period.get("startTime")),
+        "end_time": _minutes_to_hhmm(period.get("endTime")),
+    }
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _normalize_tier(tier: object) -> dict[str, object] | None:
+    if not isinstance(tier, dict):
+        return None
+    normalized: dict[str, object] = {
+        "id": _clean_text(tier.get("id")),
+        "rate": _clean_text(tier.get("rate")),
+        "start_value": _clean_text(tier.get("startValue")),
+    }
+    end_value = tier.get("endValue")
+    if end_value == -1 or _clean_text(end_value) == "-1":
+        normalized["end_value"] = None
+        normalized["unbounded"] = True
+    else:
+        normalized["end_value"] = _clean_text(end_value)
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _normalize_day_group(day_group: object) -> dict[str, object] | None:
+    if not isinstance(day_group, dict):
+        return None
+    periods = [
+        item
+        for period in day_group.get("periods", [])
+        if (item := _normalize_period(period)) is not None
+    ]
+    normalized: dict[str, object] = {
+        "id": _clean_text(day_group.get("id")),
+        "days": _normalize_days(day_group.get("days")),
+        "periods": periods,
+    }
+    return {key: value for key, value in normalized.items() if value not in (None, [])}
+
+
+def _normalize_season(season: object) -> dict[str, object] | None:
+    if not isinstance(season, dict):
+        return None
+    normalized: dict[str, object] = {
+        "id": _clean_text(season.get("id")),
+        "start_month": _int_or_none(season.get("startMonth")),
+        "end_month": _int_or_none(season.get("endMonth")),
+    }
+    days = [
+        item
+        for day_group in season.get("days", [])
+        if (item := _normalize_day_group(day_group)) is not None
+    ]
+    tiers = [
+        item
+        for tier in season.get("tiers", [])
+        if (item := _normalize_tier(tier)) is not None
+    ]
+    if days:
+        normalized["days"] = days
+    if tiers:
+        normalized["tiers"] = tiers
+    off_peak = _clean_text(season.get("offPeak"))
+    if off_peak is not None:
+        normalized["off_peak"] = off_peak
+    return {key: value for key, value in normalized.items() if value is not None}
+
+
+def _slug(value: object, fallback: str) -> str:
+    text = (_clean_text(value) or fallback).lower()
+    slug = _EXPORT_RATE_KEY_RE.sub("_", text).strip("_")
+    return slug or fallback
+
+
+def _rate_value(rate: object) -> float | None:
+    rate_text = _clean_text(rate)
+    if rate_text is None:
+        return None
+    try:
+        return float(rate_text)
+    except ValueError:
+        return None
+
+
+def _rate_unit(currency: object) -> str | None:
+    currency_text = _clean_text(currency)
+    if currency_text is None:
+        return None
+    if len(currency_text) == 3 and currency_text.isalpha():
+        currency_text = currency_text.upper()
+    return f"{currency_text}/kWh"
+
+
+def _format_rate(rate: object, currency: object) -> str | None:
+    rate_text = _clean_text(rate)
+    if rate_text is None:
+        return None
+    currency_text = _clean_text(currency)
+    if currency_text is None:
+        return rate_text
+    if len(currency_text) == 3 and currency_text.isalpha():
+        return f"{rate_text} {currency_text.upper()}"
+    return f"{currency_text}{rate_text}"
+
+
+def _rate_detail_name(*parts: object) -> str:
+    names = [_clean_text(part) for part in parts]
+    return " ".join(part.title() for part in names if part)
+
+
+def tariff_rate_sensor_specs(snapshot: TariffRateSnapshot | None) -> tuple[dict, ...]:
+    """Return per-rate sensor specs for period and tiered tariffs."""
+
+    if snapshot is None:
+        return ()
+    specs: list[dict] = []
+    used_keys: set[str] = set()
+
+    def _append_spec(base_key: str, name: str, state: float, attrs: dict) -> None:
+        key = base_key
+        index = 2
+        while key in used_keys:
+            key = f"{base_key}_{index}"
+            index += 1
+        used_keys.add(key)
+        specs.append(
+            {
+                "key": key,
+                "name": name,
+                "state": state,
+                "unit": _rate_unit(snapshot.currency),
+                "attributes": attrs,
+            }
+        )
+
+    base_attrs = {
+        "rate_structure": snapshot.rate_structure,
+        "variation_type": snapshot.variation_type,
+        "source": snapshot.source,
+        "currency": snapshot.currency,
+        "export_plan": snapshot.export_plan,
+    }
+    for season_index, season in enumerate(snapshot.seasons, start=1):
+        season_attrs = {
+            **base_attrs,
+            "season_id": season.get("id"),
+            "start_month": season.get("start_month"),
+            "end_month": season.get("end_month"),
+        }
+        for day_index, day_group in enumerate(season.get("days", []), start=1):
+            if not isinstance(day_group, dict):
+                continue
+            day_attrs = {
+                **season_attrs,
+                "day_group_id": day_group.get("id"),
+                "days": day_group.get("days"),
+            }
+            for period_index, period in enumerate(
+                day_group.get("periods", []), start=1
+            ):
+                if not isinstance(period, dict):
+                    continue
+                state = _rate_value(period.get("rate"))
+                if state is None:
+                    continue
+                period_type = _clean_text(period.get("type"))
+                period_id = _clean_text(period.get("id"))
+                name = _rate_detail_name(period_type or period_id) or (
+                    f"Period {period_index}"
+                )
+                key = "_".join(
+                    (
+                        _slug(season.get("id"), f"season_{season_index}"),
+                        _slug(day_group.get("id"), f"days_{day_index}"),
+                        _slug(period_type or period_id, f"period_{period_index}"),
+                    )
+                )
+                attrs = {
+                    **day_attrs,
+                    "period_id": period_id,
+                    "period_type": period_type,
+                    "start_time": period.get("start_time"),
+                    "end_time": period.get("end_time"),
+                    "rate": period.get("rate"),
+                    "formatted_rate": _format_rate(
+                        period.get("rate"), snapshot.currency
+                    ),
+                }
+                _append_spec(
+                    key,
+                    name,
+                    state,
+                    {attr: value for attr, value in attrs.items() if value is not None},
+                )
+        for tier_index, tier in enumerate(season.get("tiers", []), start=1):
+            if not isinstance(tier, dict):
+                continue
+            state = _rate_value(tier.get("rate"))
+            if state is None:
+                continue
+            tier_id = _clean_text(tier.get("id"))
+            name = _rate_detail_name(tier_id) or f"Tier {tier_index}"
+            key = "_".join(
+                (
+                    _slug(season.get("id"), f"season_{season_index}"),
+                    _slug(tier_id, f"tier_{tier_index}"),
+                )
+            )
+            attrs = {
+                **season_attrs,
+                "tier_id": tier_id,
+                "start_value": tier.get("start_value"),
+                "end_value": tier.get("end_value"),
+                "unbounded": tier.get("unbounded"),
+                "rate": tier.get("rate"),
+                "formatted_rate": _format_rate(tier.get("rate"), snapshot.currency),
+            }
+            _append_spec(
+                key,
+                name,
+                state,
+                {attr: value for attr, value in attrs.items() if value is not None},
+            )
+    return tuple(specs)
+
+
+def export_rate_sensor_specs(snapshot: TariffRateSnapshot | None) -> tuple[dict, ...]:
+    """Return per-export-rate sensor specs for period and tiered tariffs."""
+
+    return tariff_rate_sensor_specs(snapshot)
+
+
+def _add_months_clamped(value: date, months: int) -> date:
+    month_index = value.month - 1 + months
+    year = value.year + month_index // 12
+    month = month_index % 12 + 1
+    day = min(value.day, calendar.monthrange(year, month)[1])
+    return date(year, month, day)
+
+
+def next_billing_date(
+    snapshot: TariffBillingSnapshot,
+    *,
+    today: date | None = None,
+) -> date | None:
+    """Return the next billing date after today for a billing snapshot."""
+
+    if snapshot.start_date is None or snapshot.billing_frequency is None:
+        return None
+    interval = (
+        1
+        if snapshot.billing_interval_value is None
+        else snapshot.billing_interval_value
+    )
+    if interval < 1:
+        return None
+    try:
+        start = date.fromisoformat(snapshot.start_date)
+    except ValueError:
+        return None
+    candidate = start
+    today = today or dt_util.now().date()
+    if snapshot.billing_frequency == "DAY":
+        while candidate <= today:
+            candidate = candidate + timedelta(days=interval)
+        return candidate
+    if snapshot.billing_frequency == "MONTH":
+        elapsed_months = 0
+        while candidate <= today:
+            elapsed_months += interval
+            candidate = _add_months_clamped(start, elapsed_months)
+        return candidate
+    return None
+
+
+def parse_tariff_billing(payload: object) -> TariffBillingSnapshot | None:
+    """Return a normalized billing snapshot from a billing-details payload."""
+
+    if not isinstance(payload, dict):
+        return None
+    frequency = (_clean_text(payload.get("billingFrequency")) or "").upper()
+    interval = _int_or_none(payload.get("billingIntervalValue"))
+    start_date = _clean_text(payload.get("anyBillPeriodStartDate"))
+    if not frequency and interval is None and start_date is None:
+        return None
+    state: str | None
+    if frequency == "MONTH":
+        if interval in (None, 1):
+            state = "Monthly"
+        else:
+            state = f"Every {interval} months"
+    elif frequency == "DAY":
+        if interval in (None, 1):
+            state = "Daily"
+        else:
+            state = f"Every {interval} days"
+    else:
+        state = _clean_text(payload.get("billingFrequency"))
+    return TariffBillingSnapshot(
+        start_date=start_date,
+        billing_frequency=frequency or None,
+        billing_interval_value=interval,
+        billing_cycle=state,
+    )
+
+
+def parse_tariff_rate(
+    payload: object,
+    branch_key: str,
+) -> TariffRateSnapshot | None:
+    """Return a normalized import/export tariff snapshot."""
+
+    if not isinstance(payload, dict):
+        return None
+    branch = payload.get(branch_key)
+    if not isinstance(branch, dict):
+        return None
+    seasons = [
+        item
+        for season in branch.get("seasons", [])
+        if (item := _normalize_season(season)) is not None
+    ]
+    rate_structure = _rate_structure_label(branch.get("typeId"))
+    variation_type = _variation_label(branch.get("typeKind"))
+    state = rate_structure
+    if state is None and not seasons:
+        return None
+    return TariffRateSnapshot(
+        state=state,
+        rate_structure=rate_structure,
+        variation_type=variation_type,
+        source=_clean_text(branch.get("source")),
+        currency=_clean_text(payload.get("currency")),
+        export_plan=(
+            _clean_text(branch.get("exportPlan")) if branch_key == "buyback" else None
+        ),
+        seasons=tuple(seasons),
+    )
+
+
+class TariffRuntime:
+    """Fetch and normalize read-only site tariff data."""
+
+    def __init__(self, coordinator: EnphaseCoordinator) -> None:
+        self.coordinator = coordinator
+
+    def refresh_due(self) -> bool:
+        """Return whether tariff data should be refreshed this cycle."""
+
+        return self.coordinator._endpoint_family_should_run(TARIFF_ENDPOINT_FAMILY)
+
+    async def async_refresh(self, *, force: bool = False) -> None:
+        """Refresh tariff billing and rate snapshots."""
+
+        coord = self.coordinator
+        if not coord._endpoint_family_should_run(TARIFF_ENDPOINT_FAMILY, force=force):
+            return
+        try:
+            site_tariff_bundle = getattr(coord.client, "site_tariff_bundle", None)
+            if not callable(site_tariff_bundle):
+                raise OptionalEndpointUnavailable("Tariff API is unavailable")
+            billing_payload, tariff_payload = await site_tariff_bundle()
+            billing = parse_tariff_billing(billing_payload)
+            import_rate = parse_tariff_rate(tariff_payload, "purchase")
+            export_rate = parse_tariff_rate(tariff_payload, "buyback")
+        except (
+            aiohttp.ClientError,
+            AttributeError,
+            InvalidPayloadError,
+            OptionalEndpointUnavailable,
+            TimeoutError,
+        ) as err:
+            if self._has_stale_data():
+                coord._note_endpoint_family_failure(TARIFF_ENDPOINT_FAMILY, err)
+                return
+            raise OptionalEndpointUnavailable("Tariff data is unavailable") from err
+        if billing is None and import_rate is None and export_rate is None:
+            err = OptionalEndpointUnavailable("Tariff payload did not include data")
+            if self._has_stale_data():
+                coord._note_endpoint_family_failure(TARIFF_ENDPOINT_FAMILY, err)
+                return
+
+        refresh_time = dt_util.utcnow()
+        coord.tariff_billing = billing
+        coord.tariff_import_rate = import_rate
+        coord.tariff_export_rate = export_rate
+        coord.tariff_last_refresh_utc = refresh_time
+        if isinstance(tariff_payload, dict) and tariff_payload:
+            coord.tariff_rates_last_refresh_utc = refresh_time
+        coord._note_endpoint_family_success(TARIFF_ENDPOINT_FAMILY)
+
+    def _has_stale_data(self) -> bool:
+        """Return whether a prior tariff snapshot can stay visible."""
+
+        coord = self.coordinator
+        return (
+            getattr(coord, "tariff_billing", None) is not None
+            or getattr(coord, "tariff_import_rate", None) is not None
+            or getattr(coord, "tariff_export_rate", None) is not None
+        )
+
+    def diagnostics(self) -> dict[str, object]:
+        """Return tariff refresh diagnostics without raw tariff payloads."""
+
+        coord = self.coordinator
+        health = coord._endpoint_family_state(TARIFF_ENDPOINT_FAMILY)
+        last_refresh_utc = getattr(coord, "tariff_last_refresh_utc", None)
+        rates_last_refresh_utc = getattr(coord, "tariff_rates_last_refresh_utc", None)
+        return {
+            "billing_available": getattr(coord, "tariff_billing", None) is not None,
+            "import_rate_available": (
+                getattr(coord, "tariff_import_rate", None) is not None
+            ),
+            "export_rate_available": (
+                getattr(coord, "tariff_export_rate", None) is not None
+            ),
+            "last_refresh_utc": (
+                last_refresh_utc.isoformat()
+                if hasattr(last_refresh_utc, "isoformat")
+                else None
+            ),
+            "rates_last_refresh_utc": (
+                rates_last_refresh_utc.isoformat()
+                if hasattr(rates_last_refresh_utc, "isoformat")
+                else None
+            ),
+            "endpoint_family": {
+                "support_state": health.support_state,
+                "cooldown_active": health.cooldown_active,
+                "consecutive_failures": health.consecutive_failures,
+                "last_success_utc": (
+                    health.last_success_utc.isoformat()
+                    if health.last_success_utc is not None
+                    else None
+                ),
+                "last_failure_utc": (
+                    health.last_failure_utc.isoformat()
+                    if health.last_failure_utc is not None
+                    else None
+                ),
+                "next_retry_utc": (
+                    health.next_retry_utc.isoformat()
+                    if health.next_retry_utc is not None
+                    else None
+                ),
+                "last_status": health.last_status,
+                "last_error": health.last_error,
+            },
+        }

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Последно докладван шлюз"
       },
+      "tariff_billing_cycle": {
+        "name": "Sledvashta data na fakturirane",
+        "state_attributes": {
+          "start_date": {
+            "name": "Nachalna data"
+          },
+          "billing_frequency": {
+            "name": "Chestota na fakturirane"
+          },
+          "billing_interval_value": {
+            "name": "Stoynost na intervala za fakturirane"
+          },
+          "last_refresh_utc": {
+            "name": "Posledno opresnyavane (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Cikul na fakturirane"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Tarifa za vnos",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura na tarifata"
+          },
+          "variation_type": {
+            "name": "Tip variacia"
+          },
+          "source": {
+            "name": "Iztochnik"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "seasons": {
+            "name": "Sezoni"
+          },
+          "last_refresh_utc": {
+            "name": "Posledno opresnyavane (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Tarifa za vnos {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura na tarifata"
+          },
+          "variation_type": {
+            "name": "Tip variacia"
+          },
+          "source": {
+            "name": "Iztochnik"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "ID на сезон"
+          },
+          "start_month": {
+            "name": "Начален месец"
+          },
+          "end_month": {
+            "name": "Краен месец"
+          },
+          "day_group_id": {
+            "name": "ID на група дни"
+          },
+          "days": {
+            "name": "Дни"
+          },
+          "period_id": {
+            "name": "ID на период"
+          },
+          "period_type": {
+            "name": "Тип период"
+          },
+          "start_time": {
+            "name": "Начален час"
+          },
+          "end_time": {
+            "name": "Краен час"
+          },
+          "rate": {
+            "name": "Тарифа"
+          },
+          "formatted_rate": {
+            "name": "Форматирана тарифа"
+          },
+          "tier_id": {
+            "name": "ID на стъпало"
+          },
+          "start_value": {
+            "name": "Начална стойност"
+          },
+          "end_value": {
+            "name": "Крайна стойност"
+          },
+          "unbounded": {
+            "name": "Без горна граница"
+          },
+          "last_refresh_utc": {
+            "name": "Posledno opresnyavane (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Tarifa za iznos",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura na tarifata"
+          },
+          "variation_type": {
+            "name": "Tip variacia"
+          },
+          "source": {
+            "name": "Iztochnik"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Plan za iznos"
+          },
+          "seasons": {
+            "name": "Sezoni"
+          },
+          "last_refresh_utc": {
+            "name": "Posledno opresnyavane (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Tarifa za iznos {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura na tarifata"
+          },
+          "variation_type": {
+            "name": "Tip variacia"
+          },
+          "source": {
+            "name": "Iztochnik"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Plan za iznos"
+          },
+          "season_id": {
+            "name": "ID на сезон"
+          },
+          "start_month": {
+            "name": "Начален месец"
+          },
+          "end_month": {
+            "name": "Краен месец"
+          },
+          "day_group_id": {
+            "name": "ID на група дни"
+          },
+          "days": {
+            "name": "Дни"
+          },
+          "period_id": {
+            "name": "ID на период"
+          },
+          "period_type": {
+            "name": "Тип период"
+          },
+          "start_time": {
+            "name": "Начален час"
+          },
+          "end_time": {
+            "name": "Краен час"
+          },
+          "rate": {
+            "name": "Тарифа"
+          },
+          "formatted_rate": {
+            "name": "Форматирана тарифа"
+          },
+          "tier_id": {
+            "name": "ID на стъпало"
+          },
+          "start_value": {
+            "name": "Начална стойност"
+          },
+          "end_value": {
+            "name": "Крайна стойност"
+          },
+          "unbounded": {
+            "name": "Без горна граница"
+          },
+          "last_refresh_utc": {
+            "name": "Posledno opresnyavane (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Състояние на свързаността на микроинверторите"
       },

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Brána naposledy hlášena"
       },
+      "tariff_billing_cycle": {
+        "name": "Pristi datum fakturace",
+        "state_attributes": {
+          "start_date": {
+            "name": "Datum zacatku"
+          },
+          "billing_frequency": {
+            "name": "Frekvence fakturace"
+          },
+          "billing_interval_value": {
+            "name": "Hodnota fakturacniho intervalu"
+          },
+          "last_refresh_utc": {
+            "name": "Posledni aktualizace (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Fakturacni cyklus"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Importni tarif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura tarifu"
+          },
+          "variation_type": {
+            "name": "Typ varianty"
+          },
+          "source": {
+            "name": "Zdroj"
+          },
+          "currency": {
+            "name": "Mena"
+          },
+          "seasons": {
+            "name": "Sezony"
+          },
+          "last_refresh_utc": {
+            "name": "Posledni aktualizace (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Importni tarif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura tarifu"
+          },
+          "variation_type": {
+            "name": "Typ varianty"
+          },
+          "source": {
+            "name": "Zdroj"
+          },
+          "currency": {
+            "name": "Mena"
+          },
+          "season_id": {
+            "name": "ID sezóny"
+          },
+          "start_month": {
+            "name": "Počáteční měsíc"
+          },
+          "end_month": {
+            "name": "Koncový měsíc"
+          },
+          "day_group_id": {
+            "name": "ID skupiny dnů"
+          },
+          "days": {
+            "name": "Dny"
+          },
+          "period_id": {
+            "name": "ID období"
+          },
+          "period_type": {
+            "name": "Typ období"
+          },
+          "start_time": {
+            "name": "Čas začátku"
+          },
+          "end_time": {
+            "name": "Čas konce"
+          },
+          "rate": {
+            "name": "Sazba"
+          },
+          "formatted_rate": {
+            "name": "Formátovaná sazba"
+          },
+          "tier_id": {
+            "name": "ID pásma"
+          },
+          "start_value": {
+            "name": "Počáteční hodnota"
+          },
+          "end_value": {
+            "name": "Koncová hodnota"
+          },
+          "unbounded": {
+            "name": "Bez horní hranice"
+          },
+          "last_refresh_utc": {
+            "name": "Posledni aktualizace (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Exportni tarif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura tarifu"
+          },
+          "variation_type": {
+            "name": "Typ varianty"
+          },
+          "source": {
+            "name": "Zdroj"
+          },
+          "currency": {
+            "name": "Mena"
+          },
+          "export_plan": {
+            "name": "Exportni plan"
+          },
+          "seasons": {
+            "name": "Sezony"
+          },
+          "last_refresh_utc": {
+            "name": "Posledni aktualizace (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Exportni tarif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura tarifu"
+          },
+          "variation_type": {
+            "name": "Typ varianty"
+          },
+          "source": {
+            "name": "Zdroj"
+          },
+          "currency": {
+            "name": "Mena"
+          },
+          "export_plan": {
+            "name": "Exportni plan"
+          },
+          "season_id": {
+            "name": "ID sezóny"
+          },
+          "start_month": {
+            "name": "Počáteční měsíc"
+          },
+          "end_month": {
+            "name": "Koncový měsíc"
+          },
+          "day_group_id": {
+            "name": "ID skupiny dnů"
+          },
+          "days": {
+            "name": "Dny"
+          },
+          "period_id": {
+            "name": "ID období"
+          },
+          "period_type": {
+            "name": "Typ období"
+          },
+          "start_time": {
+            "name": "Čas začátku"
+          },
+          "end_time": {
+            "name": "Čas konce"
+          },
+          "rate": {
+            "name": "Sazba"
+          },
+          "formatted_rate": {
+            "name": "Formátovaná sazba"
+          },
+          "tier_id": {
+            "name": "ID pásma"
+          },
+          "start_value": {
+            "name": "Počáteční hodnota"
+          },
+          "end_value": {
+            "name": "Koncová hodnota"
+          },
+          "unbounded": {
+            "name": "Bez horní hranice"
+          },
+          "last_refresh_utc": {
+            "name": "Posledni aktualizace (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Stav připojení mikroinvertorů"
       },

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway sidst rapporteret"
       },
+      "tariff_billing_cycle": {
+        "name": "Naeste faktureringsdato",
+        "state_attributes": {
+          "start_date": {
+            "name": "Startdato"
+          },
+          "billing_frequency": {
+            "name": "Faktureringsfrekvens"
+          },
+          "billing_interval_value": {
+            "name": "Faktureringsintervalvaerdi"
+          },
+          "last_refresh_utc": {
+            "name": "Seneste opdatering (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Faktureringscyklus"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Importtarif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "seasons": {
+            "name": "Saesoner"
+          },
+          "last_refresh_utc": {
+            "name": "Seneste opdatering (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Importtarif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Sæson-ID"
+          },
+          "start_month": {
+            "name": "Startmåned"
+          },
+          "end_month": {
+            "name": "Slutmåned"
+          },
+          "day_group_id": {
+            "name": "Dagsgruppe-ID"
+          },
+          "days": {
+            "name": "Dage"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Takst"
+          },
+          "formatted_rate": {
+            "name": "Formateret takst"
+          },
+          "tier_id": {
+            "name": "Trin-ID"
+          },
+          "start_value": {
+            "name": "Startværdi"
+          },
+          "end_value": {
+            "name": "Slutværdi"
+          },
+          "unbounded": {
+            "name": "Uden øvre grænse"
+          },
+          "last_refresh_utc": {
+            "name": "Seneste opdatering (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Eksporttarif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Eksportplan"
+          },
+          "seasons": {
+            "name": "Saesoner"
+          },
+          "last_refresh_utc": {
+            "name": "Seneste opdatering (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Eksporttarif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Eksportplan"
+          },
+          "season_id": {
+            "name": "Sæson-ID"
+          },
+          "start_month": {
+            "name": "Startmåned"
+          },
+          "end_month": {
+            "name": "Slutmåned"
+          },
+          "day_group_id": {
+            "name": "Dagsgruppe-ID"
+          },
+          "days": {
+            "name": "Dage"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Takst"
+          },
+          "formatted_rate": {
+            "name": "Formateret takst"
+          },
+          "tier_id": {
+            "name": "Trin-ID"
+          },
+          "start_value": {
+            "name": "Startværdi"
+          },
+          "end_value": {
+            "name": "Slutværdi"
+          },
+          "unbounded": {
+            "name": "Uden øvre grænse"
+          },
+          "last_refresh_utc": {
+            "name": "Seneste opdatering (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Forbindelsesstatus for mikroinvertere"
       },

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Zuletzt gemeldetes Gateway"
       },
+      "tariff_billing_cycle": {
+        "name": "Naechstes Abrechnungsdatum",
+        "state_attributes": {
+          "start_date": {
+            "name": "Startdatum"
+          },
+          "billing_frequency": {
+            "name": "Abrechnungshaeufigkeit"
+          },
+          "billing_interval_value": {
+            "name": "Abrechnungsintervallwert"
+          },
+          "last_refresh_utc": {
+            "name": "Letzte Aktualisierung (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Abrechnungszyklus"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Importtarif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Quelle"
+          },
+          "currency": {
+            "name": "Waehrung"
+          },
+          "seasons": {
+            "name": "Saisons"
+          },
+          "last_refresh_utc": {
+            "name": "Letzte Aktualisierung (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Importtarif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Quelle"
+          },
+          "currency": {
+            "name": "Waehrung"
+          },
+          "season_id": {
+            "name": "Saison-ID"
+          },
+          "start_month": {
+            "name": "Startmonat"
+          },
+          "end_month": {
+            "name": "Endmonat"
+          },
+          "day_group_id": {
+            "name": "Tagesgruppen-ID"
+          },
+          "days": {
+            "name": "Tage"
+          },
+          "period_id": {
+            "name": "Perioden-ID"
+          },
+          "period_type": {
+            "name": "Periodentyp"
+          },
+          "start_time": {
+            "name": "Startzeit"
+          },
+          "end_time": {
+            "name": "Endzeit"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Formatierter Tarif"
+          },
+          "tier_id": {
+            "name": "Stufen-ID"
+          },
+          "start_value": {
+            "name": "Startwert"
+          },
+          "end_value": {
+            "name": "Endwert"
+          },
+          "unbounded": {
+            "name": "Unbegrenzt"
+          },
+          "last_refresh_utc": {
+            "name": "Letzte Aktualisierung (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Exporttarif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Quelle"
+          },
+          "currency": {
+            "name": "Waehrung"
+          },
+          "export_plan": {
+            "name": "Exportplan"
+          },
+          "seasons": {
+            "name": "Saisons"
+          },
+          "last_refresh_utc": {
+            "name": "Letzte Aktualisierung (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Exporttarif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Quelle"
+          },
+          "currency": {
+            "name": "Waehrung"
+          },
+          "export_plan": {
+            "name": "Exportplan"
+          },
+          "season_id": {
+            "name": "Saison-ID"
+          },
+          "start_month": {
+            "name": "Startmonat"
+          },
+          "end_month": {
+            "name": "Endmonat"
+          },
+          "day_group_id": {
+            "name": "Tagesgruppen-ID"
+          },
+          "days": {
+            "name": "Tage"
+          },
+          "period_id": {
+            "name": "Perioden-ID"
+          },
+          "period_type": {
+            "name": "Periodentyp"
+          },
+          "start_time": {
+            "name": "Startzeit"
+          },
+          "end_time": {
+            "name": "Endzeit"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Formatierter Tarif"
+          },
+          "tier_id": {
+            "name": "Stufen-ID"
+          },
+          "start_value": {
+            "name": "Startwert"
+          },
+          "end_value": {
+            "name": "Endwert"
+          },
+          "unbounded": {
+            "name": "Unbegrenzt"
+          },
+          "last_refresh_utc": {
+            "name": "Letzte Aktualisierung (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Konnektivitätsstatus der Mikrowechselrichter"
       },

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Τελευταία αναφορά Gateway"
       },
+      "tariff_billing_cycle": {
+        "name": "Epomeni imerominia chreosis",
+        "state_attributes": {
+          "start_date": {
+            "name": "Imerominia enarxis"
+          },
+          "billing_frequency": {
+            "name": "Sychnotita chreosis"
+          },
+          "billing_interval_value": {
+            "name": "Timi diastimatos chreosis"
+          },
+          "last_refresh_utc": {
+            "name": "Teleutaia ananeosi (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Kyklos chreosis"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Timologio eisagogis",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Domi timologiou"
+          },
+          "variation_type": {
+            "name": "Typos metavolis"
+          },
+          "source": {
+            "name": "Pigi"
+          },
+          "currency": {
+            "name": "Nomisma"
+          },
+          "seasons": {
+            "name": "Epoches"
+          },
+          "last_refresh_utc": {
+            "name": "Teleutaia ananeosi (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Timologio eisagogis {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Domi timologiou"
+          },
+          "variation_type": {
+            "name": "Typos metavolis"
+          },
+          "source": {
+            "name": "Pigi"
+          },
+          "currency": {
+            "name": "Nomisma"
+          },
+          "season_id": {
+            "name": "Αναγνωριστικό εποχής"
+          },
+          "start_month": {
+            "name": "Μήνας έναρξης"
+          },
+          "end_month": {
+            "name": "Μήνας λήξης"
+          },
+          "day_group_id": {
+            "name": "Αναγνωριστικό ομάδας ημερών"
+          },
+          "days": {
+            "name": "Ημέρες"
+          },
+          "period_id": {
+            "name": "Αναγνωριστικό περιόδου"
+          },
+          "period_type": {
+            "name": "Τύπος περιόδου"
+          },
+          "start_time": {
+            "name": "Ώρα έναρξης"
+          },
+          "end_time": {
+            "name": "Ώρα λήξης"
+          },
+          "rate": {
+            "name": "Τιμή"
+          },
+          "formatted_rate": {
+            "name": "Μορφοποιημένη τιμή"
+          },
+          "tier_id": {
+            "name": "Αναγνωριστικό κλιμακίου"
+          },
+          "start_value": {
+            "name": "Τιμή έναρξης"
+          },
+          "end_value": {
+            "name": "Τιμή λήξης"
+          },
+          "unbounded": {
+            "name": "Χωρίς ανώτατο όριο"
+          },
+          "last_refresh_utc": {
+            "name": "Teleutaia ananeosi (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Timologio eksagogis",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Domi timologiou"
+          },
+          "variation_type": {
+            "name": "Typos metavolis"
+          },
+          "source": {
+            "name": "Pigi"
+          },
+          "currency": {
+            "name": "Nomisma"
+          },
+          "export_plan": {
+            "name": "Schedio eksagogis"
+          },
+          "seasons": {
+            "name": "Epoches"
+          },
+          "last_refresh_utc": {
+            "name": "Teleutaia ananeosi (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Timologio eksagogis {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Domi timologiou"
+          },
+          "variation_type": {
+            "name": "Typos metavolis"
+          },
+          "source": {
+            "name": "Pigi"
+          },
+          "currency": {
+            "name": "Nomisma"
+          },
+          "export_plan": {
+            "name": "Schedio eksagogis"
+          },
+          "season_id": {
+            "name": "Αναγνωριστικό εποχής"
+          },
+          "start_month": {
+            "name": "Μήνας έναρξης"
+          },
+          "end_month": {
+            "name": "Μήνας λήξης"
+          },
+          "day_group_id": {
+            "name": "Αναγνωριστικό ομάδας ημερών"
+          },
+          "days": {
+            "name": "Ημέρες"
+          },
+          "period_id": {
+            "name": "Αναγνωριστικό περιόδου"
+          },
+          "period_type": {
+            "name": "Τύπος περιόδου"
+          },
+          "start_time": {
+            "name": "Ώρα έναρξης"
+          },
+          "end_time": {
+            "name": "Ώρα λήξης"
+          },
+          "rate": {
+            "name": "Τιμή"
+          },
+          "formatted_rate": {
+            "name": "Μορφοποιημένη τιμή"
+          },
+          "tier_id": {
+            "name": "Αναγνωριστικό κλιμακίου"
+          },
+          "start_value": {
+            "name": "Τιμή έναρξης"
+          },
+          "end_value": {
+            "name": "Τιμή λήξης"
+          },
+          "unbounded": {
+            "name": "Χωρίς ανώτατο όριο"
+          },
+          "last_refresh_utc": {
+            "name": "Teleutaia ananeosi (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Κατάσταση συνδεσιμότητας μικρομετατροπέων"
       },

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
       },
+      "tariff_billing_cycle": {
+        "name": "Next Billing Date",
+        "state_attributes": {
+          "start_date": {
+            "name": "Start Date"
+          },
+          "billing_frequency": {
+            "name": "Billing Frequency"
+          },
+          "billing_interval_value": {
+            "name": "Billing Interval Value"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Billing Cycle"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Microinverter Connectivity Status"
       },

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
       },
+      "tariff_billing_cycle": {
+        "name": "Next Billing Date",
+        "state_attributes": {
+          "start_date": {
+            "name": "Start Date"
+          },
+          "billing_frequency": {
+            "name": "Billing Frequency"
+          },
+          "billing_interval_value": {
+            "name": "Billing Interval Value"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Billing Cycle"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Microinverter Connectivity Status"
       },

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
       },
+      "tariff_billing_cycle": {
+        "name": "Next Billing Date",
+        "state_attributes": {
+          "start_date": {
+            "name": "Start Date"
+          },
+          "billing_frequency": {
+            "name": "Billing Frequency"
+          },
+          "billing_interval_value": {
+            "name": "Billing Interval Value"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Billing Cycle"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Microinverter Connectivity Status"
       },

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
       },
+      "tariff_billing_cycle": {
+        "name": "Next Billing Date",
+        "state_attributes": {
+          "start_date": {
+            "name": "Start Date"
+          },
+          "billing_frequency": {
+            "name": "Billing Frequency"
+          },
+          "billing_interval_value": {
+            "name": "Billing Interval Value"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Billing Cycle"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Microinverter Connectivity Status"
       },

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
       },
+      "tariff_billing_cycle": {
+        "name": "Next Billing Date",
+        "state_attributes": {
+          "start_date": {
+            "name": "Start Date"
+          },
+          "billing_frequency": {
+            "name": "Billing Frequency"
+          },
+          "billing_interval_value": {
+            "name": "Billing Interval Value"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Billing Cycle"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Microinverter Connectivity Status"
       },

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway Last Reported"
       },
+      "tariff_billing_cycle": {
+        "name": "Next Billing Date",
+        "state_attributes": {
+          "start_date": {
+            "name": "Start Date"
+          },
+          "billing_frequency": {
+            "name": "Billing Frequency"
+          },
+          "billing_interval_value": {
+            "name": "Billing Interval Value"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Billing Cycle"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "seasons": {
+            "name": "Seasons"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Microinverter Connectivity Status"
       },

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Puerta de enlace reportada por última vez"
       },
+      "tariff_billing_cycle": {
+        "name": "Proxima fecha de facturacion",
+        "state_attributes": {
+          "start_date": {
+            "name": "Fecha de inicio"
+          },
+          "billing_frequency": {
+            "name": "Frecuencia de facturacion"
+          },
+          "billing_interval_value": {
+            "name": "Valor del intervalo de facturacion"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizacion (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Ciclo de facturacion"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Tarifa de importacion",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estructura de tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacion"
+          },
+          "source": {
+            "name": "Fuente"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "seasons": {
+            "name": "Temporadas"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizacion (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Tarifa de importacion {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estructura de tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacion"
+          },
+          "source": {
+            "name": "Fuente"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "season_id": {
+            "name": "ID de temporada"
+          },
+          "start_month": {
+            "name": "Mes inicial"
+          },
+          "end_month": {
+            "name": "Mes final"
+          },
+          "day_group_id": {
+            "name": "ID del grupo de días"
+          },
+          "days": {
+            "name": "Días"
+          },
+          "period_id": {
+            "name": "ID del período"
+          },
+          "period_type": {
+            "name": "Tipo de período"
+          },
+          "start_time": {
+            "name": "Hora de inicio"
+          },
+          "end_time": {
+            "name": "Hora de finalización"
+          },
+          "rate": {
+            "name": "Tarifa"
+          },
+          "formatted_rate": {
+            "name": "Tarifa formateada"
+          },
+          "tier_id": {
+            "name": "ID del tramo"
+          },
+          "start_value": {
+            "name": "Valor inicial"
+          },
+          "end_value": {
+            "name": "Valor final"
+          },
+          "unbounded": {
+            "name": "Sin límite superior"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizacion (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Tarifa de exportacion",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estructura de tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacion"
+          },
+          "source": {
+            "name": "Fuente"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "export_plan": {
+            "name": "Plan de exportacion"
+          },
+          "seasons": {
+            "name": "Temporadas"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizacion (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Tarifa de exportacion {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estructura de tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacion"
+          },
+          "source": {
+            "name": "Fuente"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "export_plan": {
+            "name": "Plan de exportacion"
+          },
+          "season_id": {
+            "name": "ID de temporada"
+          },
+          "start_month": {
+            "name": "Mes inicial"
+          },
+          "end_month": {
+            "name": "Mes final"
+          },
+          "day_group_id": {
+            "name": "ID del grupo de días"
+          },
+          "days": {
+            "name": "Días"
+          },
+          "period_id": {
+            "name": "ID del período"
+          },
+          "period_type": {
+            "name": "Tipo de período"
+          },
+          "start_time": {
+            "name": "Hora de inicio"
+          },
+          "end_time": {
+            "name": "Hora de finalización"
+          },
+          "rate": {
+            "name": "Tarifa"
+          },
+          "formatted_rate": {
+            "name": "Tarifa formateada"
+          },
+          "tier_id": {
+            "name": "ID del tramo"
+          },
+          "start_value": {
+            "name": "Valor inicial"
+          },
+          "end_value": {
+            "name": "Valor final"
+          },
+          "unbounded": {
+            "name": "Sin límite superior"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizacion (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Estado de conectividad de microinversores"
       },

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway viimati teatatud"
       },
+      "tariff_billing_cycle": {
+        "name": "Jargmine arvelduskuupaev",
+        "state_attributes": {
+          "start_date": {
+            "name": "Alguskuupaev"
+          },
+          "billing_frequency": {
+            "name": "Arvelduse sagedus"
+          },
+          "billing_interval_value": {
+            "name": "Arveldusintervalli vaartus"
+          },
+          "last_refresh_utc": {
+            "name": "Viimane varskendus (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Arveldustsukkel"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Imporditariif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariifi struktuur"
+          },
+          "variation_type": {
+            "name": "Variatsiooni tuup"
+          },
+          "source": {
+            "name": "Allikas"
+          },
+          "currency": {
+            "name": "Valuuta"
+          },
+          "seasons": {
+            "name": "Hooajad"
+          },
+          "last_refresh_utc": {
+            "name": "Viimane varskendus (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Imporditariif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariifi struktuur"
+          },
+          "variation_type": {
+            "name": "Variatsiooni tuup"
+          },
+          "source": {
+            "name": "Allikas"
+          },
+          "currency": {
+            "name": "Valuuta"
+          },
+          "season_id": {
+            "name": "Hooaja ID"
+          },
+          "start_month": {
+            "name": "Alguskuu"
+          },
+          "end_month": {
+            "name": "Lõppkuu"
+          },
+          "day_group_id": {
+            "name": "Päevarühma ID"
+          },
+          "days": {
+            "name": "Päevad"
+          },
+          "period_id": {
+            "name": "Perioodi ID"
+          },
+          "period_type": {
+            "name": "Perioodi tüüp"
+          },
+          "start_time": {
+            "name": "Algusaeg"
+          },
+          "end_time": {
+            "name": "Lõppaeg"
+          },
+          "rate": {
+            "name": "Hind"
+          },
+          "formatted_rate": {
+            "name": "Vormindatud hind"
+          },
+          "tier_id": {
+            "name": "Astme ID"
+          },
+          "start_value": {
+            "name": "Algväärtus"
+          },
+          "end_value": {
+            "name": "Lõppväärtus"
+          },
+          "unbounded": {
+            "name": "Ülemise piirita"
+          },
+          "last_refresh_utc": {
+            "name": "Viimane varskendus (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Eksporditariif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariifi struktuur"
+          },
+          "variation_type": {
+            "name": "Variatsiooni tuup"
+          },
+          "source": {
+            "name": "Allikas"
+          },
+          "currency": {
+            "name": "Valuuta"
+          },
+          "export_plan": {
+            "name": "Ekspordiplaan"
+          },
+          "seasons": {
+            "name": "Hooajad"
+          },
+          "last_refresh_utc": {
+            "name": "Viimane varskendus (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Eksporditariif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariifi struktuur"
+          },
+          "variation_type": {
+            "name": "Variatsiooni tuup"
+          },
+          "source": {
+            "name": "Allikas"
+          },
+          "currency": {
+            "name": "Valuuta"
+          },
+          "export_plan": {
+            "name": "Ekspordiplaan"
+          },
+          "season_id": {
+            "name": "Hooaja ID"
+          },
+          "start_month": {
+            "name": "Alguskuu"
+          },
+          "end_month": {
+            "name": "Lõppkuu"
+          },
+          "day_group_id": {
+            "name": "Päevarühma ID"
+          },
+          "days": {
+            "name": "Päevad"
+          },
+          "period_id": {
+            "name": "Perioodi ID"
+          },
+          "period_type": {
+            "name": "Perioodi tüüp"
+          },
+          "start_time": {
+            "name": "Algusaeg"
+          },
+          "end_time": {
+            "name": "Lõppaeg"
+          },
+          "rate": {
+            "name": "Hind"
+          },
+          "formatted_rate": {
+            "name": "Vormindatud hind"
+          },
+          "tier_id": {
+            "name": "Astme ID"
+          },
+          "start_value": {
+            "name": "Algväärtus"
+          },
+          "end_value": {
+            "name": "Lõppväärtus"
+          },
+          "unbounded": {
+            "name": "Ülemise piirita"
+          },
+          "last_refresh_utc": {
+            "name": "Viimane varskendus (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Mikroinverterite ühenduvuse olek"
       },

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway viimeksi raportoitu"
       },
+      "tariff_billing_cycle": {
+        "name": "Seuraava laskutuspaiva",
+        "state_attributes": {
+          "start_date": {
+            "name": "Aloituspaiva"
+          },
+          "billing_frequency": {
+            "name": "Laskutustiheys"
+          },
+          "billing_interval_value": {
+            "name": "Laskutusvalin arvo"
+          },
+          "last_refresh_utc": {
+            "name": "Viimeisin paivitys (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Laskutusjakso"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Tuontitariffi",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffirakenne"
+          },
+          "variation_type": {
+            "name": "Vaihtelutyyppi"
+          },
+          "source": {
+            "name": "Laehde"
+          },
+          "currency": {
+            "name": "Valuutta"
+          },
+          "seasons": {
+            "name": "Kaudet"
+          },
+          "last_refresh_utc": {
+            "name": "Viimeisin paivitys (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Tuontitariffi {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffirakenne"
+          },
+          "variation_type": {
+            "name": "Vaihtelutyyppi"
+          },
+          "source": {
+            "name": "Laehde"
+          },
+          "currency": {
+            "name": "Valuutta"
+          },
+          "season_id": {
+            "name": "Kauden tunnus"
+          },
+          "start_month": {
+            "name": "Aloituskuukausi"
+          },
+          "end_month": {
+            "name": "Päättymiskuukausi"
+          },
+          "day_group_id": {
+            "name": "Päiväryhmän tunnus"
+          },
+          "days": {
+            "name": "Päivät"
+          },
+          "period_id": {
+            "name": "Jakson tunnus"
+          },
+          "period_type": {
+            "name": "Jakson tyyppi"
+          },
+          "start_time": {
+            "name": "Aloitusaika"
+          },
+          "end_time": {
+            "name": "Päättymisaika"
+          },
+          "rate": {
+            "name": "Hinta"
+          },
+          "formatted_rate": {
+            "name": "Muotoiltu hinta"
+          },
+          "tier_id": {
+            "name": "Portaan tunnus"
+          },
+          "start_value": {
+            "name": "Alkuarvo"
+          },
+          "end_value": {
+            "name": "Loppuarvo"
+          },
+          "unbounded": {
+            "name": "Ilman ylärajaa"
+          },
+          "last_refresh_utc": {
+            "name": "Viimeisin paivitys (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Vientitariffi",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffirakenne"
+          },
+          "variation_type": {
+            "name": "Vaihtelutyyppi"
+          },
+          "source": {
+            "name": "Laehde"
+          },
+          "currency": {
+            "name": "Valuutta"
+          },
+          "export_plan": {
+            "name": "Vientisuunnitelma"
+          },
+          "seasons": {
+            "name": "Kaudet"
+          },
+          "last_refresh_utc": {
+            "name": "Viimeisin paivitys (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Vientitariffi {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffirakenne"
+          },
+          "variation_type": {
+            "name": "Vaihtelutyyppi"
+          },
+          "source": {
+            "name": "Laehde"
+          },
+          "currency": {
+            "name": "Valuutta"
+          },
+          "export_plan": {
+            "name": "Vientisuunnitelma"
+          },
+          "season_id": {
+            "name": "Kauden tunnus"
+          },
+          "start_month": {
+            "name": "Aloituskuukausi"
+          },
+          "end_month": {
+            "name": "Päättymiskuukausi"
+          },
+          "day_group_id": {
+            "name": "Päiväryhmän tunnus"
+          },
+          "days": {
+            "name": "Päivät"
+          },
+          "period_id": {
+            "name": "Jakson tunnus"
+          },
+          "period_type": {
+            "name": "Jakson tyyppi"
+          },
+          "start_time": {
+            "name": "Aloitusaika"
+          },
+          "end_time": {
+            "name": "Päättymisaika"
+          },
+          "rate": {
+            "name": "Hinta"
+          },
+          "formatted_rate": {
+            "name": "Muotoiltu hinta"
+          },
+          "tier_id": {
+            "name": "Portaan tunnus"
+          },
+          "start_value": {
+            "name": "Alkuarvo"
+          },
+          "end_value": {
+            "name": "Loppuarvo"
+          },
+          "unbounded": {
+            "name": "Ilman ylärajaa"
+          },
+          "last_refresh_utc": {
+            "name": "Viimeisin paivitys (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Mikroinvertterien yhteystila"
       },

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Passerelle signalée pour la dernière fois"
       },
+      "tariff_billing_cycle": {
+        "name": "Prochaine date de facturation",
+        "state_attributes": {
+          "start_date": {
+            "name": "Date de debut"
+          },
+          "billing_frequency": {
+            "name": "Frequence de facturation"
+          },
+          "billing_interval_value": {
+            "name": "Valeur d intervalle de facturation"
+          },
+          "last_refresh_utc": {
+            "name": "Derniere actualisation (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Cycle de facturation"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Tarif d import",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structure tarifaire"
+          },
+          "variation_type": {
+            "name": "Type de variation"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Devise"
+          },
+          "seasons": {
+            "name": "Saisons"
+          },
+          "last_refresh_utc": {
+            "name": "Derniere actualisation (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Tarif d import {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structure tarifaire"
+          },
+          "variation_type": {
+            "name": "Type de variation"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Devise"
+          },
+          "season_id": {
+            "name": "ID de saison"
+          },
+          "start_month": {
+            "name": "Mois de début"
+          },
+          "end_month": {
+            "name": "Mois de fin"
+          },
+          "day_group_id": {
+            "name": "ID du groupe de jours"
+          },
+          "days": {
+            "name": "Jours"
+          },
+          "period_id": {
+            "name": "ID de période"
+          },
+          "period_type": {
+            "name": "Type de période"
+          },
+          "start_time": {
+            "name": "Heure de début"
+          },
+          "end_time": {
+            "name": "Heure de fin"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Tarif formaté"
+          },
+          "tier_id": {
+            "name": "ID du palier"
+          },
+          "start_value": {
+            "name": "Valeur de début"
+          },
+          "end_value": {
+            "name": "Valeur de fin"
+          },
+          "unbounded": {
+            "name": "Sans limite supérieure"
+          },
+          "last_refresh_utc": {
+            "name": "Derniere actualisation (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Tarif d export",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structure tarifaire"
+          },
+          "variation_type": {
+            "name": "Type de variation"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Devise"
+          },
+          "export_plan": {
+            "name": "Plan d export"
+          },
+          "seasons": {
+            "name": "Saisons"
+          },
+          "last_refresh_utc": {
+            "name": "Derniere actualisation (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Tarif d export {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structure tarifaire"
+          },
+          "variation_type": {
+            "name": "Type de variation"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Devise"
+          },
+          "export_plan": {
+            "name": "Plan d export"
+          },
+          "season_id": {
+            "name": "ID de saison"
+          },
+          "start_month": {
+            "name": "Mois de début"
+          },
+          "end_month": {
+            "name": "Mois de fin"
+          },
+          "day_group_id": {
+            "name": "ID du groupe de jours"
+          },
+          "days": {
+            "name": "Jours"
+          },
+          "period_id": {
+            "name": "ID de période"
+          },
+          "period_type": {
+            "name": "Type de période"
+          },
+          "start_time": {
+            "name": "Heure de début"
+          },
+          "end_time": {
+            "name": "Heure de fin"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Tarif formaté"
+          },
+          "tier_id": {
+            "name": "ID du palier"
+          },
+          "start_value": {
+            "name": "Valeur de début"
+          },
+          "end_value": {
+            "name": "Valeur de fin"
+          },
+          "unbounded": {
+            "name": "Sans limite supérieure"
+          },
+          "last_refresh_utc": {
+            "name": "Derniere actualisation (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "État de connectivité des micro-onduleurs"
       },

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "A Gateway legutóbbi jelentése"
       },
+      "tariff_billing_cycle": {
+        "name": "Kovetkezo szamlazasi datum",
+        "state_attributes": {
+          "start_date": {
+            "name": "Kezdo datum"
+          },
+          "billing_frequency": {
+            "name": "Szamlazasi gyakorisag"
+          },
+          "billing_interval_value": {
+            "name": "Szamlazasi intervallum erteke"
+          },
+          "last_refresh_utc": {
+            "name": "Utolso frissites (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Szamlazasi ciklus"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Import tarifa",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifaszerkezet"
+          },
+          "variation_type": {
+            "name": "Valtozattipus"
+          },
+          "source": {
+            "name": "Forras"
+          },
+          "currency": {
+            "name": "Penznem"
+          },
+          "seasons": {
+            "name": "Idoszakok"
+          },
+          "last_refresh_utc": {
+            "name": "Utolso frissites (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Import tarifa {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifaszerkezet"
+          },
+          "variation_type": {
+            "name": "Valtozattipus"
+          },
+          "source": {
+            "name": "Forras"
+          },
+          "currency": {
+            "name": "Penznem"
+          },
+          "season_id": {
+            "name": "Szezon azonosítója"
+          },
+          "start_month": {
+            "name": "Kezdő hónap"
+          },
+          "end_month": {
+            "name": "Záró hónap"
+          },
+          "day_group_id": {
+            "name": "Napcsoport azonosítója"
+          },
+          "days": {
+            "name": "Napok"
+          },
+          "period_id": {
+            "name": "Időszak azonosítója"
+          },
+          "period_type": {
+            "name": "Időszak típusa"
+          },
+          "start_time": {
+            "name": "Kezdési idő"
+          },
+          "end_time": {
+            "name": "Befejezési idő"
+          },
+          "rate": {
+            "name": "Díj"
+          },
+          "formatted_rate": {
+            "name": "Formázott díj"
+          },
+          "tier_id": {
+            "name": "Sáv azonosítója"
+          },
+          "start_value": {
+            "name": "Kezdő érték"
+          },
+          "end_value": {
+            "name": "Záró érték"
+          },
+          "unbounded": {
+            "name": "Felső korlát nélkül"
+          },
+          "last_refresh_utc": {
+            "name": "Utolso frissites (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Export tarifa",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifaszerkezet"
+          },
+          "variation_type": {
+            "name": "Valtozattipus"
+          },
+          "source": {
+            "name": "Forras"
+          },
+          "currency": {
+            "name": "Penznem"
+          },
+          "export_plan": {
+            "name": "Exportterv"
+          },
+          "seasons": {
+            "name": "Idoszakok"
+          },
+          "last_refresh_utc": {
+            "name": "Utolso frissites (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export tarifa {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifaszerkezet"
+          },
+          "variation_type": {
+            "name": "Valtozattipus"
+          },
+          "source": {
+            "name": "Forras"
+          },
+          "currency": {
+            "name": "Penznem"
+          },
+          "export_plan": {
+            "name": "Exportterv"
+          },
+          "season_id": {
+            "name": "Szezon azonosítója"
+          },
+          "start_month": {
+            "name": "Kezdő hónap"
+          },
+          "end_month": {
+            "name": "Záró hónap"
+          },
+          "day_group_id": {
+            "name": "Napcsoport azonosítója"
+          },
+          "days": {
+            "name": "Napok"
+          },
+          "period_id": {
+            "name": "Időszak azonosítója"
+          },
+          "period_type": {
+            "name": "Időszak típusa"
+          },
+          "start_time": {
+            "name": "Kezdési idő"
+          },
+          "end_time": {
+            "name": "Befejezési idő"
+          },
+          "rate": {
+            "name": "Díj"
+          },
+          "formatted_rate": {
+            "name": "Formázott díj"
+          },
+          "tier_id": {
+            "name": "Sáv azonosítója"
+          },
+          "start_value": {
+            "name": "Kezdő érték"
+          },
+          "end_value": {
+            "name": "Záró érték"
+          },
+          "unbounded": {
+            "name": "Felső korlát nélkül"
+          },
+          "last_refresh_utc": {
+            "name": "Utolso frissites (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Mikroinverterek kapcsolati állapota"
       },

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Ultimo gateway segnalato"
       },
+      "tariff_billing_cycle": {
+        "name": "Prossima data di fatturazione",
+        "state_attributes": {
+          "start_date": {
+            "name": "Data di inizio"
+          },
+          "billing_frequency": {
+            "name": "Frequenza di fatturazione"
+          },
+          "billing_interval_value": {
+            "name": "Valore intervallo di fatturazione"
+          },
+          "last_refresh_utc": {
+            "name": "Ultimo aggiornamento (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Ciclo di fatturazione"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Tariffa di importazione",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struttura tariffaria"
+          },
+          "variation_type": {
+            "name": "Tipo di variazione"
+          },
+          "source": {
+            "name": "Origine"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "seasons": {
+            "name": "Stagioni"
+          },
+          "last_refresh_utc": {
+            "name": "Ultimo aggiornamento (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Tariffa di importazione {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struttura tariffaria"
+          },
+          "variation_type": {
+            "name": "Tipo di variazione"
+          },
+          "source": {
+            "name": "Origine"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "ID stagione"
+          },
+          "start_month": {
+            "name": "Mese di inizio"
+          },
+          "end_month": {
+            "name": "Mese di fine"
+          },
+          "day_group_id": {
+            "name": "ID gruppo giorni"
+          },
+          "days": {
+            "name": "Giorni"
+          },
+          "period_id": {
+            "name": "ID periodo"
+          },
+          "period_type": {
+            "name": "Tipo periodo"
+          },
+          "start_time": {
+            "name": "Ora di inizio"
+          },
+          "end_time": {
+            "name": "Ora di fine"
+          },
+          "rate": {
+            "name": "Tariffa"
+          },
+          "formatted_rate": {
+            "name": "Tariffa formattata"
+          },
+          "tier_id": {
+            "name": "ID scaglione"
+          },
+          "start_value": {
+            "name": "Valore iniziale"
+          },
+          "end_value": {
+            "name": "Valore finale"
+          },
+          "unbounded": {
+            "name": "Senza limite superiore"
+          },
+          "last_refresh_utc": {
+            "name": "Ultimo aggiornamento (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Tariffa di esportazione",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struttura tariffaria"
+          },
+          "variation_type": {
+            "name": "Tipo di variazione"
+          },
+          "source": {
+            "name": "Origine"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Piano di esportazione"
+          },
+          "seasons": {
+            "name": "Stagioni"
+          },
+          "last_refresh_utc": {
+            "name": "Ultimo aggiornamento (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Tariffa di esportazione {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struttura tariffaria"
+          },
+          "variation_type": {
+            "name": "Tipo di variazione"
+          },
+          "source": {
+            "name": "Origine"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Piano di esportazione"
+          },
+          "season_id": {
+            "name": "ID stagione"
+          },
+          "start_month": {
+            "name": "Mese di inizio"
+          },
+          "end_month": {
+            "name": "Mese di fine"
+          },
+          "day_group_id": {
+            "name": "ID gruppo giorni"
+          },
+          "days": {
+            "name": "Giorni"
+          },
+          "period_id": {
+            "name": "ID periodo"
+          },
+          "period_type": {
+            "name": "Tipo periodo"
+          },
+          "start_time": {
+            "name": "Ora di inizio"
+          },
+          "end_time": {
+            "name": "Ora di fine"
+          },
+          "rate": {
+            "name": "Tariffa"
+          },
+          "formatted_rate": {
+            "name": "Tariffa formattata"
+          },
+          "tier_id": {
+            "name": "ID scaglione"
+          },
+          "start_value": {
+            "name": "Valore iniziale"
+          },
+          "end_value": {
+            "name": "Valore finale"
+          },
+          "unbounded": {
+            "name": "Senza limite superiore"
+          },
+          "last_refresh_utc": {
+            "name": "Ultimo aggiornamento (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Stato connettività microinverter"
       },

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Vartai paskutinį kartą pranešta"
       },
+      "tariff_billing_cycle": {
+        "name": "Kita saskaitos data",
+        "state_attributes": {
+          "start_date": {
+            "name": "Pradzios data"
+          },
+          "billing_frequency": {
+            "name": "Atsiskaitymo daznis"
+          },
+          "billing_interval_value": {
+            "name": "Atsiskaitymo intervalo verte"
+          },
+          "last_refresh_utc": {
+            "name": "Paskutinis atnaujinimas (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Saskaitos ciklas"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Importo tarifas",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifo struktura"
+          },
+          "variation_type": {
+            "name": "Variacijos tipas"
+          },
+          "source": {
+            "name": "Saltinis"
+          },
+          "currency": {
+            "name": "Valiuta"
+          },
+          "seasons": {
+            "name": "Sezonai"
+          },
+          "last_refresh_utc": {
+            "name": "Paskutinis atnaujinimas (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Importo tarifas {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifo struktura"
+          },
+          "variation_type": {
+            "name": "Variacijos tipas"
+          },
+          "source": {
+            "name": "Saltinis"
+          },
+          "currency": {
+            "name": "Valiuta"
+          },
+          "season_id": {
+            "name": "Sezono ID"
+          },
+          "start_month": {
+            "name": "Pradžios mėnuo"
+          },
+          "end_month": {
+            "name": "Pabaigos mėnuo"
+          },
+          "day_group_id": {
+            "name": "Dienų grupės ID"
+          },
+          "days": {
+            "name": "Dienos"
+          },
+          "period_id": {
+            "name": "Laikotarpio ID"
+          },
+          "period_type": {
+            "name": "Laikotarpio tipas"
+          },
+          "start_time": {
+            "name": "Pradžios laikas"
+          },
+          "end_time": {
+            "name": "Pabaigos laikas"
+          },
+          "rate": {
+            "name": "Tarifas"
+          },
+          "formatted_rate": {
+            "name": "Suformatuotas tarifas"
+          },
+          "tier_id": {
+            "name": "Pakopos ID"
+          },
+          "start_value": {
+            "name": "Pradinė vertė"
+          },
+          "end_value": {
+            "name": "Galutinė vertė"
+          },
+          "unbounded": {
+            "name": "Be viršutinės ribos"
+          },
+          "last_refresh_utc": {
+            "name": "Paskutinis atnaujinimas (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Eksporto tarifas",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifo struktura"
+          },
+          "variation_type": {
+            "name": "Variacijos tipas"
+          },
+          "source": {
+            "name": "Saltinis"
+          },
+          "currency": {
+            "name": "Valiuta"
+          },
+          "export_plan": {
+            "name": "Eksporto planas"
+          },
+          "seasons": {
+            "name": "Sezonai"
+          },
+          "last_refresh_utc": {
+            "name": "Paskutinis atnaujinimas (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Eksporto tarifas {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifo struktura"
+          },
+          "variation_type": {
+            "name": "Variacijos tipas"
+          },
+          "source": {
+            "name": "Saltinis"
+          },
+          "currency": {
+            "name": "Valiuta"
+          },
+          "export_plan": {
+            "name": "Eksporto planas"
+          },
+          "season_id": {
+            "name": "Sezono ID"
+          },
+          "start_month": {
+            "name": "Pradžios mėnuo"
+          },
+          "end_month": {
+            "name": "Pabaigos mėnuo"
+          },
+          "day_group_id": {
+            "name": "Dienų grupės ID"
+          },
+          "days": {
+            "name": "Dienos"
+          },
+          "period_id": {
+            "name": "Laikotarpio ID"
+          },
+          "period_type": {
+            "name": "Laikotarpio tipas"
+          },
+          "start_time": {
+            "name": "Pradžios laikas"
+          },
+          "end_time": {
+            "name": "Pabaigos laikas"
+          },
+          "rate": {
+            "name": "Tarifas"
+          },
+          "formatted_rate": {
+            "name": "Suformatuotas tarifas"
+          },
+          "tier_id": {
+            "name": "Pakopos ID"
+          },
+          "start_value": {
+            "name": "Pradinė vertė"
+          },
+          "end_value": {
+            "name": "Galutinė vertė"
+          },
+          "unbounded": {
+            "name": "Be viršutinės ribos"
+          },
+          "last_refresh_utc": {
+            "name": "Paskutinis atnaujinimas (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Mikroinverterių ryšio būsena"
       },

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway pēdējo reizi ziņots"
       },
+      "tariff_billing_cycle": {
+        "name": "Nakamais rekina datums",
+        "state_attributes": {
+          "start_date": {
+            "name": "Sakuma datums"
+          },
+          "billing_frequency": {
+            "name": "Rekinu biezums"
+          },
+          "billing_interval_value": {
+            "name": "Rekinu intervala vertiba"
+          },
+          "last_refresh_utc": {
+            "name": "Pedeja atjaunosana (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Rekina cikls"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Importa tarifs",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifa struktura"
+          },
+          "variation_type": {
+            "name": "Variacijas tips"
+          },
+          "source": {
+            "name": "Avots"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "seasons": {
+            "name": "Sezonas"
+          },
+          "last_refresh_utc": {
+            "name": "Pedeja atjaunosana (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Importa tarifs {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifa struktura"
+          },
+          "variation_type": {
+            "name": "Variacijas tips"
+          },
+          "source": {
+            "name": "Avots"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Sezonas ID"
+          },
+          "start_month": {
+            "name": "Sākuma mēnesis"
+          },
+          "end_month": {
+            "name": "Beigu mēnesis"
+          },
+          "day_group_id": {
+            "name": "Dienu grupas ID"
+          },
+          "days": {
+            "name": "Dienas"
+          },
+          "period_id": {
+            "name": "Perioda ID"
+          },
+          "period_type": {
+            "name": "Perioda tips"
+          },
+          "start_time": {
+            "name": "Sākuma laiks"
+          },
+          "end_time": {
+            "name": "Beigu laiks"
+          },
+          "rate": {
+            "name": "Tarifs"
+          },
+          "formatted_rate": {
+            "name": "Formatēts tarifs"
+          },
+          "tier_id": {
+            "name": "Pakāpes ID"
+          },
+          "start_value": {
+            "name": "Sākuma vērtība"
+          },
+          "end_value": {
+            "name": "Beigu vērtība"
+          },
+          "unbounded": {
+            "name": "Bez augšējās robežas"
+          },
+          "last_refresh_utc": {
+            "name": "Pedeja atjaunosana (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Eksporta tarifs",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifa struktura"
+          },
+          "variation_type": {
+            "name": "Variacijas tips"
+          },
+          "source": {
+            "name": "Avots"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Eksporta plans"
+          },
+          "seasons": {
+            "name": "Sezonas"
+          },
+          "last_refresh_utc": {
+            "name": "Pedeja atjaunosana (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Eksporta tarifs {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifa struktura"
+          },
+          "variation_type": {
+            "name": "Variacijas tips"
+          },
+          "source": {
+            "name": "Avots"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Eksporta plans"
+          },
+          "season_id": {
+            "name": "Sezonas ID"
+          },
+          "start_month": {
+            "name": "Sākuma mēnesis"
+          },
+          "end_month": {
+            "name": "Beigu mēnesis"
+          },
+          "day_group_id": {
+            "name": "Dienu grupas ID"
+          },
+          "days": {
+            "name": "Dienas"
+          },
+          "period_id": {
+            "name": "Perioda ID"
+          },
+          "period_type": {
+            "name": "Perioda tips"
+          },
+          "start_time": {
+            "name": "Sākuma laiks"
+          },
+          "end_time": {
+            "name": "Beigu laiks"
+          },
+          "rate": {
+            "name": "Tarifs"
+          },
+          "formatted_rate": {
+            "name": "Formatēts tarifs"
+          },
+          "tier_id": {
+            "name": "Pakāpes ID"
+          },
+          "start_value": {
+            "name": "Sākuma vērtība"
+          },
+          "end_value": {
+            "name": "Beigu vērtība"
+          },
+          "unbounded": {
+            "name": "Bez augšējās robežas"
+          },
+          "last_refresh_utc": {
+            "name": "Pedeja atjaunosana (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Mikroinvertoru savienojuma statuss"
       },

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway sist rapportert"
       },
+      "tariff_billing_cycle": {
+        "name": "Neste faktureringsdato",
+        "state_attributes": {
+          "start_date": {
+            "name": "Startdato"
+          },
+          "billing_frequency": {
+            "name": "Faktureringsfrekvens"
+          },
+          "billing_interval_value": {
+            "name": "Faktureringsintervallverdi"
+          },
+          "last_refresh_utc": {
+            "name": "Siste oppdatering (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Faktureringssyklus"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Importtariff",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variasjonstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "seasons": {
+            "name": "Sesonger"
+          },
+          "last_refresh_utc": {
+            "name": "Siste oppdatering (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Importtariff {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variasjonstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Sesong-ID"
+          },
+          "start_month": {
+            "name": "Startmåned"
+          },
+          "end_month": {
+            "name": "Sluttmåned"
+          },
+          "day_group_id": {
+            "name": "Daggruppe-ID"
+          },
+          "days": {
+            "name": "Dager"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Pris"
+          },
+          "formatted_rate": {
+            "name": "Formatert pris"
+          },
+          "tier_id": {
+            "name": "Trinn-ID"
+          },
+          "start_value": {
+            "name": "Startverdi"
+          },
+          "end_value": {
+            "name": "Sluttverdi"
+          },
+          "unbounded": {
+            "name": "Uten øvre grense"
+          },
+          "last_refresh_utc": {
+            "name": "Siste oppdatering (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Eksporttariff",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variasjonstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Eksportplan"
+          },
+          "seasons": {
+            "name": "Sesonger"
+          },
+          "last_refresh_utc": {
+            "name": "Siste oppdatering (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Eksporttariff {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variasjonstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Eksportplan"
+          },
+          "season_id": {
+            "name": "Sesong-ID"
+          },
+          "start_month": {
+            "name": "Startmåned"
+          },
+          "end_month": {
+            "name": "Sluttmåned"
+          },
+          "day_group_id": {
+            "name": "Daggruppe-ID"
+          },
+          "days": {
+            "name": "Dager"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Pris"
+          },
+          "formatted_rate": {
+            "name": "Formatert pris"
+          },
+          "tier_id": {
+            "name": "Trinn-ID"
+          },
+          "start_value": {
+            "name": "Startverdi"
+          },
+          "end_value": {
+            "name": "Sluttverdi"
+          },
+          "unbounded": {
+            "name": "Uten øvre grense"
+          },
+          "last_refresh_utc": {
+            "name": "Siste oppdatering (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Tilkoblingsstatus for mikroinvertere"
       },

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway Laatst gerapporteerd"
       },
+      "tariff_billing_cycle": {
+        "name": "Volgende factuurdatum",
+        "state_attributes": {
+          "start_date": {
+            "name": "Startdatum"
+          },
+          "billing_frequency": {
+            "name": "Factureringsfrequentie"
+          },
+          "billing_interval_value": {
+            "name": "Factureringsintervalwaarde"
+          },
+          "last_refresh_utc": {
+            "name": "Laatst bijgewerkt (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Factuurcyclus"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Importtarief",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariefstructuur"
+          },
+          "variation_type": {
+            "name": "Variatietype"
+          },
+          "source": {
+            "name": "Bron"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "seasons": {
+            "name": "Seizoenen"
+          },
+          "last_refresh_utc": {
+            "name": "Laatst bijgewerkt (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Importtarief {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariefstructuur"
+          },
+          "variation_type": {
+            "name": "Variatietype"
+          },
+          "source": {
+            "name": "Bron"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Seizoens-ID"
+          },
+          "start_month": {
+            "name": "Startmaand"
+          },
+          "end_month": {
+            "name": "Eindmaand"
+          },
+          "day_group_id": {
+            "name": "Daggroep-ID"
+          },
+          "days": {
+            "name": "Dagen"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttijd"
+          },
+          "end_time": {
+            "name": "Eindtijd"
+          },
+          "rate": {
+            "name": "Tarief"
+          },
+          "formatted_rate": {
+            "name": "Opgemaakt tarief"
+          },
+          "tier_id": {
+            "name": "Schijf-ID"
+          },
+          "start_value": {
+            "name": "Startwaarde"
+          },
+          "end_value": {
+            "name": "Eindwaarde"
+          },
+          "unbounded": {
+            "name": "Zonder bovengrens"
+          },
+          "last_refresh_utc": {
+            "name": "Laatst bijgewerkt (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Exporttarief",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariefstructuur"
+          },
+          "variation_type": {
+            "name": "Variatietype"
+          },
+          "source": {
+            "name": "Bron"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Exportplan"
+          },
+          "seasons": {
+            "name": "Seizoenen"
+          },
+          "last_refresh_utc": {
+            "name": "Laatst bijgewerkt (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Exporttarief {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariefstructuur"
+          },
+          "variation_type": {
+            "name": "Variatietype"
+          },
+          "source": {
+            "name": "Bron"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Exportplan"
+          },
+          "season_id": {
+            "name": "Seizoens-ID"
+          },
+          "start_month": {
+            "name": "Startmaand"
+          },
+          "end_month": {
+            "name": "Eindmaand"
+          },
+          "day_group_id": {
+            "name": "Daggroep-ID"
+          },
+          "days": {
+            "name": "Dagen"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttijd"
+          },
+          "end_time": {
+            "name": "Eindtijd"
+          },
+          "rate": {
+            "name": "Tarief"
+          },
+          "formatted_rate": {
+            "name": "Opgemaakt tarief"
+          },
+          "tier_id": {
+            "name": "Schijf-ID"
+          },
+          "start_value": {
+            "name": "Startwaarde"
+          },
+          "end_value": {
+            "name": "Eindwaarde"
+          },
+          "unbounded": {
+            "name": "Zonder bovengrens"
+          },
+          "last_refresh_utc": {
+            "name": "Laatst bijgewerkt (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Verbindingsstatus micro-omvormers"
       },

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Ostatni raport dotyczący bramy"
       },
+      "tariff_billing_cycle": {
+        "name": "Nastepna data rozliczenia",
+        "state_attributes": {
+          "start_date": {
+            "name": "Data poczatku"
+          },
+          "billing_frequency": {
+            "name": "Czestotliwosc rozliczen"
+          },
+          "billing_interval_value": {
+            "name": "Wartosc interwalu rozliczen"
+          },
+          "last_refresh_utc": {
+            "name": "Ostatnie odswiezenie (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Cykl rozliczeniowy"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Taryfa importu",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura taryfy"
+          },
+          "variation_type": {
+            "name": "Typ wariantu"
+          },
+          "source": {
+            "name": "Zrodlo"
+          },
+          "currency": {
+            "name": "Waluta"
+          },
+          "seasons": {
+            "name": "Sezony"
+          },
+          "last_refresh_utc": {
+            "name": "Ostatnie odswiezenie (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Taryfa importu {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura taryfy"
+          },
+          "variation_type": {
+            "name": "Typ wariantu"
+          },
+          "source": {
+            "name": "Zrodlo"
+          },
+          "currency": {
+            "name": "Waluta"
+          },
+          "season_id": {
+            "name": "ID sezonu"
+          },
+          "start_month": {
+            "name": "Miesiąc początkowy"
+          },
+          "end_month": {
+            "name": "Miesiąc końcowy"
+          },
+          "day_group_id": {
+            "name": "ID grupy dni"
+          },
+          "days": {
+            "name": "Dni"
+          },
+          "period_id": {
+            "name": "ID okresu"
+          },
+          "period_type": {
+            "name": "Typ okresu"
+          },
+          "start_time": {
+            "name": "Czas rozpoczęcia"
+          },
+          "end_time": {
+            "name": "Czas zakończenia"
+          },
+          "rate": {
+            "name": "Stawka"
+          },
+          "formatted_rate": {
+            "name": "Sformatowana stawka"
+          },
+          "tier_id": {
+            "name": "ID progu"
+          },
+          "start_value": {
+            "name": "Wartość początkowa"
+          },
+          "end_value": {
+            "name": "Wartość końcowa"
+          },
+          "unbounded": {
+            "name": "Bez górnego limitu"
+          },
+          "last_refresh_utc": {
+            "name": "Ostatnie odswiezenie (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Taryfa eksportu",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura taryfy"
+          },
+          "variation_type": {
+            "name": "Typ wariantu"
+          },
+          "source": {
+            "name": "Zrodlo"
+          },
+          "currency": {
+            "name": "Waluta"
+          },
+          "export_plan": {
+            "name": "Plan eksportu"
+          },
+          "seasons": {
+            "name": "Sezony"
+          },
+          "last_refresh_utc": {
+            "name": "Ostatnie odswiezenie (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Taryfa eksportu {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura taryfy"
+          },
+          "variation_type": {
+            "name": "Typ wariantu"
+          },
+          "source": {
+            "name": "Zrodlo"
+          },
+          "currency": {
+            "name": "Waluta"
+          },
+          "export_plan": {
+            "name": "Plan eksportu"
+          },
+          "season_id": {
+            "name": "ID sezonu"
+          },
+          "start_month": {
+            "name": "Miesiąc początkowy"
+          },
+          "end_month": {
+            "name": "Miesiąc końcowy"
+          },
+          "day_group_id": {
+            "name": "ID grupy dni"
+          },
+          "days": {
+            "name": "Dni"
+          },
+          "period_id": {
+            "name": "ID okresu"
+          },
+          "period_type": {
+            "name": "Typ okresu"
+          },
+          "start_time": {
+            "name": "Czas rozpoczęcia"
+          },
+          "end_time": {
+            "name": "Czas zakończenia"
+          },
+          "rate": {
+            "name": "Stawka"
+          },
+          "formatted_rate": {
+            "name": "Sformatowana stawka"
+          },
+          "tier_id": {
+            "name": "ID progu"
+          },
+          "start_value": {
+            "name": "Wartość początkowa"
+          },
+          "end_value": {
+            "name": "Wartość końcowa"
+          },
+          "unbounded": {
+            "name": "Bez górnego limitu"
+          },
+          "last_refresh_utc": {
+            "name": "Ostatnie odswiezenie (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Stan łączności mikroinwerterów"
       },

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway relatado pela última vez"
       },
+      "tariff_billing_cycle": {
+        "name": "Proxima data de faturamento",
+        "state_attributes": {
+          "start_date": {
+            "name": "Data de inicio"
+          },
+          "billing_frequency": {
+            "name": "Frequencia de faturamento"
+          },
+          "billing_interval_value": {
+            "name": "Valor do intervalo de faturamento"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima atualizacao (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Ciclo de faturamento"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Tarifa de importacao",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estrutura da tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacao"
+          },
+          "source": {
+            "name": "Fonte"
+          },
+          "currency": {
+            "name": "Moeda"
+          },
+          "seasons": {
+            "name": "Estacoes"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima atualizacao (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Tarifa de importacao {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estrutura da tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacao"
+          },
+          "source": {
+            "name": "Fonte"
+          },
+          "currency": {
+            "name": "Moeda"
+          },
+          "season_id": {
+            "name": "ID da temporada"
+          },
+          "start_month": {
+            "name": "Mês inicial"
+          },
+          "end_month": {
+            "name": "Mês final"
+          },
+          "day_group_id": {
+            "name": "ID do grupo de dias"
+          },
+          "days": {
+            "name": "Dias"
+          },
+          "period_id": {
+            "name": "ID do período"
+          },
+          "period_type": {
+            "name": "Tipo de período"
+          },
+          "start_time": {
+            "name": "Hora de início"
+          },
+          "end_time": {
+            "name": "Hora de término"
+          },
+          "rate": {
+            "name": "Tarifa"
+          },
+          "formatted_rate": {
+            "name": "Tarifa formatada"
+          },
+          "tier_id": {
+            "name": "ID da faixa"
+          },
+          "start_value": {
+            "name": "Valor inicial"
+          },
+          "end_value": {
+            "name": "Valor final"
+          },
+          "unbounded": {
+            "name": "Sem limite superior"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima atualizacao (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Tarifa de exportacao",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estrutura da tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacao"
+          },
+          "source": {
+            "name": "Fonte"
+          },
+          "currency": {
+            "name": "Moeda"
+          },
+          "export_plan": {
+            "name": "Plano de exportacao"
+          },
+          "seasons": {
+            "name": "Estacoes"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima atualizacao (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Tarifa de exportacao {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estrutura da tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacao"
+          },
+          "source": {
+            "name": "Fonte"
+          },
+          "currency": {
+            "name": "Moeda"
+          },
+          "export_plan": {
+            "name": "Plano de exportacao"
+          },
+          "season_id": {
+            "name": "ID da temporada"
+          },
+          "start_month": {
+            "name": "Mês inicial"
+          },
+          "end_month": {
+            "name": "Mês final"
+          },
+          "day_group_id": {
+            "name": "ID do grupo de dias"
+          },
+          "days": {
+            "name": "Dias"
+          },
+          "period_id": {
+            "name": "ID do período"
+          },
+          "period_type": {
+            "name": "Tipo de período"
+          },
+          "start_time": {
+            "name": "Hora de início"
+          },
+          "end_time": {
+            "name": "Hora de término"
+          },
+          "rate": {
+            "name": "Tarifa"
+          },
+          "formatted_rate": {
+            "name": "Tarifa formatada"
+          },
+          "tier_id": {
+            "name": "ID da faixa"
+          },
+          "start_value": {
+            "name": "Valor inicial"
+          },
+          "end_value": {
+            "name": "Valor final"
+          },
+          "unbounded": {
+            "name": "Sem limite superior"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima atualizacao (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Status de conectividade dos microinversores"
       },

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway Raportat ultima dată"
       },
+      "tariff_billing_cycle": {
+        "name": "Urmatoarea data de facturare",
+        "state_attributes": {
+          "start_date": {
+            "name": "Data de inceput"
+          },
+          "billing_frequency": {
+            "name": "Frecventa de facturare"
+          },
+          "billing_interval_value": {
+            "name": "Valoare interval de facturare"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizare (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Ciclu de facturare"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Tarif de import",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structura tarifului"
+          },
+          "variation_type": {
+            "name": "Tip variatie"
+          },
+          "source": {
+            "name": "Sursa"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "seasons": {
+            "name": "Sezoane"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizare (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Tarif de import {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structura tarifului"
+          },
+          "variation_type": {
+            "name": "Tip variatie"
+          },
+          "source": {
+            "name": "Sursa"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "season_id": {
+            "name": "ID sezon"
+          },
+          "start_month": {
+            "name": "Luna de început"
+          },
+          "end_month": {
+            "name": "Luna de sfârșit"
+          },
+          "day_group_id": {
+            "name": "ID grup de zile"
+          },
+          "days": {
+            "name": "Zile"
+          },
+          "period_id": {
+            "name": "ID perioadă"
+          },
+          "period_type": {
+            "name": "Tip perioadă"
+          },
+          "start_time": {
+            "name": "Ora de început"
+          },
+          "end_time": {
+            "name": "Ora de sfârșit"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Tarif formatat"
+          },
+          "tier_id": {
+            "name": "ID nivel"
+          },
+          "start_value": {
+            "name": "Valoare inițială"
+          },
+          "end_value": {
+            "name": "Valoare finală"
+          },
+          "unbounded": {
+            "name": "Fără limită superioară"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizare (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Tarif de export",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structura tarifului"
+          },
+          "variation_type": {
+            "name": "Tip variatie"
+          },
+          "source": {
+            "name": "Sursa"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "export_plan": {
+            "name": "Plan de export"
+          },
+          "seasons": {
+            "name": "Sezoane"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizare (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Tarif de export {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structura tarifului"
+          },
+          "variation_type": {
+            "name": "Tip variatie"
+          },
+          "source": {
+            "name": "Sursa"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "export_plan": {
+            "name": "Plan de export"
+          },
+          "season_id": {
+            "name": "ID sezon"
+          },
+          "start_month": {
+            "name": "Luna de început"
+          },
+          "end_month": {
+            "name": "Luna de sfârșit"
+          },
+          "day_group_id": {
+            "name": "ID grup de zile"
+          },
+          "days": {
+            "name": "Zile"
+          },
+          "period_id": {
+            "name": "ID perioadă"
+          },
+          "period_type": {
+            "name": "Tip perioadă"
+          },
+          "start_time": {
+            "name": "Ora de început"
+          },
+          "end_time": {
+            "name": "Ora de sfârșit"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Tarif formatat"
+          },
+          "tier_id": {
+            "name": "ID nivel"
+          },
+          "start_value": {
+            "name": "Valoare inițială"
+          },
+          "end_value": {
+            "name": "Valoare finală"
+          },
+          "unbounded": {
+            "name": "Fără limită superioară"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizare (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Stare conectivitate microinvertoare"
       },

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -1138,6 +1138,208 @@
       "gateway_last_reported": {
         "name": "Gateway senast rapporterad"
       },
+      "tariff_billing_cycle": {
+        "name": "Nasta faktureringsdatum",
+        "state_attributes": {
+          "start_date": {
+            "name": "Startdatum"
+          },
+          "billing_frequency": {
+            "name": "Faktureringsfrekvens"
+          },
+          "billing_interval_value": {
+            "name": "Faktureringsintervallvaerde"
+          },
+          "last_refresh_utc": {
+            "name": "Senaste uppdatering (UTC)"
+          },
+          "billing_cycle": {
+            "name": "Faktureringscykel"
+          }
+        }
+      },
+      "tariff_import_rate": {
+        "name": "Importtariff",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Kaella"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "seasons": {
+            "name": "Saesonger"
+          },
+          "last_refresh_utc": {
+            "name": "Senaste uppdatering (UTC)"
+          }
+        }
+      },
+      "tariff_import_rate_value": {
+        "name": "Importtariff {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Kaella"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Säsongs-ID"
+          },
+          "start_month": {
+            "name": "Startmånad"
+          },
+          "end_month": {
+            "name": "Slutmånad"
+          },
+          "day_group_id": {
+            "name": "Daggrupps-ID"
+          },
+          "days": {
+            "name": "Dagar"
+          },
+          "period_id": {
+            "name": "Period-ID"
+          },
+          "period_type": {
+            "name": "Periodtyp"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Pris"
+          },
+          "formatted_rate": {
+            "name": "Formaterat pris"
+          },
+          "tier_id": {
+            "name": "Nivå-ID"
+          },
+          "start_value": {
+            "name": "Startvärde"
+          },
+          "end_value": {
+            "name": "Slutvärde"
+          },
+          "unbounded": {
+            "name": "Utan övre gräns"
+          },
+          "last_refresh_utc": {
+            "name": "Senaste uppdatering (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate": {
+        "name": "Exporttariff",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Kaella"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Exportplan"
+          },
+          "seasons": {
+            "name": "Saesonger"
+          },
+          "last_refresh_utc": {
+            "name": "Senaste uppdatering (UTC)"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Exporttariff {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Kaella"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Exportplan"
+          },
+          "season_id": {
+            "name": "Säsongs-ID"
+          },
+          "start_month": {
+            "name": "Startmånad"
+          },
+          "end_month": {
+            "name": "Slutmånad"
+          },
+          "day_group_id": {
+            "name": "Daggrupps-ID"
+          },
+          "days": {
+            "name": "Dagar"
+          },
+          "period_id": {
+            "name": "Period-ID"
+          },
+          "period_type": {
+            "name": "Periodtyp"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Pris"
+          },
+          "formatted_rate": {
+            "name": "Formaterat pris"
+          },
+          "tier_id": {
+            "name": "Nivå-ID"
+          },
+          "start_value": {
+            "name": "Startvärde"
+          },
+          "end_value": {
+            "name": "Slutvärde"
+          },
+          "unbounded": {
+            "name": "Utan övre gräns"
+          },
+          "last_refresh_utc": {
+            "name": "Senaste uppdatering (UTC)"
+          }
+        }
+      },
       "microinverter_connectivity_status": {
         "name": "Anslutningsstatus för mikroväxelriktare"
       },

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3729,6 +3729,47 @@ async def test_battery_site_settings_passes_params_and_headers() -> None:
 
 
 @pytest.mark.asyncio
+async def test_site_tariff_billing_details_passes_tariff_headers() -> None:
+    token = _make_token({"user_id": "77"})
+    client = _make_client()
+    client.update_credentials(
+        eauth=token,
+        cookie="session=1; XSRF-TOKEN=xsrf-token; other=1",
+    )
+    client._json = AsyncMock(return_value={"billingFrequency": "MONTH"})
+
+    out = await client.site_tariff_billing_details()
+
+    assert out == {"billingFrequency": "MONTH"}
+    args, kwargs = client._json.await_args
+    assert args[0] == "GET"
+    assert "/service/tariff/tariff-ms/systems/SITE/billing-details" in args[1]
+    assert (
+        kwargs["headers"]["Accept"] == "application/json, text/javascript, */*; q=0.01"
+    )
+    assert kwargs["headers"]["Cookie"] == "session=1; XSRF-TOKEN=xsrf-token; other=1"
+    assert kwargs["headers"]["e-auth-token"] == token
+    assert kwargs["headers"]["Username"] == "77"
+    assert kwargs["headers"]["X-Requested-With"] == "XMLHttpRequest"
+    assert kwargs["headers"]["x-xsrf-token"] == "xsrf-token"
+    assert "Requestid" in kwargs["headers"]
+
+
+@pytest.mark.asyncio
+async def test_site_tariff_passes_include_site_details() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value={"purchase": {"typeId": "flat"}})
+
+    out = await client.site_tariff()
+
+    assert out == {"purchase": {"typeId": "flat"}}
+    args, kwargs = client._json.await_args
+    assert args[0] == "GET"
+    assert "/service/tariff/tariff-ms/systems/SITE/tariff" in args[1]
+    assert kwargs["params"] == {"include-site-details": "true"}
+
+
+@pytest.mark.asyncio
 async def test_battery_settings_details_passes_params_and_headers() -> None:
     token = _make_token({"user_id": "99"})
     client = _make_client()

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3770,6 +3770,24 @@ async def test_site_tariff_passes_include_site_details() -> None:
 
 
 @pytest.mark.asyncio
+async def test_site_tariff_bundle_fetches_billing_and_tariff() -> None:
+    client = _make_client()
+    client.site_tariff_billing_details = AsyncMock(
+        return_value={"billingFrequency": "MONTH"}
+    )
+    client.site_tariff = AsyncMock(return_value={"purchase": {"typeId": "flat"}})
+
+    out = await client.site_tariff_bundle()
+
+    assert out == (
+        {"billingFrequency": "MONTH"},
+        {"purchase": {"typeId": "flat"}},
+    )
+    client.site_tariff_billing_details.assert_awaited_once_with()
+    client.site_tariff.assert_awaited_once_with()
+
+
+@pytest.mark.asyncio
 async def test_battery_settings_details_passes_params_and_headers() -> None:
     token = _make_token({"user_id": "99"})
     client = _make_client()

--- a/tests/components/enphase_ev/test_coordinator_edge_cases.py
+++ b/tests/components/enphase_ev/test_coordinator_edge_cases.py
@@ -464,6 +464,38 @@ def test_clear_auth_refresh_rejection_state_resets_counter_and_cooldown(hass):
     assert coord._auth_refresh_rejected_ends_utc is None
 
 
+@pytest.mark.asyncio
+async def test_post_status_first_refresh_clears_auth_refresh_rejection(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import RefreshPipelineContext
+
+    coord = coordinator_factory()
+    coord.refresh_runner.async_run_refresh_call = AsyncMock(
+        return_value=("tariff_s", 0.123)
+    )
+    coord._auth_refresh_rejected_count = 2
+    coord._auth_refresh_rejected_until = time.monotonic() + 60
+    coord._auth_refresh_rejected_ends_utc = datetime.now(timezone.utc) + timedelta(
+        seconds=60
+    )
+    context = RefreshPipelineContext(
+        started_mono=time.monotonic(),
+        refresh_started_utc=datetime.now(timezone.utc),
+        phase_timings={},
+        fallback_data={},
+        first_refresh=True,
+    )
+
+    await coord._async_run_post_status_refresh_pipeline(context)
+
+    coord.refresh_runner.async_run_refresh_call.assert_awaited_once()
+    assert context.phase_timings["tariff_s"] == 0.123
+    assert coord._auth_refresh_rejected_count == 0
+    assert coord._auth_refresh_rejected_until is None
+    assert coord._auth_refresh_rejected_ends_utc is None
+
+
 def test_coordinator_init_restores_auth_refresh_state(hass, monkeypatch):
     from custom_components.enphase_ev import coordinator as coord_mod
     from custom_components.enphase_ev.coordinator import EnphaseCoordinator

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -313,6 +313,10 @@ class _RefreshOwner:
         self.current_power_runtime = SimpleNamespace(
             refresh_due=lambda: True,
         )
+        self.tariff_runtime = SimpleNamespace(
+            async_refresh=lambda: self._record("tariff"),
+            refresh_due=lambda: True,
+        )
         self.heatpump_runtime = SimpleNamespace(
             heatpump_runtime_state_refresh_due=lambda: True,
             heatpump_daily_consumption_refresh_due=lambda: True,
@@ -440,6 +444,7 @@ def test_followup_refresh_stage_binds_zero_arg_calls() -> None:
         "battery_schedules_s",
         "storm_guard_s",
         "storm_alert_s",
+        "tariff_s",
         "grid_control_check_s",
         "dry_contact_settings_s",
         "current_power_s",
@@ -501,6 +506,7 @@ def test_dynamic_followup_plan_skips_up_to_date_tasks() -> None:
     owner.inventory_runtime.hems_devices_refresh_due = lambda: False
     owner.current_power_runtime.refresh_due = lambda: False
     owner.evse_feature_flags_runtime.refresh_due = lambda: False
+    owner.tariff_runtime.refresh_due = lambda: False
 
     assert build_followup_plan(owner).stages == ()
 
@@ -525,6 +531,7 @@ def test_dynamic_followup_plan_selects_due_subset() -> None:
     stage = plan.stages[0]
     assert [task.timing_key for task in stage.parallel_tasks] == [
         "battery_site_settings_s",
+        "tariff_s",
     ]
     assert [task.timing_key for task in stage.ordered_tasks] == [
         "battery_status_s",
@@ -565,6 +572,7 @@ def test_dynamic_site_only_followup_plan_creates_inverter_stage_without_base_fol
     owner.inventory_runtime.hems_devices_refresh_due = lambda: False
     owner.current_power_runtime.refresh_due = lambda: False
     owner.evse_feature_flags_runtime.refresh_due = lambda: False
+    owner.tariff_runtime.refresh_due = lambda: False
     owner.inventory_runtime.inverters_refresh_due = lambda: True
     owner.heatpump_runtime.heatpump_runtime_state_refresh_due = lambda: False
     owner.heatpump_runtime.heatpump_daily_consumption_refresh_due = lambda: False
@@ -593,6 +601,7 @@ def test_dynamic_followup_plan_includes_due_evse_feature_flags() -> None:
     owner.inventory_runtime.devices_inventory_refresh_due = lambda: False
     owner.inventory_runtime.hems_devices_refresh_due = lambda: False
     owner.current_power_runtime.refresh_due = lambda: False
+    owner.tariff_runtime.refresh_due = lambda: False
 
     plan = build_followup_plan(owner)
 
@@ -688,6 +697,19 @@ def test_dynamic_post_session_followup_only_includes_due_tasks() -> None:
     ]
 
 
+def test_dynamic_post_session_followup_includes_all_due_tasks() -> None:
+    owner = _RefreshOwner()
+
+    plan = build_post_session_followup_plan(owner, "today")
+
+    assert len(plan.stages) == 1
+    assert [task.timing_key for task in plan.stages[0].parallel_tasks] == [
+        "evse_timeseries_s",
+        "site_energy_s",
+        "inverters_s",
+    ]
+
+
 @pytest.mark.asyncio
 async def test_coordinator_refresh_plan_runner_executes_each_stage(
     coordinator_factory,
@@ -717,7 +739,7 @@ async def test_coordinator_refresh_plan_runner_executes_each_stage(
     await coord.refresh_runner.async_run_refresh_plan({}, plan=FOLLOWUP_PLAN)
 
     assert seen == [
-        (None, True, 9, 4),
+        (None, True, 10, 4),
     ]
 
 

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -182,6 +182,30 @@ def test_endpoint_family_suppression_recovery_and_metrics(
     assert recovered.next_retry_utc is None
 
 
+def test_tariff_endpoint_family_failure_reports_degraded_service(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    monkeypatch.setattr(coord_mod.random, "uniform", lambda _a, _b: 1.0)
+
+    err = OptionalEndpointUnavailable("Tariff payload did not include data")
+
+    assert coord._note_endpoint_family_failure("tariff", err) is True  # noqa: SLF001
+
+    metrics = coord.collect_site_metrics()
+    tariff_health = metrics["endpoint_family_health"]["tariff"]
+    assert tariff_health["consecutive_failures"] == 1
+    assert tariff_health["last_error"] == "Tariff payload did not include data"
+    assert tariff_health["next_retry_utc"] is not None
+    assert metrics["tariff_available"] is False
+    assert metrics["tariff_service_status"] == "degraded"
+    assert metrics["tariff_failures"] == 1
+    assert metrics["tariff_last_error"] == "Tariff payload did not include data"
+    assert metrics["tariff_backoff_active"] is True
+    assert metrics["tariff_backoff_ends_utc"] == tariff_health["next_retry_utc"]
+    assert "tariff" in metrics["degraded_services"]
+
+
 def test_endpoint_family_misc_branches_and_diagnostics(
     coordinator_factory, monkeypatch
 ) -> None:
@@ -951,6 +975,7 @@ async def test_async_update_data_session_end_fix_handles_invalid_timestamp(
     coordinator_factory, monkeypatch
 ):
     coord = coordinator_factory()
+    coord.tariff_runtime.async_refresh = AsyncMock()
     sn = RANDOM_SERIAL
     coord._last_charging[sn] = True
 
@@ -999,6 +1024,7 @@ async def test_async_update_data_session_end_fix_default_branch(
     coordinator_factory,
 ):
     coord = coordinator_factory()
+    coord.tariff_runtime.async_refresh = AsyncMock()
     sn = RANDOM_SERIAL
     coord._last_charging[sn] = True
     coord.client.status = AsyncMock(
@@ -1035,6 +1061,7 @@ async def test_async_update_data_session_end_fix_default_branch(
 @pytest.mark.asyncio
 async def test_async_update_data_handles_invalid_global_timestamp(coordinator_factory):
     coord = coordinator_factory()
+    coord.tariff_runtime.async_refresh = AsyncMock()
     sn = RANDOM_SERIAL
     coord.client.status = AsyncMock(
         return_value={

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -1052,6 +1052,21 @@ async def test_config_entry_diagnostics_handles_firmware_catalog_snapshot_error(
 
 
 @pytest.mark.asyncio
+async def test_config_entry_diagnostics_handles_tariff_diagnostics_error(
+    hass, config_entry
+) -> None:
+    coord = DummyCoordinator()
+    coord.tariff_runtime = SimpleNamespace(
+        diagnostics=lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    diag = await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
+
+    assert diag["coordinator"]["tariff"] == {}
+
+
+@pytest.mark.asyncio
 async def test_config_entry_diagnostics_handles_scheduler_backoff_format_error(
     hass, config_entry
 ) -> None:

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -587,6 +587,14 @@ class DummyCoordinator(SimpleNamespace):
             2026, 3, 1, 0, 0, tzinfo=timezone.utc
         )
         self._heatpump_runtime_diagnostics_error = None
+        self.tariff_runtime = SimpleNamespace(
+            diagnostics=lambda: {
+                "billing_available": True,
+                "import_rate_available": True,
+                "export_rate_available": False,
+                "endpoint_family": {"support_state": "supported"},
+            }
+        )
 
     def collect_site_metrics(self):
         return {
@@ -987,6 +995,12 @@ async def test_config_entry_diagnostics_includes_coordinator(
         diag["coordinator"]["scheduler"]["backoff_ends_utc"]
         == "2025-01-01T00:00:00+00:00"
     )
+    assert diag["coordinator"]["tariff"] == {
+        "billing_available": True,
+        "import_rate_available": True,
+        "export_rate_available": False,
+        "endpoint_family": {"support_state": "supported"},
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -313,6 +313,112 @@ def test_battery_settings_entity_strings_exist_for_all_locales() -> None:
             assert value.strip(), f"{locale.name} missing value for {path}"
 
 
+def test_tariff_entity_strings_exist_for_all_locales() -> None:
+    """Ensure tariff entity and attribute labels exist in every locale."""
+
+    translations_dir = (
+        pathlib.Path(__file__).resolve().parents[3]
+        / "custom_components"
+        / "enphase_ev"
+        / "translations"
+    )
+    rate_value_attrs = [
+        "rate_structure",
+        "variation_type",
+        "source",
+        "currency",
+        "season_id",
+        "start_month",
+        "end_month",
+        "day_group_id",
+        "days",
+        "period_id",
+        "period_type",
+        "start_time",
+        "end_time",
+        "rate",
+        "formatted_rate",
+        "tier_id",
+        "start_value",
+        "end_value",
+        "unbounded",
+        "last_refresh_utc",
+    ]
+    paths = [
+        "entity.sensor.tariff_billing_cycle.name",
+        "entity.sensor.tariff_billing_cycle.state_attributes.start_date.name",
+        "entity.sensor.tariff_billing_cycle.state_attributes.billing_frequency.name",
+        "entity.sensor.tariff_billing_cycle.state_attributes.billing_interval_value.name",
+        "entity.sensor.tariff_billing_cycle.state_attributes.billing_cycle.name",
+        "entity.sensor.tariff_billing_cycle.state_attributes.last_refresh_utc.name",
+        "entity.sensor.tariff_import_rate.name",
+        "entity.sensor.tariff_import_rate.state_attributes.rate_structure.name",
+        "entity.sensor.tariff_import_rate.state_attributes.variation_type.name",
+        "entity.sensor.tariff_import_rate.state_attributes.source.name",
+        "entity.sensor.tariff_import_rate.state_attributes.currency.name",
+        "entity.sensor.tariff_import_rate.state_attributes.seasons.name",
+        "entity.sensor.tariff_import_rate.state_attributes.last_refresh_utc.name",
+        "entity.sensor.tariff_export_rate.name",
+        "entity.sensor.tariff_export_rate.state_attributes.rate_structure.name",
+        "entity.sensor.tariff_export_rate.state_attributes.variation_type.name",
+        "entity.sensor.tariff_export_rate.state_attributes.source.name",
+        "entity.sensor.tariff_export_rate.state_attributes.currency.name",
+        "entity.sensor.tariff_export_rate.state_attributes.export_plan.name",
+        "entity.sensor.tariff_export_rate.state_attributes.seasons.name",
+        "entity.sensor.tariff_export_rate.state_attributes.last_refresh_utc.name",
+    ]
+    for family in ("import", "export"):
+        key = f"tariff_{family}_rate_value"
+        paths.append(f"entity.sensor.{key}.name")
+        attrs = list(rate_value_attrs)
+        if family == "export":
+            attrs.append("export_plan")
+        for attr in attrs:
+            paths.append(f"entity.sensor.{key}.state_attributes.{attr}.name")
+    for locale in translations_dir.glob("*.json"):
+        data = json.loads(locale.read_text(encoding="utf-8"))
+        for path in paths:
+            value = _at_path(data, path)
+            assert value.strip(), f"{locale.name} missing value for {path}"
+
+
+def test_tariff_entity_strings_localized_for_non_english_locales() -> None:
+    """Guard tariff labels from silently falling back to English."""
+
+    translations_dir = (
+        pathlib.Path(__file__).resolve().parents[3]
+        / "custom_components"
+        / "enphase_ev"
+        / "translations"
+    )
+    en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
+    paths = [
+        "entity.sensor.tariff_billing_cycle.name",
+        "entity.sensor.tariff_billing_cycle.state_attributes.start_date.name",
+        "entity.sensor.tariff_billing_cycle.state_attributes.billing_cycle.name",
+        "entity.sensor.tariff_import_rate.name",
+        "entity.sensor.tariff_import_rate.state_attributes.rate_structure.name",
+        "entity.sensor.tariff_import_rate_value.name",
+        "entity.sensor.tariff_import_rate_value.state_attributes.period_type.name",
+        "entity.sensor.tariff_import_rate_value.state_attributes.formatted_rate.name",
+        "entity.sensor.tariff_export_rate.name",
+        "entity.sensor.tariff_export_rate.state_attributes.export_plan.name",
+        "entity.sensor.tariff_export_rate_value.name",
+        "entity.sensor.tariff_export_rate_value.state_attributes.rate.name",
+    ]
+    for locale in translations_dir.glob("*.json"):
+        name = locale.name
+        if name == "en.json" or name.startswith("en-"):
+            continue
+        data = json.loads(locale.read_text(encoding="utf-8"))
+        for path in paths:
+            value = _at_path(data, path)
+            assert value.strip(), f"{name} missing value for {path}"
+            assert value != _at_path(
+                en_data, path
+            ), f"{name} should localize {path} (still matches English)"
+
+
 def test_battery_cfg_schedule_status_strings_localized_for_non_english_locales() -> (
     None
 ):

--- a/tests/components/enphase_ev/test_system_health.py
+++ b/tests/components/enphase_ev/test_system_health.py
@@ -63,6 +63,13 @@ async def test_system_health_info_reports_state(
         "firmware_catalog_source_age_seconds": 60.0,
         "last_failure_status": None,
         "last_failure_description": None,
+        "tariff_available": False,
+        "tariff_service_status": "degraded",
+        "tariff_last_error": "Tariff payload did not include data",
+        "tariff_failures": 1,
+        "tariff_backoff_active": True,
+        "tariff_backoff_ends_utc": "2026-04-26T01:00:00+00:00",
+        "degraded_services": ["tariff"],
     }
 
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
@@ -91,6 +98,13 @@ async def test_system_health_info_reports_state(
     assert info["session_cache_ttl_s"] == 300
     assert info["firmware_catalog_generated_at"] == "2026-03-01T00:00:00Z"
     assert info["firmware_catalog_source_age_seconds"] == 60.0
+    assert info["tariff_available"] is False
+    assert info["tariff_service_status"] == "degraded"
+    assert info["tariff_last_error"] == "Tariff payload did not include data"
+    assert info["tariff_failures"] == 1
+    assert info["tariff_backoff_active"] is True
+    assert info["tariff_backoff_ends_utc"] == "2026-04-26T01:00:00+00:00"
+    assert info["degraded_services"] == ["tariff"]
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -1,0 +1,1202 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import aiohttp
+import pytest
+
+from custom_components.enphase_ev.api import OptionalEndpointUnavailable
+from custom_components.enphase_ev.const import DOMAIN
+from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
+from custom_components.enphase_ev.sensor import (
+    EnphaseTariffBillingSensor,
+    EnphaseTariffExportRateValueSensor,
+    EnphaseTariffRateSensor,
+    EnphaseTariffRateValueSensor,
+    async_setup_entry,
+)
+from custom_components.enphase_ev.tariff import (
+    TARIFF_ENDPOINT_FAMILY,
+    TariffRateSnapshot,
+    TariffRuntime,
+    _clean_text,
+    _format_rate,
+    export_rate_sensor_specs,
+    next_billing_date,
+    parse_tariff_billing,
+    parse_tariff_rate,
+    tariff_rate_sensor_specs,
+)
+
+
+def test_parse_tariff_billing_monthly_and_day_based() -> None:
+    monthly = parse_tariff_billing(
+        {
+            "anyBillPeriodStartDate": "2025-08-18",
+            "billingFrequency": "MONTH",
+            "billingIntervalValue": 1,
+        }
+    )
+    assert monthly is not None
+    assert monthly.state == "Monthly"
+    assert monthly.attributes == {
+        "start_date": "2025-08-18",
+        "billing_frequency": "MONTH",
+        "billing_interval_value": 1,
+        "billing_cycle": "Monthly",
+    }
+    assert next_billing_date(monthly, today=date(2026, 4, 26)) == date(2026, 5, 18)
+
+    day_based = parse_tariff_billing(
+        {
+            "anyBillPeriodStartDate": "2025-08-17",
+            "billingFrequency": "DAY",
+            "billingIntervalValue": 30,
+        }
+    )
+    assert day_based is not None
+    assert day_based.state == "Every 30 days"
+    assert next_billing_date(day_based, today=date(2025, 9, 16)) == date(2025, 10, 16)
+
+    two_month = parse_tariff_billing(
+        {"billingFrequency": "MONTH", "billingIntervalValue": 2}
+    )
+    assert two_month is not None
+    assert two_month.state == "Every 2 months"
+
+    daily = parse_tariff_billing({"billingFrequency": "DAY", "billingIntervalValue": 1})
+    assert daily is not None
+    assert daily.state == "Daily"
+
+    custom = parse_tariff_billing({"billingFrequency": "WEEK"})
+    assert custom is not None
+    assert custom.state == "WEEK"
+    assert next_billing_date(custom, today=date(2026, 4, 26)) is None
+    custom_with_start = parse_tariff_billing(
+        {"anyBillPeriodStartDate": "2026-04-01", "billingFrequency": "WEEK"}
+    )
+    assert custom_with_start is not None
+    assert next_billing_date(custom_with_start, today=date(2026, 4, 26)) is None
+
+
+def test_next_billing_date_month_end_and_invalid_values() -> None:
+    month_end = parse_tariff_billing(
+        {
+            "anyBillPeriodStartDate": "2025-01-31",
+            "billingFrequency": "MONTH",
+            "billingIntervalValue": 1,
+        }
+    )
+    assert month_end is not None
+    assert next_billing_date(month_end, today=date(2025, 2, 27)) == date(2025, 2, 28)
+    assert next_billing_date(month_end, today=date(2025, 2, 28)) == date(2025, 3, 31)
+
+    invalid_date = parse_tariff_billing(
+        {
+            "anyBillPeriodStartDate": "not-a-date",
+            "billingFrequency": "MONTH",
+            "billingIntervalValue": 1,
+        }
+    )
+    assert invalid_date is not None
+    assert next_billing_date(invalid_date, today=date(2026, 4, 26)) is None
+
+    invalid_interval = parse_tariff_billing(
+        {
+            "anyBillPeriodStartDate": "2026-04-01",
+            "billingFrequency": "DAY",
+            "billingIntervalValue": 0,
+        }
+    )
+    assert invalid_interval is not None
+    assert next_billing_date(invalid_interval, today=date(2026, 4, 26)) is None
+
+
+def test_parse_tariff_rate_flat_tou_and_tiered_shapes() -> None:
+    payload = {
+        "currency": "$",
+        "purchase": {
+            "typeKind": "seasonal-and-weekends",
+            "typeId": "tou",
+            "source": "manual",
+            "seasons": [
+                {
+                    "id": "summer",
+                    "startMonth": "12",
+                    "endMonth": "5",
+                    "days": [
+                        {
+                            "id": "weekdays",
+                            "days": [1, 2, 3, 4, 5],
+                            "periods": [
+                                {
+                                    "id": "peak-1",
+                                    "rate": "0.31",
+                                    "type": "peak",
+                                    "startTime": "840",
+                                    "endTime": "1260",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            ],
+        },
+        "buyback": {
+            "typeKind": "single",
+            "typeId": "tiered",
+            "source": "netFit",
+            "exportPlan": "netFit",
+            "seasons": [
+                {
+                    "id": "default",
+                    "startMonth": "1",
+                    "endMonth": "12",
+                    "offPeak": "0.04",
+                    "tiers": [
+                        {
+                            "id": "tier-1",
+                            "rate": "0.06",
+                            "startValue": "10",
+                            "endValue": "20",
+                        },
+                        {
+                            "id": "tier-2",
+                            "rate": "0.10",
+                            "startValue": "20",
+                            "endValue": -1,
+                        },
+                    ],
+                }
+            ],
+        },
+    }
+
+    purchase = parse_tariff_rate(payload, "purchase")
+    assert purchase is not None
+    assert purchase.state == "Time of use"
+    assert purchase.variation_type == "Seasonal weekdays and weekends"
+    assert purchase.seasons[0]["days"][0]["periods"][0]["start_time"] == "14:00"
+    assert purchase.seasons[0]["days"][0]["periods"][0]["end_time"] == "21:00"
+
+    buyback = parse_tariff_rate(payload, "buyback")
+    assert buyback is not None
+    assert buyback.state == "Tiered"
+    assert buyback.export_plan == "netFit"
+    assert buyback.attributes["export_plan"] == "netFit"
+    assert buyback.seasons[0]["off_peak"] == "0.04"
+    assert buyback.seasons[0]["tiers"][1]["unbounded"] is True
+
+
+def test_tariff_rate_sensor_specs_for_tou_and_tiered_rates() -> None:
+    import_tou = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "id": "off-peak",
+                                        "type": "off-peak",
+                                        "rate": "0.18",
+                                    },
+                                    {"id": "peak-1", "type": "peak", "rate": "0.31"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+
+    import_specs = tariff_rate_sensor_specs(import_tou)
+
+    assert [spec["name"] for spec in import_specs] == ["Off-Peak", "Peak"]
+    assert [spec["state"] for spec in import_specs] == [0.18, 0.31]
+    assert [spec["unit"] for spec in import_specs] == ["$/kWh", "$/kWh"]
+    assert import_specs[0]["attributes"]["formatted_rate"] == "$0.18"
+    assert import_specs[0]["attributes"]["source"] == "manual"
+
+    export_tou = parse_tariff_rate(
+        {
+            "currency": "$",
+            "buyback": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "netFit",
+                "exportPlan": "netFit",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "startMonth": "1",
+                        "endMonth": "12",
+                        "days": [
+                            {
+                                "id": "week",
+                                "days": [1, 2, 3, 4, 5, 6, 7],
+                                "periods": [
+                                    {
+                                        "id": "off-peak",
+                                        "type": "off-peak",
+                                        "rate": "0.02",
+                                    },
+                                    {
+                                        "id": "peak-1",
+                                        "type": "peak",
+                                        "rate": "0.06",
+                                        "startTime": "960",
+                                        "endTime": "1320",
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "buyback",
+    )
+
+    specs = export_rate_sensor_specs(export_tou)
+
+    assert [spec["name"] for spec in specs] == ["Off-Peak", "Peak"]
+    assert [spec["state"] for spec in specs] == [0.02, 0.06]
+    assert [spec["unit"] for spec in specs] == ["$/kWh", "$/kWh"]
+    assert specs[0]["key"] == "default_week_off_peak"
+    assert specs[1]["attributes"]["rate_structure"] == "Time of use"
+    assert specs[1]["attributes"]["period_type"] == "peak"
+    assert specs[1]["attributes"]["start_time"] == "16:00"
+    assert specs[1]["attributes"]["end_time"] == "22:00"
+    assert specs[1]["attributes"]["export_plan"] == "netFit"
+
+    tiered = parse_tariff_rate(
+        {
+            "currency": "AUD",
+            "buyback": {
+                "typeKind": "single",
+                "typeId": "tiered",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "tiers": [
+                            {"id": "tier-1", "rate": "0.04", "startValue": "0"},
+                            {"id": "tier-2", "rate": "0.10", "endValue": -1},
+                        ],
+                    }
+                ],
+            },
+        },
+        "buyback",
+    )
+
+    tier_specs = export_rate_sensor_specs(tiered)
+
+    assert [spec["state"] for spec in tier_specs] == [0.04, 0.10]
+    assert [spec["unit"] for spec in tier_specs] == ["AUD/kWh", "AUD/kWh"]
+    assert tier_specs[1]["attributes"]["unbounded"] is True
+
+
+def test_export_rate_sensor_specs_handles_sparse_and_duplicate_rows() -> None:
+    assert export_rate_sensor_specs(None) == ()
+    sparse = parse_tariff_rate(
+        {
+            "buyback": {
+                "typeId": "tou",
+                "seasons": [
+                    {
+                        "days": [
+                            "bad",
+                            {
+                                "periods": [
+                                    "bad",
+                                    {"id": "", "rate": None},
+                                    {"id": "text", "rate": "not-numeric"},
+                                    {"id": "", "rate": "0.01"},
+                                    {"id": "", "rate": "0.02"},
+                                ]
+                            },
+                        ],
+                        "tiers": [
+                            "bad",
+                            {"id": "", "rate": None},
+                            {"id": "", "rate": "0.03"},
+                        ],
+                    }
+                ],
+            }
+        },
+        "buyback",
+    )
+
+    specs = export_rate_sensor_specs(sparse)
+
+    assert [spec["key"] for spec in specs] == [
+        "season_1_days_1_period_3",
+        "season_1_days_1_period_4",
+        "season_1_tier_2",
+    ]
+    assert [spec["name"] for spec in specs] == ["Period 3", "Period 4", "Tier 2"]
+    assert [spec["state"] for spec in specs] == [0.01, 0.02, 0.03]
+    assert [spec["unit"] for spec in specs] == [None, None, None]
+
+    duplicate_keys = parse_tariff_rate(
+        {
+            "buyback": {
+                "typeId": "tou",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {"type": "peak", "rate": "0.01"},
+                                    {"type": "peak", "rate": "0.02"},
+                                    {"type": "free"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        },
+        "buyback",
+    )
+
+    duplicate_specs = export_rate_sensor_specs(duplicate_keys)
+
+    assert [spec["key"] for spec in duplicate_specs] == [
+        "default_week_peak",
+        "default_week_peak_2",
+    ]
+
+    assert (
+        export_rate_sensor_specs(
+            TariffRateSnapshot(
+                state="Time of use",
+                rate_structure="Time of use",
+                variation_type=None,
+                source=None,
+                currency=None,
+                export_plan=None,
+                seasons=(
+                    {
+                        "days": ["bad", {"periods": ["bad", {"rate": "0.04"}]}],
+                        "tiers": ["bad", {"id": "free"}],
+                    },
+                ),
+            )
+        )[0]["state"]
+        == 0.04
+    )
+
+
+def test_parse_tariff_rate_rejects_empty_or_bad_branches() -> None:
+    class BadString:
+        def __str__(self) -> str:
+            raise RuntimeError("bad")
+
+    assert _clean_text(BadString()) is None
+    assert _format_rate(None, "$") is None
+    assert parse_tariff_rate({}, "purchase") is None
+    assert parse_tariff_rate("bad", "purchase") is None
+    assert parse_tariff_rate({"purchase": {"seasons": []}}, "purchase") is None
+    assert parse_tariff_billing("bad") is None
+    assert parse_tariff_billing({}) is None
+    bad_interval = parse_tariff_billing(
+        {"billingFrequency": "WEEK", "billingIntervalValue": "bad"}
+    )
+    assert bad_interval is not None
+    assert bad_interval.billing_interval_value is None
+    assert parse_tariff_rate(
+        {
+            "purchase": {
+                "typeId": "custom",
+                "typeKind": "custom-kind",
+                "seasons": [
+                    "bad",
+                    {
+                        "days": ["bad", {"periods": ["bad"]}],
+                        "tiers": ["bad", {"endValue": "bad"}],
+                    },
+                ],
+            }
+        },
+        "purchase",
+    ).attributes["seasons"] == [{"days": [{}], "tiers": [{"end_value": "bad"}]}]
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_refreshes_snapshots(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff_bundle = AsyncMock(
+        return_value=(
+            {
+                "anyBillPeriodStartDate": "2025-08-18",
+                "billingFrequency": "MONTH",
+                "billingIntervalValue": 1,
+            },
+            {
+                "currency": "$",
+                "purchase": {
+                    "typeKind": "single",
+                    "typeId": "flat",
+                    "source": "manual",
+                    "seasons": [
+                        {
+                            "id": "default",
+                            "startMonth": "1",
+                            "endMonth": "12",
+                            "days": [
+                                {
+                                    "id": "week",
+                                    "days": [1, 2, 3, 4, 5, 6, 7],
+                                    "periods": [{"rate": "0.03"}],
+                                }
+                            ],
+                        }
+                    ],
+                },
+                "buyback": {
+                    "typeKind": "single",
+                    "typeId": "flat",
+                    "source": "grossFit",
+                    "exportPlan": "grossFit",
+                    "seasons": [
+                        {
+                            "id": "default",
+                            "startMonth": "1",
+                            "endMonth": "12",
+                            "days": [
+                                {
+                                    "id": "week",
+                                    "days": [1, 2, 3, 4, 5, 6, 7],
+                                    "periods": [{"rate": "0.01"}],
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+        )
+    )
+
+    await TariffRuntime(coord).async_refresh()
+
+    assert coord.tariff_billing.state == "Monthly"
+    assert coord.tariff_import_rate.state == "Flat"
+    assert coord.tariff_export_rate.export_plan == "grossFit"
+    assert coord.tariff_last_refresh_utc is not None
+    assert coord.tariff_rates_last_refresh_utc is coord.tariff_last_refresh_utc
+    assert coord._endpoint_family_state("tariff").support_state == "supported"
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_keeps_stale_data_on_failure(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.tariff_billing = parse_tariff_billing(
+        {"billingFrequency": "MONTH", "billingIntervalValue": 1}
+    )
+    coord._note_endpoint_family_success("tariff")
+    coord._endpoint_family_state("tariff").next_retry_mono = None
+    err = aiohttp.ClientError("boom")
+    coord.client.site_tariff_bundle = AsyncMock(side_effect=err)
+
+    await TariffRuntime(coord).async_refresh()
+
+    assert coord.tariff_billing.state == "Monthly"
+    health = coord._endpoint_family_state("tariff")
+    assert health.consecutive_failures == 1
+    assert health.cooldown_active is True
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_keeps_stale_data_on_empty_payload(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.tariff_billing = parse_tariff_billing(
+        {"billingFrequency": "MONTH", "billingIntervalValue": 1}
+    )
+    coord._note_endpoint_family_success("tariff")
+    coord._endpoint_family_state("tariff").next_retry_mono = None
+    coord.client.site_tariff_bundle = AsyncMock(return_value=({}, {}))
+
+    await TariffRuntime(coord).async_refresh()
+
+    assert coord.tariff_billing.state == "Monthly"
+    health = coord._endpoint_family_state("tariff")
+    assert health.consecutive_failures == 1
+    assert health.last_error == "Tariff payload did not include data"
+
+
+def test_tariff_runtime_refresh_due_uses_endpoint_family_gate(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._endpoint_family_should_run = MagicMock(return_value=True)  # noqa: SLF001
+
+    assert TariffRuntime(coord).refresh_due() is True
+    coord._endpoint_family_should_run.assert_called_once_with("tariff")  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_respects_endpoint_gate(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord._endpoint_family_should_run = MagicMock(return_value=False)  # noqa: SLF001
+    coord.client.site_tariff_bundle = AsyncMock()
+
+    await TariffRuntime(coord).async_refresh()
+
+    coord.client.site_tariff_bundle.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_raises_without_stale_data(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff_bundle = AsyncMock(side_effect=aiohttp.ClientError("boom"))
+
+    with pytest.raises(OptionalEndpointUnavailable):
+        await TariffRuntime(coord).async_refresh()
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_raises_when_client_method_missing(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client = object()
+
+    with pytest.raises(OptionalEndpointUnavailable):
+        await TariffRuntime(coord).async_refresh()
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_keeps_stale_data_on_client_attribute_error(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.tariff_billing = parse_tariff_billing(
+        {"billingFrequency": "MONTH", "billingIntervalValue": 1}
+    )
+    coord._note_endpoint_family_success("tariff")
+    coord._endpoint_family_state("tariff").next_retry_mono = None
+    coord.client.site_tariff_bundle = AsyncMock(side_effect=AttributeError("boom"))
+
+    await TariffRuntime(coord).async_refresh()
+
+    assert coord.tariff_billing.state == "Monthly"
+    health = coord._endpoint_family_state("tariff")
+    assert health.consecutive_failures == 1
+    assert health.cooldown_active is True
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_treats_empty_payload_without_stale_data_as_unconfigured(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff_bundle = AsyncMock(return_value=({}, {}))
+
+    await TariffRuntime(coord).async_refresh()
+
+    assert coord.tariff_billing is None
+    assert coord.tariff_import_rate is None
+    assert coord.tariff_export_rate is None
+    assert coord.tariff_last_refresh_utc is not None
+    assert getattr(coord, "tariff_rates_last_refresh_utc", None) is None
+    health = coord._endpoint_family_state("tariff")
+    assert health.support_state == "supported"
+    assert health.consecutive_failures == 0
+    assert health.last_error is None
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_marks_non_empty_no_rate_payload_authoritative(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff_bundle = AsyncMock(
+        return_value=(
+            {
+                "anyBillPeriodStartDate": "2026-04-01",
+                "billingFrequency": "MONTH",
+                "billingIntervalValue": 1,
+            },
+            {"currency": "$"},
+        )
+    )
+
+    await TariffRuntime(coord).async_refresh()
+
+    assert coord.tariff_billing.state == "Monthly"
+    assert coord.tariff_import_rate is None
+    assert coord.tariff_export_rate is None
+    assert coord.tariff_rates_last_refresh_utc is coord.tariff_last_refresh_utc
+
+
+def test_tariff_runtime_diagnostics(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.tariff_last_refresh_utc = datetime(2026, 4, 26, tzinfo=timezone.utc)
+    coord.tariff_rates_last_refresh_utc = datetime(2026, 4, 26, 1, tzinfo=timezone.utc)
+    coord.tariff_billing = parse_tariff_billing(
+        {"billingFrequency": "MONTH", "billingIntervalValue": 1}
+    )
+    health = coord._endpoint_family_state(TARIFF_ENDPOINT_FAMILY)
+    health.support_state = "supported"
+    health.consecutive_failures = 1
+    health.last_failure_utc = datetime(2026, 4, 25, tzinfo=timezone.utc)
+    health.last_error = "Tariff payload did not include data"
+
+    diag = TariffRuntime(coord).diagnostics()
+
+    assert diag["billing_available"] is True
+    assert diag["import_rate_available"] is False
+    assert diag["export_rate_available"] is False
+    assert diag["last_refresh_utc"] == "2026-04-26T00:00:00+00:00"
+    assert diag["rates_last_refresh_utc"] == "2026-04-26T01:00:00+00:00"
+    assert diag["endpoint_family"]["support_state"] == "supported"
+    assert diag["endpoint_family"]["consecutive_failures"] == 1
+    assert diag["endpoint_family"]["last_failure_utc"] == "2026-04-25T00:00:00+00:00"
+    assert (
+        diag["endpoint_family"]["last_error"] == "Tariff payload did not include data"
+    )
+
+
+def test_tariff_sensors_expose_state_attributes_and_gateway_device(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.tariff_last_refresh_utc = datetime(2026, 4, 26, tzinfo=timezone.utc)
+    coord.tariff_billing = parse_tariff_billing(
+        {
+            "anyBillPeriodStartDate": "2025-08-18",
+            "billingFrequency": "MONTH",
+            "billingIntervalValue": 1,
+        }
+    )
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "flat",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "startMonth": "1",
+                        "endMonth": "12",
+                        "days": [{"id": "week", "periods": [{"rate": "0.03"}]}],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+
+    billing_sensor = EnphaseTariffBillingSensor(coord)
+    import_sensor = EnphaseTariffRateSensor(coord, True)
+    export_sensor = EnphaseTariffRateSensor(coord, False)
+
+    assert billing_sensor.native_value == date(2026, 5, 18)
+    assert billing_sensor.icon == "mdi:calendar-month"
+    assert billing_sensor.device_class == "date"
+    assert billing_sensor.extra_state_attributes["start_date"] == "2025-08-18"
+    assert billing_sensor.extra_state_attributes["billing_cycle"] == "Monthly"
+    assert import_sensor.native_value == "Flat"
+    assert import_sensor.icon == "mdi:cash-minus"
+    assert export_sensor.icon == "mdi:cash-plus"
+    assert import_sensor.extra_state_attributes["seasons"][0]["id"] == "default"
+    assert billing_sensor.device_info["identifiers"]
+
+
+def test_export_rate_value_sensor_exposes_rate_state_and_attributes(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.tariff_last_refresh_utc = datetime(2026, 4, 26, tzinfo=timezone.utc)
+    coord.tariff_export_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "buyback": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "netFit",
+                "exportPlan": "netFit",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "startMonth": "1",
+                        "endMonth": "12",
+                        "days": [
+                            {
+                                "id": "week",
+                                "days": [1, 2, 3, 4, 5, 6, 7],
+                                "periods": [
+                                    {
+                                        "id": "peak-1",
+                                        "type": "peak",
+                                        "rate": "0.06",
+                                        "startTime": "960",
+                                        "endTime": "1320",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "buyback",
+    )
+    spec = export_rate_sensor_specs(coord.tariff_export_rate)[0]
+
+    sensor = EnphaseTariffExportRateValueSensor(coord, spec)
+
+    assert sensor.native_value == 0.06
+    assert sensor.native_unit_of_measurement == "$/kWh"
+    assert sensor.state_class == "measurement"
+    assert sensor.icon == "mdi:cash-plus"
+    assert sensor.translation_key == "tariff_export_rate_value"
+    assert sensor.translation_placeholders == {"detail": "Peak"}
+    assert sensor.available is True
+    assert sensor.extra_state_attributes["rate_structure"] == "Time of use"
+    assert sensor.extra_state_attributes["period_type"] == "peak"
+    assert (
+        sensor.extra_state_attributes["last_refresh_utc"] == "2026-04-26T00:00:00+00:00"
+    )
+
+    coord.tariff_export_rate = None
+
+    assert sensor.available is False
+    assert sensor.native_value is None
+
+
+def test_import_rate_value_sensor_exposes_rate_state_and_attributes(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.tariff_last_refresh_utc = datetime(2026, 4, 26, tzinfo=timezone.utc)
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "id": "off-peak",
+                                        "type": "off-peak",
+                                        "rate": "0.18",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    spec = tariff_rate_sensor_specs(coord.tariff_import_rate)[0]
+
+    sensor = EnphaseTariffRateValueSensor(coord, spec, is_import=True)
+
+    assert sensor.native_value == 0.18
+    assert sensor.native_unit_of_measurement == "$/kWh"
+    assert sensor.state_class == "measurement"
+    assert sensor.suggested_display_precision == 4
+    assert sensor.icon == "mdi:cash-minus"
+    assert sensor.translation_key == "tariff_import_rate_value"
+    assert sensor.translation_placeholders == {"detail": "Off-Peak"}
+    assert sensor.available is True
+    assert sensor.extra_state_attributes["rate_structure"] == "Time of use"
+    assert sensor.extra_state_attributes["period_type"] == "off-peak"
+
+
+def test_rate_value_sensor_uses_home_assistant_currency_for_unit(
+    hass,
+    coordinator_factory,
+    monkeypatch,
+) -> None:
+    coord = coordinator_factory()
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [{"type": "peak", "rate": "0.31"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    spec = tariff_rate_sensor_specs(coord.tariff_import_rate)[0]
+    sensor = EnphaseTariffRateValueSensor(coord, spec, is_import=True)
+    sensor.hass = hass
+    monkeypatch.setattr(hass.config, "currency", "AUD")
+
+    assert sensor.native_unit_of_measurement == "AUD/kWh"
+    assert sensor.extra_state_attributes["currency"] == "$"
+    assert sensor.extra_state_attributes["formatted_rate"] == "$0.31"
+
+
+def test_tariff_sensor_falls_back_to_cloud_device(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.inventory_view.type_device_info = MagicMock(return_value=None)
+    coord.tariff_billing = parse_tariff_billing(
+        {
+            "anyBillPeriodStartDate": "2026-04-01",
+            "billingFrequency": "DAY",
+            "billingIntervalValue": 30,
+        }
+    )
+
+    sensor = EnphaseTariffBillingSensor(coord)
+
+    assert sensor.native_value == date(2026, 5, 1)
+    assert ("enphase_ev", f"type:{coord.site_id}:cloud") in sensor.device_info[
+        "identifiers"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tariff_sensors_not_created_without_enphase_data(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    monkeypatch.setattr(
+        coord,
+        "async_add_topology_listener",
+        lambda callback: (lambda: None),
+        raising=False,
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    added = []
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **_: added.extend(entities)
+    )
+
+    tariff_unique_ids = [
+        entity.unique_id for entity in added if "tariff" in str(entity.unique_id)
+    ]
+    assert tariff_unique_ids == []
+
+
+@pytest.mark.asyncio
+async def test_tariff_sensor_created_when_previously_registered_without_data(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from homeassistant.helpers import entity_registry as er
+
+    coord = coordinator_factory()
+    monkeypatch.setattr(
+        coord,
+        "async_add_topology_listener",
+        lambda callback: (lambda: None),
+        raising=False,
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    ent_reg = er.async_get(hass)
+    ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_{coord.site_id}_tariff_billing_cycle",
+        config_entry=config_entry,
+    )
+    added = []
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **_: added.extend(entities)
+    )
+
+    tariff_unique_ids = [
+        entity.unique_id for entity in added if "tariff" in str(entity.unique_id)
+    ]
+    assert tariff_unique_ids == [f"{DOMAIN}_site_{coord.site_id}_tariff_billing_cycle"]
+
+
+@pytest.mark.asyncio
+async def test_tariff_dynamic_rate_entities_removed_when_branch_removed(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from homeassistant.helpers import entity_registry as er
+
+    coord = coordinator_factory()
+    monkeypatch.setattr(
+        coord,
+        "async_add_topology_listener",
+        lambda callback: (lambda: None),
+        raising=False,
+    )
+    coord.tariff_billing = parse_tariff_billing(
+        {
+            "anyBillPeriodStartDate": "2026-04-01",
+            "billingFrequency": "MONTH",
+            "billingIntervalValue": 1,
+        }
+    )
+    coord.tariff_import_rate = TariffRateSnapshot(
+        state="Flat",
+        rate_structure="Flat",
+        variation_type="Single",
+        source="manual",
+        currency="$",
+        export_plan=None,
+        seasons=(),
+    )
+    coord.tariff_rates_last_refresh_utc = datetime(2026, 4, 26, tzinfo=timezone.utc)
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    ent_reg = er.async_get(hass)
+    old_import_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate_default_week_off_peak"
+    )
+    old_export_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_export_rate_default_week_peak"
+    )
+    for unique_id in (old_import_unique_id, old_export_unique_id):
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            config_entry=config_entry,
+        )
+    added = []
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **_: added.extend(entities)
+    )
+
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_import_unique_id) is None
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_export_unique_id) is None
+    assert [
+        entity.unique_id for entity in added if "tariff" in str(entity.unique_id)
+    ] == [
+        f"{DOMAIN}_site_{coord.site_id}_tariff_billing_cycle",
+        f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_tariff_dynamic_rate_entities_removed_when_rates_unconfigured(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from homeassistant.helpers import entity_registry as er
+
+    coord = coordinator_factory()
+    monkeypatch.setattr(
+        coord,
+        "async_add_topology_listener",
+        lambda callback: (lambda: None),
+        raising=False,
+    )
+    coord.tariff_billing = parse_tariff_billing(
+        {
+            "anyBillPeriodStartDate": "2026-04-01",
+            "billingFrequency": "MONTH",
+            "billingIntervalValue": 1,
+        }
+    )
+    coord.tariff_rates_last_refresh_utc = datetime(2026, 4, 26, tzinfo=timezone.utc)
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    ent_reg = er.async_get(hass)
+    old_import_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate_default_week_off_peak"
+    )
+    old_export_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_export_rate_default_week_peak"
+    )
+    for unique_id in (old_import_unique_id, old_export_unique_id):
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            config_entry=config_entry,
+        )
+    added = []
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **_: added.extend(entities)
+    )
+
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_import_unique_id) is None
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_export_unique_id) is None
+    assert [
+        entity.unique_id for entity in added if "tariff" in str(entity.unique_id)
+    ] == [f"{DOMAIN}_site_{coord.site_id}_tariff_billing_cycle"]
+
+
+@pytest.mark.asyncio
+async def test_tariff_dynamic_rate_entities_preserved_without_current_context(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from homeassistant.helpers import entity_registry as er
+
+    coord = coordinator_factory()
+    monkeypatch.setattr(
+        coord,
+        "async_add_topology_listener",
+        lambda callback: (lambda: None),
+        raising=False,
+    )
+    coord.tariff_billing = parse_tariff_billing(
+        {
+            "anyBillPeriodStartDate": "2026-04-01",
+            "billingFrequency": "MONTH",
+            "billingIntervalValue": 1,
+        }
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    ent_reg = er.async_get(hass)
+    old_import_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate_default_week_off_peak"
+    )
+    old_export_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_export_rate_default_week_peak"
+    )
+    for unique_id in (old_import_unique_id, old_export_unique_id):
+        ent_reg.async_get_or_create(
+            "sensor",
+            DOMAIN,
+            unique_id,
+            config_entry=config_entry,
+        )
+    added = []
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **_: added.extend(entities)
+    )
+
+    assert (
+        ent_reg.async_get_entity_id("sensor", DOMAIN, old_import_unique_id) is not None
+    )
+    assert (
+        ent_reg.async_get_entity_id("sensor", DOMAIN, old_export_unique_id) is not None
+    )
+    assert [
+        entity.unique_id for entity in added if "tariff" in str(entity.unique_id)
+    ] == [f"{DOMAIN}_site_{coord.site_id}_tariff_billing_cycle"]
+
+
+@pytest.mark.asyncio
+async def test_tariff_rate_sensor_entities_resync_when_structure_changes(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from homeassistant.helpers import entity_registry as er
+
+    coord = coordinator_factory()
+    listeners = []
+    monkeypatch.setattr(
+        coord,
+        "async_add_topology_listener",
+        lambda callback: (lambda: None),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        coord,
+        "async_add_listener",
+        lambda callback: listeners.append(callback) or (lambda: None),
+        raising=False,
+    )
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [{"type": "off-peak", "rate": "0.18"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    added = []
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **_: added.extend(entities)
+    )
+
+    old_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate_default_week_off_peak"
+    )
+    assert old_unique_id in {entity.unique_id for entity in added}
+    ent_reg = er.async_get(hass)
+    ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        old_unique_id,
+        config_entry=config_entry,
+    )
+
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [{"type": "peak", "rate": "0.31"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    for listener in listeners:
+        listener()
+
+    new_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate_default_week_peak"
+    )
+    assert new_unique_id in {entity.unique_id for entity in added}
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from datetime import date, datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
@@ -782,6 +783,8 @@ def test_export_rate_value_sensor_exposes_rate_state_and_attributes(
 
     assert sensor.available is False
     assert sensor.native_value is None
+    assert sensor.native_unit_of_measurement is None
+    assert sensor.extra_state_attributes == {}
 
 
 def test_import_rate_value_sensor_exposes_rate_state_and_attributes(
@@ -888,6 +891,41 @@ def test_tariff_sensor_falls_back_to_cloud_device(coordinator_factory) -> None:
     assert ("enphase_ev", f"type:{coord.site_id}:cloud") in sensor.device_info[
         "identifiers"
     ]
+
+
+def test_tariff_sensor_uses_cloud_type_device_when_gateway_absent(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    cloud_info = {"identifiers": {(DOMAIN, "cloud_type")}}
+
+    def type_device_info(type_key):
+        return cloud_info if type_key == "cloud" else None
+
+    coord.inventory_view.type_device_info = type_device_info
+    coord.tariff_billing = parse_tariff_billing(
+        {
+            "anyBillPeriodStartDate": "2026-04-01",
+            "billingFrequency": "DAY",
+            "billingIntervalValue": 1,
+        }
+    )
+
+    sensor = EnphaseTariffBillingSensor(coord)
+
+    assert sensor.device_info is cloud_info
+
+
+def test_tariff_sensors_handle_missing_snapshots(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    billing_sensor = EnphaseTariffBillingSensor(coord)
+    import_sensor = EnphaseTariffRateSensor(coord, True)
+
+    assert billing_sensor.available is False
+    assert billing_sensor.native_value is None
+    assert billing_sensor.extra_state_attributes == {}
+    assert import_sensor.available is False
+    assert import_sensor.extra_state_attributes == {}
 
 
 @pytest.mark.asyncio
@@ -1107,6 +1145,231 @@ async def test_tariff_dynamic_rate_entities_preserved_without_current_context(
     assert [
         entity.unique_id for entity in added if "tariff" in str(entity.unique_id)
     ] == [f"{DOMAIN}_site_{coord.site_id}_tariff_billing_cycle"]
+
+
+@pytest.mark.asyncio
+async def test_tariff_setup_registry_filter_branches(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev import sensor as sensor_module
+
+    coord = coordinator_factory()
+    monkeypatch.setattr(
+        coord,
+        "async_add_topology_listener",
+        lambda callback: (lambda: None),
+        raising=False,
+    )
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [{"type": "peak", "rate": "0.31"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    current_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate_default_week_peak"
+    )
+    fake_registry = SimpleNamespace(
+        entities={
+            "binary_sensor.skip": SimpleNamespace(
+                domain=None,
+                entity_id="binary_sensor.skip",
+                platform=DOMAIN,
+                config_entry_id=config_entry.entry_id,
+                unique_id=current_unique_id,
+            ),
+            "sensor.other_platform": SimpleNamespace(
+                domain="sensor",
+                entity_id="sensor.other_platform",
+                platform="other",
+                config_entry_id=config_entry.entry_id,
+                unique_id=current_unique_id,
+            ),
+            "sensor.other_entry": SimpleNamespace(
+                domain="sensor",
+                entity_id="sensor.other_entry",
+                platform=DOMAIN,
+                config_entry_id="other-entry",
+                unique_id=current_unique_id,
+            ),
+            "sensor.current": SimpleNamespace(
+                domain="sensor",
+                entity_id="sensor.current",
+                platform=DOMAIN,
+                config_entry_id=config_entry.entry_id,
+                unique_id=current_unique_id,
+            ),
+        },
+        async_get_entity_id=MagicMock(return_value=None),
+        async_remove=MagicMock(),
+    )
+    monkeypatch.setattr(sensor_module.er, "async_get", lambda hass: fake_registry)
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    added = []
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **_: added.extend(entities)
+    )
+
+    assert current_unique_id in {entity.unique_id for entity in added}
+    fake_registry.async_remove.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tariff_setup_handles_registry_without_values(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from custom_components.enphase_ev import sensor as sensor_module
+
+    coord = coordinator_factory()
+    listeners = []
+    monkeypatch.setattr(
+        coord,
+        "async_add_topology_listener",
+        lambda callback: listeners.append(callback) or (lambda: None),
+        raising=False,
+    )
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [{"id": "week", "periods": [{"rate": "0.20"}]}],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    fake_registry = SimpleNamespace(
+        entities={},
+        async_get_entity_id=MagicMock(return_value=None),
+        async_remove=MagicMock(),
+    )
+    monkeypatch.setattr(sensor_module.er, "async_get", lambda hass: fake_registry)
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    added = []
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **_: added.extend(entities)
+    )
+
+    assert any("tariff_import_rate" in str(entity.unique_id) for entity in added)
+    fake_registry.entities = object()
+    for listener in listeners:
+        listener()
+    fake_registry.async_remove.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_tariff_setup_adds_export_value_sensor(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    monkeypatch.setattr(
+        coord,
+        "async_add_topology_listener",
+        lambda callback: (lambda: None),
+        raising=False,
+    )
+    coord.tariff_export_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "buyback": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [{"type": "peak", "rate": "0.06"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "buyback",
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    added = []
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **_: added.extend(entities)
+    )
+
+    assert f"{DOMAIN}_site_{coord.site_id}_tariff_export_rate_default_week_peak" in {
+        entity.unique_id for entity in added
+    }
+
+
+@pytest.mark.asyncio
+async def test_tariff_setup_prunes_dynamic_export_for_summary_snapshot(
+    hass, config_entry, coordinator_factory, monkeypatch
+) -> None:
+    from homeassistant.helpers import entity_registry as er
+
+    coord = coordinator_factory()
+    monkeypatch.setattr(
+        coord,
+        "async_add_topology_listener",
+        lambda callback: (lambda: None),
+        raising=False,
+    )
+    coord.tariff_export_rate = TariffRateSnapshot(
+        state="Flat",
+        rate_structure="Flat",
+        variation_type="Single",
+        source="manual",
+        currency="$",
+        export_plan=None,
+        seasons=(),
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    ent_reg = er.async_get(hass)
+    old_export_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_export_rate_default_week_peak"
+    )
+    ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        old_export_unique_id,
+        config_entry=config_entry,
+    )
+    added = []
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **_: added.extend(entities)
+    )
+
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_export_unique_id) is None
+    assert f"{DOMAIN}_site_{coord.site_id}_tariff_export_rate" in {
+        entity.unique_id for entity in added
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds read-only Enphase site tariff visibility through Home Assistant sensors for next billing date, import rate values, and export rate values. Tariff data is fetched through the documented tariff microservice endpoints, normalized into Home Assistant-friendly attributes, attached to the IQ Gateway device when available, and retained as stale data while the tariff backend is degraded.

The implementation also adds tariff service diagnostics/system health reporting, localized entity and attribute strings, icons, README/CHANGELOG updates, and regression coverage for optional endpoint handling, dynamic rate entity cleanup, locale coverage, and Energy Dashboard price units.

## Related Issues

None linked.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/tariff.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_tariff.py tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev/test_tariff.py -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/tariff.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m json.tool custom_components/enphase_ev/strings.json >/dev/null && for f in custom_components/enphase_ev/translations/*.json; do python -m json.tool \"$f\" >/dev/null || exit 1; done"
```

Results:

- `tests/components/enphase_ev`: 2973 passed
- full `pytest -q`: 3075 passed
- targeted tariff coverage: 100% for `custom_components/enphase_ev/tariff.py`
- ruff, pre-commit, quality-scale validation, Black, and JSON validation passed

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Tariff reads are optional and degrade service status rather than blocking coordinator refresh.
- Dynamic tariff rate entities are pruned only after a confirmed tariff-rate endpoint read, preserving registry entries across transient empty restart reads.
- Price sensor units use Home Assistant's configured currency for Energy Dashboard validation while preserving Enphase currency symbols in attributes.
