### PR TITLE
Preserve current power cache freshness on restore

### DIFF
--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -6354,6 +6354,11 @@ class EnphaseCurrentPowerConsumptionSensor(_SiteBaseEntity, RestoreSensor):
             parsed = dt_util.parse_datetime(sample_raw)
             if parsed is not None:
                 self._last_good_sample_utc = _normalize_utc_datetime(parsed)
+        cached_raw = attrs.get("cached_at_utc")
+        if isinstance(cached_raw, str):
+            parsed_cached = dt_util.parse_datetime(cached_raw)
+            if parsed_cached is not None:
+                self._last_good_cached_at_utc = _normalize_utc_datetime(parsed_cached)
         source = attrs.get("source")
         if isinstance(source, str) and source.strip():
             self._last_good_source = source
@@ -6390,7 +6395,7 @@ class EnphaseCurrentPowerConsumptionSensor(_SiteBaseEntity, RestoreSensor):
         return datetime.now(timezone.utc)
 
     def _cached_sample_is_fresh(self) -> bool:
-        sample_utc = self._last_good_sample_utc or self._last_good_cached_at_utc
+        sample_utc = self._last_good_cached_at_utc or self._last_good_sample_utc
         if sample_utc is None:
             return False
         reference_utc = self._freshness_reference_utc()
@@ -6474,6 +6479,11 @@ class EnphaseCurrentPowerConsumptionSensor(_SiteBaseEntity, RestoreSensor):
         return {
             "sampled_at_utc": (
                 sample_utc.isoformat() if sample_utc is not None else None
+            ),
+            "cached_at_utc": (
+                self._last_good_cached_at_utc.isoformat()
+                if self._last_good_cached_at_utc is not None
+                else None
             ),
             "source": source,
             "reported_units": units,

--- a/tests/components/enphase_ev/test_latency_and_connectivity.py
+++ b/tests/components/enphase_ev/test_latency_and_connectivity.py
@@ -57,6 +57,7 @@ def test_current_power_consumption_sensor_value_and_attributes():
     assert sensor.native_value == 752
     assert sensor.extra_state_attributes == {
         "sampled_at_utc": "2026-03-11T05:40:00+00:00",
+        "cached_at_utc": "2026-03-11T05:40:00+00:00",
         "source": "app-api:get_latest_power",
         "reported_units": "W",
         "reported_precision": 0,
@@ -143,6 +144,7 @@ def test_current_power_consumption_sensor_keeps_fresh_last_good_runtime_sample(
     assert sensor.native_value == 752
     assert sensor.extra_state_attributes == {
         "sampled_at_utc": "2026-03-11T05:40:45+00:00",
+        "cached_at_utc": "2026-03-11T05:40:45+00:00",
         "source": "app-api:get_latest_power",
         "reported_units": "W",
         "reported_precision": 0,
@@ -259,6 +261,7 @@ async def test_current_power_consumption_sensor_restores_last_good_state(
     assert sensor.native_value == 752
     assert sensor.extra_state_attributes == {
         "sampled_at_utc": "2026-03-11T05:40:45+00:00",
+        "cached_at_utc": None,
         "source": "app-api:get_latest_power",
         "reported_units": "W",
         "reported_precision": None,
@@ -292,6 +295,60 @@ async def test_current_power_consumption_sensor_restore_tolerates_last_state_err
 
     assert sensor.available is False
     assert sensor.native_value is None
+
+
+@pytest.mark.asyncio
+async def test_current_power_consumption_sensor_restore_prefers_cached_at_freshness(
+    monkeypatch,
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseCurrentPowerConsumptionSensor
+    from custom_components.enphase_ev import sensor as sensor_mod
+    from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+    coord = _make_site_coord()
+    coord.last_update_success = True
+
+    async def _noop(self):
+        return None
+
+    monkeypatch.setattr(CoordinatorEntity, "async_added_to_hass", _noop)
+    monkeypatch.setattr(
+        sensor_mod.dt_util,
+        "utcnow",
+        lambda: datetime(2026, 3, 11, 5, 41, tzinfo=timezone.utc),
+    )
+
+    sensor = EnphaseCurrentPowerConsumptionSensor(coord)
+    sensor.async_get_last_sensor_data = AsyncMock(  # type: ignore[method-assign]
+        return_value=type("LastSensorData", (), {"native_value": "752.0"})()
+    )
+    sensor.async_get_last_state = AsyncMock(  # type: ignore[method-assign]
+        return_value=type(
+            "LastState",
+            (),
+            {
+                "attributes": {
+                    "sampled_at_utc": "2026-03-11T05:35:00+00:00",
+                    "cached_at_utc": "2026-03-11T05:40:45+00:00",
+                    "source": "app-api:get_latest_power",
+                    "reported_units": "W",
+                    "reported_precision": 0,
+                }
+            },
+        )()
+    )
+
+    await sensor.async_added_to_hass()
+
+    assert sensor.available is True
+    assert sensor.native_value == 752
+    assert sensor.extra_state_attributes == {
+        "sampled_at_utc": "2026-03-11T05:35:00+00:00",
+        "cached_at_utc": "2026-03-11T05:40:45+00:00",
+        "source": "app-api:get_latest_power",
+        "reported_units": "W",
+        "reported_precision": 0,
+    }
 
 
 def test_site_cloud_reachable_binary_sensor_states():


### PR DESCRIPTION
## Summary
- preserve current power cache freshness across restore/restart by persisting `cached_at_utc`
- prefer the cache timestamp over upstream sample time when deciding whether a restored current-power value is still fresh
- add regression coverage for the stale-sample/fresh-cache restore case

## Testing
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_latency_and_connectivity.py"`
