### PR TITLE
[codex] Reduce refresh-path overhead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to this project will be documented in this file.
 ### 🐛 Bug fixes
 - Bounded the `Current Production Power` live-sample cache so stale values are not reused indefinitely when the latest-power endpoint stops returning valid samples.
 - Smoothed idle heat-pump power over existing low-load energy samples so whole-Wh cloud readings no longer flicker between `0 W` and standby load, while exposing the raw short-window value in diagnostics.
+- Reduced unnecessary EV charger post-status follow-up lookups, kept idle session-history catch-up off the main refresh path when cached data is still usable, and aligned HEMS preflight/device refresh cadence with fast polling to lower steady-state cloud overhead.
 
 ### 🔧 Improvements
 - Clarified the Enphase authentication-block repair message and added a manual stored-credential reauthentication service for trying one immediate unblock attempt.

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1099,6 +1099,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             return base_ttl
         return max(base_ttl, soft_ttl + SESSION_HISTORY_IDLE_HARD_TTL_GRACE_S)
 
+    def _session_history_prioritize_inline_refresh(self, payload: dict) -> bool:
+        cache_ttl = self._session_history_cache_ttl
+        base_ttl = float(cache_ttl or DEFAULT_SESSION_HISTORY_INTERVAL_MIN * 60)
+        return self._session_history_soft_ttl(payload) < base_ttl
+
     async def _async_fetch_sessions_today(
         self,
         sn: str,
@@ -2236,56 +2241,102 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     ]:
         if first_refresh:
             return {}, {}, {}, {}
+        charger_config_keys = (
+            DEFAULT_CHARGE_LEVEL_SETTING,
+            PHASE_SWITCH_CONFIG_SETTING,
+        )
         tasks: dict[str, asyncio.Task[object]] = {}
+        now = time.monotonic()
         unique_candidates = list(dict.fromkeys(charge_mode_candidates))
         serials = [sn for sn, _obj in records]
-        if unique_candidates:
+        charge_modes = self.evse_runtime.resolve_cached_charge_modes(
+            unique_candidates,
+            now=now,
+        )
+        green_settings = self.evse_runtime.resolve_cached_green_battery_settings(
+            serials,
+            now=now,
+        )
+        auth_settings = self.evse_runtime.resolve_cached_auth_settings(
+            serials,
+            now=now,
+        )
+        charger_config = self.evse_runtime.resolve_cached_charger_config(
+            serials,
+            keys=charger_config_keys,
+            now=now,
+        )
+        charge_mode_lookup_candidates = self.evse_runtime.charge_mode_lookup_candidates(
+            unique_candidates,
+            now=now,
+        )
+        if charge_mode_lookup_candidates:
             tasks["charge_modes"] = asyncio.create_task(
                 self._async_run_timed_refresh_lookup(
                     phase_timings,
                     "charge_mode_s",
                     lambda: self.evse_runtime.async_resolve_charge_modes(
-                        unique_candidates
+                        charge_mode_lookup_candidates
                     ),
                 )
             )
-        if serials:
+        green_lookup_candidates = self.evse_runtime.green_battery_lookup_candidates(
+            serials,
+            now=now,
+        )
+        if green_lookup_candidates:
             tasks["green_settings"] = asyncio.create_task(
                 self._async_run_timed_refresh_lookup(
                     phase_timings,
                     "green_settings_s",
-                    lambda: self._async_resolve_green_battery_settings(serials),
+                    lambda: self._async_resolve_green_battery_settings(
+                        green_lookup_candidates
+                    ),
                 )
             )
+        auth_lookup_candidates = self.evse_runtime.auth_settings_lookup_candidates(
+            serials,
+            now=now,
+        )
+        if auth_lookup_candidates:
             tasks["auth_settings"] = asyncio.create_task(
                 self._async_run_timed_refresh_lookup(
                     phase_timings,
                     "auth_settings_s",
-                    lambda: self._async_resolve_auth_settings(serials),
+                    lambda: self._async_resolve_auth_settings(auth_lookup_candidates),
                 )
             )
+        charger_config_lookup_candidates = (
+            self.evse_runtime.charger_config_lookup_candidates(
+                serials,
+                keys=charger_config_keys,
+                now=now,
+            )
+        )
+        if charger_config_lookup_candidates:
             tasks["charger_config"] = asyncio.create_task(
                 self._async_run_timed_refresh_lookup(
                     phase_timings,
                     "charger_config_s",
                     lambda: self._async_resolve_charger_config(
-                        serials,
-                        keys=(
-                            DEFAULT_CHARGE_LEVEL_SETTING,
-                            PHASE_SWITCH_CONFIG_SETTING,
-                        ),
+                        charger_config_lookup_candidates,
+                        keys=charger_config_keys,
                     ),
                 )
             )
         if not tasks:
-            return {}, {}, {}, {}
+            return charge_modes, green_settings, auth_settings, charger_config
         results = await asyncio.gather(*tasks.values())
         resolved = dict(zip(tasks.keys(), results, strict=False))
+        charge_modes.update(resolved.get("charge_modes", {}))
+        green_settings.update(resolved.get("green_settings", {}))
+        auth_settings.update(resolved.get("auth_settings", {}))
+        charger_config.update(resolved.get("charger_config", {}))
         return (
-            resolved.get("charge_modes", {}),
-            resolved.get("green_settings", {}),
-            resolved.get("auth_settings", {}),
-            resolved.get("charger_config", {}),
+            charge_modes,
+            green_settings,
+            auth_settings,
+            charger_config,
         )
 
     def _start_refresh_pipeline(self) -> RefreshPipelineContext:
