### PR TITLE
Migrate integration tooling to Python 3.14

### DIFF
--- a/.github/workflows/auto_label_issues.yml
+++ b/.github/workflows/auto_label_issues.yml
@@ -74,7 +74,7 @@ jobs:
           FEATURE_AREA: ${{ steps.issue_parser.outputs.issueparser_area }}
           DEVICE_FAMILY: ${{ steps.issue_parser.outputs.issueparser_device_family }}
         with:
-          python-version: '3.x'
+          python-version: '3.14'
 
       - name: Reconcile automation labels
         env:

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -60,7 +60,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
           cache-dependency-path: |
             .pre-commit-config.yaml

--- a/.github/workflows/firmware-catalog.yml
+++ b/.github/workflows/firmware-catalog.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Build firmware catalog
         run: |

--- a/.github/workflows/quality-scale.yml
+++ b/.github/workflows/quality-scale.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
           cache: "pip"
           cache-dependency-path: |
             devtools/docker/requirements-dev.txt

--- a/.github/workflows/service-status.yml
+++ b/.github/workflows/service-status.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Read previous service-status history
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,11 @@ on:
       - '.ruff.toml'
       - '.strict-typing'
       - 'devtools/docker/requirements-dev.txt'
+      - 'devtools/docker/requirements-min-ha.txt'
       - 'quality_scale.yaml'
+      - 'scripts/importtime_profile.py'
       - 'scripts/validate_quality_scale.py'
+      - 'tests/scripts/test_importtime_profile.py'
       - '.github/workflows/ci.yml'
       - '.github/workflows/tests.yml'
   workflow_dispatch:
@@ -34,7 +37,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: |
             .pre-commit-config.yaml
@@ -67,7 +70,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: |
             devtools/docker/requirements-dev.txt
@@ -90,7 +93,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: |
             devtools/docker/requirements-dev.txt
@@ -109,6 +112,66 @@ jobs:
           custom_components/enphase_ev/runtime_data.py
           custom_components/enphase_ev/config_flow.py
 
+  python314-diagnostics:
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            devtools/docker/requirements-dev.txt
+            .github/workflows/tests.yml
+      - name: Install deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade -r devtools/docker/requirements-dev.txt aiohttp async-timeout voluptuous
+      - name: Gate integration import deprecations and profile import time
+        run: |
+          python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log
+      - name: Upload import-time profile
+        uses: actions/upload-artifact@v6
+        with:
+          name: importtime-enphase-ev-python314
+          path: importtime-enphase-ev.log
+
+  minimum-homeassistant:
+    runs-on: ubuntu-latest
+    needs: pre-commit
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.14'
+          cache: 'pip'
+          cache-dependency-path: |
+            devtools/docker/requirements-min-ha.txt
+            .github/workflows/tests.yml
+      - name: Install minimum Home Assistant test deps
+        run: |
+          # pytest-homeassistant-custom-component pins exact Home Assistant patch
+          # releases, so keep the full pytest job on the latest compatible stack
+          # and install the plugin without dependencies for this minimum test path.
+          python -m pip install --upgrade pip
+          pip install --upgrade -r devtools/docker/requirements-min-ha.txt
+          pip install --no-deps "pytest-homeassistant-custom-component==0.13.317"
+          python -c "from homeassistant.const import __version__; assert __version__ == '2026.3.0', __version__; print(f'Home Assistant {__version__}')"
+      - name: Run minimum Home Assistant tests
+        run: >
+          pytest -q
+          tests/components/enphase_ev/test_manifest.py
+          tests/components/enphase_ev/test_device_action.py
+          tests/components/enphase_ev/test_device_trigger.py
+          tests/components/enphase_ev/test_schedule_sync.py
+
   pytest:
     runs-on: ubuntu-latest
     needs: pre-commit
@@ -119,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.13']
+        python-version: ['3.14']
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -134,6 +197,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install --upgrade -r devtools/docker/requirements-dev.txt aiohttp async-timeout voluptuous
+          python -c "from homeassistant.const import __version__; print(f'Home Assistant {__version__}')"
       - name: Run tests
         id: pytest
         continue-on-error: true
@@ -169,7 +233,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: '3.13'
+          python-version: '3.14'
           cache: 'pip'
           cache-dependency-path: |
             devtools/docker/requirements-dev.txt

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@
 
 ## Coding Style & Naming Conventions
 - Follow Home Assistant integration patterns and keep dependencies limited to the standard library or Home Assistant unless there is a strong reason otherwise.
-- Target Home Assistant `2024.12.0+` behavior and Python `3.13` syntax/runtime expectations.
+- Target Home Assistant `2026.3.0+` behavior and Python `3.14` syntax/runtime expectations.
 - Keep external I/O async and avoid blocking the event loop; use executor jobs only for genuinely blocking work.
 - Keep code Black-formatted, Ruff-clean, and consistent with lazy logging and clear type hints.
 - Keep `try` blocks narrow and raise the most specific Home Assistant exception available.

--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -1208,7 +1208,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: EnphaseConfigEntry) -> b
         elif callable(hass_create_background):
             hass_create_background(coro, name)
         else:
-            hass.async_create_task(coro)
+            hass.async_create_task(coro, name=name)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/enphase_ev/api_models.py
+++ b/custom_components/enphase_ev/api_models.py
@@ -1,8 +1,9 @@
 """Typed API boundary models for the Enphase EV client."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
+
+type CookieJar = dict[str, str]
+type HeaderMap = dict[str, str]
 
 
 @dataclass(slots=True)
@@ -13,7 +14,7 @@ class AuthTokens:
     session_id: str | None = None
     access_token: str | None = None
     token_expires_at: int | None = None
-    raw_cookies: dict[str, str] | None = None
+    raw_cookies: CookieJar | None = None
 
 
 @dataclass(slots=True)
@@ -39,5 +40,5 @@ class TextResponse:
     status: int
     text: str
     url: str
-    headers: dict[str, str]
+    headers: HeaderMap
     location: str | None = None

--- a/custom_components/enphase_ev/api_parsers.py
+++ b/custom_components/enphase_ev/api_parsers.py
@@ -5,9 +5,32 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta, timezone
+from typing import TypedDict
 
 from .api_models import ChargerInfo, SiteInfo
 from .runtime_helpers import coerce_optional_text
+
+type PayloadMap = dict[str, object]
+type DayEnergyValues = dict[str, float]
+type DateKeyParser = Callable[[object], str | None]
+type EnergyCoercer = Callable[..., float | None]
+
+
+class LatestPowerPayload(TypedDict, total=False):
+    """Payload shape returned by latest-power normalizers."""
+
+    value: float
+    units: str
+    precision: int
+    time: int
+
+
+class HeatpumpSGReadyModeDetails(TypedDict):
+    """Normalized SG Ready details derived from raw HEMS labels."""
+
+    sg_ready_mode_label: str | None
+    sg_ready_active: bool | None
+    sg_ready_contact_state: str | None
 
 
 @dataclass(slots=True, frozen=True)
@@ -19,10 +42,10 @@ class LatestPowerSample:
     precision: int | None = None
     time: int | None = None
 
-    def to_dict(self) -> dict[str, object]:
+    def to_dict(self) -> LatestPowerPayload:
         """Return the payload shape used by existing API consumers."""
 
-        payload: dict[str, object] = {"value": self.value}
+        payload: LatestPowerPayload = {"value": self.value}
         if self.units is not None:
             payload["units"] = self.units
         if self.precision is not None:
@@ -37,12 +60,12 @@ class EVSEDailyEnergyEntry:
     """Normalized EVSE daily energy timeseries for one charger."""
 
     serial: str
-    day_values_kwh: dict[str, float]
+    day_values_kwh: DayEnergyValues
     energy_kwh: float | None
     current_value_kwh: float | None
-    metadata: dict[str, object]
+    metadata: PayloadMap
 
-    def to_dict(self) -> dict[str, object]:
+    def to_dict(self) -> PayloadMap:
         """Return the payload shape used by existing API consumers."""
 
         return {
@@ -60,9 +83,9 @@ class EVSELifetimeEnergyEntry:
 
     serial: str
     energy_kwh: float
-    metadata: dict[str, object]
+    metadata: PayloadMap
 
-    def to_dict(self) -> dict[str, object]:
+    def to_dict(self) -> PayloadMap:
         """Return the payload shape used by existing API consumers."""
 
         return {"serial": self.serial, "energy_kwh": self.energy_kwh, **self.metadata}
@@ -72,9 +95,9 @@ class EVSELifetimeEnergyEntry:
 class HEMSHeatpumpState:
     """Normalized HEMS heat pump runtime state."""
 
-    payload: dict[str, object]
+    payload: PayloadMap
 
-    def to_dict(self) -> dict[str, object]:
+    def to_dict(self) -> PayloadMap:
         """Return the payload shape used by existing API consumers."""
 
         return dict(self.payload)
@@ -86,9 +109,9 @@ class HEMSDailyConsumptionEntry:
 
     device_uid: str | None
     device_name: str | None
-    consumption: list[dict[str, object]]
+    consumption: list[PayloadMap]
 
-    def to_dict(self) -> dict[str, object]:
+    def to_dict(self) -> PayloadMap:
         """Return the payload shape used by existing API consumers."""
 
         return {
@@ -270,14 +293,14 @@ def parse_latest_power_payload(payload: object) -> LatestPowerSample | None:
     )
 
 
-def normalize_latest_power_payload(payload: object) -> dict[str, object] | None:
+def normalize_latest_power_payload(payload: object) -> LatestPowerPayload | None:
     """Normalize app-api latest power payloads into a common shape."""
 
     sample = parse_latest_power_payload(payload)
     return sample.to_dict() if sample is not None else None
 
 
-def normalize_lifetime_energy_payload(payload: object) -> dict | None:
+def normalize_lifetime_energy_payload(payload: object) -> PayloadMap | None:
     """Normalize site/HEMS lifetime-energy payloads into a common shape."""
 
     data = payload
@@ -327,7 +350,7 @@ def normalize_lifetime_energy_payload(payload: object) -> dict | None:
         "systemId": "system_id",
     }
 
-    normalized: dict[str, object] = {}
+    normalized: PayloadMap = {}
     for key, value in data.items():
         canonical_key = array_field_aliases.get(key, key)
         if canonical_key in array_fields:
@@ -437,7 +460,7 @@ def coerce_evse_timeseries_energy(
     return round(numeric, 6)
 
 
-def normalize_evse_timeseries_metadata(payload: object) -> dict[str, object]:
+def normalize_evse_timeseries_metadata(payload: object) -> PayloadMap:
     """Normalize shared EVSE timeseries metadata."""
 
     if not isinstance(payload, dict):
@@ -448,7 +471,7 @@ def normalize_evse_timeseries_metadata(payload: object) -> dict[str, object]:
         or payload.get("interval_min")
         or payload.get("intervalMinutes")
     )
-    metadata: dict[str, object] = {}
+    metadata: PayloadMap = {}
     if interval is not None and interval > 0:
         metadata["interval_minutes"] = interval
     last_report = (
@@ -463,14 +486,14 @@ def normalize_evse_timeseries_metadata(payload: object) -> dict[str, object]:
 
 
 def daily_values_from_mapping(
-    payload: dict[str, object],
+    payload: PayloadMap,
     *,
-    parse_date_key: Callable[[object], str | None] = parse_evse_timeseries_date_key,
-    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
-) -> tuple[dict[str, float], float | None]:
+    parse_date_key: DateKeyParser = parse_evse_timeseries_date_key,
+    coerce_energy: EnergyCoercer = coerce_evse_timeseries_energy,
+) -> tuple[DayEnergyValues, float | None]:
     """Extract per-day EVSE values from a mapping payload."""
 
-    day_values: dict[str, float] = {}
+    day_values: DayEnergyValues = {}
     current_value: float | None = None
     unit_hint = payload.get("unit") or payload.get("source_unit")
     for key, raw in payload.items():
@@ -505,12 +528,12 @@ def daily_values_from_sequence(
     *,
     start_date_value: object | None = None,
     unit_hint: object | None = None,
-    parse_date_key: Callable[[object], str | None] = parse_evse_timeseries_date_key,
-    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
-) -> tuple[dict[str, float], float | None]:
+    parse_date_key: DateKeyParser = parse_evse_timeseries_date_key,
+    coerce_energy: EnergyCoercer = coerce_evse_timeseries_energy,
+) -> tuple[DayEnergyValues, float | None]:
     """Extract per-day EVSE values from a sequence payload."""
 
-    day_values: dict[str, float] = {}
+    day_values: DayEnergyValues = {}
     current_value: float | None = None
     start_day = parse_date_key(start_date_value)
     start_dt = None
@@ -566,14 +589,14 @@ def parse_evse_daily_entry(
     serial: str,
     payload: object,
     *,
-    base_metadata: dict[str, object] | None = None,
-    parse_date_key: Callable[[object], str | None] = parse_evse_timeseries_date_key,
-    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
+    base_metadata: PayloadMap | None = None,
+    parse_date_key: DateKeyParser = parse_evse_timeseries_date_key,
+    coerce_energy: EnergyCoercer = coerce_evse_timeseries_energy,
 ) -> EVSEDailyEnergyEntry | None:
     """Parse one EVSE daily timeseries entry."""
 
     metadata = dict(base_metadata or {})
-    day_values: dict[str, float] = {}
+    day_values: DayEnergyValues = {}
     current_value: float | None = None
     if isinstance(payload, dict):
         metadata.update(normalize_evse_timeseries_metadata(payload))
@@ -639,10 +662,10 @@ def normalize_evse_daily_entry(
     serial: str,
     payload: object,
     *,
-    base_metadata: dict[str, object] | None = None,
-    parse_date_key: Callable[[object], str | None] = parse_evse_timeseries_date_key,
-    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
-) -> dict[str, object] | None:
+    base_metadata: PayloadMap | None = None,
+    parse_date_key: DateKeyParser = parse_evse_timeseries_date_key,
+    coerce_energy: EnergyCoercer = coerce_evse_timeseries_energy,
+) -> PayloadMap | None:
     """Normalize one EVSE daily timeseries entry."""
 
     entry = parse_evse_daily_entry(
@@ -659,8 +682,8 @@ def parse_evse_lifetime_entry(
     serial: str,
     payload: object,
     *,
-    base_metadata: dict[str, object] | None = None,
-    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
+    base_metadata: PayloadMap | None = None,
+    coerce_energy: EnergyCoercer = coerce_evse_timeseries_energy,
 ) -> EVSELifetimeEnergyEntry | None:
     """Parse one EVSE lifetime timeseries entry."""
 
@@ -742,9 +765,9 @@ def normalize_evse_lifetime_entry(
     serial: str,
     payload: object,
     *,
-    base_metadata: dict[str, object] | None = None,
-    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
-) -> dict[str, object] | None:
+    base_metadata: PayloadMap | None = None,
+    coerce_energy: EnergyCoercer = coerce_evse_timeseries_energy,
+) -> PayloadMap | None:
     """Normalize one EVSE lifetime timeseries entry."""
 
     entry = parse_evse_lifetime_entry(
@@ -760,9 +783,9 @@ def normalize_evse_timeseries_payload(
     payload: object,
     *,
     daily: bool,
-    parse_date_key: Callable[[object], str | None] = parse_evse_timeseries_date_key,
-    coerce_energy: Callable[..., float | None] = coerce_evse_timeseries_energy,
-) -> dict[str, dict[str, object]] | None:
+    parse_date_key: DateKeyParser = parse_evse_timeseries_date_key,
+    coerce_energy: EnergyCoercer = coerce_evse_timeseries_energy,
+) -> dict[str, PayloadMap] | None:
     """Normalize EVSE timeseries payloads keyed by charger serial."""
 
     data = payload
@@ -780,7 +803,7 @@ def normalize_evse_timeseries_payload(
         )
         if isinstance(candidates, list):
             data = candidates
-    normalized: dict[str, dict[str, object]] = {}
+    normalized: dict[str, PayloadMap] = {}
     if isinstance(data, list):
         for item in data:
             if not isinstance(item, dict):
@@ -847,7 +870,7 @@ def clean_optional_text(value: object) -> str | None:
     return coerce_optional_text(value)
 
 
-def heatpump_sg_ready_mode_details(value: object) -> dict[str, object]:
+def heatpump_sg_ready_mode_details(value: object) -> HeatpumpSGReadyModeDetails:
     """Map raw HEMS SG Ready mode labels to app-facing semantics."""
 
     text = clean_optional_text(value)
@@ -929,7 +952,7 @@ def parse_hems_heatpump_state_payload(payload: object) -> HEMSHeatpumpState | No
     )
 
 
-def normalize_hems_heatpump_state_payload(payload: object) -> dict | None:
+def normalize_hems_heatpump_state_payload(payload: object) -> PayloadMap | None:
     """Normalize HEMS heat-pump runtime state payloads."""
 
     state = parse_hems_heatpump_state_payload(payload)
@@ -953,13 +976,13 @@ def parse_hems_daily_consumption_entry(
         if payload.get("device_name") is not None
         else payload.get("device-name")
     )
-    buckets: list[dict[str, object]] = []
+    buckets: list[PayloadMap] = []
     raw_buckets = payload.get("consumption")
     if isinstance(raw_buckets, list):
         for item in raw_buckets:
             if not isinstance(item, dict):
                 continue
-            bucket: dict[str, object] = {
+            bucket: PayloadMap = {
                 "solar": coerce_lifetime_energy_value(item.get("solar")),
                 "battery": coerce_lifetime_energy_value(item.get("battery")),
                 "grid": coerce_lifetime_energy_value(item.get("grid")),
@@ -980,14 +1003,14 @@ def parse_hems_daily_consumption_entry(
 
 def normalize_hems_daily_consumption_entry(
     payload: object,
-) -> dict[str, object] | None:
+) -> PayloadMap | None:
     """Normalize a HEMS daily-consumption device entry."""
 
     entry = parse_hems_daily_consumption_entry(payload)
     return entry.to_dict() if entry is not None else None
 
 
-def normalize_hems_energy_consumption_payload(payload: object) -> dict | None:
+def normalize_hems_energy_consumption_payload(payload: object) -> PayloadMap | None:
     """Normalize HEMS daily energy-consumption payloads."""
 
     if not isinstance(payload, dict):
@@ -998,12 +1021,12 @@ def normalize_hems_energy_consumption_payload(payload: object) -> dict | None:
 
     endpoint_type = clean_optional_text(payload.get("type"))
     endpoint_timestamp = payload.get("timestamp")
-    families: dict[str, object] = {
+    families: PayloadMap = {
         "heat-pump": [],
         "evse": [],
         "water-heater": [],
     }
-    normalized: dict[str, object] = {
+    normalized: PayloadMap = {
         "type": endpoint_type,
         "timestamp": endpoint_timestamp,
         "endpoint_type": endpoint_type,
@@ -1016,7 +1039,7 @@ def normalize_hems_energy_consumption_payload(payload: object) -> dict | None:
             raw_family = data.get(family_key.replace("-", "_"))
         if not isinstance(raw_family, list):
             continue
-        entries: list[dict[str, object]] = []
+        entries: list[PayloadMap] = []
         for item in raw_family:
             normalized_entry = normalize_hems_daily_consumption_entry(item)
             if normalized_entry is not None:
@@ -1025,13 +1048,13 @@ def normalize_hems_energy_consumption_payload(payload: object) -> dict | None:
     return normalized
 
 
-def normalize_pv_system_today_payload(payload: object) -> dict | None:
+def normalize_pv_system_today_payload(payload: object) -> PayloadMap | None:
     """Normalize site-today payloads used by heat-pump daily totals."""
 
     if not isinstance(payload, dict):
         return None
     stats = payload.get("stats")
-    normalized_stats: list[dict[str, object]] = []
+    normalized_stats: list[PayloadMap] = []
     if isinstance(stats, list):
         for item in stats:
             if not isinstance(item, dict):
@@ -1049,7 +1072,7 @@ def normalize_pv_system_today_payload(payload: object) -> dict | None:
     return normalized
 
 
-def normalize_hems_power_timeseries_payload(payload: object) -> dict | None:
+def normalize_hems_power_timeseries_payload(payload: object) -> PayloadMap | None:
     """Normalize HEMS heat-pump power timeseries payloads."""
 
     data = payload
@@ -1102,7 +1125,7 @@ def normalize_hems_power_timeseries_payload(payload: object) -> dict | None:
     else:
         values = []
 
-    normalized: dict[str, object] = {
+    normalized: PayloadMap = {
         "heat_pump_consumption": values,
     }
     device_uid = data.get("device_uid")

--- a/custom_components/enphase_ev/auth_refresh_runtime.py
+++ b/custom_components/enphase_ev/auth_refresh_runtime.py
@@ -88,7 +88,10 @@ class AuthRefreshRuntime:
 
             task = getattr(coord, "_auth_refresh_task", None)
             if task is None or task.done():
-                task = asyncio.create_task(self.async_run_auto_refresh())
+                task = asyncio.create_task(
+                    self.async_run_auto_refresh(),
+                    name="enphase_ev_auth_refresh",
+                )
                 coord._auth_refresh_task = task
                 task.add_done_callback(self.clear_auth_refresh_task)
 
@@ -145,7 +148,10 @@ class AuthRefreshRuntime:
 
             task = getattr(coord, "_auth_refresh_task", None)
             if task is None or task.done():
-                task = asyncio.create_task(self.async_run_auto_refresh())
+                task = asyncio.create_task(
+                    self.async_run_auto_refresh(),
+                    name="enphase_ev_auth_refresh",
+                )
                 coord._auth_refresh_task = task
                 task.add_done_callback(self.clear_auth_refresh_task)
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -364,7 +364,12 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         if callable(set_reauth_cb):
             result = set_reauth_cb(self._handle_client_unauthorized)
             if inspect.isawaitable(result):
-                self.hass.async_create_task(result)
+                try:
+                    self.hass.async_create_task(
+                        result, name=f"{DOMAIN}_set_reauth_callback"
+                    )
+                except TypeError:
+                    self.hass.async_create_task(result)
         from .schedule_sync import ScheduleSync
 
         self.schedule_sync = ScheduleSync(hass, self, config_entry)
@@ -2290,7 +2295,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     lambda: self.evse_runtime.async_resolve_charge_modes(
                         charge_mode_lookup_candidates
                     ),
-                )
+                ),
+                name=f"{DOMAIN}_resolve_charge_modes",
             )
         green_lookup_candidates = self.evse_runtime.green_battery_lookup_candidates(
             serials,
@@ -2304,7 +2310,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     lambda: self._async_resolve_green_battery_settings(
                         green_lookup_candidates
                     ),
-                )
+                ),
+                name=f"{DOMAIN}_resolve_green_battery_settings",
             )
         auth_lookup_candidates = self.evse_runtime.auth_settings_lookup_candidates(
             serials,
@@ -2316,7 +2323,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     phase_timings,
                     "auth_settings_s",
                     lambda: self._async_resolve_auth_settings(auth_lookup_candidates),
-                )
+                ),
+                name=f"{DOMAIN}_resolve_auth_settings",
             )
         charger_config_lookup_candidates = (
             self.evse_runtime.charger_config_lookup_candidates(
@@ -2334,7 +2342,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                         charger_config_lookup_candidates,
                         keys=charger_config_keys,
                     ),
-                )
+                ),
+                name=f"{DOMAIN}_resolve_charger_config",
             )
         if not tasks:
             return charge_modes, green_settings, auth_settings, charger_config
@@ -6317,7 +6326,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._clear_backoff_timer()
             self._backoff_until = None
             self.backoff_ends_utc = None
-            self.hass.async_create_task(self.async_request_refresh())
+            self.hass.async_create_task(
+                self.async_request_refresh(), name=f"{DOMAIN}_backoff_refresh"
+            )
             return
         self._clear_backoff_timer()
         try:

--- a/custom_components/enphase_ev/device_action.py
+++ b/custom_components/enphase_ev/device_action.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
 import voluptuous as vol
-from homeassistant.components.device_automation.const import CONF_TYPE
-from homeassistant.const import CONF_DEVICE_ID
+from homeassistant.const import CONF_DEVICE_ID, CONF_TYPE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.typing import ConfigType

--- a/custom_components/enphase_ev/device_trigger.py
+++ b/custom_components/enphase_ev/device_trigger.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.automation.triggers import state as state_trigger
+try:
+    from homeassistant.components.automation.triggers import state as state_trigger
+except ModuleNotFoundError:
+    from homeassistant.components.homeassistant.triggers import state as state_trigger
 from homeassistant.const import STATE_OFF, STATE_ON
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er

--- a/custom_components/enphase_ev/discovery_snapshot.py
+++ b/custom_components/enphase_ev/discovery_snapshot.py
@@ -349,7 +349,9 @@ class DiscoverySnapshotManager:
             self.coordinator._discovery_snapshot_save_cancel = None
             if not self.coordinator._discovery_snapshot_pending:
                 return
-            self.coordinator.hass.async_create_task(self.async_save())
+            self.coordinator.hass.async_create_task(
+                self.async_save(), name=f"{DOMAIN}_discovery_snapshot_save"
+            )
 
         self.coordinator._discovery_snapshot_save_cancel = async_call_later(
             self.coordinator.hass, DISCOVERY_SNAPSHOT_SAVE_DELAY_S, _run

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -141,7 +141,10 @@ class EvseRuntime:
                 return await awaitable
 
         wrapped = {
-            sn: asyncio.create_task(_run(awaitable))
+            sn: asyncio.create_task(
+                _run(awaitable),
+                name=f"{DOMAIN}_evse_lookup_{redact_identifier(sn)}",
+            )
             for sn, awaitable in pending.items()
         }
         responses = await asyncio.gather(*wrapped.values(), return_exceptions=True)
@@ -767,7 +770,7 @@ class EvseRuntime:
         try:
             task = coord.hass.async_create_task(
                 restart(sn_str, delay),
-                name=f"enphase_ev_amp_restart_{sn_str}",
+                name=f"enphase_ev_amp_restart_{redact_identifier(sn_str)}",
             )
         except TypeError:
             task = coord.hass.async_create_task(restart(sn_str, delay))

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -15,7 +15,7 @@ from zoneinfo import ZoneInfo
 from homeassistant.core import callback
 from homeassistant.util import dt as dt_util
 
-from .const import DEFAULT_FAST_POLL_INTERVAL
+from .const import DEFAULT_FAST_POLL_INTERVAL, DOMAIN
 from .device_types import (
     member_is_retired as device_member_is_retired,
     normalize_type_key,
@@ -2023,12 +2023,18 @@ class InventoryRuntime:
                         return source_type, None, err
                 return source_type, payload if isinstance(payload, dict) else None, None
 
-            detail_results = await asyncio.gather(
-                *(
-                    _fetch_detail(source_type)
-                    for source_type in SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES
-                )
-            )
+            detail_tasks: list[
+                asyncio.Task[tuple[str, dict[str, object] | None, Exception | None]]
+            ] = []
+            async with asyncio.TaskGroup() as task_group:
+                for source_type in SYSTEM_DASHBOARD_DIAGNOSTIC_TYPES:
+                    detail_tasks.append(
+                        task_group.create_task(
+                            _fetch_detail(source_type),
+                            name=f"{DOMAIN}_system_dashboard_detail_{source_type}",
+                        )
+                    )
+            detail_results = [task.result() for task in detail_tasks]
             for source_type, payload, err in detail_results:
                 if err is not None:
                     if first_error is None:

--- a/custom_components/enphase_ev/refresh_runner.py
+++ b/custom_components/enphase_ev/refresh_runner.py
@@ -110,7 +110,8 @@ class RefreshRunner:
                         log_label,
                         callback_factory,
                         endpoint_family=endpoint_family,
-                    )
+                    ),
+                    name=f"{DOMAIN}_refresh_{timing_key}",
                 )
                 for timing_key, log_label, callback_factory, endpoint_family in calls
             ]
@@ -255,7 +256,7 @@ class RefreshRunner:
         try:
             coordinator._warmup_task = coordinator.hass.async_create_task(
                 self.async_startup_warmup_runner(),
-                name=f"{DOMAIN}_warmup_{coordinator.site_id}",
+                name=f"{DOMAIN}_warmup_site",
             )
         except TypeError:
             coordinator._warmup_task = coordinator.hass.async_create_task(

--- a/custom_components/enphase_ev/runtime_data.py
+++ b/custom_components/enphase_ev/runtime_data.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING
 
 from homeassistant.config_entries import ConfigEntry
 from .const import DOMAIN
@@ -30,7 +30,7 @@ class EnphaseRuntimeData:
     skip_reload_once: bool = False
 
 
-EnphaseConfigEntry: TypeAlias = ConfigEntry[EnphaseRuntimeData]
+type EnphaseConfigEntry = ConfigEntry[EnphaseRuntimeData]
 
 
 def get_runtime_data(entry: EnphaseConfigEntry) -> EnphaseRuntimeData:

--- a/custom_components/enphase_ev/schedule_sync.py
+++ b/custom_components/enphase_ev/schedule_sync.py
@@ -153,9 +153,17 @@ class ScheduleSync:
         @callback
         def _run(_now) -> None:
             self._pending_patch_refresh.discard(sn)
-            self.hass.async_create_task(
-                self.async_refresh(reason="patch", serials=[sn])
-            )
+            coro = self.async_refresh(reason="patch", serials=[sn])
+            try:
+                self.hass.async_create_task(
+                    coro,
+                    name=f"{DOMAIN}_schedule_patch_refresh_{redact_identifier(sn)}",
+                )
+            except TypeError:
+                coro.close()
+                self.hass.async_create_task(
+                    self.async_refresh(reason="patch", serials=[sn])
+                )
 
         async_call_later(self.hass, PATCH_REFRESH_DELAY_S, _run)
 
@@ -413,11 +421,27 @@ class ScheduleSync:
 
     @callback
     def _handle_interval(self, *_args) -> None:
-        self.hass.async_create_task(self.async_refresh(reason="interval"))
+        coro = self.async_refresh(reason="interval")
+        try:
+            self.hass.async_create_task(
+                coro,
+                name=f"{DOMAIN}_schedule_interval_refresh",
+            )
+        except TypeError:
+            coro.close()
+            self.hass.async_create_task(self.async_refresh(reason="interval"))
 
     @callback
     def _handle_coordinator_update(self) -> None:
-        self.hass.async_create_task(self._refresh_if_stale())
+        coro = self._refresh_if_stale()
+        try:
+            self.hass.async_create_task(
+                coro,
+                name=f"{DOMAIN}_schedule_coordinator_refresh",
+            )
+        except TypeError:
+            coro.close()
+            self.hass.async_create_task(self._refresh_if_stale())
 
     async def _refresh_if_stale(self) -> None:
         if not self._last_sync:
@@ -462,9 +486,16 @@ class ScheduleSync:
                     async with semaphore:
                         return (sn, *await self._async_fetch_serial_sync(sn))
 
-                results = await asyncio.gather(
-                    *(_fetch_one(sn) for sn in unique_serials)
-                )
+                tasks = []
+                async with asyncio.TaskGroup() as group:
+                    for sn in unique_serials:
+                        tasks.append(
+                            group.create_task(
+                                _fetch_one(sn),
+                                name=f"{DOMAIN}_schedule_fetch_{redact_identifier(sn)}",
+                            )
+                        )
+                results = [task.result() for task in tasks]
                 auth_result = next(
                     (
                         result

--- a/custom_components/enphase_ev/sensor_battery_helpers.py
+++ b/custom_components/enphase_ev/sensor_battery_helpers.py
@@ -2,9 +2,30 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import datetime, timezone
 import math
-from typing import Protocol
+from typing import Protocol, TypedDict
+
+type BatterySnapshot = dict[str, object]
+
+
+class BatteryLastReportedDeviceSnapshot(TypedDict):
+    """Device details attached to a battery last-reported aggregate."""
+
+    serial_number: object
+    name: object
+    status: object
+
+
+class BatteryLastReportedSnapshot(TypedDict):
+    """Aggregate battery last-reported payload exposed to sensors."""
+
+    total_batteries: int
+    without_last_report_count: int
+    latest_reported: datetime | None
+    latest_reported_utc: str | None
+    latest_reported_device: BatteryLastReportedDeviceSnapshot | None
 
 
 class BatteryLastReportedCoordinator(Protocol):
@@ -12,7 +33,7 @@ class BatteryLastReportedCoordinator(Protocol):
 
     battery_status_payload: object
 
-    def iter_battery_serials(self) -> object: ...
+    def iter_battery_serials(self) -> Iterable[str]: ...
 
     def battery_storage(self, serial: str) -> object: ...
 
@@ -80,7 +101,7 @@ def battery_optional_bool(value: object) -> bool | None:
     return None
 
 
-def battery_snapshot_last_reported(snapshot: dict[str, object]) -> datetime | None:
+def battery_snapshot_last_reported(snapshot: BatterySnapshot) -> datetime | None:
     """Return the newest last-report timestamp carried by a battery snapshot."""
 
     # Battery status API reports storages[].last_report as epoch seconds.
@@ -93,11 +114,11 @@ def battery_snapshot_last_reported(snapshot: dict[str, object]) -> datetime | No
 
 def battery_last_reported_members(
     coord: BatteryLastReportedCoordinator,
-) -> list[dict[str, object]]:
+) -> list[BatterySnapshot]:
     """Return battery members suitable for last-reported aggregation."""
 
     payload = getattr(coord, "battery_status_payload", None)
-    storage_members: list[dict[str, object]] = []
+    storage_members: list[BatterySnapshot] = []
     if isinstance(payload, dict):
         storages = payload.get("storages")
         if isinstance(storages, list):
@@ -129,12 +150,12 @@ def battery_last_reported_members(
 
 def battery_last_reported_snapshot(
     coord: BatteryLastReportedCoordinator,
-) -> dict[str, object]:
+) -> BatteryLastReportedSnapshot:
     """Return an aggregate last-reported snapshot for site battery storage."""
 
     members = battery_last_reported_members(coord)
     latest_reported: datetime | None = None
-    latest_reported_device: dict[str, object] | None = None
+    latest_reported_device: BatteryLastReportedDeviceSnapshot | None = None
     without_last_report_count = 0
     for snapshot in members:
         last_reported = battery_snapshot_last_reported(snapshot)

--- a/custom_components/enphase_ev/session_history.py
+++ b/custom_components/enphase_ev/session_history.py
@@ -15,7 +15,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.util import dt as dt_util
 
 from .api import InvalidPayloadError, SessionHistoryUnavailable, Unauthorized
-from .log_redaction import redact_text
+from .log_redaction import redact_identifier, redact_text
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -453,7 +453,13 @@ class SessionHistoryManager:
                     return sn, None
                 return sn, sessions
 
-        tasks = [asyncio.create_task(_refresh(sn)) for sn in serial_list]
+        tasks = [
+            asyncio.create_task(
+                _refresh(sn),
+                name=f"enphase_ev_session_refresh_{redact_identifier(sn)}",
+            )
+            for sn in serial_list
+        ]
         responses = await asyncio.gather(*tasks, return_exceptions=True)
         updates: dict[str, list[dict]] = {}
         for response in responses:

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -6,6 +6,11 @@ from typing import Any
 
 from .const import BATTERY_PROFILE_DEFAULT_RESERVE
 
+type PayloadMap = dict[str, object]
+type PayloadRecords = list[PayloadMap]
+type PayloadMapByKey = dict[str, PayloadMap]
+type CacheSource = tuple[object, ...]
+
 
 @dataclass(slots=True)
 class DiscoveryState:
@@ -16,36 +21,32 @@ class DiscoveryState:
     _warmup_in_progress: bool = False
     _warmup_last_error: str | None = None
     _restored_site_energy_channels: set[str] = field(default_factory=set)
-    _restored_gateway_iq_energy_router_records: list[dict[str, object]] = field(
+    _restored_gateway_iq_energy_router_records: PayloadRecords = field(
         default_factory=list
     )
     _topology_listeners: list[Any] = field(default_factory=list)
     _topology_snapshot_cache: object | None = None
-    _gateway_inventory_summary_cache: dict[str, object] = field(default_factory=dict)
-    _gateway_inventory_summary_source: tuple[object, ...] | None = None
-    _microinverter_inventory_summary_cache: dict[str, object] = field(
-        default_factory=dict
-    )
-    _microinverter_inventory_summary_source: tuple[object, ...] | None = None
-    _heatpump_inventory_summary_cache: dict[str, object] = field(default_factory=dict)
-    _heatpump_inventory_summary_source: tuple[object, ...] | None = None
-    _heatpump_type_summaries_cache: dict[str, dict[str, object]] = field(
-        default_factory=dict
-    )
-    _heatpump_type_summaries_source: tuple[object, ...] | None = None
-    _gateway_iq_energy_router_records_cache: list[dict[str, object]] = field(
+    _gateway_inventory_summary_cache: PayloadMap = field(default_factory=dict)
+    _gateway_inventory_summary_source: CacheSource | None = None
+    _microinverter_inventory_summary_cache: PayloadMap = field(default_factory=dict)
+    _microinverter_inventory_summary_source: CacheSource | None = None
+    _heatpump_inventory_summary_cache: PayloadMap = field(default_factory=dict)
+    _heatpump_inventory_summary_source: CacheSource | None = None
+    _heatpump_type_summaries_cache: PayloadMapByKey = field(default_factory=dict)
+    _heatpump_type_summaries_source: CacheSource | None = None
+    _gateway_iq_energy_router_records_cache: PayloadRecords = field(
         default_factory=list
     )
-    _gateway_iq_energy_router_records_source: tuple[object, ...] | None = None
-    _gateway_iq_energy_router_records_by_key_cache: dict[str, dict[str, object]] = (
-        field(default_factory=dict)
+    _gateway_iq_energy_router_records_source: CacheSource | None = None
+    _gateway_iq_energy_router_records_by_key_cache: PayloadMapByKey = field(
+        default_factory=dict
     )
     _topology_refresh_suppressed: int = 0
     _topology_refresh_pending: bool = False
     _site_energy_discovery_ready: bool = False
     _hems_inventory_ready: bool = False
     _devices_inventory_ready: bool = False
-    _debug_summary_log_cache: dict[str, object] = field(default_factory=dict)
+    _debug_summary_log_cache: PayloadMap = field(default_factory=dict)
 
 
 @dataclass(frozen=True, slots=True)
@@ -131,7 +132,7 @@ class RefreshHealthState:
     _auth_block_issue_reported: bool = False
     _session_history_issue_reported: bool = False
     _site_energy_issue_reported: bool = False
-    _payload_health: dict[str, dict[str, object]] = field(default_factory=dict)
+    _payload_health: PayloadMapByKey = field(default_factory=dict)
     _phase_timings: dict[str, float] = field(default_factory=dict)
     _bootstrap_phase_timings: dict[str, float] = field(default_factory=dict)
     _warmup_phase_timings: dict[str, float] = field(default_factory=dict)
@@ -155,33 +156,29 @@ class RefreshHealthState:
 class InventoryState:
     _inverters_inventory_cache_until: float | None = None
     _devices_inventory_cache_until: float | None = None
-    _devices_inventory_payload: dict[str, object] | None = None
-    _status_payload_cache: dict[str, object] | None = None
+    _devices_inventory_payload: PayloadMap | None = None
+    _status_payload_cache: PayloadMap | None = None
     _system_dashboard_cache_until: float | None = None
-    _system_dashboard_devices_tree_raw: dict[str, object] | None = None
-    _system_dashboard_devices_tree_payload: dict[str, object] | None = None
-    _system_dashboard_devices_details_raw: dict[str, dict[str, dict[str, object]]] = (
-        field(default_factory=dict)
+    _system_dashboard_devices_tree_raw: PayloadMap | None = None
+    _system_dashboard_devices_tree_payload: PayloadMap | None = None
+    _system_dashboard_devices_details_raw: dict[str, dict[str, PayloadMap]] = field(
+        default_factory=dict
     )
-    _system_dashboard_devices_details_payloads: dict[str, dict[str, object]] = field(
+    _system_dashboard_devices_details_payloads: PayloadMapByKey = field(
         default_factory=dict
     )
     _system_dashboard_detail_failures: dict[str, str] = field(default_factory=dict)
-    _system_dashboard_hierarchy_index: dict[str, dict[str, object]] = field(
-        default_factory=dict
-    )
-    _system_dashboard_hierarchy_summary: dict[str, object] = field(default_factory=dict)
-    _system_dashboard_type_summaries: dict[str, dict[str, object]] = field(
-        default_factory=dict
-    )
-    _inverters_inventory_payload: dict[str, object] | None = None
+    _system_dashboard_hierarchy_index: PayloadMapByKey = field(default_factory=dict)
+    _system_dashboard_hierarchy_summary: PayloadMap = field(default_factory=dict)
+    _system_dashboard_type_summaries: PayloadMapByKey = field(default_factory=dict)
+    _inverters_inventory_payload: PayloadMap | None = None
     _inverter_status_cache_until: float | None = None
-    _inverter_status_payload: dict[str, object] | None = None
+    _inverter_status_payload: PayloadMap | None = None
     _inverter_production_cache_until: float | None = None
-    _inverter_production_payload: dict[str, object] | None = None
-    _inverter_data: dict[str, dict[str, object]] = field(default_factory=dict)
+    _inverter_production_payload: PayloadMap | None = None
+    _inverter_data: PayloadMapByKey = field(default_factory=dict)
     _inverter_order: list[str] = field(default_factory=list)
-    _inverter_panel_info: dict[str, object] | None = None
+    _inverter_panel_info: PayloadMap | None = None
     _inverter_status_type_counts: dict[str, int] = field(default_factory=dict)
     _inverter_summary_counts: dict[str, int] = field(
         default_factory=lambda: {
@@ -193,7 +190,7 @@ class InventoryState:
         }
     )
     _inverter_model_counts: dict[str, int] = field(default_factory=dict)
-    _type_device_buckets: dict[str, dict[str, object]] = field(default_factory=dict)
+    _type_device_buckets: PayloadMapByKey = field(default_factory=dict)
     _type_device_order: list[str] = field(default_factory=list)
     _inverter_production_cache_key: tuple[str, str] | None = None
 
@@ -202,15 +199,15 @@ class InventoryState:
 class HeatpumpState:
     _hems_support_preflight_cache_until: float | None = None
     _hems_devices_cache_until: float | None = None
-    _hems_devices_payload: dict[str, object] | None = None
+    _hems_devices_payload: PayloadMap | None = None
     _hems_devices_last_success_mono: float | None = None
     _hems_devices_last_success_utc: datetime | None = None
     _hems_devices_using_stale: bool = False
     _heatpump_runtime_diagnostics_cache_until: float | None = None
-    _show_livestream_payload: dict[str, object] | None = None
-    _heatpump_events_payloads: list[dict[str, object]] = field(default_factory=list)
+    _show_livestream_payload: PayloadMap | None = None
+    _heatpump_events_payloads: PayloadRecords = field(default_factory=list)
     _heatpump_runtime_diagnostics_error: str | None = None
-    _heatpump_runtime_state: dict[str, object] | None = None
+    _heatpump_runtime_state: PayloadMap | None = None
     _heatpump_runtime_state_cache_until: float | None = None
     _heatpump_runtime_state_backoff_until: float | None = None
     _heatpump_runtime_state_last_error: str | None = None
@@ -218,7 +215,7 @@ class HeatpumpState:
     _heatpump_runtime_state_last_success_utc: datetime | None = None
     _heatpump_runtime_state_using_stale: bool = False
     _heatpump_known_present: bool = False
-    _heatpump_daily_consumption: dict[str, object] | None = None
+    _heatpump_daily_consumption: PayloadMap | None = None
     _heatpump_daily_consumption_cache_until: float | None = None
     _heatpump_daily_consumption_backoff_until: float | None = None
     _heatpump_daily_consumption_last_error: str | None = None
@@ -244,9 +241,7 @@ class HeatpumpState:
     _heatpump_power_window_seconds: float | None = None
     _heatpump_power_validation: str | None = None
     _heatpump_power_smoothed: bool = False
-    _heatpump_power_sample_history: list[dict[str, object]] = field(
-        default_factory=list
-    )
+    _heatpump_power_sample_history: PayloadRecords = field(default_factory=list)
     _heatpump_power_cache_until: float | None = None
     _heatpump_power_backoff_until: float | None = None
     _heatpump_power_last_error: str | None = None
@@ -256,7 +251,7 @@ class HeatpumpState:
     _heatpump_power_selection_marker: tuple[tuple[str, str, str, str], ...] | None = (
         None
     )
-    _heatpump_power_snapshot: dict[str, object] | None = None
+    _heatpump_power_snapshot: PayloadMap | None = None
 
 
 @dataclass(slots=True)
@@ -266,7 +261,7 @@ class EVSEState:
         default_factory=dict
     )
     _green_battery_pending: dict[str, tuple[bool, float]] = field(default_factory=dict)
-    _charger_config_cache: dict[str, tuple[dict[str, object], float]] = field(
+    _charger_config_cache: dict[str, tuple[PayloadMap, float]] = field(
         default_factory=dict
     )
     _charger_config_backoff_until: dict[str, float] = field(default_factory=dict)
@@ -275,21 +270,17 @@ class EVSEState:
     ] = field(default_factory=dict)
     _app_auth_pending: dict[str, tuple[bool, float]] = field(default_factory=dict)
     _evse_feature_flags_cache_until: float | None = None
-    _evse_feature_flags_payload: dict[str, object] | None = None
-    _evse_site_feature_flags: dict[str, object] = field(default_factory=dict)
-    _evse_feature_flags_by_serial: dict[str, dict[str, object]] = field(
-        default_factory=dict
-    )
+    _evse_feature_flags_payload: PayloadMap | None = None
+    _evse_site_feature_flags: PayloadMap = field(default_factory=dict)
+    _evse_feature_flags_by_serial: PayloadMapByKey = field(default_factory=dict)
     _last_charging: dict[str, bool] = field(default_factory=dict)
     _last_actual_charging: dict[str, bool | None] = field(default_factory=dict)
     _pending_charging: dict[str, tuple[bool, float]] = field(default_factory=dict)
     _desired_charging: dict[str, bool] = field(default_factory=dict)
     _auto_resume_attempts: dict[str, float] = field(default_factory=dict)
     _session_end_fix: dict[str, int] = field(default_factory=dict)
-    _evse_power_snapshots: dict[str, dict[str, object]] = field(default_factory=dict)
-    _evse_transition_snapshots: dict[str, list[dict[str, object]]] = field(
-        default_factory=dict
-    )
+    _evse_power_snapshots: PayloadMapByKey = field(default_factory=dict)
+    _evse_transition_snapshots: dict[str, PayloadRecords] = field(default_factory=dict)
 
 
 @dataclass(slots=True)
@@ -300,13 +291,13 @@ class BatteryState:
     _storm_guard_pending_expires_mono: float | None = None
     _storm_alert_active: bool | None = None
     _storm_alert_critical_override: bool | None = None
-    _storm_alerts: list[dict[str, object]] = field(default_factory=list)
+    _storm_alerts: PayloadRecords = field(default_factory=list)
     _storm_guard_cache_until: float | None = None
     _storm_alert_cache_until: float | None = None
     _grid_control_check_cache_until: float | None = None
     _grid_control_check_last_success_mono: float | None = None
     _grid_control_check_failures: int = 0
-    _grid_control_check_payload: dict[str, object] | None = None
+    _grid_control_check_payload: PayloadMap | None = None
     _grid_control_disable: bool | None = None
     _grid_control_active_download: bool | None = None
     _grid_control_sunlight_backup_system_check: bool | None = None
@@ -316,12 +307,10 @@ class BatteryState:
     _dry_contact_settings_cache_until: float | None = None
     _dry_contact_settings_last_success_mono: float | None = None
     _dry_contact_settings_failures: int = 0
-    _dry_contact_settings_payload: dict[str, object] | None = None
+    _dry_contact_settings_payload: PayloadMap | None = None
     _dry_contact_settings_supported: bool | None = None
-    _dry_contact_settings_entries: list[dict[str, object]] = field(default_factory=list)
-    _dry_contact_unmatched_settings: list[dict[str, object]] = field(
-        default_factory=list
-    )
+    _dry_contact_settings_entries: PayloadRecords = field(default_factory=list)
+    _dry_contact_unmatched_settings: PayloadRecords = field(default_factory=list)
     _battery_site_settings_cache_until: float | None = None
     _battery_show_production: bool | None = None
     _battery_show_consumption: bool | None = None
@@ -342,7 +331,7 @@ class BatteryState:
     _battery_region: str | None = None
     _battery_locale: str | None = None
     _battery_timezone: str | None = None
-    _battery_feature_details: dict[str, object] = field(default_factory=dict)
+    _battery_feature_details: PayloadMap = field(default_factory=dict)
     _battery_user_is_owner: bool | None = None
     _battery_user_is_installer: bool | None = None
     _battery_site_status_code: str | None = None
@@ -366,9 +355,9 @@ class BatteryState:
     _battery_cfg_control: BatteryControlCapability | None = None
     _battery_rbd_control: BatteryControlCapability | None = None
     _battery_system_task: bool | None = None
-    _battery_profile_evse_device: dict[str, object] | None = None
+    _battery_profile_evse_device: PayloadMap | None = None
     _battery_use_battery_for_self_consumption: bool | None = None
-    _battery_profile_devices: list[dict[str, object]] = field(default_factory=list)
+    _battery_profile_devices: PayloadRecords = field(default_factory=list)
     _battery_pending_profile: str | None = None
     _battery_pending_reserve: int | None = None
     _battery_pending_sub_type: str | None = None
@@ -426,48 +415,55 @@ class BatteryState:
     _battery_rbd_schedule_status: str | None = None
     _battery_rbd_schedule_enabled: bool | None = None
     _battery_rbd_toggle_target_enabled: bool | None = None
-    _battery_schedules_payload: dict[str, object] | None = None
+    _battery_schedules_payload: PayloadMap | None = None
     _battery_accepted_itc_disclaimer: str | None = None
     _battery_very_low_soc: int | None = None
     _battery_very_low_soc_min: int | None = None
     _battery_very_low_soc_max: int | None = None
-    _battery_site_settings_payload: dict[str, object] | None = None
-    _battery_profile_payload: dict[str, object] | None = None
-    _battery_settings_payload: dict[str, object] | None = None
+    _battery_site_settings_payload: PayloadMap | None = None
+    _battery_profile_payload: PayloadMap | None = None
+    _battery_settings_payload: PayloadMap | None = None
     _battery_status_cache_until: float | None = None
-    _battery_status_payload: dict[str, object] | None = None
-    _battery_backup_history_payload: dict[str, object] | None = None
-    _battery_backup_history_events: list[dict[str, object]] = field(
-        default_factory=list
-    )
+    _battery_status_payload: PayloadMap | None = None
+    _battery_backup_history_payload: PayloadMap | None = None
+    _battery_backup_history_events: PayloadRecords = field(default_factory=list)
     _battery_backup_history_cache_until: float | None = None
-    _battery_storage_data: dict[str, dict[str, object]] = field(default_factory=dict)
+    _battery_storage_data: PayloadMapByKey = field(default_factory=dict)
     _battery_storage_order: list[str] = field(default_factory=list)
     _battery_aggregate_charge_pct: float | None = None
     _battery_aggregate_status: str | None = None
-    _battery_aggregate_status_details: dict[str, object] = field(default_factory=dict)
+    _battery_aggregate_status_details: PayloadMap = field(default_factory=dict)
     _battery_summary_sample_utc: datetime | None = None
     _ac_battery_devices_cache_until: float | None = None
-    _ac_battery_devices_payload: dict[str, object] | None = None
-    _ac_battery_devices_html_payload: dict[str, object] | None = None
+    _ac_battery_devices_payload: PayloadMap | None = None
+    _ac_battery_devices_html_payload: PayloadMap | None = None
     _ac_battery_telemetry_cache_until: float | None = None
-    _ac_battery_telemetry_payloads: dict[str, object] = field(default_factory=dict)
-    _ac_battery_events_payloads: dict[str, object] = field(default_factory=dict)
-    _ac_battery_data: dict[str, dict[str, object]] = field(default_factory=dict)
+    _ac_battery_telemetry_payloads: PayloadMap = field(default_factory=dict)
+    _ac_battery_events_payloads: PayloadMap = field(default_factory=dict)
+    _ac_battery_data: PayloadMapByKey = field(default_factory=dict)
     _ac_battery_order: list[str] = field(default_factory=list)
     _ac_battery_aggregate_status: str | None = None
-    _ac_battery_aggregate_status_details: dict[str, object] = field(
-        default_factory=dict
-    )
+    _ac_battery_aggregate_status_details: PayloadMap = field(default_factory=dict)
     _ac_battery_power_w: float | None = None
     _ac_battery_summary_sample_utc: datetime | None = None
     _ac_battery_selected_sleep_min_soc: int | None = None
     _ac_battery_sleep_state: str | None = None
     _ac_battery_control_pending: bool = False
-    _ac_battery_last_command: dict[str, object] | None = None
+    _ac_battery_last_command: PayloadMap | None = None
 
 
-STATE_MODELS = {
+type CoordinatorState = (
+    DiscoveryState
+    | RefreshHealthState
+    | InventoryState
+    | HeatpumpState
+    | EVSEState
+    | BatteryState
+)
+type StateModelRegistry = dict[str, type[CoordinatorState]]
+
+
+STATE_MODELS: StateModelRegistry = {
     "discovery_state": DiscoveryState,
     "refresh_state": RefreshHealthState,
     "inventory_state": InventoryState,

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -982,7 +982,9 @@ class ChargingSwitch(EnphaseBaseEntity, RestoreEntity, SwitchEntity):
         self._coord.kick_fast(FAST_TOGGLE_POLL_HOLD_S)
         if self.hass is None:
             return
-        self.hass.async_create_task(self._coord.async_request_refresh())
+        self.hass.async_create_task(
+            self._coord.async_request_refresh(), name=f"{DOMAIN}_switch_failure_refresh"
+        )
 
     def _force_write_state(self) -> None:
         if self.hass is None or not self.entity_id:

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -204,7 +204,10 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
             return
         if self._refresh_task is not None and not self._refresh_task.done():
             return
-        self._refresh_task = self.hass.async_create_task(self._async_refresh_catalog())
+        self._refresh_task = self.hass.async_create_task(
+            self._async_refresh_catalog(),
+            name=f"{DOMAIN}_firmware_catalog_refresh_{self._device_type}",
+        )
 
     async def _async_refresh_catalog(self) -> None:
         try:
@@ -391,7 +394,10 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
             return
         if self._refresh_task is not None and not self._refresh_task.done():
             return
-        self._refresh_task = self.hass.async_create_task(self._async_refresh_state())
+        self._refresh_task = self.hass.async_create_task(
+            self._async_refresh_state(),
+            name=f"{DOMAIN}_evse_firmware_refresh_{redact_identifier(self._serial)}",
+        )
 
     async def _async_refresh_details(self) -> None:
         try:

--- a/devtools/docker/Dockerfile
+++ b/devtools/docker/Dockerfile
@@ -2,7 +2,7 @@
 # Based on official Home Assistant developer guide for Docker environments:
 # https://developers.home-assistant.io/docs/development_environment
 
-FROM python:3.13-slim
+FROM python:3.14-slim
 
 ENV PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PYTHONDONTWRITEBYTECODE=1 \

--- a/devtools/docker/requirements-dev.txt
+++ b/devtools/docker/requirements-dev.txt
@@ -1,4 +1,4 @@
-homeassistant>=2024.12.0
+homeassistant>=2026.3.0
 pytest
 pytest-asyncio
 pytest-homeassistant-custom-component

--- a/devtools/docker/requirements-min-ha.txt
+++ b/devtools/docker/requirements-min-ha.txt
@@ -1,0 +1,36 @@
+# Dependencies for the GitHub Actions minimum Home Assistant test job.
+#
+# pytest-homeassistant-custom-component pins exact Home Assistant patch releases.
+# Install that package with --no-deps in the workflow so this file can keep the
+# advertised integration minimum pinned to Home Assistant 2026.3.0.
+homeassistant==2026.3.0
+aiohttp
+async-timeout
+voluptuous
+PyYAML
+coverage==7.10.6
+freezegun==1.5.2
+license-expression==30.4.3
+mock-open==1.4.0
+numpy==2.3.2
+paho-mqtt==2.1.0
+pydantic==2.12.2
+pipdeptree==2.26.1
+pylint-per-file-ignores==1.4.0
+pytest==9.0.0
+pytest-aiohttp==1.1.0
+pytest-asyncio==1.3.0
+pytest-cov==7.0.0
+pytest-freezer==0.4.9
+pytest-github-actions-annotate-failures==0.3.0
+pytest-picked==0.5.1
+pytest-socket==0.7.0
+pytest-sugar==1.0.0
+pytest-timeout==2.4.0
+pytest-unordered==0.7.0
+pytest-xdist==3.8.0
+requests-mock==1.12.1
+respx==0.22.0
+SQLAlchemy==2.0.41
+syrupy==5.0.0
+tqdm==4.67.1

--- a/hacs.json
+++ b/hacs.json
@@ -1,6 +1,6 @@
 {
     "name": "Enphase Energy",
-    "homeassistant": "2024.12.0",
+    "homeassistant": "2026.3.0",
     "render_readme": true,
     "content_in_root": false
 }

--- a/scripts/importtime_profile.py
+++ b/scripts/importtime_profile.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""Profile Enphase integration import time with Python 3.14 importtime output."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import sys
+from typing import Sequence
+
+DEFAULT_PACKAGE = "custom_components.enphase_ev"
+
+
+def discover_modules(root: Path, package: str = DEFAULT_PACKAGE) -> tuple[str, ...]:
+    """Return top-level modules in the integration package."""
+
+    package_path = root / Path(*package.split("."))
+    if not package_path.is_dir():
+        raise ValueError(f"Package path not found: {package_path}")
+
+    modules = [package]
+    modules.extend(
+        f"{package}.{path.stem}"
+        for path in sorted(package_path.glob("*.py"))
+        if path.name != "__init__.py"
+    )
+    return tuple(modules)
+
+
+def build_import_runner(
+    modules: Sequence[str], *, warning_module_pattern: str | None = None
+) -> str:
+    """Return Python code that imports every requested module."""
+
+    modules_json = json.dumps(list(modules))
+    warning_lines = ""
+    if warning_module_pattern is not None:
+        warning_lines = (
+            "import warnings\n"
+            f"_warning_module = {warning_module_pattern!r}\n"
+            "for _category in (\n"
+            "    DeprecationWarning,\n"
+            "    PendingDeprecationWarning,\n"
+            "    FutureWarning,\n"
+            "    SyntaxWarning,\n"
+            "):\n"
+            "    warnings.filterwarnings(\n"
+            '        "error", category=_category, module=_warning_module\n'
+            "    )\n"
+        )
+    return (
+        "import importlib\n"
+        f"{warning_lines}"
+        f"modules = {modules_json}\n"
+        "for module in modules:\n"
+        "    importlib.import_module(module)\n"
+        "print(f'imported {len(modules)} modules')\n"
+    )
+
+
+def run_importtime(
+    root: Path,
+    modules: Sequence[str],
+    *,
+    python: str = sys.executable,
+    strict_warnings: bool = False,
+    warning_module_pattern: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    """Run the Python 3.14 import-time profiler for the requested modules."""
+
+    if strict_warnings and warning_module_pattern is None:
+        warning_module_pattern = rf"{re.escape(DEFAULT_PACKAGE)}(\.|$)"
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        part for part in (str(root), env.get("PYTHONPATH", "")) if part
+    )
+    return subprocess.run(
+        [
+            python,
+            "-X",
+            "importtime=2",
+            "-c",
+            build_import_runner(modules, warning_module_pattern=warning_module_pattern),
+        ],
+        cwd=root,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def render_report(result: subprocess.CompletedProcess[str]) -> str:
+    """Combine importtime stderr with the import runner summary."""
+
+    sections: list[str] = []
+    if result.stdout:
+        sections.append(result.stdout.rstrip())
+    if result.stderr:
+        sections.append(result.stderr.rstrip())
+    return "\n\n".join(sections) + "\n"
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run Python 3.14 '-X importtime=2' against Enphase integration modules."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="Repository root to import from.",
+    )
+    parser.add_argument(
+        "--python",
+        default=sys.executable,
+        help="Python executable to run with '-X importtime=2'.",
+    )
+    parser.add_argument(
+        "--package",
+        default=DEFAULT_PACKAGE,
+        help="Package to discover modules from when --module is not provided.",
+    )
+    parser.add_argument(
+        "--module",
+        action="append",
+        dest="modules",
+        help="Explicit module to import. May be supplied more than once.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional path for the combined importtime report.",
+    )
+    parser.add_argument(
+        "--strict-integration-warnings",
+        action="store_true",
+        help=(
+            "Treat import-time DeprecationWarning, PendingDeprecationWarning, "
+            "FutureWarning, and SyntaxWarning from the integration package as errors."
+        ),
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    root = args.repo_root.resolve()
+    modules = tuple(args.modules or discover_modules(root, args.package))
+    warning_module_pattern = (
+        rf"{re.escape(args.package)}(\.|$)"
+        if args.strict_integration_warnings
+        else None
+    )
+    result = run_importtime(
+        root,
+        modules,
+        python=args.python,
+        strict_warnings=args.strict_integration_warnings,
+        warning_module_pattern=warning_module_pattern,
+    )
+    report = render_report(result)
+
+    if args.output:
+        args.output.write_text(report, encoding="utf-8")
+    else:
+        print(report, end="")
+
+    if result.returncode != 0 and args.output:
+        print(report, file=sys.stderr, end="")
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_quality_scale.py
+++ b/scripts/validate_quality_scale.py
@@ -82,8 +82,9 @@ OFFICIAL_REQUIRED_RULES: dict[str, tuple[str, ...]] = {
     ),
 }
 NA_ALLOWED_RULES = {"discovery", "discovery-update-info"}
-STRICT_CONFIG_ENTRY_ALIAS = (
-    "EnphaseConfigEntry: TypeAlias = ConfigEntry[EnphaseRuntimeData]"
+STRICT_CONFIG_ENTRY_ALIASES = (
+    "EnphaseConfigEntry: TypeAlias = ConfigEntry[EnphaseRuntimeData]",
+    "type EnphaseConfigEntry = ConfigEntry[EnphaseRuntimeData]",
 )
 EXTERNAL_CONFIG_ENTRY_MARKER = "quality-scale: external-config-entry"
 BRANDS_GITHUB_API_URL = (
@@ -254,7 +255,7 @@ def _validate_strict_typing_contract(root: Path) -> list[str]:
         return messages
 
     runtime_data = runtime_data_path.read_text()
-    if STRICT_CONFIG_ENTRY_ALIAS not in runtime_data:
+    if not any(alias in runtime_data for alias in STRICT_CONFIG_ENTRY_ALIASES):
         messages.append(
             "ERROR: runtime_data.py must define EnphaseConfigEntry as "
             "ConfigEntry[EnphaseRuntimeData]"

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -3615,7 +3615,7 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
 
     create_calls: list[object] = []
 
-    def _capture_create_task(coro):
+    def _capture_create_task(coro, *, name=None):
         create_calls.append(coro)
         coro.close()
         return None
@@ -3779,7 +3779,8 @@ async def test_startup_warmup_runner_and_task_edge_paths(
 
     coord._warmup_task = None  # noqa: SLF001
     await coord.async_start_startup_warmup()
-    assert create_calls == [f"{DOMAIN}_warmup_{coord.site_id}", None]
+    assert create_calls == [f"{DOMAIN}_warmup_site", None]
+    assert coord.site_id not in str(create_calls[0])
     assert coord._warmup_task == "task"  # noqa: SLF001
 
 

--- a/tests/components/enphase_ev/test_device_trigger.py
+++ b/tests/components/enphase_ev/test_device_trigger.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import sys
-from importlib import import_module
+from importlib import import_module, reload
 from types import ModuleType
 from unittest.mock import AsyncMock, MagicMock
 
@@ -34,6 +34,46 @@ sys.modules["homeassistant.components.automation"].triggers = triggers_pkg
 device_trigger = import_module("custom_components.enphase_ev.device_trigger")
 const_module = import_module("custom_components.enphase_ev.const")
 DOMAIN = const_module.DOMAIN
+
+
+def test_device_trigger_import_falls_back_to_homeassistant_state_trigger():
+    """Use the Home Assistant trigger module path when automation triggers are absent."""
+    fallback_pkg = ModuleType("homeassistant.components.homeassistant.triggers")
+    fallback_state_mod = ModuleType(
+        "homeassistant.components.homeassistant.triggers.state"
+    )
+    fallback_pkg.state = fallback_state_mod
+
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        monkeypatch.setitem(
+            sys.modules,
+            "homeassistant.components.automation",
+            ModuleType("homeassistant.components.automation"),
+        )
+        monkeypatch.delitem(
+            sys.modules,
+            "homeassistant.components.automation.triggers",
+            raising=False,
+        )
+        monkeypatch.delitem(
+            sys.modules,
+            "homeassistant.components.automation.triggers.state",
+            raising=False,
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "homeassistant.components.homeassistant.triggers",
+            fallback_pkg,
+        )
+        monkeypatch.setitem(
+            sys.modules,
+            "homeassistant.components.homeassistant.triggers.state",
+            fallback_state_mod,
+        )
+
+        assert reload(device_trigger).state_trigger is fallback_state_mod
+
+    assert reload(device_trigger).state_trigger is state_mod
 
 
 @pytest.fixture

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -557,8 +557,10 @@ async def test_evse_runtime_schedule_amp_restart_uses_coordinator_override(
 
     coord.__dict__["_async_restart_after_amp_change"] = _fake_restart
     tasks: list[asyncio.Task[None]] = []
+    names: list[str | None] = []
 
     def _capture(coro, name=None):
+        names.append(name)
         task = asyncio.create_task(coro)
         tasks.append(task)
         return task
@@ -570,6 +572,7 @@ async def test_evse_runtime_schedule_amp_restart_uses_coordinator_override(
     assert pending.cancelled()
     await tasks[0]
     assert calls == [("EV1", 12)]
+    assert names == ["enphase_ev_amp_restart_E...1"]
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_helper_modules.py
+++ b/tests/components/enphase_ev/test_helper_modules.py
@@ -1364,7 +1364,7 @@ async def test_session_history_clear_cancels_tasks_and_clears_state(hass) -> Non
     manager._block_until["EV-01"] = time.monotonic() + 60
     manager._criteria_checked_mono = time.monotonic()
     manager._refresh_in_progress.add("EV-01")
-    task = hass.loop.create_task(asyncio.sleep(30))
+    task = asyncio.create_task(asyncio.sleep(30))
     manager._enrichment_tasks.add(task)
 
     manager.clear()

--- a/tests/components/enphase_ev/test_manifest.py
+++ b/tests/components/enphase_ev/test_manifest.py
@@ -1,6 +1,8 @@
 import json
 import pathlib
 
+MIN_HOME_ASSISTANT_VERSION = "2026.3.0"
+
 
 def test_manifest_keys_present():
     manifest_path = (
@@ -47,4 +49,20 @@ def test_minimum_homeassistant_version_is_declared_in_hacs_only():
     hacs = json.loads((root / "hacs.json").read_text())
 
     assert "homeassistant" not in manifest
-    assert hacs.get("homeassistant") == "2024.12.0"
+    assert hacs.get("homeassistant") == MIN_HOME_ASSISTANT_VERSION
+
+
+def test_development_requirements_cover_minimum_homeassistant_version():
+    root = pathlib.Path(__file__).resolve().parents[3]
+
+    hacs = json.loads((root / "hacs.json").read_text())
+    requirements_dev = (
+        root / "devtools" / "docker" / "requirements-dev.txt"
+    ).read_text()
+    requirements_min_ha = (
+        root / "devtools" / "docker" / "requirements-min-ha.txt"
+    ).read_text()
+
+    assert hacs.get("homeassistant") == MIN_HOME_ASSISTANT_VERSION
+    assert f"homeassistant>={MIN_HOME_ASSISTANT_VERSION}" in requirements_dev
+    assert f"homeassistant=={MIN_HOME_ASSISTANT_VERSION}" in requirements_min_ha

--- a/tests/components/enphase_ev/test_schedule_sync.py
+++ b/tests/components/enphase_ev/test_schedule_sync.py
@@ -642,13 +642,15 @@ async def test_schedule_sync_post_patch_refresh_dedupes(hass, monkeypatch) -> No
     sync = ScheduleSync(hass, SimpleNamespace(), None)
     callbacks: list[callable] = []
     created: list[bool] = []
+    names: list[str | None] = []
 
     def _fake_call_later(_hass, _delay, action):
         callbacks.append(action)
         return lambda: None
 
-    def _create_task(coro):
+    def _create_task(coro, *, name=None):
         created.append(True)
+        names.append(name)
         coro.close()
 
     monkeypatch.setattr(schedule_sync_mod, "async_call_later", _fake_call_later)
@@ -662,6 +664,9 @@ async def test_schedule_sync_post_patch_refresh_dedupes(hass, monkeypatch) -> No
     callbacks[0](None)
 
     assert created == [True]
+    assert len(names) == 1
+    assert RANDOM_SERIAL not in str(names[0])
+    assert "..." in str(names[0])
     assert RANDOM_SERIAL not in sync._pending_patch_refresh
 
 
@@ -1149,6 +1154,46 @@ async def test_schedule_sync_callbacks_trigger_refresh(hass) -> None:
     sync._handle_coordinator_update()
     await hass.async_block_till_done()
     assert sync.async_refresh.await_count >= 3
+
+
+@pytest.mark.asyncio
+async def test_schedule_sync_callbacks_fall_back_for_legacy_create_task(
+    hass, monkeypatch
+) -> None:
+    slot_id = f"{RANDOM_SITE_ID}:{RANDOM_SERIAL}:slot-9"
+    payload = {
+        "meta": {"serverTimeStamp": "2025-01-01T00:00:00.000+00:00"},
+        "config": {},
+        "slots": [_slot(slot_id)],
+    }
+    entry = MockConfigEntry(domain=DOMAIN, data={"site_id": RANDOM_SITE_ID}, options={})
+    sync, _client = await _setup_sync(hass, entry, payload)
+    sync.async_refresh = AsyncMock()
+
+    tasks: list[asyncio.Task] = []
+    callbacks: list[callable] = []
+
+    def _legacy_create_task(coro, *, name=None):
+        if name is not None:
+            raise TypeError("legacy")
+        task = asyncio.create_task(coro)
+        tasks.append(task)
+        return task
+
+    def _fake_call_later(_hass, _delay, action):
+        callbacks.append(action)
+        return lambda: None
+
+    monkeypatch.setattr(hass, "async_create_task", _legacy_create_task)
+    monkeypatch.setattr(schedule_sync_mod, "async_call_later", _fake_call_later)
+    sync._handle_interval()
+    sync._last_sync = dt_util.utcnow() - timedelta(minutes=10)
+    sync._handle_coordinator_update()
+    sync._schedule_post_patch_refresh(RANDOM_SERIAL)
+    callbacks[0](None)
+    await asyncio.gather(*tasks)
+
+    assert sync.async_refresh.await_count == 3
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_session_history_additional.py
+++ b/tests/components/enphase_ev/test_session_history_additional.py
@@ -58,11 +58,14 @@ async def test_async_enrich_sessions_handles_task_errors(monkeypatch):
         client_getter=lambda: None,
         cache_ttl=60,
     )
+    serial = "123456789012"
+    names: list[str | None] = []
 
     async def fake_gather(*tasks, **kwargs):
         return [RuntimeError("boom")]
 
-    def fake_task(coro):
+    def fake_task(coro, *, name=None):
+        names.append(name)
         coro.close()
         return None
 
@@ -70,9 +73,12 @@ async def test_async_enrich_sessions_handles_task_errors(monkeypatch):
     monkeypatch.setattr(sh_mod.asyncio, "create_task", fake_task)
 
     updates = await manager._async_enrich_sessions(
-        ["SN"], day_local=datetime.now(timezone.utc)
+        [serial], day_local=datetime.now(timezone.utc)
     )
     assert updates == {}
+    assert len(names) == 1
+    assert serial not in str(names[0])
+    assert "1234...9012" in str(names[0])
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_task_names.py
+++ b/tests/components/enphase_ev/test_task_names.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+INTEGRATION_ROOT = Path("custom_components/enphase_ev")
+TASK_FACTORY_NAMES = {"async_create_task", "create_task"}
+REDACTION_HELPERS = {"redact_identifier", "redact_site_id"}
+SENSITIVE_NAMES = {"sn", "sn_str", "serial", "site_id"}
+SENSITIVE_ATTRIBUTES = {"_serial", "serial", "site_id"}
+
+
+def _call_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
+def _contains_unredacted_identifier(node: ast.AST) -> bool:
+    call_name = _call_name(node.func) if isinstance(node, ast.Call) else None
+    if call_name in REDACTION_HELPERS:
+        return False
+    if isinstance(node, ast.Name):
+        name = node.id.lower()
+        return name in SENSITIVE_NAMES or "serial" in name
+    if isinstance(node, ast.Attribute):
+        attr = node.attr.lower()
+        return attr in SENSITIVE_ATTRIBUTES or "serial" in attr
+    return any(
+        _contains_unredacted_identifier(child) for child in ast.iter_child_nodes(node)
+    )
+
+
+def _unsafe_task_names(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    unsafe_names: list[str] = []
+    for node in ast.walk(tree):
+        if (
+            not isinstance(node, ast.Call)
+            or _call_name(node.func) not in TASK_FACTORY_NAMES
+        ):
+            continue
+        name_keyword = next(
+            (keyword for keyword in node.keywords if keyword.arg == "name"),
+            None,
+        )
+        if name_keyword is None:
+            continue
+        name_value = name_keyword.value
+        if isinstance(name_value, ast.Constant):
+            continue
+        if _contains_unredacted_identifier(name_value):
+            unsafe_names.append(f"{path}:{node.lineno}: {ast.unparse(name_value)}")
+    return unsafe_names
+
+
+def test_task_names_do_not_include_unredacted_identifiers() -> None:
+    unsafe_names = [
+        unsafe_name
+        for path in sorted(INTEGRATION_ROOT.rglob("*.py"))
+        for unsafe_name in _unsafe_task_names(path)
+    ]
+
+    assert unsafe_names == []

--- a/tests/scripts/test_importtime_profile.py
+++ b/tests/scripts/test_importtime_profile.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+import subprocess
+import sys
+
+
+def _load_module():
+    root = Path(__file__).resolve().parents[2]
+    module_path = root / "scripts" / "importtime_profile.py"
+    spec = importlib.util.spec_from_file_location("importtime_profile", module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+importtime_profile = _load_module()
+
+
+def test_discover_modules_returns_integration_package_modules(tmp_path: Path) -> None:
+    package_root = tmp_path / "custom_components" / "enphase_ev"
+    package_root.mkdir(parents=True)
+    (package_root / "__init__.py").write_text("", encoding="utf-8")
+    (package_root / "sensor.py").write_text("", encoding="utf-8")
+    (package_root / "api.py").write_text("", encoding="utf-8")
+    (package_root / "README.md").write_text("ignored", encoding="utf-8")
+
+    modules = importtime_profile.discover_modules(tmp_path)
+
+    assert modules == (
+        "custom_components.enphase_ev",
+        "custom_components.enphase_ev.api",
+        "custom_components.enphase_ev.sensor",
+    )
+
+
+def test_build_import_runner_imports_each_module() -> None:
+    runner = importtime_profile.build_import_runner(
+        ("package", "package.module"),
+        warning_module_pattern=r"package(\.|$)",
+    )
+
+    assert "importlib.import_module(module)" in runner
+    assert '"package", "package.module"' in runner
+    assert "warnings.filterwarnings" in runner
+    assert "DeprecationWarning" in runner
+    assert "imported {len(modules)} modules" in runner
+
+
+def test_run_importtime_uses_python314_importtime(monkeypatch, tmp_path: Path) -> None:
+    calls: list[dict[str, object]] = []
+
+    def fake_run(*args, **kwargs):
+        calls.append({"args": args, "kwargs": kwargs})
+        return subprocess.CompletedProcess(args[0], 0, "imported 1 modules\n", "")
+
+    monkeypatch.setattr(importtime_profile.subprocess, "run", fake_run)
+
+    result = importtime_profile.run_importtime(
+        tmp_path,
+        ("custom_components.enphase_ev",),
+        python="python3.14",
+        strict_warnings=True,
+    )
+
+    assert result.returncode == 0
+    command = calls[0]["args"][0]
+    assert command[:3] == ["python3.14", "-X", "importtime=2"]
+    assert "custom_components\\\\.enphase_ev" in command[4]
+    assert calls[0]["kwargs"]["cwd"] == tmp_path
+    assert calls[0]["kwargs"]["text"] is True
+    assert calls[0]["kwargs"]["capture_output"] is True
+    assert str(tmp_path) in calls[0]["kwargs"]["env"]["PYTHONPATH"].split(os.pathsep)
+
+
+def test_main_writes_output(monkeypatch, tmp_path: Path) -> None:
+    def fake_run_importtime(
+        _root,
+        _modules,
+        *,
+        python,
+        strict_warnings,
+        warning_module_pattern,
+    ):
+        assert strict_warnings is True
+        assert warning_module_pattern == r"custom_components\.enphase_ev(\.|$)"
+        return subprocess.CompletedProcess(
+            [python], 0, "imported 1 modules\n", "import time: test\n"
+        )
+
+    monkeypatch.setattr(
+        importtime_profile,
+        "run_importtime",
+        fake_run_importtime,
+    )
+    output = tmp_path / "importtime.log"
+
+    exit_code = importtime_profile.main(
+        [
+            "--repo-root",
+            str(tmp_path),
+            "--module",
+            "custom_components.enphase_ev",
+            "--strict-integration-warnings",
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert exit_code == 0
+    assert output.read_text(encoding="utf-8") == (
+        "imported 1 modules\n\nimport time: test\n"
+    )

--- a/tests/scripts/test_validate_quality_scale.py
+++ b/tests/scripts/test_validate_quality_scale.py
@@ -490,6 +490,22 @@ def test_strict_typing_contract_requires_strict_typing_entry(
     assert "must include custom_components/enphase_ev" in "\n".join(messages)
 
 
+def test_strict_typing_contract_accepts_python314_type_alias(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".strict-typing").write_text("custom_components/enphase_ev\n")
+    integration_dir = tmp_path / "custom_components" / "enphase_ev"
+    integration_dir.mkdir(parents=True)
+    (integration_dir / "py.typed").write_text("")
+    (integration_dir / "runtime_data.py").write_text(
+        "type EnphaseConfigEntry = ConfigEntry[EnphaseRuntimeData]\n"
+    )
+
+    messages = validate_quality_scale._validate_strict_typing_contract(tmp_path)
+
+    assert messages == []
+
+
 def test_strict_typing_contract_reports_missing_runtime_data(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary

Migrate the integration runtime and repository tooling to Python 3.14 / Home Assistant 2026.3.0 while keeping public README/changelog minimum-version text unchanged until release timing.

This includes:
- updating HACS, Docker, and GitHub Actions runtime baselines to Python 3.14 / Home Assistant 2026.3.0
- adding a true minimum Home Assistant CI path pinned to `homeassistant==2026.3.0`
- adding Python 3.14 import diagnostics
- applying scoped Python 3.14 typing/task improvements
- redacting task names that previously exposed raw charger serials/site identifiers
- adding a static regression test to prevent unredacted identifiers in future task names

## Related Issues

Addresses review findings for minimum Home Assistant CI coverage and Python 3.14 task-name privacy.

## Type of change

- [ ] Bugfix
- [x] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_task_names.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_task_names.py tests/components/enphase_ev/test_manifest.py tests/scripts"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev tests/components/enphase_ev tests/scripts scripts"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev_final.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev_final.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev_final.coverage python -m coverage report -m --include=custom_components/enphase_ev/schedule_sync.py,custom_components/enphase_ev/evse_runtime.py,custom_components/enphase_ev/session_history.py,custom_components/enphase_ev/update.py,custom_components/enphase_ev/refresh_runner.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "git status --short && pre-commit run --all-files"
git diff --check
```

Results:
- targeted manifest/task/script tests: `112 passed`
- coverage run: `2986 passed`, 100% coverage for touched integration modules
- full pytest: `3093 passed`
- pre-commit: passed

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Public README and changelog minimum-version text is intentionally unchanged in this PR per release-timing request, even though HACS/tooling now gates on Home Assistant 2026.3.0.