@@ -4131,7 +4182,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                         sn
                     )
                     continue
-                immediate_by_day.setdefault((day_key, max_cache_age), []).append(sn)
+                target = (
+                    immediate_by_day
+                    if self._session_history_prioritize_inline_refresh(cur)
+                    else background_by_day
+                )
+                target.setdefault((day_key, max_cache_age), []).append(sn)
                 continue
             if first_refresh:
                 background_by_day.setdefault((day_key, max_cache_age), []).append(sn)

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -189,6 +189,10 @@ class EvseRuntime:
             )
         return {}
 
+    @staticmethod
+    def _unique_serials(serials: Iterable[str]) -> list[str]:
+        return [sn for sn in dict.fromkeys(serials) if sn]
+
     def sum_session_energy(self, sessions: list[dict]) -> float:
         manager = getattr(self.coordinator, "session_history", None)
         if manager is not None:
@@ -590,26 +594,12 @@ class EvseRuntime:
     async def async_resolve_charge_modes(
         self, serials: Iterable[str]
     ) -> dict[str, ChargeModeResolution]:
-        coord = self.coordinator
-        results: dict[str, ChargeModeResolution] = {}
+        results = self.resolve_cached_charge_modes(serials)
         pending: dict[str, asyncio.Task[str | None]] = {}
-        if coord._scheduler_backoff_active():
-            for sn in dict.fromkeys(serials):
-                if not sn:
-                    continue
-                cached = self.cached_charge_mode_preference(sn)
-                if cached is not None:
-                    results[sn] = ChargeModeResolution(cached, "cache_backoff")
-            return results
-        for sn in dict.fromkeys(serials):
-            if not sn:
-                continue
-            cached = self.cached_charge_mode_preference(sn)
-            if cached is not None:
-                results[sn] = ChargeModeResolution(cached, "cache")
-                continue
+        for sn in self.charge_mode_lookup_candidates(serials):
             pending[sn] = self.async_get_charge_mode(sn)
         if pending:
+            coord = self.coordinator
             for sn, response in (await self._run_lookup_tasks(pending)).items():
                 if isinstance(response, Exception):
                     _LOGGER.debug(
@@ -1418,27 +1408,12 @@ class EvseRuntime:
     async def async_resolve_green_battery_settings(
         self, serials: Iterable[str]
     ) -> dict[str, tuple[bool | None, bool]]:
-        coord = self.coordinator
-        results: dict[str, tuple[bool | None, bool]] = {}
+        results = self.resolve_cached_green_battery_settings(serials)
         pending: dict[str, asyncio.Task[tuple[bool | None, bool] | None]] = {}
-        now = time.monotonic()
-        if coord._scheduler_backoff_active():
-            for sn in dict.fromkeys(serials):
-                if not sn:
-                    continue
-                cached = coord._green_battery_cache.get(sn)
-                if cached and (now - cached[2] < GREEN_BATTERY_CACHE_TTL):
-                    results[sn] = (cached[0], cached[1])
-            return results
-        for sn in dict.fromkeys(serials):
-            if not sn:
-                continue
-            cached = coord._green_battery_cache.get(sn)
-            if cached and (now - cached[2] < GREEN_BATTERY_CACHE_TTL):
-                results[sn] = (cached[0], cached[1])
-                continue
+        for sn in self.green_battery_lookup_candidates(serials):
             pending[sn] = self.async_get_green_battery_setting(sn)
         if pending:
+            coord = self.coordinator
             for sn, response in (await self._run_lookup_tasks(pending)).items():
                 if isinstance(response, Exception):
                     _LOGGER.debug(
@@ -1465,30 +1440,15 @@ class EvseRuntime:
     async def async_resolve_auth_settings(
         self, serials: Iterable[str]
     ) -> dict[str, tuple[bool | None, bool | None, bool, bool]]:
-        coord = self.coordinator
-        results: dict[str, tuple[bool | None, bool | None, bool, bool]] = {}
+        results = self.resolve_cached_auth_settings(serials)
         pending: dict[
             str,
             asyncio.Task[tuple[bool | None, bool | None, bool, bool] | None],
         ] = {}
-        now = time.monotonic()
-        if coord._auth_settings_backoff_active():
-            for sn in dict.fromkeys(serials):
-                if not sn:
-                    continue
-                cached = coord._auth_settings_cache.get(sn)
-                if cached and (now - cached[4] < AUTH_SETTINGS_CACHE_TTL):
-                    results[sn] = cached[0], cached[1], cached[2], cached[3]
-            return results
-        for sn in dict.fromkeys(serials):
-            if not sn:
-                continue
-            cached = coord._auth_settings_cache.get(sn)
-            if cached and (now - cached[4] < AUTH_SETTINGS_CACHE_TTL):
-                results[sn] = cached[0], cached[1], cached[2], cached[3]
-                continue
+        for sn in self.auth_settings_lookup_candidates(serials):
             pending[sn] = self.async_get_auth_settings(sn)
         if pending:
+            coord = self.coordinator
             for sn, response in (await self._run_lookup_tasks(pending)).items():
                 if isinstance(response, Exception):
                     _LOGGER.debug(
@@ -1533,22 +1493,9 @@ class EvseRuntime:
         if not requested:
             return {}
 
-        results: dict[str, dict[str, object]] = {}
+        results = self.resolve_cached_charger_config(serials, keys=requested)
         pending: dict[str, asyncio.Task[dict[str, object] | None]] = {}
-        now = time.monotonic()
-        for sn in dict.fromkeys(serials):
-            if not sn:
-                continue
-            cached = coord._charger_config_cache.get(sn)
-            if cached and (now - cached[1] < CHARGER_CONFIG_CACHE_TTL):
-                cached_values = dict(cached[0])
-                if all(key in cached_values for key in requested):
-                    results[sn] = {
-                        key: cached_values[key]
-                        for key in requested
-                        if key in cached_values
-                    }
-                    continue
+        for sn in self.charger_config_lookup_candidates(serials, keys=requested):
             pending[sn] = self.async_get_charger_config(sn, keys=requested)
         if pending:
             for sn, response in (await self._run_lookup_tasks(pending)).items():
@@ -1576,6 +1523,149 @@ class EvseRuntime:
                 if response:
                     results[sn] = response
         return results
+
+    def resolve_cached_charge_modes(
+        self,
+        serials: Iterable[str],
+        *,
+        now: float | None = None,
+    ) -> dict[str, ChargeModeResolution]:
+        if now is None:
+            now = time.monotonic()
+        source = (
+            "cache_backoff" if self.coordinator._scheduler_backoff_active() else "cache"
+        )
+        results: dict[str, ChargeModeResolution] = {}
+        for sn in self._unique_serials(serials):
+            cached = self.cached_charge_mode_preference(sn, now=now)
+            if cached is not None:
+                results[sn] = ChargeModeResolution(cached, source)
+        return results
+
+    def charge_mode_lookup_candidates(
+        self,
+        serials: Iterable[str],
+        *,
+        now: float | None = None,
+    ) -> list[str]:
+        if self.coordinator._scheduler_backoff_active():
+            return []
+        if now is None:
+            now = time.monotonic()
+        return [
+            sn
+            for sn in self._unique_serials(serials)
+            if self.cached_charge_mode_preference(sn, now=now) is None
+        ]
+
+    def resolve_cached_green_battery_settings(
+        self,
+        serials: Iterable[str],
+        *,
+        now: float | None = None,
+    ) -> dict[str, tuple[bool | None, bool]]:
+        if now is None:
+            now = time.monotonic()
+        results: dict[str, tuple[bool | None, bool]] = {}
+        for sn in self._unique_serials(serials):
+            cached = self.coordinator._green_battery_cache.get(sn)
+            if cached and (now - cached[2] < GREEN_BATTERY_CACHE_TTL):
+                results[sn] = (cached[0], cached[1])
+        return results
+
+    def green_battery_lookup_candidates(
+        self,
+        serials: Iterable[str],
+        *,
+        now: float | None = None,
+    ) -> list[str]:
+        if self.coordinator._scheduler_backoff_active():
+            return []
+        if now is None:
+            now = time.monotonic()
+        return [
+            sn
+            for sn in self._unique_serials(serials)
+            if sn not in self.resolve_cached_green_battery_settings((sn,), now=now)
+        ]
+
+    def resolve_cached_auth_settings(
+        self,
+        serials: Iterable[str],
+        *,
+        now: float | None = None,
+    ) -> dict[str, tuple[bool | None, bool | None, bool, bool]]:
+        if now is None:
+            now = time.monotonic()
+        results: dict[str, tuple[bool | None, bool | None, bool, bool]] = {}
+        for sn in self._unique_serials(serials):
+            cached = self.coordinator._auth_settings_cache.get(sn)
+            if cached and (now - cached[4] < AUTH_SETTINGS_CACHE_TTL):
+                results[sn] = cached[0], cached[1], cached[2], cached[3]
+        return results
+
+    def auth_settings_lookup_candidates(
+        self,
+        serials: Iterable[str],
+        *,
+        now: float | None = None,
+    ) -> list[str]:
+        if self.coordinator._auth_settings_backoff_active():
+            return []
+        if now is None:
+            now = time.monotonic()
+        return [
+            sn
+            for sn in self._unique_serials(serials)
+            if sn not in self.resolve_cached_auth_settings((sn,), now=now)
+        ]
+
+    def resolve_cached_charger_config(
+        self,
+        serials: Iterable[str],
+        *,
+        keys: Iterable[str],
+        now: float | None = None,
+    ) -> dict[str, dict[str, object]]:
+        if now is None:
+            now = time.monotonic()
+        requested = tuple(keys)
+        results: dict[str, dict[str, object]] = {}
+        for sn in self._unique_serials(serials):
+            cached = self.coordinator._charger_config_cache.get(sn)
+            if not cached or now - cached[1] >= CHARGER_CONFIG_CACHE_TTL:
+                continue
+            cached_values = dict(cached[0])
+            if all(key in cached_values for key in requested):
+                results[sn] = {
+                    key: cached_values[key] for key in requested if key in cached_values
+                }
+        return results
+
+    def charger_config_lookup_candidates(
+        self,
+        serials: Iterable[str],
+        *,
+        keys: Iterable[str],
+        now: float | None = None,
+    ) -> list[str]:
+        if now is None:
+            now = time.monotonic()
+        requested = tuple(keys)
+        cached_results = self.resolve_cached_charger_config(
+            serials,
+            keys=requested,
+            now=now,
+        )
+        candidates: list[str] = []
+        for sn in self._unique_serials(serials):
+            if sn in cached_results:
+                continue
+            backoff_until = self.coordinator._charger_config_backoff_until.get(sn)
+            if backoff_until is not None and backoff_until > now:
+                continue
+            candidates.append(sn)
+        return candidates
 
     def resolve_charge_mode_pref(self, sn: str) -> str | None:
         sn_str = str(sn)

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -13,6 +13,7 @@ from zoneinfo import ZoneInfo
 from homeassistant.util import dt as dt_util
 
 from .const import (
+    DEFAULT_FAST_POLL_INTERVAL,
     HEMS_SUPPORT_PREFLIGHT_CACHE_TTL,
     HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL,
     HEATPUMP_DAILY_CONSUMPTION_FAILURE_BACKOFF_S,
@@ -22,6 +23,7 @@ from .const import (
     HEATPUMP_RUNTIME_STATE_CACHE_TTL,
     HEATPUMP_RUNTIME_STATE_FAILURE_BACKOFF_S,
     HEATPUMP_RUNTIME_STATE_STALE_AFTER_S,
+    OPT_FAST_POLL_INTERVAL,
 )
 from .device_types import normalize_type_key
 from .log_redaction import redact_site_id, redact_text, truncate_identifier
@@ -259,6 +261,21 @@ class HeatpumpRuntime:
                 return True
         return False
 
+    def hems_refresh_floor_s(self) -> float:
+        floor = float(DEFAULT_FAST_POLL_INTERVAL)
+        config_entry = getattr(self.coordinator, "config_entry", None)
+        options = getattr(config_entry, "options", None)
+        if options is None:
+            return floor
+        try:
+            configured = float(options.get(OPT_FAST_POLL_INTERVAL, floor))
+        except (AttributeError, TypeError, ValueError):
+            return floor
+        return max(floor, configured)
+
+    def hems_support_preflight_cache_ttl_s(self) -> float:
+        return max(HEMS_SUPPORT_PREFLIGHT_CACHE_TTL, self.hems_refresh_floor_s())
+
     @staticmethod
     async def _async_call_refreshable_fetcher(
         fetcher, *, force: bool = False
@@ -285,15 +302,14 @@ class HeatpumpRuntime:
             return
 
         now = time.monotonic()
+        cache_ttl = self.hems_support_preflight_cache_ttl_s()
         if not force and self._hems_support_preflight_cache_until is not None:
             if now < self._hems_support_preflight_cache_until:
                 return
 
         fetcher = getattr(self.client, "system_dashboard_summary", None)
         if not callable(fetcher):
-            self._hems_support_preflight_cache_until = (
-                now + HEMS_SUPPORT_PREFLIGHT_CACHE_TTL
-            )
+            self._hems_support_preflight_cache_until = now + cache_ttl
             return
 
         try:
@@ -304,9 +320,7 @@ class HeatpumpRuntime:
                 redact_site_id(self.site_id),
                 redact_text(err, site_ids=(self.site_id,)),
             )
-            self._hems_support_preflight_cache_until = (
-                now + HEMS_SUPPORT_PREFLIGHT_CACHE_TTL
-            )
+            self._hems_support_preflight_cache_until = now + cache_ttl
             return
 
         if isinstance(payload, dict):
@@ -314,9 +328,7 @@ class HeatpumpRuntime:
             if is_hems is not None:
                 self.client._hems_site_supported = is_hems  # noqa: SLF001
 
-        self._hems_support_preflight_cache_until = (
-            now + HEMS_SUPPORT_PREFLIGHT_CACHE_TTL
-        )
+        self._hems_support_preflight_cache_until = now + cache_ttl
 
     async def async_refresh_hems_support_preflight(
         self, *, force: bool = False

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -15,6 +15,7 @@ from zoneinfo import ZoneInfo
 from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
 
+from .const import DEFAULT_FAST_POLL_INTERVAL
 from .device_types import (
     member_is_retired as device_member_is_retired,
     normalize_type_key,
@@ -168,6 +169,19 @@ class InventoryRuntime:
 
     def _redact_battery_payload(self, payload: object) -> object:
         return redact_battery_payload(payload)
+
+    def _hems_refresh_floor_s(self) -> float:
+        runtime = getattr(self.coordinator, "heatpump_runtime", None)
+        helper = getattr(runtime, "hems_refresh_floor_s", None)
+        if callable(helper):
+            try:
+                return max(float(helper()), float(DEFAULT_FAST_POLL_INTERVAL))
+            except (TypeError, ValueError):
+                pass
+        return float(DEFAULT_FAST_POLL_INTERVAL)
+
+    def _hems_devices_cache_ttl_s(self) -> float:
+        return max(HEMS_DEVICES_CACHE_TTL, self._hems_refresh_floor_s())
 
     @staticmethod
     def _debug_sorted_keys(value: object) -> list[str]:
@@ -1800,6 +1814,7 @@ class InventoryRuntime:
 
     async def _async_refresh_hems_devices(self, *, force: bool = False) -> None:
         now = time.monotonic()
+        cache_ttl = self._hems_devices_cache_ttl_s()
         if not force and self._hems_devices_cache_until:
             if now < self._hems_devices_cache_until:
                 return
@@ -1813,9 +1828,7 @@ class InventoryRuntime:
                 _hems_inventory_ready=True,
             )
             self._merge_heatpump_type_bucket()
-            self._set_shared_state_attr(
-                "_hems_devices_cache_until", now + HEMS_DEVICES_CACHE_TTL
-            )
+            self._set_shared_state_attr("_hems_devices_cache_until", now + cache_ttl)
             self._debug_log_summary_if_changed(
                 "hems_inventory",
                 "HEMS discovery summary",
@@ -1845,7 +1858,7 @@ class InventoryRuntime:
                     _hems_devices_payload=None,
                     _hems_devices_using_stale=False,
                     _hems_inventory_ready=True,
-                    _hems_devices_cache_until=now + HEMS_DEVICES_CACHE_TTL,
+                    _hems_devices_cache_until=now + cache_ttl,
                 )
             elif stale_allowed:
                 # A short stale window avoids removing heat-pump entities during
@@ -1854,14 +1867,14 @@ class InventoryRuntime:
                     _hems_devices_payload=previous_payload,
                     _hems_devices_using_stale=True,
                     _hems_inventory_ready=True,
-                    _hems_devices_cache_until=now + HEMS_DEVICES_CACHE_TTL,
+                    _hems_devices_cache_until=now + cache_ttl,
                 )
             else:
                 self._update_shared_state(
                     _hems_devices_payload=None,
                     _hems_devices_using_stale=False,
                     _hems_inventory_ready=False,
-                    _hems_devices_cache_until=now + HEMS_DEVICES_CACHE_TTL,
+                    _hems_devices_cache_until=now + cache_ttl,
                 )
             self._merge_heatpump_type_bucket()
             self._debug_log_summary_if_changed(
@@ -1880,7 +1893,7 @@ class InventoryRuntime:
                 )
                 self._merge_heatpump_type_bucket()
                 self._set_shared_state_attr(
-                    "_hems_devices_cache_until", now + HEMS_DEVICES_CACHE_TTL
+                    "_hems_devices_cache_until", now + cache_ttl
                 )
                 self._debug_log_summary_if_changed(
                     "hems_inventory",
@@ -1896,7 +1909,7 @@ class InventoryRuntime:
                 )
                 self._merge_heatpump_type_bucket()
                 self._set_shared_state_attr(
-                    "_hems_devices_cache_until", now + HEMS_DEVICES_CACHE_TTL
+                    "_hems_devices_cache_until", now + cache_ttl
                 )
                 self._debug_log_summary_if_changed(
                     "hems_inventory",
@@ -1910,9 +1923,7 @@ class InventoryRuntime:
                 _hems_inventory_ready=False,
             )
             self._merge_heatpump_type_bucket()
-            self._set_shared_state_attr(
-                "_hems_devices_cache_until", now + HEMS_DEVICES_CACHE_TTL
-            )
+            self._set_shared_state_attr("_hems_devices_cache_until", now + cache_ttl)
             self._debug_log_summary_if_changed(
                 "hems_inventory",
                 "HEMS discovery summary",
@@ -1934,9 +1945,7 @@ class InventoryRuntime:
             _hems_inventory_ready=True,
         )
         self._merge_heatpump_type_bucket()
-        self._set_shared_state_attr(
-            "_hems_devices_cache_until", now + HEMS_DEVICES_CACHE_TTL
-        )
+        self._set_shared_state_attr("_hems_devices_cache_until", now + cache_ttl)
         self._debug_log_summary_if_changed(
             "hems_inventory",
             "HEMS discovery summary",

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -3044,7 +3044,7 @@ async def test_aged_unavailable_session_history_without_valid_cache_refreshes_in
 
 
 @pytest.mark.asyncio
-async def test_missing_session_cache_age_refreshes_inline_after_startup(
+async def test_missing_session_cache_age_defers_idle_refresh_after_startup(
     hass, monkeypatch
 ) -> None:
     await hass.config.async_set_time_zone("UTC")
@@ -3065,6 +3065,62 @@ async def test_missing_session_cache_age_refreshes_inline_after_startup(
                     "session_d": {},
                     "sch_d": {},
                     "charging": False,
+                }
+            ]
+        }
+    )
+    coord.client.summary_v2 = AsyncMock(
+        return_value=[{"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"}]
+    )
+    coord.client.charge_mode = AsyncMock(return_value=None)
+    coord.session_history.get_cache_view = MagicMock(  # type: ignore[assignment]
+        return_value=SessionCacheView(
+            sessions=[{"session_id": "cached", "energy_kwh": 1.0}],
+            cache_age=None,
+            needs_refresh=True,
+            blocked=False,
+            state="valid",
+            has_valid_cache=True,
+            last_error=None,
+        )
+    )
+    coord._async_enrich_sessions = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value={RANDOM_SERIAL: [{"session_id": "fresh", "energy_kwh": 2.5}]}
+    )
+    coord._schedule_session_enrichment = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+
+    data = await coord._async_update_data()
+
+    assert data[RANDOM_SERIAL]["energy_today_sessions"] == [
+        {"session_id": "cached", "energy_kwh": 1.0}
+    ]
+    coord._async_enrich_sessions.assert_not_awaited()  # type: ignore[attr-defined]
+    coord._schedule_session_enrichment.assert_called_once()  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+async def test_missing_session_cache_age_refreshes_active_session_inline(
+    hass, monkeypatch
+) -> None:
+    await hass.config.async_set_time_zone("UTC")
+    coord = _make_coordinator(hass, monkeypatch)
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord.data = {RANDOM_SERIAL: {"display_name": "Garage EV"}}
+
+    now_local = datetime(2025, 10, 16, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: now_local)
+
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                    "charging": True,
+                    "pluggedIn": True,
                 }
             ]
         }

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -9,6 +10,7 @@ import aiohttp
 import pytest
 from homeassistant.exceptions import ConfigEntryAuthFailed
 
+from custom_components.enphase_ev.evse_runtime import ChargeModeResolution
 from custom_components.enphase_ev.refresh_plan import (
     FOLLOWUP_STAGE,
     FOLLOWUP_PLAN,
@@ -914,6 +916,46 @@ async def test_post_status_evse_enrichments_run_concurrently(
     assert "green_settings_s" in phase_timings
     assert "auth_settings_s" in phase_timings
     assert "charger_config_s" in phase_timings
+
+
+@pytest.mark.asyncio
+async def test_post_status_evse_enrichments_reuse_fresh_cache_without_lookup_tasks(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    phase_timings: dict[str, float] = {}
+    now = time.monotonic()
+    coord._charge_mode_cache = {"SERIAL-1": ("SMART_CHARGING", now)}  # noqa: SLF001
+    coord._green_battery_cache = {"SERIAL-1": (True, True, now)}  # noqa: SLF001
+    coord._auth_settings_cache = {  # noqa: SLF001
+        "SERIAL-1": (True, False, True, True, now)
+    }
+    coord._charger_config_cache = {  # noqa: SLF001
+        "SERIAL-1": ({"DefaultChargeLevel": 32, "phase_switch_config": "auto"}, now)
+    }
+    coord.evse_runtime.async_resolve_charge_modes = AsyncMock()
+    coord._async_resolve_green_battery_settings = AsyncMock()  # noqa: SLF001
+    coord._async_resolve_auth_settings = AsyncMock()  # noqa: SLF001
+    coord._async_resolve_charger_config = AsyncMock()  # noqa: SLF001
+
+    result = await coord._async_resolve_post_status_evse_enrichments(
+        phase_timings,
+        records=[("SERIAL-1", {"sn": "SERIAL-1"})],
+        charge_mode_candidates=["SERIAL-1"],
+        first_refresh=False,
+    )
+
+    assert result == (
+        {"SERIAL-1": ChargeModeResolution("SMART_CHARGING", "cache")},
+        {"SERIAL-1": (True, True)},
+        {"SERIAL-1": (True, False, True, True)},
+        {"SERIAL-1": {"DefaultChargeLevel": 32, "phase_switch_config": "auto"}},
+    )
+    coord.evse_runtime.async_resolve_charge_modes.assert_not_awaited()
+    coord._async_resolve_green_battery_settings.assert_not_awaited()  # noqa: SLF001
+    coord._async_resolve_auth_settings.assert_not_awaited()  # noqa: SLF001
+    coord._async_resolve_charger_config.assert_not_awaited()  # noqa: SLF001
+    assert phase_timings == {}
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -170,6 +170,25 @@ async def test_heatpump_runtime_public_async_wrappers(
     )
 
 
+@pytest.mark.asyncio
+async def test_heatpump_runtime_preflight_uses_fast_poll_cache_floor(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.heatpump_runtime
+    coord.client._hems_site_supported = None  # noqa: SLF001
+    coord.client.system_dashboard_summary = AsyncMock(return_value=None)
+
+    await runtime._async_refresh_hems_support_preflight()  # noqa: SLF001
+
+    coord.client.system_dashboard_summary.assert_awaited_once_with()
+    assert runtime.hems_support_preflight_cache_ttl_s() == pytest.approx(30.0)
+    assert runtime._hems_support_preflight_cache_until is not None  # noqa: SLF001
+    assert (
+        runtime._hems_support_preflight_cache_until >= time.monotonic() + 29.0
+    )  # noqa: SLF001
+
+
 @pytest.mark.parametrize(
     ("current_snapshot", "previous_snapshot", "expected_validation"),
     [

--- a/tests/components/enphase_ev/test_inventory_runtime.py
+++ b/tests/components/enphase_ev/test_inventory_runtime.py
@@ -105,6 +105,17 @@ def test_inventory_runtime_helper_paths(coordinator_factory) -> None:
     }
 
 
+def test_inventory_runtime_hems_refresh_floor_falls_back_on_bad_runtime_value(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    coord.heatpump_runtime.hems_refresh_floor_s = lambda: "bad"  # type: ignore[method-assign]  # noqa: SLF001
+
+    assert runtime._hems_refresh_floor_s() == 30.0  # noqa: SLF001
+    assert runtime._hems_devices_cache_ttl_s() == 30.0  # noqa: SLF001
+
+
 def test_inventory_runtime_summary_and_inverter_helper_paths(
     coordinator_factory,
 ) -> None:
@@ -2048,6 +2059,32 @@ async def test_inventory_runtime_refresh_hems_devices_unsupported_and_redaction_
     await runtime._async_refresh_hems_devices(force=True)  # noqa: SLF001
     assert runtime._hems_devices_payload is None  # noqa: SLF001
     assert runtime._hems_inventory_ready is True  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_inventory_runtime_refresh_hems_devices_uses_fast_poll_cache_floor(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    coord.client._hems_site_supported = True  # noqa: SLF001
+    coord.client.hems_devices = AsyncMock(
+        return_value={"data": {"hems-devices": {"heat-pump": []}}}
+    )
+    monkeypatch.setattr(
+        inventory_runtime_mod, "redact_battery_payload", lambda payload: payload
+    )
+
+    await runtime._async_refresh_hems_devices()
+
+    coord.client.hems_devices.assert_awaited_once_with(refresh_data=False)
+    assert runtime._hems_devices_cache_until is not None  # noqa: SLF001
+    assert runtime._hems_devices_last_success_mono is not None  # noqa: SLF001
+    assert runtime._hems_devices_cache_ttl_s() == pytest.approx(30.0)  # noqa: SLF001
+    assert (
+        runtime._hems_devices_cache_until
+        - runtime._hems_devices_last_success_mono  # noqa: SLF001
+    ) == pytest.approx(30.0)
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_performance_audit_regressions.py
+++ b/tests/components/enphase_ev/test_performance_audit_regressions.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import time
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from homeassistant.util import dt as dt_util
+
+from custom_components.enphase_ev.const import (
+    DEFAULT_CHARGE_LEVEL_SETTING,
+    PHASE_SWITCH_CONFIG_SETTING,
+)
+from custom_components.enphase_ev.session_history import SessionCacheView
+
+from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
+
+
+def _prepare_refresh_target(
+    coord,
+    monkeypatch,
+    *,
+    charging: bool,
+    first_refresh: bool,
+    session_view: SessionCacheView,
+) -> None:
+    now_local = datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(dt_util, "now", lambda: now_local)
+
+    coord._has_successful_refresh = not first_refresh  # noqa: SLF001
+    coord._scheduler_available = True  # noqa: SLF001
+    coord.data = {RANDOM_SERIAL: {"display_name": "Garage EV"}}
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "charging": charging,
+                    "pluggedIn": charging,
+                    "charge_mode": "IMMEDIATE",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                }
+            ],
+            "ts": 1_700_000_000,
+        }
+    )
+    coord.summary = SimpleNamespace(
+        prepare_refresh=lambda **_kwargs: False,
+        async_fetch=AsyncMock(
+            return_value=[{"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"}]
+        ),
+        invalidate=lambda: None,
+    )
+    coord.evse_timeseries = SimpleNamespace(
+        refresh_due=MagicMock(return_value=False),
+        async_refresh=AsyncMock(),
+        merge_charger_payloads=MagicMock(),
+        diagnostics=lambda: {},
+    )
+    coord._async_run_post_status_refresh_pipeline = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value=None
+    )
+    coord._async_run_post_session_refresh_pipeline = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value=None
+    )
+    coord._async_resolve_green_battery_settings = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value={}
+    )
+    coord._async_resolve_auth_settings = AsyncMock(return_value={})  # noqa: SLF001
+    coord._async_resolve_charger_config = AsyncMock(return_value={})  # noqa: SLF001
+    coord.session_history.get_cache_view = MagicMock(return_value=session_view)  # type: ignore[assignment]
+    coord._async_enrich_sessions = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value={RANDOM_SERIAL: [{"session_id": "fresh", "energy_kwh": 2.0}]}
+    )
+    coord._schedule_session_enrichment = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+    coord._prune_runtime_caches = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+    coord.energy._async_refresh_site_energy = AsyncMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord._sync_site_energy_issue = MagicMock()  # noqa: SLF001
+    coord._sync_battery_profile_pending_issue = MagicMock()  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_post_status_evse_enrichment_uses_hot_caches_without_followup_io(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    now = time.monotonic()
+    coord._green_battery_cache["EV1"] = (True, True, now)  # noqa: SLF001
+    coord._auth_settings_cache["EV1"] = (True, False, True, True, now)  # noqa: SLF001
+    coord._charger_config_cache["EV1"] = (  # noqa: SLF001
+        {
+            DEFAULT_CHARGE_LEVEL_SETTING: 32,
+            PHASE_SWITCH_CONFIG_SETTING: "three_phase",
+        },
+        now,
+    )
+    coord.evse_runtime.async_get_green_battery_setting = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("green battery lookup should stay cached")
+    )
+    coord.evse_runtime.async_get_auth_settings = AsyncMock(  # type: ignore[method-assign]
+        side_effect=AssertionError("auth settings lookup should stay cached")
+    )
+    coord.client.charger_config = AsyncMock(
+        side_effect=AssertionError("charger config lookup should stay cached")
+    )
+
+    charge_modes, green_settings, auth_settings, charger_config = (
+        await coord._async_resolve_post_status_evse_enrichments(  # noqa: SLF001
+            {},
+            records=[("EV1", {"sn": "EV1"})],
+            charge_mode_candidates=[],
+            first_refresh=False,
+        )
+    )
+
+    assert charge_modes == {}
+    assert green_settings == {"EV1": (True, True)}
+    assert auth_settings == {"EV1": (True, False, True, True)}
+    assert charger_config == {
+        "EV1": {
+            DEFAULT_CHARGE_LEVEL_SETTING: 32,
+            PHASE_SWITCH_CONFIG_SETTING: "three_phase",
+        }
+    }
+    coord.evse_runtime.async_get_green_battery_setting.assert_not_awaited()
+    coord.evse_runtime.async_get_auth_settings.assert_not_awaited()
+    coord.client.charger_config.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_get_charger_config_returns_none_during_backoff_without_cache(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    coord._charger_config_backoff_until["EV1"] = time.monotonic() + 60  # noqa: SLF001
+    coord.client.charger_config = AsyncMock(
+        side_effect=AssertionError("charger config lookup should be backoff-gated")
+    )
+
+    result = await coord.evse_runtime.async_get_charger_config(
+        "EV1",
+        keys=[DEFAULT_CHARGE_LEVEL_SETTING],
+    )
+
+    assert result is None
+    coord.client.charger_config.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_hems_refresh_skips_preflight_when_device_cache_is_hot(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    runtime._hems_devices_cache_until = time.monotonic() + 60  # noqa: SLF001
+    coord.heatpump_runtime.async_refresh_hems_support_preflight = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        side_effect=AssertionError("preflight should be skipped")
+    )
+    coord.client.hems_devices = AsyncMock(
+        side_effect=AssertionError("device refresh should be skipped")
+    )
+
+    await runtime._async_refresh_hems_devices()
+
+    coord.heatpump_runtime.async_refresh_hems_support_preflight.assert_not_awaited()
+    coord.client.hems_devices.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_hems_refresh_reuses_preflight_cache_across_due_device_refreshes(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.inventory_runtime
+    coord.client._hems_site_supported = None  # noqa: SLF001
+    coord.client.system_dashboard_summary = AsyncMock(return_value={"is_hems": True})
+    coord.client.hems_devices = AsyncMock(
+        return_value={"data": {"hems-devices": {"heat-pump": []}}}
+    )
+
+    await runtime._async_refresh_hems_devices()
+
+    assert runtime._hems_support_preflight_cache_until is not None  # noqa: SLF001
+    coord.client._hems_site_supported = None  # noqa: SLF001
+    runtime._hems_devices_cache_until = None  # noqa: SLF001
+
+    await runtime._async_refresh_hems_devices()
+
+    coord.client.system_dashboard_summary.assert_awaited_once()
+    assert coord.client.hems_devices.await_count == 2
+
+
+@pytest.mark.parametrize(
+    ("first_refresh", "cache_age", "expected_inline", "expected_background"),
+    [
+        (True, 180.0, False, True),
+        (False, 180.0, False, True),
+        (False, 10_000.0, True, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_session_history_refresh_classifies_inline_vs_background_paths(
+    coordinator_factory,
+    monkeypatch,
+    first_refresh: bool,
+    cache_age: float,
+    expected_inline: bool,
+    expected_background: bool,
+) -> None:
+    coord = coordinator_factory()
+    _prepare_refresh_target(
+        coord,
+        monkeypatch,
+        charging=True,
+        first_refresh=first_refresh,
+        session_view=SessionCacheView(
+            sessions=[{"session_id": "cached", "energy_kwh": 1.25}],
+            cache_age=cache_age,
+            needs_refresh=True,
+            blocked=False,
+            state="valid",
+            has_valid_cache=True,
+            last_error=None,
+        ),
+    )
+
+    data = await coord._async_update_data()  # noqa: SLF001
+
+    if expected_inline:
+        coord._async_enrich_sessions.assert_awaited_once()  # type: ignore[attr-defined]  # noqa: SLF001
+        coord._schedule_session_enrichment.assert_not_called()  # type: ignore[attr-defined]  # noqa: SLF001
+        assert data[RANDOM_SERIAL]["energy_today_sessions"] == [
+            {"session_id": "fresh", "energy_kwh": 2.0}
+        ]
+        assert (
+            coord._async_enrich_sessions.await_args.kwargs["max_cache_age"]  # type: ignore[attr-defined]  # noqa: SLF001
+            == 120.0
+        )
+        return
+
+    if expected_background:
+        coord._async_enrich_sessions.assert_not_awaited()  # type: ignore[attr-defined]  # noqa: SLF001
+        coord._schedule_session_enrichment.assert_called_once()  # type: ignore[attr-defined]  # noqa: SLF001
+        assert data[RANDOM_SERIAL]["energy_today_sessions"] == [
+            {"session_id": "cached", "energy_kwh": 1.25}
+        ]
+        assert (
+            coord._schedule_session_enrichment.call_args.kwargs["max_cache_age"]  # type: ignore[attr-defined]  # noqa: SLF001
+            == 120.0
+        )


### PR DESCRIPTION
## Summary
- reduce coordinator refresh-path overhead by reusing hot EVSE cache entries before spawning post-status follow-up lookups
- keep ambiguous idle session-history catch-up off the main refresh path while preserving inline refresh for active and recent sessions
- align HEMS support-preflight and HEMS device refresh cadence with fast polling, and add focused regression coverage for the new gating and fallback paths

## Testing
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev tests/components/enphase_ev"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/evse_runtime.py,custom_components/enphase_ev/heatpump_runtime.py,custom_components/enphase_ev/inventory_runtime.py --fail-under=100"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:ro ha-dev bash -lc "pre-commit run --all-files"`
