### PR TITLE
Add editable tariff rate controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ All notable changes to this project will be documented in this file.
 - None
 
 ### ✨ New features
-- Added read-only site tariff sensors for next billing date, import rate values, and export rate values, attached to the IQ Gateway device when available.
+- Added site tariff sensors for next billing date and Energy-dashboard-ready current import/export prices, attached to the IQ Gateway device when available.
+- Added editable tariff rate number entities and a `set_tariff_rate` service for updating existing Enphase import/export tariff values.
 - Tariff sensors now refresh with normal sensor polling and keep their last known values while the Enphase tariff backend is degraded.
 
 ### 🐛 Bug fixes

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 - Advisory firmware update entities for gateway and EV charger devices with locale-aware release-note links
 - Heat-pump runtime status, connectivity, SG-Ready mode, power, and current-day consumption details sourced from HEMS endpoints
 - Site and battery energy telemetry, including derived grid-import, grid-export, and battery power sensors for Home Assistant Energy Dashboard use
-- Read-only site tariff visibility for next billing date, import rate values, and export rate values when Enphase exposes tariff data; tariff values refresh with normal sensor polling and retain the last known values while the tariff backend is unavailable
+- Site tariff visibility for next billing date, Energy-dashboard-ready current import/export price sensors, and editable tariff rate number entities when Enphase exposes tariff data
 - Health diagnostics, service-availability tracking, and actionable repair issues
 - Detailed diagnostic and inventory entities remain available but are disabled by default when they are mainly useful for troubleshooting
 - Broad localization support across all user-facing integration strings

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2442,8 +2442,8 @@ class EnphaseEVClient:
                 headers["X-XSRF-Token"] = xsrf
         return headers
 
-    def _tariff_headers(self) -> dict[str, str | None]:
-        """Return headers for tariff microservice read calls."""
+    def _tariff_headers(self, *, write: bool = False) -> dict[str, str | None]:
+        """Return headers for tariff microservice calls."""
 
         token, user_id = self._battery_config_auth_context()
         headers: dict[str, str | None] = {
@@ -2458,6 +2458,10 @@ class EnphaseEVClient:
         xsrf = self._xsrf_token()
         if xsrf:
             headers["x-xsrf-token"] = xsrf
+        if write:
+            headers["Content-Type"] = "application/json"
+            headers["Origin"] = BASE_URL
+            headers["Referer"] = f"{BASE_URL}/"
         return headers
 
     def _battery_config_cookie_eauth_headers(
@@ -5035,6 +5039,34 @@ class EnphaseEVClient:
             self.site_tariff(),
         )
         return billing, tariff
+
+    async def site_tariff_update(self, payload: dict[str, Any]) -> dict:
+        """Update site import/export tariff configuration."""
+
+        _token, user_id = self._battery_config_auth_context()
+        url = f"{BASE_URL}/service/tariff/tariff-ms/systems/{self._site}/tariff"
+        params = {"user-id": user_id} if user_id else None
+        return await self._json(
+            "PUT",
+            url,
+            json=payload,
+            params=params,
+            headers=self._tariff_headers(write=True),
+        )
+
+    async def notify_tariff_change(self) -> dict:
+        """Notify the EVSE scheduler service that site tariff data changed."""
+
+        url = (
+            f"{BASE_URL}/service/evse_scheduler/api/v1/siteConfig/"
+            f"{self._site}/tariff_change"
+        )
+        return await self._json(
+            "PUT",
+            url,
+            json=None,
+            headers=self._tariff_headers(write=True),
+        )
 
     async def battery_profile_details(self, *, locale: str | None = None) -> dict:
         """Return BatteryConfig profile details for system + EVSE settings."""

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 
 from homeassistant.components.number import NumberEntity, NumberMode
-from homeassistant.const import PERCENTAGE, UnitOfElectricCurrent
+from homeassistant.const import PERCENTAGE, UnitOfElectricCurrent, UnitOfEnergy
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers.entity import DeviceInfo, EntityCategory
@@ -25,6 +25,7 @@ from .runtime_helpers import (
     inventory_type_device_info as _type_device_info,
 )
 from .runtime_data import EnphaseConfigEntry, get_runtime_data
+from .tariff import tariff_rate_sensor_specs
 
 PARALLEL_UPDATES = 0
 
@@ -81,6 +82,30 @@ def _retained_site_number_unique_ids(
     return unique_ids
 
 
+def _tariff_rate_number_unique_id(
+    coord: EnphaseCoordinator, spec: dict, *, is_import: bool
+) -> str:
+    prefix = "tariff_import_rate" if is_import else "tariff_export_rate"
+    return f"{DOMAIN}_site_{coord.site_id}_{prefix}_{spec['key']}_number"
+
+
+def _tariff_rate_number_entities(coord: EnphaseCoordinator) -> dict[str, NumberEntity]:
+    entities: dict[str, NumberEntity] = {}
+    for is_import, attr in (
+        (True, "tariff_import_rate"),
+        (False, "tariff_export_rate"),
+    ):
+        for spec in tariff_rate_sensor_specs(getattr(coord, attr, None)):
+            locator = (spec.get("attributes") or {}).get("tariff_locator")
+            if not isinstance(locator, dict):
+                continue
+            unique_id = _tariff_rate_number_unique_id(coord, spec, is_import=is_import)
+            entities[unique_id] = EnphaseTariffRateNumber(
+                coord, spec, is_import=is_import
+            )
+    return entities
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: EnphaseConfigEntry,
@@ -101,6 +126,11 @@ async def async_setup_entry(
             f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_limit",
             f"{DOMAIN}_site_{coord.site_id}_battery_new_schedule_limit",
         }
+
+    def _tariff_number_managed(unique_id: str) -> bool:
+        return unique_id.startswith(
+            f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate_"
+        ) or unique_id.startswith(f"{DOMAIN}_site_{coord.site_id}_tariff_export_rate_")
 
     def _core_site_number_unique_ids() -> set[str]:
         return {
@@ -152,9 +182,17 @@ async def async_setup_entry(
         retained_site_number_unique_ids = _retained_site_number_unique_ids(coord, entry)
         active_site_number_unique_ids: set[str] = set()
         site_entities: list[NumberEntity] = []
+        tariff_entities = _tariff_rate_number_entities(coord)
+        active_site_number_unique_ids |= set(tariff_entities)
+        site_entities.extend(
+            entity
+            for unique_id, entity in tariff_entities.items()
+            if unique_id not in added_site_number_unique_ids
+        )
         if _site_has_battery(coord) and _type_available(coord, "encharge"):
             if _battery_write_access_confirmed(coord):
                 active_site_number_unique_ids = _core_site_number_unique_ids()
+                active_site_number_unique_ids |= set(tariff_entities)
             if battery_scheduler_enabled(entry):
                 active_site_number_unique_ids |= retained_site_number_unique_ids & {
                     f"{DOMAIN}_site_{coord.site_id}_battery_schedule_edit_limit"
@@ -162,18 +200,18 @@ async def async_setup_entry(
             current_site_entities = _site_number_entities_by_unique_id(
                 retained_site_number_unique_ids
             )
-            site_entities = [
+            site_entities.extend(
                 entity
                 for unique_id, entity in current_site_entities.items()
                 if unique_id not in added_site_number_unique_ids
-            ]
-            if site_entities:
-                async_add_entities(site_entities, update_before_add=False)
-                added_site_number_unique_ids.update(
-                    entity.unique_id
-                    for entity in site_entities
-                    if isinstance(entity.unique_id, str)
-                )
+            )
+        if site_entities:
+            async_add_entities(site_entities, update_before_add=False)
+            added_site_number_unique_ids.update(
+                entity.unique_id
+                for entity in site_entities
+                if isinstance(entity.unique_id, str)
+            )
         serials = [sn for sn in current_serials if sn not in known_serials]
         if not serials:
             entities: list[NumberEntity] = []
@@ -205,6 +243,7 @@ async def async_setup_entry(
             },
             is_managed=lambda unique_id: (
                 unique_id in _managed_site_number_unique_ids()
+                or _tariff_number_managed(unique_id)
                 or unique_id.endswith(("_amps_number", "_schedule_edit_limit"))
             ),
         )
@@ -469,3 +508,94 @@ class BatteryScheduleEditLimitNumber(_BatteryScheduleEditorLimitNumber):
     async def async_set_native_value(self, value: float) -> None:
         if self._editor is not None:
             self._editor.set_edit_limit(int(value))
+
+
+class EnphaseTariffRateNumber(CoordinatorEntity, NumberEntity):
+    """Editable tariff rate value."""
+
+    _attr_has_entity_name = True
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value = 0.0
+    _attr_native_step = 0.0001
+    _attr_suggested_display_precision = 4
+
+    def __init__(self, coord: EnphaseCoordinator, spec: dict, *, is_import: bool):
+        super().__init__(coord)
+        self._coord = coord
+        self._is_import = is_import
+        self._rate_attr = "tariff_import_rate" if is_import else "tariff_export_rate"
+        self._rate_prefix = "tariff_import_rate" if is_import else "tariff_export_rate"
+        self._detail_key = str(spec.get("key") or "rate")
+        detail_name = str(
+            spec.get("name") or self._detail_key.replace("_", " ").title()
+        )
+        self._attr_translation_key = f"{self._rate_prefix}_value"
+        self._attr_translation_placeholders = {"detail": detail_name}
+        self._attr_unique_id = _tariff_rate_number_unique_id(
+            coord, spec, is_import=is_import
+        )
+        self._attr_icon = "mdi:cash-minus" if is_import else "mdi:cash-plus"
+
+    def _spec(self) -> dict | None:
+        for spec in tariff_rate_sensor_specs(
+            getattr(self._coord, self._rate_attr, None)
+        ):
+            if spec.get("key") == self._detail_key:
+                return spec
+        return None
+
+    @property
+    def available(self) -> bool:  # type: ignore[override]
+        spec = self._spec()
+        client = getattr(self._coord, "client", None)
+        return (
+            super().available
+            and spec is not None
+            and isinstance((spec.get("attributes") or {}).get("tariff_locator"), dict)
+            and callable(getattr(client, "site_tariff", None))
+            and callable(getattr(client, "site_tariff_update", None))
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        spec = self._spec()
+        if spec is None:
+            return None
+        value = spec.get("state")
+        return float(value) if value is not None else None
+
+    @property
+    def native_unit_of_measurement(self) -> str | None:
+        hass = getattr(self, "hass", None)
+        currency = getattr(getattr(hass, "config", None), "currency", None)
+        if isinstance(currency, str) and currency.strip():
+            return f"{currency.strip()}/{UnitOfEnergy.KILO_WATT_HOUR}"
+        spec = self._spec()
+        if spec is None:
+            return None
+        return spec.get("unit")
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        spec = self._spec()
+        if spec is None:
+            return {}
+        return dict(spec.get("attributes") or {})
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        info = _type_device_info(self._coord, "envoy")
+        if info is not None:
+            return info
+        info = _type_device_info(self._coord, "cloud")
+        if info is not None:
+            return info
+        return DeviceInfo(
+            identifiers={(DOMAIN, f"site:{self._coord.site_id}")},
+            manufacturer="Enphase",
+        )
+
+    async def async_set_native_value(self, value: float) -> None:
+        spec = self._spec()
+        locator = (spec.get("attributes") or {}).get("tariff_locator") if spec else None
+        await self._coord.tariff_runtime.async_set_tariff_rate(locator, value)

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -67,7 +67,12 @@ from .runtime_helpers import (
     inventory_type_available as _type_available,
     inventory_type_device_info as _type_device_info,
 )
-from .tariff import next_billing_date, tariff_rate_sensor_specs
+from .tariff import (
+    current_tariff_rate_sensor_spec,
+    next_billing_date,
+    next_tariff_rate_change,
+    tariff_rate_sensor_specs,
+)
 from . import sensor_battery_helpers as _battery_helpers
 from .evse_runtime import evse_power_is_actively_charging
 
@@ -268,6 +273,17 @@ def _tariff_data_available(coord: EnphaseCoordinator) -> bool:
     )
 
 
+def _tariff_now(coord: EnphaseCoordinator, hass: HomeAssistant | None) -> datetime:
+    tz_name = None
+    site_tz = getattr(coord, "_site_timezone_name", None)
+    if callable(site_tz):
+        tz_name = site_tz()
+    if not isinstance(tz_name, str) or not tz_name.strip():
+        tz_name = getattr(getattr(hass, "config", None), "time_zone", None)
+    tzinfo = dt_util.get_time_zone(tz_name) if isinstance(tz_name, str) else None
+    return dt_util.now(tzinfo or dt_util.DEFAULT_TIME_ZONE)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: EnphaseConfigEntry,
@@ -384,11 +400,7 @@ async def async_setup_entry(
     @callback
     def _async_remove_site_sensor_entities_with_prefix(
         prefix: str,
-        current_keys: set[str],
     ) -> None:
-        for key in list(known_site_entity_keys):
-            if key.startswith(prefix) and key not in current_keys:
-                _async_remove_site_sensor_entity(key)
         unique_prefix = _site_sensor_unique_id(prefix)
         for reg_entry in list(_entity_registry_values()):
             entry_domain = getattr(reg_entry, "domain", None)
@@ -406,8 +418,6 @@ async def async_setup_entry(
             if not unique_id or not unique_id.startswith(unique_prefix):
                 continue
             key = unique_id[len(f"{DOMAIN}_site_{coord.site_id}_") :]
-            if key in current_keys:
-                continue
             ent_reg.async_remove(reg_entry.entity_id)
             known_site_entity_keys.discard(key)
 
@@ -808,74 +818,44 @@ async def async_setup_entry(
         tariff_rates_refresh_seen = (
             getattr(coord, "tariff_rates_last_refresh_utc", None) is not None
         )
-        import_rate_specs = tariff_rate_sensor_specs(
-            tariff_import_rate,
-        )
-        if import_rate_specs:
-            current_import_keys = {
-                f"tariff_import_rate_{spec['key']}" for spec in import_rate_specs
-            }
-            _async_remove_site_sensor_entity("tariff_import_rate")
-            _async_remove_site_sensor_entities_with_prefix(
-                "tariff_import_rate_",
-                current_import_keys,
-            )
-            for spec in import_rate_specs:
-                key = f"tariff_import_rate_{spec['key']}"
-                _add_site_entity(
-                    key, EnphaseTariffRateValueSensor(coord, spec, is_import=True)
-                )
-        elif (
-            tariff_import_rate is not None
-            or "tariff_import_rate" in known_site_entity_keys
-            or _site_sensor_entity_registered("tariff_import_rate")
-        ):
-            if tariff_import_rate is not None:
-                _async_remove_site_sensor_entities_with_prefix(
-                    "tariff_import_rate_",
-                    set(),
-                )
-            _add_site_entity("tariff_import_rate", EnphaseTariffRateSensor(coord, True))
-        elif tariff_rates_refresh_seen:
-            _async_remove_site_sensor_entities_with_prefix(
-                "tariff_import_rate_",
-                set(),
-            )
-        export_rate_specs = tariff_rate_sensor_specs(
-            tariff_export_rate,
-        )
-        if export_rate_specs:
-            current_export_keys = {
-                f"tariff_export_rate_{spec['key']}" for spec in export_rate_specs
-            }
-            _async_remove_site_sensor_entity("tariff_export_rate")
-            _async_remove_site_sensor_entities_with_prefix(
-                "tariff_export_rate_",
-                current_export_keys,
-            )
-            for spec in export_rate_specs:
-                key = f"tariff_export_rate_{spec['key']}"
-                _add_site_entity(
-                    key, EnphaseTariffRateValueSensor(coord, spec, is_import=False)
-                )
-        elif (
-            tariff_export_rate is not None
-            or "tariff_export_rate" in known_site_entity_keys
-            or _site_sensor_entity_registered("tariff_export_rate")
-        ):
-            if tariff_export_rate is not None:
-                _async_remove_site_sensor_entities_with_prefix(
-                    "tariff_export_rate_",
-                    set(),
-                )
+        current_import_rate_key = "tariff_current_import_rate"
+        if tariff_import_rate is not None:
             _add_site_entity(
-                "tariff_export_rate", EnphaseTariffRateSensor(coord, False)
+                current_import_rate_key,
+                EnphaseCurrentTariffRateSensor(coord, is_import=True),
             )
         elif tariff_rates_refresh_seen:
-            _async_remove_site_sensor_entities_with_prefix(
-                "tariff_export_rate_",
-                set(),
+            _async_remove_site_sensor_entity(current_import_rate_key)
+        elif current_import_rate_key in known_site_entity_keys or (
+            _site_sensor_entity_registered(current_import_rate_key)
+        ):
+            _add_site_entity(
+                current_import_rate_key,
+                EnphaseCurrentTariffRateSensor(coord, is_import=True),
             )
+        _async_remove_site_sensor_entity("tariff_import_rate")
+        _async_remove_site_sensor_entities_with_prefix(
+            "tariff_import_rate_",
+        )
+        current_export_rate_key = "tariff_current_export_rate"
+        if tariff_export_rate is not None:
+            _add_site_entity(
+                current_export_rate_key,
+                EnphaseCurrentTariffRateSensor(coord, is_import=False),
+            )
+        elif tariff_rates_refresh_seen:
+            _async_remove_site_sensor_entity(current_export_rate_key)
+        elif current_export_rate_key in known_site_entity_keys or (
+            _site_sensor_entity_registered(current_export_rate_key)
+        ):
+            _add_site_entity(
+                current_export_rate_key,
+                EnphaseCurrentTariffRateSensor(coord, is_import=False),
+            )
+        _async_remove_site_sensor_entity("tariff_export_rate")
+        _async_remove_site_sensor_entities_with_prefix(
+            "tariff_export_rate_",
+        )
 
         for record in router_records:
             router_key = str(record.get("key", "")).strip()
@@ -8458,6 +8438,7 @@ class EnphaseBatteryLastReportedSensor(_SiteBaseEntity):
 class _EnphaseTariffBaseSensor(_SiteBaseEntity):
     _unrecorded_attributes = _SiteBaseEntity._unrecorded_attributes.union(
         {
+            "configured_rates",
             "seasons",
             "last_refresh_utc",
         }
@@ -8555,7 +8536,145 @@ class EnphaseTariffRateSensor(_EnphaseTariffBaseSensor):
         return attrs
 
 
+class EnphaseCurrentTariffRateSensor(_EnphaseTariffBaseSensor):
+    _attr_state_class = SensorStateClass.MEASUREMENT
+    _attr_suggested_display_precision = 4
+
+    def __init__(self, coord: EnphaseCoordinator, *, is_import: bool):
+        self._is_import = is_import
+        key = (
+            "tariff_current_import_rate" if is_import else "tariff_current_export_rate"
+        )
+        name = "Current Import Rate" if is_import else "Current Export Rate"
+        self._rate_attr = "tariff_import_rate" if is_import else "tariff_export_rate"
+        self._attr_translation_key = key
+        self._attr_icon = "mdi:cash-minus" if is_import else "mdi:cash-plus"
+        self._tariff_boundary_cancel: CALLBACK_TYPE | None = None
+        super().__init__(coord, key, name, type_key=None)
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        self._ensure_tariff_boundary_timer()
+
+    async def async_will_remove_from_hass(self) -> None:
+        await super().async_will_remove_from_hass()
+        self._cancel_tariff_boundary_timer()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        super()._handle_coordinator_update()
+        self._ensure_tariff_boundary_timer()
+
+    def _spec(self):
+        return current_tariff_rate_sensor_spec(
+            getattr(self._coord, self._rate_attr, None),
+            _tariff_now(self._coord, getattr(self, "hass", None)),
+        )
+
+    def _configured_rates(self) -> list[dict[str, object]]:
+        rates: list[dict[str, object]] = []
+        for spec in tariff_rate_sensor_specs(
+            getattr(self._coord, self._rate_attr, None)
+        ):
+            attrs = spec.get("attributes") or {}
+            rate: dict[str, object] = {
+                key: value
+                for key, value in {
+                    "name": spec.get("name"),
+                    "rate": attrs.get("rate"),
+                    "formatted_rate": attrs.get("formatted_rate"),
+                    "unit": spec.get("unit"),
+                    "season_id": attrs.get("season_id"),
+                    "start_month": attrs.get("start_month"),
+                    "end_month": attrs.get("end_month"),
+                    "day_group_id": attrs.get("day_group_id"),
+                    "days": attrs.get("days"),
+                    "period_type": attrs.get("period_type"),
+                    "start_time": attrs.get("start_time"),
+                    "end_time": attrs.get("end_time"),
+                    "tier_id": attrs.get("tier_id"),
+                    "start_value": attrs.get("start_value"),
+                    "end_value": attrs.get("end_value"),
+                    "unbounded": attrs.get("unbounded"),
+                    "tariff_locator": attrs.get("tariff_locator"),
+                }.items()
+                if value is not None
+            }
+            rates.append(rate)
+        return rates
+
+    @property
+    def available(self) -> bool:
+        return self._spec() is not None and super().available
+
+    @property
+    def native_value(self):
+        spec = self._spec()
+        if spec is None:
+            return None
+        return spec.get("state")
+
+    @property
+    def native_unit_of_measurement(self):
+        spec = self._spec()
+        if spec is None:
+            return None
+        hass = getattr(self, "hass", None)
+        currency = _gateway_clean_text(
+            getattr(getattr(hass, "config", None), "currency", None)
+        )
+        if currency is not None:
+            return f"{currency}/{UnitOfEnergy.KILO_WATT_HOUR}"
+        return spec.get("unit")
+
+    @property
+    def extra_state_attributes(self):
+        spec = self._spec()
+        if spec is None:
+            return {}
+        attrs = dict(spec.get("attributes") or {})
+        attrs["active_rate_name"] = spec.get("name")
+        attrs["configured_rates"] = self._configured_rates()
+        attrs.update(self._last_refresh_attr())
+        return attrs
+
+    @callback
+    def _ensure_tariff_boundary_timer(self) -> None:
+        if self.hass is None:
+            return
+        when = _tariff_now(self._coord, self.hass)
+        next_change = next_tariff_rate_change(
+            getattr(self._coord, self._rate_attr, None),
+            when,
+        )
+        self._cancel_tariff_boundary_timer()
+        if next_change is None:
+            return
+        fire_at = dt_util.as_utc(next_change)
+        if fire_at <= dt_util.utcnow():
+            fire_at = dt_util.utcnow() + timedelta(seconds=1)
+        self._tariff_boundary_cancel = async_track_point_in_utc_time(
+            self.hass, self._handle_tariff_boundary, fire_at
+        )
+
+    @callback
+    def _handle_tariff_boundary(self, _now: datetime) -> None:
+        self._cancel_tariff_boundary_timer()
+        self.async_write_ha_state()
+        self._ensure_tariff_boundary_timer()
+
+    @callback
+    def _cancel_tariff_boundary_timer(self) -> None:
+        if self._tariff_boundary_cancel:
+            try:
+                self._tariff_boundary_cancel()
+            except Exception:  # noqa: BLE001
+                pass
+            self._tariff_boundary_cancel = None
+
+
 class EnphaseTariffRateValueSensor(_EnphaseTariffBaseSensor):
+    _attr_entity_registry_enabled_default = False
     _attr_state_class = SensorStateClass.MEASUREMENT
     _attr_suggested_display_precision = 4
 

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -10,8 +10,10 @@ import voluptuous as vol
 from homeassistant.core import HomeAssistant, ServiceCall, SupportsResponse
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers import service as ha_service
+from homeassistant.helpers import target as ha_target
 
 from .battery_schedule_editor import (
     battery_schedule_inventory,
@@ -51,6 +53,7 @@ REGISTERED_SERVICES = (
     "delete_schedule",
     "validate_schedule",
     "update_cfg_schedule",
+    "set_tariff_rate",
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -542,6 +545,12 @@ def async_setup_services(
         ),
         _validate_cfg_schedule,
     )
+    SET_TARIFF_RATE_SCHEMA = vol.Schema(
+        {
+            vol.Optional("entity_id"): cv.entity_ids,
+            vol.Required("rate"): vol.All(vol.Coerce(float), vol.Range(min=0)),
+        }
+    )
 
     def _extract_device_ids(call: ServiceCall) -> list[str]:
         device_ids: set[str] = set()
@@ -598,6 +607,62 @@ def async_setup_services(
             translation_domain=DOMAIN,
             translation_key="exceptions.grid_site_required",
         )
+
+    def _extract_entity_ids(call: ServiceCall) -> list[str]:
+        entity_ids: set[str] = set()
+        extractor = getattr(ha_target, "async_extract_referenced_entity_ids", None)
+        if callable(extractor):
+            try:
+                entity_ids |= {str(entity_id) for entity_id in extractor(hass, call)}
+            except Exception:
+                pass
+        else:
+            extractor = getattr(ha_service, "async_extract_referenced_entity_ids", None)
+            if callable(extractor):
+                try:
+                    entity_ids |= {
+                        str(entity_id) for entity_id in extractor(hass, call)
+                    }
+                except Exception:
+                    pass
+        raw_entity_ids = call.data.get("entity_id")
+        if raw_entity_ids:
+            if isinstance(raw_entity_ids, str):
+                entity_ids.add(raw_entity_ids)
+            else:
+                entity_ids |= {str(entity_id) for entity_id in raw_entity_ids}
+        return list(entity_ids)
+
+    def _coordinator_from_tariff_entity(
+        entity_id: str,
+    ) -> EnphaseCoordinator | None:
+        ent_reg = er.async_get(hass)
+        reg_entry = ent_reg.async_get(entity_id)
+        if reg_entry is None:
+            return None
+        entry_domain = getattr(reg_entry, "domain", entity_id.partition(".")[0])
+        if reg_entry.platform != DOMAIN or entry_domain not in {"sensor", "number"}:
+            return None
+        unique_id = str(reg_entry.unique_id or "")
+        if not any(
+            token in unique_id
+            for token in (
+                "_tariff_import_rate_",
+                "_tariff_export_rate_",
+                "_tariff_current_import_rate",
+                "_tariff_current_export_rate",
+            )
+        ):
+            return None
+        config_entry_id = getattr(reg_entry, "config_entry_id", None)
+        if config_entry_id:
+            coord = _get_coordinator_for_entry_id(str(config_entry_id))
+            if coord is not None:
+                return coord
+        for coord in _iter_loaded_coordinators():
+            if f"{DOMAIN}_site_{coord.site_id}_" in unique_id:
+                return coord
+        return None
 
     async def _resolve_charger_targets(
         call: ServiceCall,
@@ -1008,6 +1073,37 @@ def async_setup_services(
         for _device_id, sn, coord in await _resolve_charger_targets(call):
             await coord.schedule_sync.async_refresh(reason="service", serials=[sn])
 
+    async def _svc_set_tariff_rate(call: ServiceCall) -> None:
+        entity_ids = _extract_entity_ids(call)
+        if not entity_ids:
+            _raise_service_validation(
+                "tariff_rate_entity_required",
+                message="Select exactly one tariff rate entity.",
+            )
+        if len(entity_ids) != 1:
+            _raise_service_validation(
+                "tariff_rate_entity_required",
+                message="Select exactly one tariff rate entity.",
+            )
+        entity_id = entity_ids[0]
+        coord = _coordinator_from_tariff_entity(entity_id)
+        if coord is None:
+            _raise_service_validation(
+                "tariff_rate_entity_invalid",
+                placeholders={"entity_id": entity_id},
+                message=f"Entity is not an Enphase tariff rate entity: {entity_id}",
+            )
+        state = hass.states.get(entity_id)
+        locator = None if state is None else state.attributes.get("tariff_locator")
+        if not isinstance(locator, dict):
+            _raise_service_validation(
+                "tariff_rate_target_invalid",
+                message="Tariff rate target is invalid.",
+            )
+        await coord.tariff_runtime.async_set_tariff_rate(
+            locator, float(call.data["rate"])
+        )
+
     hass.services.async_register(
         DOMAIN, "force_refresh", _svc_force_refresh, schema=FORCE_REFRESH_SCHEMA
     )
@@ -1069,6 +1165,12 @@ def async_setup_services(
         "update_cfg_schedule",
         _svc_update_cfg_schedule,
         schema=UPDATE_CFG_SCHEMA,
+    )
+    hass.services.async_register(
+        DOMAIN,
+        "set_tariff_rate",
+        _svc_set_tariff_rate,
+        schema=SET_TARIFF_RATE_SCHEMA,
     )
 
 

--- a/custom_components/enphase_ev/services.yaml
+++ b/custom_components/enphase_ev/services.yaml
@@ -164,6 +164,20 @@ force_refresh:
             text:
               multiline: false
 
+set_tariff_rate:
+  name: Set Tariff Rate
+  description: Update one existing Enphase import or export tariff rate value.
+  target:
+    entity:
+      integration: enphase_ev
+  fields:
+    rate:
+      required: true
+      selector:
+        number:
+          min: 0
+          step: any
+
 add_schedule:
   name: Add Battery Schedule
   description: Create a battery schedule for CFG, DTG, or RBD

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -393,6 +393,24 @@
     },
     "battery_schedule_ids_not_found": {
       "message": "Schedule ID(s) not found in current data: {schedule_ids}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tariff rate must be a non-negative number."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Tariff rate target was not found in the latest tariff payload."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Tariff rate target is invalid."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Tariff write API is unavailable."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Select exactly one tariff rate entity."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entity is not an Enphase tariff rate entity: {entity_id}"
     }
   },
   "options": {
@@ -1283,6 +1301,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1377,6 +1398,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_rbd_schedules": {
         "name": "Battery RBD Schedules"
+      },
+      "tariff_current_import_rate": {
+        "name": "Current Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Current Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_new_schedule_limit": {
         "name": "Battery New Schedule Limit"
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "config_entry_id": {
           "name": "Config Entry ID",
           "description": "Optional config entry identifier for a single Enphase site entry."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Set Tariff Rate",
+      "description": "Update one existing Enphase import or export tariff rate value.",
+      "fields": {
+        "rate": {
+          "name": "Rate",
+          "description": "New non-negative tariff rate value."
         }
       }
     }

--- a/custom_components/enphase_ev/tariff.py
+++ b/custom_components/enphase_ev/tariff.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import calendar
+import copy
 from dataclasses import dataclass
-from datetime import date, timedelta
+from datetime import date, datetime, time as dt_time, timedelta
+import logging
+import math
 import re
 from typing import TYPE_CHECKING
 
@@ -12,12 +15,86 @@ import aiohttp
 from homeassistant.util import dt as dt_util
 
 from .api import InvalidPayloadError, OptionalEndpointUnavailable
+from .const import DOMAIN
+from .service_validation import raise_translated_service_validation
 
 if TYPE_CHECKING:
     from .coordinator import EnphaseCoordinator
 
 TARIFF_ENDPOINT_FAMILY = "tariff"
 _EXPORT_RATE_KEY_RE = re.compile(r"[^a-z0-9]+")
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass(slots=True, frozen=True)
+class TariffRateLocator:
+    """Stable location for an editable tariff rate in the raw payload."""
+
+    branch: str
+    kind: str
+    season_index: int
+    season_id: str | None = None
+    day_index: int | None = None
+    day_group_id: str | None = None
+    period_index: int | None = None
+    period_id: str | None = None
+    period_type: str | None = None
+    tier_index: int | None = None
+    tier_id: str | None = None
+
+    def as_dict(self) -> dict[str, object]:
+        """Return a JSON-serializable locator."""
+
+        return {
+            key: value
+            for key, value in {
+                "branch": self.branch,
+                "kind": self.kind,
+                "season_index": self.season_index,
+                "season_id": self.season_id,
+                "day_index": self.day_index,
+                "day_group_id": self.day_group_id,
+                "period_index": self.period_index,
+                "period_id": self.period_id,
+                "period_type": self.period_type,
+                "tier_index": self.tier_index,
+                "tier_id": self.tier_id,
+            }.items()
+            if value is not None
+        }
+
+    @classmethod
+    def from_object(cls, value: object) -> "TariffRateLocator | None":
+        """Parse a locator from entity state attributes or service data."""
+
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, dict):
+            return None
+        branch = _clean_text(value.get("branch"))
+        kind = _clean_text(value.get("kind"))
+        season_index = _int_or_none(value.get("season_index"))
+        if branch not in {"purchase", "buyback"} or kind not in {
+            "period",
+            "tier",
+            "off_peak",
+        }:
+            return None
+        if season_index is None or season_index < 1:
+            return None
+        return cls(
+            branch=branch,
+            kind=kind,
+            season_index=season_index,
+            season_id=_clean_text(value.get("season_id")),
+            day_index=_int_or_none(value.get("day_index")),
+            day_group_id=_clean_text(value.get("day_group_id")),
+            period_index=_int_or_none(value.get("period_index")),
+            period_id=_clean_text(value.get("period_id")),
+            period_type=_clean_text(value.get("period_type")),
+            tier_index=_int_or_none(value.get("tier_index")),
+            tier_id=_clean_text(value.get("tier_id")),
+        )
 
 
 @dataclass(slots=True, frozen=True)
@@ -58,6 +135,7 @@ class TariffRateSnapshot:
     currency: str | None
     export_plan: str | None
     seasons: tuple[dict[str, object], ...]
+    branch_key: str | None = None
 
     @property
     def attributes(self) -> dict[str, object]:
@@ -248,6 +326,144 @@ def _rate_detail_name(*parts: object) -> str:
     return " ".join(part.title() for part in names if part)
 
 
+def _month_matches(
+    month: int,
+    start_month: object,
+    end_month: object,
+) -> bool:
+    start = _int_or_none(start_month)
+    end = _int_or_none(end_month)
+    if start is None or end is None:
+        return True
+    if not 1 <= start <= 12 or not 1 <= end <= 12:
+        return True
+    if start <= end:
+        return start <= month <= end
+    return month >= start or month <= end
+
+
+def _time_to_minutes(value: object) -> int | None:
+    text = _clean_text(value)
+    if text is None:
+        return None
+    parts = text.split(":", 1)
+    if len(parts) != 2:
+        return None
+    try:
+        hour = int(parts[0])
+        minute = int(parts[1])
+    except ValueError:
+        return None
+    if not 0 <= hour <= 23 or not 0 <= minute <= 59:
+        return None
+    return hour * 60 + minute
+
+
+def _time_window_matches(
+    minute_of_day: int,
+    start_time: object,
+    end_time: object,
+) -> bool:
+    start = _time_to_minutes(start_time)
+    end = _time_to_minutes(end_time)
+    if start is None or end is None or start == end:
+        return True
+    if start < end:
+        return start <= minute_of_day < end
+    return minute_of_day >= start or minute_of_day < end
+
+
+def current_tariff_rate_sensor_spec(
+    snapshot: TariffRateSnapshot | None,
+    when: datetime,
+) -> dict | None:
+    """Return the unambiguous current rate spec for an Energy price sensor."""
+
+    specs = tariff_rate_sensor_specs(snapshot)
+    if not specs:
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    month = when.month
+    weekday = when.isoweekday()
+    minute_of_day = when.hour * 60 + when.minute
+
+    matches: list[dict] = []
+    for spec in specs:
+        attrs = spec.get("attributes") or {}
+        if not _month_matches(
+            month,
+            attrs.get("start_month"),
+            attrs.get("end_month"),
+        ):
+            continue
+        days = attrs.get("days")
+        if (
+            isinstance(days, list)
+            and days
+            and weekday
+            not in {day for item in days if (day := _int_or_none(item)) is not None}
+        ):
+            continue
+        if not _time_window_matches(
+            minute_of_day,
+            attrs.get("start_time"),
+            attrs.get("end_time"),
+        ):
+            continue
+        matches.append(spec)
+    if len(matches) != 1:
+        return None
+    return matches[0]
+
+
+def next_tariff_rate_change(
+    snapshot: TariffRateSnapshot | None,
+    when: datetime,
+) -> datetime | None:
+    """Return the next time the active tariff rate may change."""
+
+    specs = tariff_rate_sensor_specs(snapshot)
+    if not specs:
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
+    active = current_tariff_rate_sensor_spec(snapshot, when)
+    active_key = None if active is None else active.get("key")
+    active_state = None if active is None else active.get("state")
+    tzinfo = when.tzinfo
+    candidates: set[datetime] = set()
+    start_date = when.date()
+    for day_offset in range(0, 370):
+        day = start_date + timedelta(days=day_offset)
+        candidates.add(datetime.combine(day, dt_time.min, tzinfo))
+        for spec in specs:
+            attrs = spec.get("attributes") or {}
+            for attr in ("start_time", "end_time"):
+                minute_of_day = _time_to_minutes(attrs.get(attr))
+                if minute_of_day is None:
+                    continue
+                candidates.add(
+                    datetime.combine(
+                        day,
+                        dt_time(minute_of_day // 60, minute_of_day % 60),
+                        tzinfo,
+                    )
+                )
+
+    for candidate in sorted(candidates):
+        if candidate <= when:
+            continue
+        candidate_spec = current_tariff_rate_sensor_spec(snapshot, candidate)
+        candidate_key = None if candidate_spec is None else candidate_spec.get("key")
+        candidate_state = (
+            None if candidate_spec is None else candidate_spec.get("state")
+        )
+        if (candidate_key, candidate_state) != (active_key, active_state):
+            return candidate
+    return None
+
+
 def tariff_rate_sensor_specs(snapshot: TariffRateSnapshot | None) -> tuple[dict, ...]:
     """Return per-rate sensor specs for period and tiered tariffs."""
 
@@ -280,6 +496,9 @@ def tariff_rate_sensor_specs(snapshot: TariffRateSnapshot | None) -> tuple[dict,
         "currency": snapshot.currency,
         "export_plan": snapshot.export_plan,
     }
+    branch_key = (
+        snapshot.branch_key if snapshot.branch_key in {"purchase", "buyback"} else None
+    )
     for season_index, season in enumerate(snapshot.seasons, start=1):
         season_attrs = {
             **base_attrs,
@@ -287,6 +506,33 @@ def tariff_rate_sensor_specs(snapshot: TariffRateSnapshot | None) -> tuple[dict,
             "start_month": season.get("start_month"),
             "end_month": season.get("end_month"),
         }
+        off_peak_state = _rate_value(season.get("off_peak"))
+        if off_peak_state is not None:
+            attrs = {
+                **season_attrs,
+                "rate": season.get("off_peak"),
+                "formatted_rate": _format_rate(
+                    season.get("off_peak"), snapshot.currency
+                ),
+            }
+            if branch_key is not None:
+                attrs["tariff_locator"] = TariffRateLocator(
+                    branch=branch_key,
+                    kind="off_peak",
+                    season_index=season_index,
+                    season_id=_clean_text(season.get("id")),
+                ).as_dict()
+            _append_spec(
+                "_".join(
+                    (
+                        _slug(season.get("id"), f"season_{season_index}"),
+                        "off_peak",
+                    )
+                ),
+                "Off-Peak",
+                off_peak_state,
+                {attr: value for attr, value in attrs.items() if value is not None},
+            )
         for day_index, day_group in enumerate(season.get("days", []), start=1):
             if not isinstance(day_group, dict):
                 continue
@@ -326,6 +572,18 @@ def tariff_rate_sensor_specs(snapshot: TariffRateSnapshot | None) -> tuple[dict,
                         period.get("rate"), snapshot.currency
                     ),
                 }
+                if branch_key is not None:
+                    attrs["tariff_locator"] = TariffRateLocator(
+                        branch=branch_key,
+                        kind="period",
+                        season_index=season_index,
+                        season_id=_clean_text(season.get("id")),
+                        day_index=day_index,
+                        day_group_id=_clean_text(day_group.get("id")),
+                        period_index=period_index,
+                        period_id=period_id,
+                        period_type=period_type,
+                    ).as_dict()
                 _append_spec(
                     key,
                     name,
@@ -355,6 +613,15 @@ def tariff_rate_sensor_specs(snapshot: TariffRateSnapshot | None) -> tuple[dict,
                 "rate": tier.get("rate"),
                 "formatted_rate": _format_rate(tier.get("rate"), snapshot.currency),
             }
+            if branch_key is not None:
+                attrs["tariff_locator"] = TariffRateLocator(
+                    branch=branch_key,
+                    kind="tier",
+                    season_index=season_index,
+                    season_id=_clean_text(season.get("id")),
+                    tier_index=tier_index,
+                    tier_id=tier_id,
+                ).as_dict()
             _append_spec(
                 key,
                 name,
@@ -475,11 +742,118 @@ def parse_tariff_rate(
             _clean_text(branch.get("exportPlan")) if branch_key == "buyback" else None
         ),
         seasons=tuple(seasons),
+        branch_key=branch_key,
+    )
+
+
+def _format_write_rate(value: float) -> str:
+    if not math.isfinite(value) or value < 0:
+        _raise_tariff_validation(
+            "tariff_rate_invalid",
+            message="Tariff rate must be a non-negative number.",
+        )
+    return f"{value:.10f}".rstrip("0").rstrip(".") or "0"
+
+
+def _raise_tariff_validation(
+    key: str,
+    *,
+    placeholders: dict[str, object] | None = None,
+    message: str | None = None,
+) -> None:
+    raise_translated_service_validation(
+        translation_domain=DOMAIN,
+        translation_key=f"exceptions.{key}",
+        translation_placeholders=placeholders,
+        message=message,
+    )
+
+
+def _index_item(items: object, index: int | None) -> dict[str, object] | None:
+    if index is None or index < 1 or not isinstance(items, list):
+        return None
+    try:
+        item = items[index - 1]
+    except IndexError:
+        return None
+    return item if isinstance(item, dict) else None
+
+
+def _matches_text(actual: object, expected: str | None) -> bool:
+    return expected is None or _clean_text(actual) == expected
+
+
+def _locate_tariff_rate(
+    payload: dict[str, object],
+    locator: TariffRateLocator,
+) -> tuple[dict[str, object], str]:
+    branch = payload.get(locator.branch)
+    if not isinstance(branch, dict):
+        _raise_tariff_validation(
+            "tariff_rate_target_not_found",
+            message="Tariff rate target was not found in the latest tariff payload.",
+        )
+    season = _index_item(branch.get("seasons"), locator.season_index)
+    if season is None or not _matches_text(season.get("id"), locator.season_id):
+        _raise_tariff_validation(
+            "tariff_rate_target_not_found",
+            message="Tariff rate target was not found in the latest tariff payload.",
+        )
+
+    if locator.kind == "off_peak":
+        if "offPeak" not in season:
+            _raise_tariff_validation(
+                "tariff_rate_target_not_found",
+                message=(
+                    "Tariff rate target was not found in the latest tariff payload."
+                ),
+            )
+        return season, "offPeak"
+
+    if locator.kind == "period":
+        day_group = _index_item(season.get("days"), locator.day_index)
+        if day_group is None or not _matches_text(
+            day_group.get("id"), locator.day_group_id
+        ):
+            _raise_tariff_validation(
+                "tariff_rate_target_not_found",
+                message=(
+                    "Tariff rate target was not found in the latest tariff payload."
+                ),
+            )
+        period = _index_item(day_group.get("periods"), locator.period_index)
+        if (
+            period is None
+            or not _matches_text(period.get("id"), locator.period_id)
+            or not _matches_text(period.get("type"), locator.period_type)
+        ):
+            _raise_tariff_validation(
+                "tariff_rate_target_not_found",
+                message=(
+                    "Tariff rate target was not found in the latest tariff payload."
+                ),
+            )
+        return period, "rate"
+
+    if locator.kind == "tier":
+        tier = _index_item(season.get("tiers"), locator.tier_index)
+        if tier is None or not _matches_text(tier.get("id"), locator.tier_id):
+            _raise_tariff_validation(
+                "tariff_rate_target_not_found",
+                message=(
+                    "Tariff rate target was not found in the latest tariff payload."
+                ),
+            )
+        return tier, "rate"
+
+    _raise_tariff_validation(
+        "tariff_rate_target_invalid",
+        message="Tariff rate target is invalid.",
     )
 
 
 class TariffRuntime:
-    """Fetch and normalize read-only site tariff data."""
+    """Fetch, normalize, and update site tariff data."""
 
     def __init__(self, coordinator: EnphaseCoordinator) -> None:
         self.coordinator = coordinator
@@ -528,6 +902,59 @@ class TariffRuntime:
         if isinstance(tariff_payload, dict) and tariff_payload:
             coord.tariff_rates_last_refresh_utc = refresh_time
         coord._note_endpoint_family_success(TARIFF_ENDPOINT_FAMILY)
+
+    async def async_set_tariff_rate(
+        self,
+        locator: TariffRateLocator | dict[str, object],
+        value: float,
+    ) -> dict:
+        """Update one existing tariff rate value."""
+
+        parsed_locator = TariffRateLocator.from_object(locator)
+        if parsed_locator is None:
+            _raise_tariff_validation(
+                "tariff_rate_target_invalid",
+                message="Tariff rate target is invalid.",
+            )
+        try:
+            rate_value = float(value)
+        except (TypeError, ValueError):
+            _raise_tariff_validation(
+                "tariff_rate_invalid",
+                message="Tariff rate must be a non-negative number.",
+            )
+        rate = _format_write_rate(rate_value)
+        coord = self.coordinator
+        site_tariff = getattr(coord.client, "site_tariff", None)
+        site_tariff_update = getattr(coord.client, "site_tariff_update", None)
+        if not callable(site_tariff) or not callable(site_tariff_update):
+            _raise_tariff_validation(
+                "tariff_rate_api_unavailable",
+                message="Tariff write API is unavailable.",
+            )
+        payload = await site_tariff()
+        if not isinstance(payload, dict):
+            _raise_tariff_validation(
+                "tariff_rate_api_unavailable",
+                message="Tariff write API is unavailable.",
+            )
+        update_payload = copy.deepcopy(payload)
+        target, field = _locate_tariff_rate(update_payload, parsed_locator)
+        target[field] = rate
+        result = await site_tariff_update(update_payload)
+
+        notifier = getattr(coord.client, "notify_tariff_change", None)
+        if callable(notifier):
+            try:
+                await notifier()
+            except (aiohttp.ClientError, AttributeError, TimeoutError) as err:
+                _LOGGER.debug(
+                    "Tariff change notification failed for site %s: %s",
+                    getattr(coord, "site_id", None),
+                    err,
+                )
+        await coord.tariff_runtime.async_refresh(force=True)
+        return result
 
     def _has_stale_data(self) -> bool:
         """Return whether a prior tariff snapshot can stay visible."""

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Актуализацията на графика е в конфликт със съществуващ график на батерията: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Тарифната ставка трябва да бъде неотрицателно число."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Целевата тарифна ставка не беше намерена в последните тарифни данни."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Целевата тарифна ставка е невалидна."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "API за запис на тарифи е недостъпен."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Изберете точно един обект за тарифна ставка."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Обектът не е тарифна ставка на Enphase: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Posledno opresnyavane (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Локатор на тарифата"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Posledno opresnyavane (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Локатор на тарифата"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Резюме на графика на батерията"
+      },
+      "tariff_current_import_rate": {
+        "name": "Текуща тарифа за внос",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura na tarifata"
+          },
+          "variation_type": {
+            "name": "Tip variacia"
+          },
+          "source": {
+            "name": "Iztochnik"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "ID на сезон"
+          },
+          "start_month": {
+            "name": "Начален месец"
+          },
+          "end_month": {
+            "name": "Краен месец"
+          },
+          "day_group_id": {
+            "name": "ID на група дни"
+          },
+          "days": {
+            "name": "Дни"
+          },
+          "period_id": {
+            "name": "ID на период"
+          },
+          "period_type": {
+            "name": "Тип период"
+          },
+          "start_time": {
+            "name": "Начален час"
+          },
+          "end_time": {
+            "name": "Краен час"
+          },
+          "rate": {
+            "name": "Тарифа"
+          },
+          "formatted_rate": {
+            "name": "Форматирана тарифа"
+          },
+          "tier_id": {
+            "name": "ID на стъпало"
+          },
+          "start_value": {
+            "name": "Начална стойност"
+          },
+          "end_value": {
+            "name": "Крайна стойност"
+          },
+          "unbounded": {
+            "name": "Без горна граница"
+          },
+          "last_refresh_utc": {
+            "name": "Posledno opresnyavane (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Локатор на тарифата"
+          },
+          "active_rate_name": {
+            "name": "Име на активната тарифа"
+          },
+          "configured_rates": {
+            "name": "Конфигурирани тарифи"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Текуща тарифа за износ",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura na tarifata"
+          },
+          "variation_type": {
+            "name": "Tip variacia"
+          },
+          "source": {
+            "name": "Iztochnik"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Plan za iznos"
+          },
+          "season_id": {
+            "name": "ID на сезон"
+          },
+          "start_month": {
+            "name": "Начален месец"
+          },
+          "end_month": {
+            "name": "Краен месец"
+          },
+          "day_group_id": {
+            "name": "ID на група дни"
+          },
+          "days": {
+            "name": "Дни"
+          },
+          "period_id": {
+            "name": "ID на период"
+          },
+          "period_type": {
+            "name": "Тип период"
+          },
+          "start_time": {
+            "name": "Начален час"
+          },
+          "end_time": {
+            "name": "Краен час"
+          },
+          "rate": {
+            "name": "Тарифа"
+          },
+          "formatted_rate": {
+            "name": "Форматирана тарифа"
+          },
+          "tier_id": {
+            "name": "ID на стъпало"
+          },
+          "start_value": {
+            "name": "Начална стойност"
+          },
+          "end_value": {
+            "name": "Крайна стойност"
+          },
+          "unbounded": {
+            "name": "Без горна граница"
+          },
+          "last_refresh_utc": {
+            "name": "Posledno opresnyavane (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Локатор на тарифата"
+          },
+          "active_rate_name": {
+            "name": "Име на активната тарифа"
+          },
+          "configured_rates": {
+            "name": "Конфигурирани тарифи"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "График на батерията"
+      },
+      "tariff_import_rate_value": {
+        "name": "Tarifa za vnos {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura na tarifata"
+          },
+          "variation_type": {
+            "name": "Tip variacia"
+          },
+          "source": {
+            "name": "Iztochnik"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "ID на сезон"
+          },
+          "start_month": {
+            "name": "Начален месец"
+          },
+          "end_month": {
+            "name": "Краен месец"
+          },
+          "day_group_id": {
+            "name": "ID на група дни"
+          },
+          "days": {
+            "name": "Дни"
+          },
+          "period_id": {
+            "name": "ID на период"
+          },
+          "period_type": {
+            "name": "Тип период"
+          },
+          "start_time": {
+            "name": "Начален час"
+          },
+          "end_time": {
+            "name": "Краен час"
+          },
+          "rate": {
+            "name": "Тарифа"
+          },
+          "formatted_rate": {
+            "name": "Форматирана тарифа"
+          },
+          "tier_id": {
+            "name": "ID на стъпало"
+          },
+          "start_value": {
+            "name": "Начална стойност"
+          },
+          "end_value": {
+            "name": "Крайна стойност"
+          },
+          "unbounded": {
+            "name": "Без горна граница"
+          },
+          "last_refresh_utc": {
+            "name": "Posledno opresnyavane (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Локатор на тарифата"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Tarifa za iznos {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura na tarifata"
+          },
+          "variation_type": {
+            "name": "Tip variacia"
+          },
+          "source": {
+            "name": "Iztochnik"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Plan za iznos"
+          },
+          "season_id": {
+            "name": "ID на сезон"
+          },
+          "start_month": {
+            "name": "Начален месец"
+          },
+          "end_month": {
+            "name": "Краен месец"
+          },
+          "day_group_id": {
+            "name": "ID на група дни"
+          },
+          "days": {
+            "name": "Дни"
+          },
+          "period_id": {
+            "name": "ID на период"
+          },
+          "period_type": {
+            "name": "Тип период"
+          },
+          "start_time": {
+            "name": "Начален час"
+          },
+          "end_time": {
+            "name": "Краен час"
+          },
+          "rate": {
+            "name": "Тарифа"
+          },
+          "formatted_rate": {
+            "name": "Форматирана тарифа"
+          },
+          "tier_id": {
+            "name": "ID на стъпало"
+          },
+          "start_value": {
+            "name": "Начална стойност"
+          },
+          "end_value": {
+            "name": "Крайна стойност"
+          },
+          "unbounded": {
+            "name": "Без горна граница"
+          },
+          "last_refresh_utc": {
+            "name": "Posledno opresnyavane (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Локатор на тарифата"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "ID на сайта",
           "description": "Незадължителен идентификатор на сайта; открива се автоматично, когато е избрано устройство на сайта."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Задаване на тарифна ставка",
+      "description": "Актуализира една съществуваща стойност на тарифна ставка за импорт или експорт на Enphase.",
+      "fields": {
+        "rate": {
+          "name": "Ставка",
+          "description": "Нова неотрицателна стойност на тарифната ставка."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Aktualizace plánu je v konfliktu se stávajícím plánem baterie: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tarifní sazba musí být nezáporné číslo."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Cílová tarifní sazba nebyla v nejnovějších tarifních datech nalezena."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Cílová tarifní sazba je neplatná."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "API pro zápis tarifů není dostupné."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Vyberte právě jednu entitu tarifní sazby."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entita není tarifní sazba Enphase: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Posledni aktualizace (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Lokátor tarifu"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Posledni aktualizace (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Lokátor tarifu"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Shrnutí plánu baterie"
+      },
+      "tariff_current_import_rate": {
+        "name": "Aktuální importní sazba",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura tarifu"
+          },
+          "variation_type": {
+            "name": "Typ varianty"
+          },
+          "source": {
+            "name": "Zdroj"
+          },
+          "currency": {
+            "name": "Mena"
+          },
+          "season_id": {
+            "name": "ID sezóny"
+          },
+          "start_month": {
+            "name": "Počáteční měsíc"
+          },
+          "end_month": {
+            "name": "Koncový měsíc"
+          },
+          "day_group_id": {
+            "name": "ID skupiny dnů"
+          },
+          "days": {
+            "name": "Dny"
+          },
+          "period_id": {
+            "name": "ID období"
+          },
+          "period_type": {
+            "name": "Typ období"
+          },
+          "start_time": {
+            "name": "Čas začátku"
+          },
+          "end_time": {
+            "name": "Čas konce"
+          },
+          "rate": {
+            "name": "Sazba"
+          },
+          "formatted_rate": {
+            "name": "Formátovaná sazba"
+          },
+          "tier_id": {
+            "name": "ID pásma"
+          },
+          "start_value": {
+            "name": "Počáteční hodnota"
+          },
+          "end_value": {
+            "name": "Koncová hodnota"
+          },
+          "unbounded": {
+            "name": "Bez horní hranice"
+          },
+          "last_refresh_utc": {
+            "name": "Posledni aktualizace (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Lokátor tarifu"
+          },
+          "active_rate_name": {
+            "name": "Název aktivní sazby"
+          },
+          "configured_rates": {
+            "name": "Nakonfigurované sazby"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Aktuální exportní sazba",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura tarifu"
+          },
+          "variation_type": {
+            "name": "Typ varianty"
+          },
+          "source": {
+            "name": "Zdroj"
+          },
+          "currency": {
+            "name": "Mena"
+          },
+          "export_plan": {
+            "name": "Exportni plan"
+          },
+          "season_id": {
+            "name": "ID sezóny"
+          },
+          "start_month": {
+            "name": "Počáteční měsíc"
+          },
+          "end_month": {
+            "name": "Koncový měsíc"
+          },
+          "day_group_id": {
+            "name": "ID skupiny dnů"
+          },
+          "days": {
+            "name": "Dny"
+          },
+          "period_id": {
+            "name": "ID období"
+          },
+          "period_type": {
+            "name": "Typ období"
+          },
+          "start_time": {
+            "name": "Čas začátku"
+          },
+          "end_time": {
+            "name": "Čas konce"
+          },
+          "rate": {
+            "name": "Sazba"
+          },
+          "formatted_rate": {
+            "name": "Formátovaná sazba"
+          },
+          "tier_id": {
+            "name": "ID pásma"
+          },
+          "start_value": {
+            "name": "Počáteční hodnota"
+          },
+          "end_value": {
+            "name": "Koncová hodnota"
+          },
+          "unbounded": {
+            "name": "Bez horní hranice"
+          },
+          "last_refresh_utc": {
+            "name": "Posledni aktualizace (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Lokátor tarifu"
+          },
+          "active_rate_name": {
+            "name": "Název aktivní sazby"
+          },
+          "configured_rates": {
+            "name": "Nakonfigurované sazby"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Limit baterie"
+      },
+      "tariff_import_rate_value": {
+        "name": "Importni tarif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura tarifu"
+          },
+          "variation_type": {
+            "name": "Typ varianty"
+          },
+          "source": {
+            "name": "Zdroj"
+          },
+          "currency": {
+            "name": "Mena"
+          },
+          "season_id": {
+            "name": "ID sezóny"
+          },
+          "start_month": {
+            "name": "Počáteční měsíc"
+          },
+          "end_month": {
+            "name": "Koncový měsíc"
+          },
+          "day_group_id": {
+            "name": "ID skupiny dnů"
+          },
+          "days": {
+            "name": "Dny"
+          },
+          "period_id": {
+            "name": "ID období"
+          },
+          "period_type": {
+            "name": "Typ období"
+          },
+          "start_time": {
+            "name": "Čas začátku"
+          },
+          "end_time": {
+            "name": "Čas konce"
+          },
+          "rate": {
+            "name": "Sazba"
+          },
+          "formatted_rate": {
+            "name": "Formátovaná sazba"
+          },
+          "tier_id": {
+            "name": "ID pásma"
+          },
+          "start_value": {
+            "name": "Počáteční hodnota"
+          },
+          "end_value": {
+            "name": "Koncová hodnota"
+          },
+          "unbounded": {
+            "name": "Bez horní hranice"
+          },
+          "last_refresh_utc": {
+            "name": "Posledni aktualizace (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Lokátor tarifu"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Exportni tarif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura tarifu"
+          },
+          "variation_type": {
+            "name": "Typ varianty"
+          },
+          "source": {
+            "name": "Zdroj"
+          },
+          "currency": {
+            "name": "Mena"
+          },
+          "export_plan": {
+            "name": "Exportni plan"
+          },
+          "season_id": {
+            "name": "ID sezóny"
+          },
+          "start_month": {
+            "name": "Počáteční měsíc"
+          },
+          "end_month": {
+            "name": "Koncový měsíc"
+          },
+          "day_group_id": {
+            "name": "ID skupiny dnů"
+          },
+          "days": {
+            "name": "Dny"
+          },
+          "period_id": {
+            "name": "ID období"
+          },
+          "period_type": {
+            "name": "Typ období"
+          },
+          "start_time": {
+            "name": "Čas začátku"
+          },
+          "end_time": {
+            "name": "Čas konce"
+          },
+          "rate": {
+            "name": "Sazba"
+          },
+          "formatted_rate": {
+            "name": "Formátovaná sazba"
+          },
+          "tier_id": {
+            "name": "ID pásma"
+          },
+          "start_value": {
+            "name": "Počáteční hodnota"
+          },
+          "end_value": {
+            "name": "Koncová hodnota"
+          },
+          "unbounded": {
+            "name": "Bez horní hranice"
+          },
+          "last_refresh_utc": {
+            "name": "Posledni aktualizace (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Lokátor tarifu"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "ID lokality",
           "description": "Volitelný identifikátor lokality; zjistí se automaticky, když je vybráno zařízení lokality."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Nastavit tarifní sazbu",
+      "description": "Aktualizuje jednu existující hodnotu importní nebo exportní tarifní sazby Enphase.",
+      "fields": {
+        "rate": {
+          "name": "Sazba",
+          "description": "Nová nezáporná hodnota tarifní sazby."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Planlæg opdatering er i konflikt med en eksisterende batteritidsplan: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tarifprisen skal være et ikke-negativt tal."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Den valgte tarifpris blev ikke fundet i de seneste tarifdata."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Den valgte tarifpris er ugyldig."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "API til tarifskrivning er ikke tilgængelig."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Vælg præcis én tarifpris-enhed."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Enheden er ikke en Enphase-tarifpris: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Seneste opdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariflokator"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Seneste opdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariflokator"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Oversigt over batteritidsplan"
+      },
+      "tariff_current_import_rate": {
+        "name": "Aktuel importtarif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Sæson-ID"
+          },
+          "start_month": {
+            "name": "Startmåned"
+          },
+          "end_month": {
+            "name": "Slutmåned"
+          },
+          "day_group_id": {
+            "name": "Dagsgruppe-ID"
+          },
+          "days": {
+            "name": "Dage"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Takst"
+          },
+          "formatted_rate": {
+            "name": "Formateret takst"
+          },
+          "tier_id": {
+            "name": "Trin-ID"
+          },
+          "start_value": {
+            "name": "Startværdi"
+          },
+          "end_value": {
+            "name": "Slutværdi"
+          },
+          "unbounded": {
+            "name": "Uden øvre grænse"
+          },
+          "last_refresh_utc": {
+            "name": "Seneste opdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariflokator"
+          },
+          "active_rate_name": {
+            "name": "Aktivt tarifnavn"
+          },
+          "configured_rates": {
+            "name": "Konfigurerede tariffer"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Aktuel eksporttarif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Eksportplan"
+          },
+          "season_id": {
+            "name": "Sæson-ID"
+          },
+          "start_month": {
+            "name": "Startmåned"
+          },
+          "end_month": {
+            "name": "Slutmåned"
+          },
+          "day_group_id": {
+            "name": "Dagsgruppe-ID"
+          },
+          "days": {
+            "name": "Dage"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Takst"
+          },
+          "formatted_rate": {
+            "name": "Formateret takst"
+          },
+          "tier_id": {
+            "name": "Trin-ID"
+          },
+          "start_value": {
+            "name": "Startværdi"
+          },
+          "end_value": {
+            "name": "Slutværdi"
+          },
+          "unbounded": {
+            "name": "Uden øvre grænse"
+          },
+          "last_refresh_utc": {
+            "name": "Seneste opdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariflokator"
+          },
+          "active_rate_name": {
+            "name": "Aktivt tarifnavn"
+          },
+          "configured_rates": {
+            "name": "Konfigurerede tariffer"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Batteritidsplangrænse"
+      },
+      "tariff_import_rate_value": {
+        "name": "Importtarif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Sæson-ID"
+          },
+          "start_month": {
+            "name": "Startmåned"
+          },
+          "end_month": {
+            "name": "Slutmåned"
+          },
+          "day_group_id": {
+            "name": "Dagsgruppe-ID"
+          },
+          "days": {
+            "name": "Dage"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Takst"
+          },
+          "formatted_rate": {
+            "name": "Formateret takst"
+          },
+          "tier_id": {
+            "name": "Trin-ID"
+          },
+          "start_value": {
+            "name": "Startværdi"
+          },
+          "end_value": {
+            "name": "Slutværdi"
+          },
+          "unbounded": {
+            "name": "Uden øvre grænse"
+          },
+          "last_refresh_utc": {
+            "name": "Seneste opdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariflokator"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Eksporttarif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Eksportplan"
+          },
+          "season_id": {
+            "name": "Sæson-ID"
+          },
+          "start_month": {
+            "name": "Startmåned"
+          },
+          "end_month": {
+            "name": "Slutmåned"
+          },
+          "day_group_id": {
+            "name": "Dagsgruppe-ID"
+          },
+          "days": {
+            "name": "Dage"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Takst"
+          },
+          "formatted_rate": {
+            "name": "Formateret takst"
+          },
+          "tier_id": {
+            "name": "Trin-ID"
+          },
+          "start_value": {
+            "name": "Startværdi"
+          },
+          "end_value": {
+            "name": "Slutværdi"
+          },
+          "unbounded": {
+            "name": "Uden øvre grænse"
+          },
+          "last_refresh_utc": {
+            "name": "Seneste opdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariflokator"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Site-id",
           "description": "Valgfrit site-id; registreres automatisk, når en site-enhed vælges."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Indstil tarifpris",
+      "description": "Opdaterer én eksisterende Enphase import- eller eksporttarifpris.",
+      "fields": {
+        "rate": {
+          "name": "Pris",
+          "description": "Ny ikke-negativ tarifpris."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Konflikte bei der Aktualisierung des Zeitplans mit einem vorhandenen Batterieplan: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Der Tarifsatz muss eine nicht negative Zahl sein."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Das Ziel für den Tarifsatz wurde in den neuesten Tarifdaten nicht gefunden."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Das Ziel für den Tarifsatz ist ungültig."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Die API zum Schreiben von Tarifen ist nicht verfügbar."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Wähle genau eine Tarifsatz-Entität aus."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Die Entität ist kein Enphase-Tarifsatz: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Letzte Aktualisierung (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarif-Locator"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Letzte Aktualisierung (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarif-Locator"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Zusammenfassung des Batterieplans"
+      },
+      "tariff_current_import_rate": {
+        "name": "Aktueller Importtarif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Quelle"
+          },
+          "currency": {
+            "name": "Waehrung"
+          },
+          "season_id": {
+            "name": "Saison-ID"
+          },
+          "start_month": {
+            "name": "Startmonat"
+          },
+          "end_month": {
+            "name": "Endmonat"
+          },
+          "day_group_id": {
+            "name": "Tagesgruppen-ID"
+          },
+          "days": {
+            "name": "Tage"
+          },
+          "period_id": {
+            "name": "Perioden-ID"
+          },
+          "period_type": {
+            "name": "Periodentyp"
+          },
+          "start_time": {
+            "name": "Startzeit"
+          },
+          "end_time": {
+            "name": "Endzeit"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Formatierter Tarif"
+          },
+          "tier_id": {
+            "name": "Stufen-ID"
+          },
+          "start_value": {
+            "name": "Startwert"
+          },
+          "end_value": {
+            "name": "Endwert"
+          },
+          "unbounded": {
+            "name": "Unbegrenzt"
+          },
+          "last_refresh_utc": {
+            "name": "Letzte Aktualisierung (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarif-Locator"
+          },
+          "active_rate_name": {
+            "name": "Name des aktiven Tarifs"
+          },
+          "configured_rates": {
+            "name": "Konfigurierte Tarife"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Aktueller Exporttarif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Quelle"
+          },
+          "currency": {
+            "name": "Waehrung"
+          },
+          "export_plan": {
+            "name": "Exportplan"
+          },
+          "season_id": {
+            "name": "Saison-ID"
+          },
+          "start_month": {
+            "name": "Startmonat"
+          },
+          "end_month": {
+            "name": "Endmonat"
+          },
+          "day_group_id": {
+            "name": "Tagesgruppen-ID"
+          },
+          "days": {
+            "name": "Tage"
+          },
+          "period_id": {
+            "name": "Perioden-ID"
+          },
+          "period_type": {
+            "name": "Periodentyp"
+          },
+          "start_time": {
+            "name": "Startzeit"
+          },
+          "end_time": {
+            "name": "Endzeit"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Formatierter Tarif"
+          },
+          "tier_id": {
+            "name": "Stufen-ID"
+          },
+          "start_value": {
+            "name": "Startwert"
+          },
+          "end_value": {
+            "name": "Endwert"
+          },
+          "unbounded": {
+            "name": "Unbegrenzt"
+          },
+          "last_refresh_utc": {
+            "name": "Letzte Aktualisierung (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarif-Locator"
+          },
+          "active_rate_name": {
+            "name": "Name des aktiven Tarifs"
+          },
+          "configured_rates": {
+            "name": "Konfigurierte Tarife"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Batteriezeitplanbegrenzung"
+      },
+      "tariff_import_rate_value": {
+        "name": "Importtarif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Quelle"
+          },
+          "currency": {
+            "name": "Waehrung"
+          },
+          "season_id": {
+            "name": "Saison-ID"
+          },
+          "start_month": {
+            "name": "Startmonat"
+          },
+          "end_month": {
+            "name": "Endmonat"
+          },
+          "day_group_id": {
+            "name": "Tagesgruppen-ID"
+          },
+          "days": {
+            "name": "Tage"
+          },
+          "period_id": {
+            "name": "Perioden-ID"
+          },
+          "period_type": {
+            "name": "Periodentyp"
+          },
+          "start_time": {
+            "name": "Startzeit"
+          },
+          "end_time": {
+            "name": "Endzeit"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Formatierter Tarif"
+          },
+          "tier_id": {
+            "name": "Stufen-ID"
+          },
+          "start_value": {
+            "name": "Startwert"
+          },
+          "end_value": {
+            "name": "Endwert"
+          },
+          "unbounded": {
+            "name": "Unbegrenzt"
+          },
+          "last_refresh_utc": {
+            "name": "Letzte Aktualisierung (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarif-Locator"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Exporttarif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Quelle"
+          },
+          "currency": {
+            "name": "Waehrung"
+          },
+          "export_plan": {
+            "name": "Exportplan"
+          },
+          "season_id": {
+            "name": "Saison-ID"
+          },
+          "start_month": {
+            "name": "Startmonat"
+          },
+          "end_month": {
+            "name": "Endmonat"
+          },
+          "day_group_id": {
+            "name": "Tagesgruppen-ID"
+          },
+          "days": {
+            "name": "Tage"
+          },
+          "period_id": {
+            "name": "Perioden-ID"
+          },
+          "period_type": {
+            "name": "Periodentyp"
+          },
+          "start_time": {
+            "name": "Startzeit"
+          },
+          "end_time": {
+            "name": "Endzeit"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Formatierter Tarif"
+          },
+          "tier_id": {
+            "name": "Stufen-ID"
+          },
+          "start_value": {
+            "name": "Startwert"
+          },
+          "end_value": {
+            "name": "Endwert"
+          },
+          "unbounded": {
+            "name": "Unbegrenzt"
+          },
+          "last_refresh_utc": {
+            "name": "Letzte Aktualisierung (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarif-Locator"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Standort-ID",
           "description": "Optionale Standortkennung; wird automatisch erkannt, wenn ein Standortgerät ausgewählt ist."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Tarifsatz festlegen",
+      "description": "Aktualisiert einen vorhandenen Enphase Import- oder Exporttarifsatz.",
+      "fields": {
+        "rate": {
+          "name": "Satz",
+          "description": "Neuer nicht negativer Tarifsatz."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Η ενημέρωση του χρονοδιαγράμματος έρχεται σε διένεξη με ένα υπάρχον πρόγραμμα μπαταρίας: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Η τιμή τιμολογίου πρέπει να είναι μη αρνητικός αριθμός."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Ο στόχος της τιμής τιμολογίου δεν βρέθηκε στα πιο πρόσφατα δεδομένα."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Ο στόχος της τιμής τιμολογίου δεν είναι έγκυρος."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Το API εγγραφής τιμολογίου δεν είναι διαθέσιμο."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Επιλέξτε ακριβώς μία οντότητα τιμής τιμολογίου."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Η οντότητα δεν είναι τιμή τιμολογίου Enphase: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Teleutaia ananeosi (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Εντοπιστής τιμολογίου"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Teleutaia ananeosi (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Εντοπιστής τιμολογίου"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Περίληψη χρονοδιαγράμματος μπαταρίας"
+      },
+      "tariff_current_import_rate": {
+        "name": "Τρέχουσα χρέωση εισαγωγής",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Domi timologiou"
+          },
+          "variation_type": {
+            "name": "Typos metavolis"
+          },
+          "source": {
+            "name": "Pigi"
+          },
+          "currency": {
+            "name": "Nomisma"
+          },
+          "season_id": {
+            "name": "Αναγνωριστικό εποχής"
+          },
+          "start_month": {
+            "name": "Μήνας έναρξης"
+          },
+          "end_month": {
+            "name": "Μήνας λήξης"
+          },
+          "day_group_id": {
+            "name": "Αναγνωριστικό ομάδας ημερών"
+          },
+          "days": {
+            "name": "Ημέρες"
+          },
+          "period_id": {
+            "name": "Αναγνωριστικό περιόδου"
+          },
+          "period_type": {
+            "name": "Τύπος περιόδου"
+          },
+          "start_time": {
+            "name": "Ώρα έναρξης"
+          },
+          "end_time": {
+            "name": "Ώρα λήξης"
+          },
+          "rate": {
+            "name": "Τιμή"
+          },
+          "formatted_rate": {
+            "name": "Μορφοποιημένη τιμή"
+          },
+          "tier_id": {
+            "name": "Αναγνωριστικό κλιμακίου"
+          },
+          "start_value": {
+            "name": "Τιμή έναρξης"
+          },
+          "end_value": {
+            "name": "Τιμή λήξης"
+          },
+          "unbounded": {
+            "name": "Χωρίς ανώτατο όριο"
+          },
+          "last_refresh_utc": {
+            "name": "Teleutaia ananeosi (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Εντοπιστής τιμολογίου"
+          },
+          "active_rate_name": {
+            "name": "Όνομα ενεργής χρέωσης"
+          },
+          "configured_rates": {
+            "name": "Διαμορφωμένες χρεώσεις"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Τρέχουσα χρέωση εξαγωγής",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Domi timologiou"
+          },
+          "variation_type": {
+            "name": "Typos metavolis"
+          },
+          "source": {
+            "name": "Pigi"
+          },
+          "currency": {
+            "name": "Nomisma"
+          },
+          "export_plan": {
+            "name": "Schedio eksagogis"
+          },
+          "season_id": {
+            "name": "Αναγνωριστικό εποχής"
+          },
+          "start_month": {
+            "name": "Μήνας έναρξης"
+          },
+          "end_month": {
+            "name": "Μήνας λήξης"
+          },
+          "day_group_id": {
+            "name": "Αναγνωριστικό ομάδας ημερών"
+          },
+          "days": {
+            "name": "Ημέρες"
+          },
+          "period_id": {
+            "name": "Αναγνωριστικό περιόδου"
+          },
+          "period_type": {
+            "name": "Τύπος περιόδου"
+          },
+          "start_time": {
+            "name": "Ώρα έναρξης"
+          },
+          "end_time": {
+            "name": "Ώρα λήξης"
+          },
+          "rate": {
+            "name": "Τιμή"
+          },
+          "formatted_rate": {
+            "name": "Μορφοποιημένη τιμή"
+          },
+          "tier_id": {
+            "name": "Αναγνωριστικό κλιμακίου"
+          },
+          "start_value": {
+            "name": "Τιμή έναρξης"
+          },
+          "end_value": {
+            "name": "Τιμή λήξης"
+          },
+          "unbounded": {
+            "name": "Χωρίς ανώτατο όριο"
+          },
+          "last_refresh_utc": {
+            "name": "Teleutaia ananeosi (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Εντοπιστής τιμολογίου"
+          },
+          "active_rate_name": {
+            "name": "Όνομα ενεργής χρέωσης"
+          },
+          "configured_rates": {
+            "name": "Διαμορφωμένες χρεώσεις"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Όριο χρονοδιαγράμματος μπαταρίας"
+      },
+      "tariff_import_rate_value": {
+        "name": "Timologio eisagogis {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Domi timologiou"
+          },
+          "variation_type": {
+            "name": "Typos metavolis"
+          },
+          "source": {
+            "name": "Pigi"
+          },
+          "currency": {
+            "name": "Nomisma"
+          },
+          "season_id": {
+            "name": "Αναγνωριστικό εποχής"
+          },
+          "start_month": {
+            "name": "Μήνας έναρξης"
+          },
+          "end_month": {
+            "name": "Μήνας λήξης"
+          },
+          "day_group_id": {
+            "name": "Αναγνωριστικό ομάδας ημερών"
+          },
+          "days": {
+            "name": "Ημέρες"
+          },
+          "period_id": {
+            "name": "Αναγνωριστικό περιόδου"
+          },
+          "period_type": {
+            "name": "Τύπος περιόδου"
+          },
+          "start_time": {
+            "name": "Ώρα έναρξης"
+          },
+          "end_time": {
+            "name": "Ώρα λήξης"
+          },
+          "rate": {
+            "name": "Τιμή"
+          },
+          "formatted_rate": {
+            "name": "Μορφοποιημένη τιμή"
+          },
+          "tier_id": {
+            "name": "Αναγνωριστικό κλιμακίου"
+          },
+          "start_value": {
+            "name": "Τιμή έναρξης"
+          },
+          "end_value": {
+            "name": "Τιμή λήξης"
+          },
+          "unbounded": {
+            "name": "Χωρίς ανώτατο όριο"
+          },
+          "last_refresh_utc": {
+            "name": "Teleutaia ananeosi (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Εντοπιστής τιμολογίου"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Timologio eksagogis {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Domi timologiou"
+          },
+          "variation_type": {
+            "name": "Typos metavolis"
+          },
+          "source": {
+            "name": "Pigi"
+          },
+          "currency": {
+            "name": "Nomisma"
+          },
+          "export_plan": {
+            "name": "Schedio eksagogis"
+          },
+          "season_id": {
+            "name": "Αναγνωριστικό εποχής"
+          },
+          "start_month": {
+            "name": "Μήνας έναρξης"
+          },
+          "end_month": {
+            "name": "Μήνας λήξης"
+          },
+          "day_group_id": {
+            "name": "Αναγνωριστικό ομάδας ημερών"
+          },
+          "days": {
+            "name": "Ημέρες"
+          },
+          "period_id": {
+            "name": "Αναγνωριστικό περιόδου"
+          },
+          "period_type": {
+            "name": "Τύπος περιόδου"
+          },
+          "start_time": {
+            "name": "Ώρα έναρξης"
+          },
+          "end_time": {
+            "name": "Ώρα λήξης"
+          },
+          "rate": {
+            "name": "Τιμή"
+          },
+          "formatted_rate": {
+            "name": "Μορφοποιημένη τιμή"
+          },
+          "tier_id": {
+            "name": "Αναγνωριστικό κλιμακίου"
+          },
+          "start_value": {
+            "name": "Τιμή έναρξης"
+          },
+          "end_value": {
+            "name": "Τιμή λήξης"
+          },
+          "unbounded": {
+            "name": "Χωρίς ανώτατο όριο"
+          },
+          "last_refresh_utc": {
+            "name": "Teleutaia ananeosi (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Εντοπιστής τιμολογίου"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "ID εγκατάστασης",
           "description": "Προαιρετικό αναγνωριστικό εγκατάστασης· εντοπίζεται αυτόματα όταν επιλεγεί συσκευή εγκατάστασης."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Ορισμός τιμής τιμολογίου",
+      "description": "Ενημερώνει μία υπάρχουσα τιμή εισαγωγής ή εξαγωγής Enphase.",
+      "fields": {
+        "rate": {
+          "name": "Τιμή",
+          "description": "Νέα μη αρνητική τιμή τιμολογίου."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Schedule update conflicts with an existing battery schedule: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tariff rate must be a non-negative number."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Tariff rate target was not found in the latest tariff payload."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Tariff rate target is invalid."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Tariff write API is unavailable."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Select exactly one tariff rate entity."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entity is not an Enphase tariff rate entity: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_rbd_schedules": {
         "name": "Battery RBD Schedules"
+      },
+      "tariff_current_import_rate": {
+        "name": "Current Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Current Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_new_schedule_limit": {
         "name": "Battery New Schedule Limit"
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Site ID",
           "description": "Optional site identifier; detected automatically when a site device is selected."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Set Tariff Rate",
+      "description": "Update one existing Enphase import or export tariff rate value.",
+      "fields": {
+        "rate": {
+          "name": "Rate",
+          "description": "New non-negative tariff rate value."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Schedule update conflicts with an existing battery schedule: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tariff rate must be a non-negative number."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Tariff rate target was not found in the latest tariff payload."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Tariff rate target is invalid."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Tariff write API is unavailable."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Select exactly one tariff rate entity."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entity is not an Enphase tariff rate entity: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_rbd_schedules": {
         "name": "Battery RBD Schedules"
+      },
+      "tariff_current_import_rate": {
+        "name": "Current Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Current Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_new_schedule_limit": {
         "name": "Battery New Schedule Limit"
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Site ID",
           "description": "Optional site identifier; detected automatically when a site device is selected."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Set Tariff Rate",
+      "description": "Update one existing Enphase import or export tariff rate value.",
+      "fields": {
+        "rate": {
+          "name": "Rate",
+          "description": "New non-negative tariff rate value."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Schedule update conflicts with an existing battery schedule: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tariff rate must be a non-negative number."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Tariff rate target was not found in the latest tariff payload."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Tariff rate target is invalid."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Tariff write API is unavailable."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Select exactly one tariff rate entity."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entity is not an Enphase tariff rate entity: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_rbd_schedules": {
         "name": "Battery RBD Schedules"
+      },
+      "tariff_current_import_rate": {
+        "name": "Current Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Current Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_new_schedule_limit": {
         "name": "Battery New Schedule Limit"
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Site ID",
           "description": "Optional site identifier; detected automatically when a site device is selected."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Set Tariff Rate",
+      "description": "Update one existing Enphase import or export tariff rate value.",
+      "fields": {
+        "rate": {
+          "name": "Rate",
+          "description": "New non-negative tariff rate value."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Schedule update conflicts with an existing battery schedule: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tariff rate must be a non-negative number."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Tariff rate target was not found in the latest tariff payload."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Tariff rate target is invalid."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Tariff write API is unavailable."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Select exactly one tariff rate entity."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entity is not an Enphase tariff rate entity: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_rbd_schedules": {
         "name": "Battery RBD Schedules"
+      },
+      "tariff_current_import_rate": {
+        "name": "Current Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Current Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_new_schedule_limit": {
         "name": "Battery New Schedule Limit"
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Site ID",
           "description": "Optional site identifier; detected automatically when a site device is selected."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Set Tariff Rate",
+      "description": "Update one existing Enphase import or export tariff rate value.",
+      "fields": {
+        "rate": {
+          "name": "Rate",
+          "description": "New non-negative tariff rate value."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Schedule update conflicts with an existing battery schedule: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tariff rate must be a non-negative number."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Tariff rate target was not found in the latest tariff payload."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Tariff rate target is invalid."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Tariff write API is unavailable."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Select exactly one tariff rate entity."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entity is not an Enphase tariff rate entity: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_rbd_schedules": {
         "name": "Battery RBD Schedules"
+      },
+      "tariff_current_import_rate": {
+        "name": "Current Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Current Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_new_schedule_limit": {
         "name": "Battery New Schedule Limit"
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Site ID",
           "description": "Optional site identifier; detected automatically when a site device is selected."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Set Tariff Rate",
+      "description": "Update one existing Enphase import or export tariff rate value.",
+      "fields": {
+        "rate": {
+          "name": "Rate",
+          "description": "New non-negative tariff rate value."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -393,6 +393,24 @@
     },
     "battery_schedule_validation_rejected_detail": {
       "message": "Schedule rejected by the Enphase validation endpoint: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tariff rate must be a non-negative number."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Tariff rate target was not found in the latest tariff payload."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Tariff rate target is invalid."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Tariff write API is unavailable."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Select exactly one tariff rate entity."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entity is not an Enphase tariff rate entity: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_rbd_schedules": {
         "name": "Battery RBD Schedules"
+      },
+      "tariff_current_import_rate": {
+        "name": "Current Import Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Current Export Rate",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          },
+          "active_rate_name": {
+            "name": "Active Rate Name"
+          },
+          "configured_rates": {
+            "name": "Configured Rates"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_new_schedule_limit": {
         "name": "Battery New Schedule Limit"
+      },
+      "tariff_import_rate_value": {
+        "name": "Import Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export Rate {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Rate Structure"
+          },
+          "variation_type": {
+            "name": "Variation Type"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Currency"
+          },
+          "export_plan": {
+            "name": "Export Plan"
+          },
+          "season_id": {
+            "name": "Season ID"
+          },
+          "start_month": {
+            "name": "Start Month"
+          },
+          "end_month": {
+            "name": "End Month"
+          },
+          "day_group_id": {
+            "name": "Day Group"
+          },
+          "days": {
+            "name": "Days"
+          },
+          "period_id": {
+            "name": "Period ID"
+          },
+          "period_type": {
+            "name": "Period Type"
+          },
+          "start_time": {
+            "name": "Start Time"
+          },
+          "end_time": {
+            "name": "End Time"
+          },
+          "rate": {
+            "name": "Rate"
+          },
+          "formatted_rate": {
+            "name": "Formatted Rate"
+          },
+          "tier_id": {
+            "name": "Tier ID"
+          },
+          "start_value": {
+            "name": "Start Value"
+          },
+          "end_value": {
+            "name": "End Value"
+          },
+          "unbounded": {
+            "name": "Unbounded"
+          },
+          "last_refresh_utc": {
+            "name": "Last Refresh (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariff Locator"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Site ID",
           "description": "Optional site identifier; detected automatically when a site device is selected."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Set Tariff Rate",
+      "description": "Update one existing Enphase import or export tariff rate value.",
+      "fields": {
+        "rate": {
+          "name": "Rate",
+          "description": "New non-negative tariff rate value."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "La actualización del horario entra en conflicto con un horario de batería existente: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "La tarifa debe ser un número no negativo."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "El destino de la tarifa no se encontró en los datos de tarifa más recientes."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "El destino de la tarifa no es válido."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "La API de escritura de tarifas no está disponible."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Selecciona exactamente una entidad de tarifa."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "La entidad no es una tarifa de Enphase: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Ultima actualizacion (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizador de tarifa"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Ultima actualizacion (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizador de tarifa"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Resumen de horarios de la batería"
+      },
+      "tariff_current_import_rate": {
+        "name": "Tarifa actual de importación",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estructura de tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacion"
+          },
+          "source": {
+            "name": "Fuente"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "season_id": {
+            "name": "ID de temporada"
+          },
+          "start_month": {
+            "name": "Mes inicial"
+          },
+          "end_month": {
+            "name": "Mes final"
+          },
+          "day_group_id": {
+            "name": "ID del grupo de días"
+          },
+          "days": {
+            "name": "Días"
+          },
+          "period_id": {
+            "name": "ID del período"
+          },
+          "period_type": {
+            "name": "Tipo de período"
+          },
+          "start_time": {
+            "name": "Hora de inicio"
+          },
+          "end_time": {
+            "name": "Hora de finalización"
+          },
+          "rate": {
+            "name": "Tarifa"
+          },
+          "formatted_rate": {
+            "name": "Tarifa formateada"
+          },
+          "tier_id": {
+            "name": "ID del tramo"
+          },
+          "start_value": {
+            "name": "Valor inicial"
+          },
+          "end_value": {
+            "name": "Valor final"
+          },
+          "unbounded": {
+            "name": "Sin límite superior"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizacion (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizador de tarifa"
+          },
+          "active_rate_name": {
+            "name": "Nombre de tarifa activa"
+          },
+          "configured_rates": {
+            "name": "Tarifas configuradas"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Tarifa actual de exportación",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estructura de tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacion"
+          },
+          "source": {
+            "name": "Fuente"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "export_plan": {
+            "name": "Plan de exportacion"
+          },
+          "season_id": {
+            "name": "ID de temporada"
+          },
+          "start_month": {
+            "name": "Mes inicial"
+          },
+          "end_month": {
+            "name": "Mes final"
+          },
+          "day_group_id": {
+            "name": "ID del grupo de días"
+          },
+          "days": {
+            "name": "Días"
+          },
+          "period_id": {
+            "name": "ID del período"
+          },
+          "period_type": {
+            "name": "Tipo de período"
+          },
+          "start_time": {
+            "name": "Hora de inicio"
+          },
+          "end_time": {
+            "name": "Hora de finalización"
+          },
+          "rate": {
+            "name": "Tarifa"
+          },
+          "formatted_rate": {
+            "name": "Tarifa formateada"
+          },
+          "tier_id": {
+            "name": "ID del tramo"
+          },
+          "start_value": {
+            "name": "Valor inicial"
+          },
+          "end_value": {
+            "name": "Valor final"
+          },
+          "unbounded": {
+            "name": "Sin límite superior"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizacion (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizador de tarifa"
+          },
+          "active_rate_name": {
+            "name": "Nombre de tarifa activa"
+          },
+          "configured_rates": {
+            "name": "Tarifas configuradas"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Límite de horario de la batería"
+      },
+      "tariff_import_rate_value": {
+        "name": "Tarifa de importacion {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estructura de tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacion"
+          },
+          "source": {
+            "name": "Fuente"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "season_id": {
+            "name": "ID de temporada"
+          },
+          "start_month": {
+            "name": "Mes inicial"
+          },
+          "end_month": {
+            "name": "Mes final"
+          },
+          "day_group_id": {
+            "name": "ID del grupo de días"
+          },
+          "days": {
+            "name": "Días"
+          },
+          "period_id": {
+            "name": "ID del período"
+          },
+          "period_type": {
+            "name": "Tipo de período"
+          },
+          "start_time": {
+            "name": "Hora de inicio"
+          },
+          "end_time": {
+            "name": "Hora de finalización"
+          },
+          "rate": {
+            "name": "Tarifa"
+          },
+          "formatted_rate": {
+            "name": "Tarifa formateada"
+          },
+          "tier_id": {
+            "name": "ID del tramo"
+          },
+          "start_value": {
+            "name": "Valor inicial"
+          },
+          "end_value": {
+            "name": "Valor final"
+          },
+          "unbounded": {
+            "name": "Sin límite superior"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizacion (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizador de tarifa"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Tarifa de exportacion {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estructura de tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacion"
+          },
+          "source": {
+            "name": "Fuente"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "export_plan": {
+            "name": "Plan de exportacion"
+          },
+          "season_id": {
+            "name": "ID de temporada"
+          },
+          "start_month": {
+            "name": "Mes inicial"
+          },
+          "end_month": {
+            "name": "Mes final"
+          },
+          "day_group_id": {
+            "name": "ID del grupo de días"
+          },
+          "days": {
+            "name": "Días"
+          },
+          "period_id": {
+            "name": "ID del período"
+          },
+          "period_type": {
+            "name": "Tipo de período"
+          },
+          "start_time": {
+            "name": "Hora de inicio"
+          },
+          "end_time": {
+            "name": "Hora de finalización"
+          },
+          "rate": {
+            "name": "Tarifa"
+          },
+          "formatted_rate": {
+            "name": "Tarifa formateada"
+          },
+          "tier_id": {
+            "name": "ID del tramo"
+          },
+          "start_value": {
+            "name": "Valor inicial"
+          },
+          "end_value": {
+            "name": "Valor final"
+          },
+          "unbounded": {
+            "name": "Sin límite superior"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizacion (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizador de tarifa"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "ID del sitio",
           "description": "Identificador opcional del sitio; se detecta automáticamente al seleccionar un dispositivo del sitio."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Establecer tarifa",
+      "description": "Actualiza un valor existente de tarifa de importación o exportación de Enphase.",
+      "fields": {
+        "rate": {
+          "name": "Tarifa",
+          "description": "Nuevo valor de tarifa no negativo."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Ajakava uuendus on vastuolus olemasoleva aku ajakavaga: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tariifimäär peab olema mittenegatiivne arv."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Tariifimäära sihtkohta ei leitud viimastest tariifiandmetest."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Tariifimäära sihtkoht on vigane."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Tariifide kirjutamise API pole saadaval."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Vali täpselt üks tariifimäära olem."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Olem ei ole Enphase tariifimäär: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Viimane varskendus (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariifi lokaator"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Viimane varskendus (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariifi lokaator"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Aku ajakavade kokkuvõte"
+      },
+      "tariff_current_import_rate": {
+        "name": "Praegune imporditariif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariifi struktuur"
+          },
+          "variation_type": {
+            "name": "Variatsiooni tuup"
+          },
+          "source": {
+            "name": "Allikas"
+          },
+          "currency": {
+            "name": "Valuuta"
+          },
+          "season_id": {
+            "name": "Hooaja ID"
+          },
+          "start_month": {
+            "name": "Alguskuu"
+          },
+          "end_month": {
+            "name": "Lõppkuu"
+          },
+          "day_group_id": {
+            "name": "Päevarühma ID"
+          },
+          "days": {
+            "name": "Päevad"
+          },
+          "period_id": {
+            "name": "Perioodi ID"
+          },
+          "period_type": {
+            "name": "Perioodi tüüp"
+          },
+          "start_time": {
+            "name": "Algusaeg"
+          },
+          "end_time": {
+            "name": "Lõppaeg"
+          },
+          "rate": {
+            "name": "Hind"
+          },
+          "formatted_rate": {
+            "name": "Vormindatud hind"
+          },
+          "tier_id": {
+            "name": "Astme ID"
+          },
+          "start_value": {
+            "name": "Algväärtus"
+          },
+          "end_value": {
+            "name": "Lõppväärtus"
+          },
+          "unbounded": {
+            "name": "Ülemise piirita"
+          },
+          "last_refresh_utc": {
+            "name": "Viimane varskendus (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariifi lokaator"
+          },
+          "active_rate_name": {
+            "name": "Aktiivse tariifi nimi"
+          },
+          "configured_rates": {
+            "name": "Seadistatud tariifid"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Praegune eksporditariif",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariifi struktuur"
+          },
+          "variation_type": {
+            "name": "Variatsiooni tuup"
+          },
+          "source": {
+            "name": "Allikas"
+          },
+          "currency": {
+            "name": "Valuuta"
+          },
+          "export_plan": {
+            "name": "Ekspordiplaan"
+          },
+          "season_id": {
+            "name": "Hooaja ID"
+          },
+          "start_month": {
+            "name": "Alguskuu"
+          },
+          "end_month": {
+            "name": "Lõppkuu"
+          },
+          "day_group_id": {
+            "name": "Päevarühma ID"
+          },
+          "days": {
+            "name": "Päevad"
+          },
+          "period_id": {
+            "name": "Perioodi ID"
+          },
+          "period_type": {
+            "name": "Perioodi tüüp"
+          },
+          "start_time": {
+            "name": "Algusaeg"
+          },
+          "end_time": {
+            "name": "Lõppaeg"
+          },
+          "rate": {
+            "name": "Hind"
+          },
+          "formatted_rate": {
+            "name": "Vormindatud hind"
+          },
+          "tier_id": {
+            "name": "Astme ID"
+          },
+          "start_value": {
+            "name": "Algväärtus"
+          },
+          "end_value": {
+            "name": "Lõppväärtus"
+          },
+          "unbounded": {
+            "name": "Ülemise piirita"
+          },
+          "last_refresh_utc": {
+            "name": "Viimane varskendus (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariifi lokaator"
+          },
+          "active_rate_name": {
+            "name": "Aktiivse tariifi nimi"
+          },
+          "configured_rates": {
+            "name": "Seadistatud tariifid"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Aku ajakava piirang"
+      },
+      "tariff_import_rate_value": {
+        "name": "Imporditariif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariifi struktuur"
+          },
+          "variation_type": {
+            "name": "Variatsiooni tuup"
+          },
+          "source": {
+            "name": "Allikas"
+          },
+          "currency": {
+            "name": "Valuuta"
+          },
+          "season_id": {
+            "name": "Hooaja ID"
+          },
+          "start_month": {
+            "name": "Alguskuu"
+          },
+          "end_month": {
+            "name": "Lõppkuu"
+          },
+          "day_group_id": {
+            "name": "Päevarühma ID"
+          },
+          "days": {
+            "name": "Päevad"
+          },
+          "period_id": {
+            "name": "Perioodi ID"
+          },
+          "period_type": {
+            "name": "Perioodi tüüp"
+          },
+          "start_time": {
+            "name": "Algusaeg"
+          },
+          "end_time": {
+            "name": "Lõppaeg"
+          },
+          "rate": {
+            "name": "Hind"
+          },
+          "formatted_rate": {
+            "name": "Vormindatud hind"
+          },
+          "tier_id": {
+            "name": "Astme ID"
+          },
+          "start_value": {
+            "name": "Algväärtus"
+          },
+          "end_value": {
+            "name": "Lõppväärtus"
+          },
+          "unbounded": {
+            "name": "Ülemise piirita"
+          },
+          "last_refresh_utc": {
+            "name": "Viimane varskendus (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariifi lokaator"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Eksporditariif {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariifi struktuur"
+          },
+          "variation_type": {
+            "name": "Variatsiooni tuup"
+          },
+          "source": {
+            "name": "Allikas"
+          },
+          "currency": {
+            "name": "Valuuta"
+          },
+          "export_plan": {
+            "name": "Ekspordiplaan"
+          },
+          "season_id": {
+            "name": "Hooaja ID"
+          },
+          "start_month": {
+            "name": "Alguskuu"
+          },
+          "end_month": {
+            "name": "Lõppkuu"
+          },
+          "day_group_id": {
+            "name": "Päevarühma ID"
+          },
+          "days": {
+            "name": "Päevad"
+          },
+          "period_id": {
+            "name": "Perioodi ID"
+          },
+          "period_type": {
+            "name": "Perioodi tüüp"
+          },
+          "start_time": {
+            "name": "Algusaeg"
+          },
+          "end_time": {
+            "name": "Lõppaeg"
+          },
+          "rate": {
+            "name": "Hind"
+          },
+          "formatted_rate": {
+            "name": "Vormindatud hind"
+          },
+          "tier_id": {
+            "name": "Astme ID"
+          },
+          "start_value": {
+            "name": "Algväärtus"
+          },
+          "end_value": {
+            "name": "Lõppväärtus"
+          },
+          "unbounded": {
+            "name": "Ülemise piirita"
+          },
+          "last_refresh_utc": {
+            "name": "Viimane varskendus (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariifi lokaator"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Saidi ID",
           "description": "Valikuline saidi identifikaator; tuvastatakse automaatselt, kui saidi seade on valitud."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Määra tariifimäär",
+      "description": "Uuendab ühte olemasolevat Enphase impordi- või eksporditariifi väärtust.",
+      "fields": {
+        "rate": {
+          "name": "Määr",
+          "description": "Uus mittenegatiivne tariifimäär."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Aikataulun päivitys on ristiriidassa olemassa olevan akun aikataulun kanssa: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tariffihinnan on oltava ei-negatiivinen luku."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Tariffihinnan kohdetta ei löytynyt uusimmista tariffitiedoista."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Tariffihinnan kohde on virheellinen."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Tariffien kirjoitusrajapinta ei ole saatavilla."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Valitse täsmälleen yksi tariffihintaentiteetti."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entiteetti ei ole Enphase-tariffihinta: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Viimeisin paivitys (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariffin paikannin"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Viimeisin paivitys (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariffin paikannin"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Akun aikataulujen yhteenveto"
+      },
+      "tariff_current_import_rate": {
+        "name": "Nykyinen tuontihinta",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffirakenne"
+          },
+          "variation_type": {
+            "name": "Vaihtelutyyppi"
+          },
+          "source": {
+            "name": "Laehde"
+          },
+          "currency": {
+            "name": "Valuutta"
+          },
+          "season_id": {
+            "name": "Kauden tunnus"
+          },
+          "start_month": {
+            "name": "Aloituskuukausi"
+          },
+          "end_month": {
+            "name": "Päättymiskuukausi"
+          },
+          "day_group_id": {
+            "name": "Päiväryhmän tunnus"
+          },
+          "days": {
+            "name": "Päivät"
+          },
+          "period_id": {
+            "name": "Jakson tunnus"
+          },
+          "period_type": {
+            "name": "Jakson tyyppi"
+          },
+          "start_time": {
+            "name": "Aloitusaika"
+          },
+          "end_time": {
+            "name": "Päättymisaika"
+          },
+          "rate": {
+            "name": "Hinta"
+          },
+          "formatted_rate": {
+            "name": "Muotoiltu hinta"
+          },
+          "tier_id": {
+            "name": "Portaan tunnus"
+          },
+          "start_value": {
+            "name": "Alkuarvo"
+          },
+          "end_value": {
+            "name": "Loppuarvo"
+          },
+          "unbounded": {
+            "name": "Ilman ylärajaa"
+          },
+          "last_refresh_utc": {
+            "name": "Viimeisin paivitys (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariffin paikannin"
+          },
+          "active_rate_name": {
+            "name": "Aktiivisen hinnan nimi"
+          },
+          "configured_rates": {
+            "name": "Määritetyt hinnat"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Nykyinen vientihinta",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffirakenne"
+          },
+          "variation_type": {
+            "name": "Vaihtelutyyppi"
+          },
+          "source": {
+            "name": "Laehde"
+          },
+          "currency": {
+            "name": "Valuutta"
+          },
+          "export_plan": {
+            "name": "Vientisuunnitelma"
+          },
+          "season_id": {
+            "name": "Kauden tunnus"
+          },
+          "start_month": {
+            "name": "Aloituskuukausi"
+          },
+          "end_month": {
+            "name": "Päättymiskuukausi"
+          },
+          "day_group_id": {
+            "name": "Päiväryhmän tunnus"
+          },
+          "days": {
+            "name": "Päivät"
+          },
+          "period_id": {
+            "name": "Jakson tunnus"
+          },
+          "period_type": {
+            "name": "Jakson tyyppi"
+          },
+          "start_time": {
+            "name": "Aloitusaika"
+          },
+          "end_time": {
+            "name": "Päättymisaika"
+          },
+          "rate": {
+            "name": "Hinta"
+          },
+          "formatted_rate": {
+            "name": "Muotoiltu hinta"
+          },
+          "tier_id": {
+            "name": "Portaan tunnus"
+          },
+          "start_value": {
+            "name": "Alkuarvo"
+          },
+          "end_value": {
+            "name": "Loppuarvo"
+          },
+          "unbounded": {
+            "name": "Ilman ylärajaa"
+          },
+          "last_refresh_utc": {
+            "name": "Viimeisin paivitys (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariffin paikannin"
+          },
+          "active_rate_name": {
+            "name": "Aktiivisen hinnan nimi"
+          },
+          "configured_rates": {
+            "name": "Määritetyt hinnat"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Akun aikataulun raja"
+      },
+      "tariff_import_rate_value": {
+        "name": "Tuontitariffi {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffirakenne"
+          },
+          "variation_type": {
+            "name": "Vaihtelutyyppi"
+          },
+          "source": {
+            "name": "Laehde"
+          },
+          "currency": {
+            "name": "Valuutta"
+          },
+          "season_id": {
+            "name": "Kauden tunnus"
+          },
+          "start_month": {
+            "name": "Aloituskuukausi"
+          },
+          "end_month": {
+            "name": "Päättymiskuukausi"
+          },
+          "day_group_id": {
+            "name": "Päiväryhmän tunnus"
+          },
+          "days": {
+            "name": "Päivät"
+          },
+          "period_id": {
+            "name": "Jakson tunnus"
+          },
+          "period_type": {
+            "name": "Jakson tyyppi"
+          },
+          "start_time": {
+            "name": "Aloitusaika"
+          },
+          "end_time": {
+            "name": "Päättymisaika"
+          },
+          "rate": {
+            "name": "Hinta"
+          },
+          "formatted_rate": {
+            "name": "Muotoiltu hinta"
+          },
+          "tier_id": {
+            "name": "Portaan tunnus"
+          },
+          "start_value": {
+            "name": "Alkuarvo"
+          },
+          "end_value": {
+            "name": "Loppuarvo"
+          },
+          "unbounded": {
+            "name": "Ilman ylärajaa"
+          },
+          "last_refresh_utc": {
+            "name": "Viimeisin paivitys (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariffin paikannin"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Vientitariffi {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffirakenne"
+          },
+          "variation_type": {
+            "name": "Vaihtelutyyppi"
+          },
+          "source": {
+            "name": "Laehde"
+          },
+          "currency": {
+            "name": "Valuutta"
+          },
+          "export_plan": {
+            "name": "Vientisuunnitelma"
+          },
+          "season_id": {
+            "name": "Kauden tunnus"
+          },
+          "start_month": {
+            "name": "Aloituskuukausi"
+          },
+          "end_month": {
+            "name": "Päättymiskuukausi"
+          },
+          "day_group_id": {
+            "name": "Päiväryhmän tunnus"
+          },
+          "days": {
+            "name": "Päivät"
+          },
+          "period_id": {
+            "name": "Jakson tunnus"
+          },
+          "period_type": {
+            "name": "Jakson tyyppi"
+          },
+          "start_time": {
+            "name": "Aloitusaika"
+          },
+          "end_time": {
+            "name": "Päättymisaika"
+          },
+          "rate": {
+            "name": "Hinta"
+          },
+          "formatted_rate": {
+            "name": "Muotoiltu hinta"
+          },
+          "tier_id": {
+            "name": "Portaan tunnus"
+          },
+          "start_value": {
+            "name": "Alkuarvo"
+          },
+          "end_value": {
+            "name": "Loppuarvo"
+          },
+          "unbounded": {
+            "name": "Ilman ylärajaa"
+          },
+          "last_refresh_utc": {
+            "name": "Viimeisin paivitys (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariffin paikannin"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Sivuston ID",
           "description": "Valinnainen sivustotunniste; havaitaan automaattisesti, kun sivuston laite valitaan."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Aseta tariffihinta",
+      "description": "Päivittää yhden olemassa olevan Enphase-tuonti- tai vientitariffin arvon.",
+      "fields": {
+        "rate": {
+          "name": "Hinta",
+          "description": "Uusi ei-negatiivinen tariffihinta."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "La mise à jour du planning est en conflit avec un planning de batterie existant : {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Le tarif doit être un nombre non négatif."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "La cible du tarif est introuvable dans les dernières données tarifaires."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "La cible du tarif est invalide."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "L’API d’écriture des tarifs est indisponible."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Sélectionnez exactement une entité de tarif."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "L’entité n’est pas un tarif Enphase : {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Derniere actualisation (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localisateur de tarif"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Derniere actualisation (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localisateur de tarif"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Résumé des plannings de batterie"
+      },
+      "tariff_current_import_rate": {
+        "name": "Tarif d'importation actuel",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structure tarifaire"
+          },
+          "variation_type": {
+            "name": "Type de variation"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Devise"
+          },
+          "season_id": {
+            "name": "ID de saison"
+          },
+          "start_month": {
+            "name": "Mois de début"
+          },
+          "end_month": {
+            "name": "Mois de fin"
+          },
+          "day_group_id": {
+            "name": "ID du groupe de jours"
+          },
+          "days": {
+            "name": "Jours"
+          },
+          "period_id": {
+            "name": "ID de période"
+          },
+          "period_type": {
+            "name": "Type de période"
+          },
+          "start_time": {
+            "name": "Heure de début"
+          },
+          "end_time": {
+            "name": "Heure de fin"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Tarif formaté"
+          },
+          "tier_id": {
+            "name": "ID du palier"
+          },
+          "start_value": {
+            "name": "Valeur de début"
+          },
+          "end_value": {
+            "name": "Valeur de fin"
+          },
+          "unbounded": {
+            "name": "Sans limite supérieure"
+          },
+          "last_refresh_utc": {
+            "name": "Derniere actualisation (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localisateur de tarif"
+          },
+          "active_rate_name": {
+            "name": "Nom du tarif actif"
+          },
+          "configured_rates": {
+            "name": "Tarifs configurés"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Tarif d'exportation actuel",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structure tarifaire"
+          },
+          "variation_type": {
+            "name": "Type de variation"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Devise"
+          },
+          "export_plan": {
+            "name": "Plan d export"
+          },
+          "season_id": {
+            "name": "ID de saison"
+          },
+          "start_month": {
+            "name": "Mois de début"
+          },
+          "end_month": {
+            "name": "Mois de fin"
+          },
+          "day_group_id": {
+            "name": "ID du groupe de jours"
+          },
+          "days": {
+            "name": "Jours"
+          },
+          "period_id": {
+            "name": "ID de période"
+          },
+          "period_type": {
+            "name": "Type de période"
+          },
+          "start_time": {
+            "name": "Heure de début"
+          },
+          "end_time": {
+            "name": "Heure de fin"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Tarif formaté"
+          },
+          "tier_id": {
+            "name": "ID du palier"
+          },
+          "start_value": {
+            "name": "Valeur de début"
+          },
+          "end_value": {
+            "name": "Valeur de fin"
+          },
+          "unbounded": {
+            "name": "Sans limite supérieure"
+          },
+          "last_refresh_utc": {
+            "name": "Derniere actualisation (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localisateur de tarif"
+          },
+          "active_rate_name": {
+            "name": "Nom du tarif actif"
+          },
+          "configured_rates": {
+            "name": "Tarifs configurés"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Limite du planning de batterie"
+      },
+      "tariff_import_rate_value": {
+        "name": "Tarif d import {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structure tarifaire"
+          },
+          "variation_type": {
+            "name": "Type de variation"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Devise"
+          },
+          "season_id": {
+            "name": "ID de saison"
+          },
+          "start_month": {
+            "name": "Mois de début"
+          },
+          "end_month": {
+            "name": "Mois de fin"
+          },
+          "day_group_id": {
+            "name": "ID du groupe de jours"
+          },
+          "days": {
+            "name": "Jours"
+          },
+          "period_id": {
+            "name": "ID de période"
+          },
+          "period_type": {
+            "name": "Type de période"
+          },
+          "start_time": {
+            "name": "Heure de début"
+          },
+          "end_time": {
+            "name": "Heure de fin"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Tarif formaté"
+          },
+          "tier_id": {
+            "name": "ID du palier"
+          },
+          "start_value": {
+            "name": "Valeur de début"
+          },
+          "end_value": {
+            "name": "Valeur de fin"
+          },
+          "unbounded": {
+            "name": "Sans limite supérieure"
+          },
+          "last_refresh_utc": {
+            "name": "Derniere actualisation (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localisateur de tarif"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Tarif d export {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structure tarifaire"
+          },
+          "variation_type": {
+            "name": "Type de variation"
+          },
+          "source": {
+            "name": "Source"
+          },
+          "currency": {
+            "name": "Devise"
+          },
+          "export_plan": {
+            "name": "Plan d export"
+          },
+          "season_id": {
+            "name": "ID de saison"
+          },
+          "start_month": {
+            "name": "Mois de début"
+          },
+          "end_month": {
+            "name": "Mois de fin"
+          },
+          "day_group_id": {
+            "name": "ID du groupe de jours"
+          },
+          "days": {
+            "name": "Jours"
+          },
+          "period_id": {
+            "name": "ID de période"
+          },
+          "period_type": {
+            "name": "Type de période"
+          },
+          "start_time": {
+            "name": "Heure de début"
+          },
+          "end_time": {
+            "name": "Heure de fin"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Tarif formaté"
+          },
+          "tier_id": {
+            "name": "ID du palier"
+          },
+          "start_value": {
+            "name": "Valeur de début"
+          },
+          "end_value": {
+            "name": "Valeur de fin"
+          },
+          "unbounded": {
+            "name": "Sans limite supérieure"
+          },
+          "last_refresh_utc": {
+            "name": "Derniere actualisation (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localisateur de tarif"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "ID du site",
           "description": "Identifiant de site facultatif; détecté automatiquement lorsqu’un appareil de site est sélectionné."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Définir le tarif",
+      "description": "Met à jour une valeur existante de tarif d’importation ou d’exportation Enphase.",
+      "fields": {
+        "rate": {
+          "name": "Tarif",
+          "description": "Nouvelle valeur de tarif non négative."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Az ütemezési frissítés ütközik egy meglévő akkumulátorütemezéssel: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "A tarifadíjnak nem negatív számnak kell lennie."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "A tarifadíj célja nem található a legfrissebb tarifaadatokban."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "A tarifadíj célja érvénytelen."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "A tarifaírási API nem érhető el."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Pontosan egy tarifadíj entitást válassz ki."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Az entitás nem Enphase tarifadíj: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Utolso frissites (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifa helymeghatározó"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Utolso frissites (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifa helymeghatározó"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Akkumulátor-ütemezési összefoglaló"
+      },
+      "tariff_current_import_rate": {
+        "name": "Aktuális import díjszabás",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifaszerkezet"
+          },
+          "variation_type": {
+            "name": "Valtozattipus"
+          },
+          "source": {
+            "name": "Forras"
+          },
+          "currency": {
+            "name": "Penznem"
+          },
+          "season_id": {
+            "name": "Szezon azonosítója"
+          },
+          "start_month": {
+            "name": "Kezdő hónap"
+          },
+          "end_month": {
+            "name": "Záró hónap"
+          },
+          "day_group_id": {
+            "name": "Napcsoport azonosítója"
+          },
+          "days": {
+            "name": "Napok"
+          },
+          "period_id": {
+            "name": "Időszak azonosítója"
+          },
+          "period_type": {
+            "name": "Időszak típusa"
+          },
+          "start_time": {
+            "name": "Kezdési idő"
+          },
+          "end_time": {
+            "name": "Befejezési idő"
+          },
+          "rate": {
+            "name": "Díj"
+          },
+          "formatted_rate": {
+            "name": "Formázott díj"
+          },
+          "tier_id": {
+            "name": "Sáv azonosítója"
+          },
+          "start_value": {
+            "name": "Kezdő érték"
+          },
+          "end_value": {
+            "name": "Záró érték"
+          },
+          "unbounded": {
+            "name": "Felső korlát nélkül"
+          },
+          "last_refresh_utc": {
+            "name": "Utolso frissites (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifa helymeghatározó"
+          },
+          "active_rate_name": {
+            "name": "Aktív díjszabás neve"
+          },
+          "configured_rates": {
+            "name": "Beállított díjszabások"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Aktuális export díjszabás",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifaszerkezet"
+          },
+          "variation_type": {
+            "name": "Valtozattipus"
+          },
+          "source": {
+            "name": "Forras"
+          },
+          "currency": {
+            "name": "Penznem"
+          },
+          "export_plan": {
+            "name": "Exportterv"
+          },
+          "season_id": {
+            "name": "Szezon azonosítója"
+          },
+          "start_month": {
+            "name": "Kezdő hónap"
+          },
+          "end_month": {
+            "name": "Záró hónap"
+          },
+          "day_group_id": {
+            "name": "Napcsoport azonosítója"
+          },
+          "days": {
+            "name": "Napok"
+          },
+          "period_id": {
+            "name": "Időszak azonosítója"
+          },
+          "period_type": {
+            "name": "Időszak típusa"
+          },
+          "start_time": {
+            "name": "Kezdési idő"
+          },
+          "end_time": {
+            "name": "Befejezési idő"
+          },
+          "rate": {
+            "name": "Díj"
+          },
+          "formatted_rate": {
+            "name": "Formázott díj"
+          },
+          "tier_id": {
+            "name": "Sáv azonosítója"
+          },
+          "start_value": {
+            "name": "Kezdő érték"
+          },
+          "end_value": {
+            "name": "Záró érték"
+          },
+          "unbounded": {
+            "name": "Felső korlát nélkül"
+          },
+          "last_refresh_utc": {
+            "name": "Utolso frissites (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifa helymeghatározó"
+          },
+          "active_rate_name": {
+            "name": "Aktív díjszabás neve"
+          },
+          "configured_rates": {
+            "name": "Beállított díjszabások"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Akkumulátor ütemezési korlát"
+      },
+      "tariff_import_rate_value": {
+        "name": "Import tarifa {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifaszerkezet"
+          },
+          "variation_type": {
+            "name": "Valtozattipus"
+          },
+          "source": {
+            "name": "Forras"
+          },
+          "currency": {
+            "name": "Penznem"
+          },
+          "season_id": {
+            "name": "Szezon azonosítója"
+          },
+          "start_month": {
+            "name": "Kezdő hónap"
+          },
+          "end_month": {
+            "name": "Záró hónap"
+          },
+          "day_group_id": {
+            "name": "Napcsoport azonosítója"
+          },
+          "days": {
+            "name": "Napok"
+          },
+          "period_id": {
+            "name": "Időszak azonosítója"
+          },
+          "period_type": {
+            "name": "Időszak típusa"
+          },
+          "start_time": {
+            "name": "Kezdési idő"
+          },
+          "end_time": {
+            "name": "Befejezési idő"
+          },
+          "rate": {
+            "name": "Díj"
+          },
+          "formatted_rate": {
+            "name": "Formázott díj"
+          },
+          "tier_id": {
+            "name": "Sáv azonosítója"
+          },
+          "start_value": {
+            "name": "Kezdő érték"
+          },
+          "end_value": {
+            "name": "Záró érték"
+          },
+          "unbounded": {
+            "name": "Felső korlát nélkül"
+          },
+          "last_refresh_utc": {
+            "name": "Utolso frissites (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifa helymeghatározó"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Export tarifa {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifaszerkezet"
+          },
+          "variation_type": {
+            "name": "Valtozattipus"
+          },
+          "source": {
+            "name": "Forras"
+          },
+          "currency": {
+            "name": "Penznem"
+          },
+          "export_plan": {
+            "name": "Exportterv"
+          },
+          "season_id": {
+            "name": "Szezon azonosítója"
+          },
+          "start_month": {
+            "name": "Kezdő hónap"
+          },
+          "end_month": {
+            "name": "Záró hónap"
+          },
+          "day_group_id": {
+            "name": "Napcsoport azonosítója"
+          },
+          "days": {
+            "name": "Napok"
+          },
+          "period_id": {
+            "name": "Időszak azonosítója"
+          },
+          "period_type": {
+            "name": "Időszak típusa"
+          },
+          "start_time": {
+            "name": "Kezdési idő"
+          },
+          "end_time": {
+            "name": "Befejezési idő"
+          },
+          "rate": {
+            "name": "Díj"
+          },
+          "formatted_rate": {
+            "name": "Formázott díj"
+          },
+          "tier_id": {
+            "name": "Sáv azonosítója"
+          },
+          "start_value": {
+            "name": "Kezdő érték"
+          },
+          "end_value": {
+            "name": "Záró érték"
+          },
+          "unbounded": {
+            "name": "Felső korlát nélkül"
+          },
+          "last_refresh_utc": {
+            "name": "Utolso frissites (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifa helymeghatározó"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Hely azonosítója",
           "description": "Opcionális helyazonosító; automatikusan felismerhető, ha helyeszköz van kiválasztva."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Tarifadíj beállítása",
+      "description": "Frissít egy meglévő Enphase import- vagy exporttarifadíj értéket.",
+      "fields": {
+        "rate": {
+          "name": "Díj",
+          "description": "Új, nem negatív tarifadíj érték."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "L'aggiornamento della pianificazione è in conflitto con una pianificazione della batteria esistente: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "La tariffa deve essere un numero non negativo."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "La destinazione della tariffa non è stata trovata nei dati tariffari più recenti."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "La destinazione della tariffa non è valida."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "L’API di scrittura delle tariffe non è disponibile."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Seleziona esattamente un’entità tariffaria."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "L’entità non è una tariffa Enphase: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Ultimo aggiornamento (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizzatore tariffa"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Ultimo aggiornamento (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizzatore tariffa"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Riepilogo pianificazioni batteria"
+      },
+      "tariff_current_import_rate": {
+        "name": "Tariffa di importazione attuale",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struttura tariffaria"
+          },
+          "variation_type": {
+            "name": "Tipo di variazione"
+          },
+          "source": {
+            "name": "Origine"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "ID stagione"
+          },
+          "start_month": {
+            "name": "Mese di inizio"
+          },
+          "end_month": {
+            "name": "Mese di fine"
+          },
+          "day_group_id": {
+            "name": "ID gruppo giorni"
+          },
+          "days": {
+            "name": "Giorni"
+          },
+          "period_id": {
+            "name": "ID periodo"
+          },
+          "period_type": {
+            "name": "Tipo periodo"
+          },
+          "start_time": {
+            "name": "Ora di inizio"
+          },
+          "end_time": {
+            "name": "Ora di fine"
+          },
+          "rate": {
+            "name": "Tariffa"
+          },
+          "formatted_rate": {
+            "name": "Tariffa formattata"
+          },
+          "tier_id": {
+            "name": "ID scaglione"
+          },
+          "start_value": {
+            "name": "Valore iniziale"
+          },
+          "end_value": {
+            "name": "Valore finale"
+          },
+          "unbounded": {
+            "name": "Senza limite superiore"
+          },
+          "last_refresh_utc": {
+            "name": "Ultimo aggiornamento (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizzatore tariffa"
+          },
+          "active_rate_name": {
+            "name": "Nome tariffa attiva"
+          },
+          "configured_rates": {
+            "name": "Tariffe configurate"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Tariffa di esportazione attuale",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struttura tariffaria"
+          },
+          "variation_type": {
+            "name": "Tipo di variazione"
+          },
+          "source": {
+            "name": "Origine"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Piano di esportazione"
+          },
+          "season_id": {
+            "name": "ID stagione"
+          },
+          "start_month": {
+            "name": "Mese di inizio"
+          },
+          "end_month": {
+            "name": "Mese di fine"
+          },
+          "day_group_id": {
+            "name": "ID gruppo giorni"
+          },
+          "days": {
+            "name": "Giorni"
+          },
+          "period_id": {
+            "name": "ID periodo"
+          },
+          "period_type": {
+            "name": "Tipo periodo"
+          },
+          "start_time": {
+            "name": "Ora di inizio"
+          },
+          "end_time": {
+            "name": "Ora di fine"
+          },
+          "rate": {
+            "name": "Tariffa"
+          },
+          "formatted_rate": {
+            "name": "Tariffa formattata"
+          },
+          "tier_id": {
+            "name": "ID scaglione"
+          },
+          "start_value": {
+            "name": "Valore iniziale"
+          },
+          "end_value": {
+            "name": "Valore finale"
+          },
+          "unbounded": {
+            "name": "Senza limite superiore"
+          },
+          "last_refresh_utc": {
+            "name": "Ultimo aggiornamento (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizzatore tariffa"
+          },
+          "active_rate_name": {
+            "name": "Nome tariffa attiva"
+          },
+          "configured_rates": {
+            "name": "Tariffe configurate"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Limite pianificazione batteria"
+      },
+      "tariff_import_rate_value": {
+        "name": "Tariffa di importazione {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struttura tariffaria"
+          },
+          "variation_type": {
+            "name": "Tipo di variazione"
+          },
+          "source": {
+            "name": "Origine"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "ID stagione"
+          },
+          "start_month": {
+            "name": "Mese di inizio"
+          },
+          "end_month": {
+            "name": "Mese di fine"
+          },
+          "day_group_id": {
+            "name": "ID gruppo giorni"
+          },
+          "days": {
+            "name": "Giorni"
+          },
+          "period_id": {
+            "name": "ID periodo"
+          },
+          "period_type": {
+            "name": "Tipo periodo"
+          },
+          "start_time": {
+            "name": "Ora di inizio"
+          },
+          "end_time": {
+            "name": "Ora di fine"
+          },
+          "rate": {
+            "name": "Tariffa"
+          },
+          "formatted_rate": {
+            "name": "Tariffa formattata"
+          },
+          "tier_id": {
+            "name": "ID scaglione"
+          },
+          "start_value": {
+            "name": "Valore iniziale"
+          },
+          "end_value": {
+            "name": "Valore finale"
+          },
+          "unbounded": {
+            "name": "Senza limite superiore"
+          },
+          "last_refresh_utc": {
+            "name": "Ultimo aggiornamento (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizzatore tariffa"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Tariffa di esportazione {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struttura tariffaria"
+          },
+          "variation_type": {
+            "name": "Tipo di variazione"
+          },
+          "source": {
+            "name": "Origine"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Piano di esportazione"
+          },
+          "season_id": {
+            "name": "ID stagione"
+          },
+          "start_month": {
+            "name": "Mese di inizio"
+          },
+          "end_month": {
+            "name": "Mese di fine"
+          },
+          "day_group_id": {
+            "name": "ID gruppo giorni"
+          },
+          "days": {
+            "name": "Giorni"
+          },
+          "period_id": {
+            "name": "ID periodo"
+          },
+          "period_type": {
+            "name": "Tipo periodo"
+          },
+          "start_time": {
+            "name": "Ora di inizio"
+          },
+          "end_time": {
+            "name": "Ora di fine"
+          },
+          "rate": {
+            "name": "Tariffa"
+          },
+          "formatted_rate": {
+            "name": "Tariffa formattata"
+          },
+          "tier_id": {
+            "name": "ID scaglione"
+          },
+          "start_value": {
+            "name": "Valore iniziale"
+          },
+          "end_value": {
+            "name": "Valore finale"
+          },
+          "unbounded": {
+            "name": "Senza limite superiore"
+          },
+          "last_refresh_utc": {
+            "name": "Ultimo aggiornamento (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizzatore tariffa"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "ID sito",
           "description": "Identificatore sito opzionale; rilevato automaticamente quando viene selezionato un dispositivo del sito."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Imposta tariffa",
+      "description": "Aggiorna un valore esistente della tariffa di importazione o esportazione Enphase.",
+      "fields": {
+        "rate": {
+          "name": "Tariffa",
+          "description": "Nuovo valore tariffario non negativo."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Tvarkaraščio atnaujinimas konfliktuoja su esamu baterijos tvarkaraščiu: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tarifo kaina turi būti neneigiamas skaičius."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Tarifo kainos tikslas nerastas naujausiuose tarifo duomenyse."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Tarifo kainos tikslas netinkamas."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Tarifų rašymo API nepasiekiama."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Pasirinkite tiksliai vieną tarifo kainos objektą."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Objektas nėra Enphase tarifo kaina: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Paskutinis atnaujinimas (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifo lokatorius"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Paskutinis atnaujinimas (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifo lokatorius"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Baterijos tvarkaraščių santrauka"
+      },
+      "tariff_current_import_rate": {
+        "name": "Dabartinis importo tarifas",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifo struktura"
+          },
+          "variation_type": {
+            "name": "Variacijos tipas"
+          },
+          "source": {
+            "name": "Saltinis"
+          },
+          "currency": {
+            "name": "Valiuta"
+          },
+          "season_id": {
+            "name": "Sezono ID"
+          },
+          "start_month": {
+            "name": "Pradžios mėnuo"
+          },
+          "end_month": {
+            "name": "Pabaigos mėnuo"
+          },
+          "day_group_id": {
+            "name": "Dienų grupės ID"
+          },
+          "days": {
+            "name": "Dienos"
+          },
+          "period_id": {
+            "name": "Laikotarpio ID"
+          },
+          "period_type": {
+            "name": "Laikotarpio tipas"
+          },
+          "start_time": {
+            "name": "Pradžios laikas"
+          },
+          "end_time": {
+            "name": "Pabaigos laikas"
+          },
+          "rate": {
+            "name": "Tarifas"
+          },
+          "formatted_rate": {
+            "name": "Suformatuotas tarifas"
+          },
+          "tier_id": {
+            "name": "Pakopos ID"
+          },
+          "start_value": {
+            "name": "Pradinė vertė"
+          },
+          "end_value": {
+            "name": "Galutinė vertė"
+          },
+          "unbounded": {
+            "name": "Be viršutinės ribos"
+          },
+          "last_refresh_utc": {
+            "name": "Paskutinis atnaujinimas (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifo lokatorius"
+          },
+          "active_rate_name": {
+            "name": "Aktyvaus tarifo pavadinimas"
+          },
+          "configured_rates": {
+            "name": "Sukonfigūruoti tarifai"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Dabartinis eksporto tarifas",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifo struktura"
+          },
+          "variation_type": {
+            "name": "Variacijos tipas"
+          },
+          "source": {
+            "name": "Saltinis"
+          },
+          "currency": {
+            "name": "Valiuta"
+          },
+          "export_plan": {
+            "name": "Eksporto planas"
+          },
+          "season_id": {
+            "name": "Sezono ID"
+          },
+          "start_month": {
+            "name": "Pradžios mėnuo"
+          },
+          "end_month": {
+            "name": "Pabaigos mėnuo"
+          },
+          "day_group_id": {
+            "name": "Dienų grupės ID"
+          },
+          "days": {
+            "name": "Dienos"
+          },
+          "period_id": {
+            "name": "Laikotarpio ID"
+          },
+          "period_type": {
+            "name": "Laikotarpio tipas"
+          },
+          "start_time": {
+            "name": "Pradžios laikas"
+          },
+          "end_time": {
+            "name": "Pabaigos laikas"
+          },
+          "rate": {
+            "name": "Tarifas"
+          },
+          "formatted_rate": {
+            "name": "Suformatuotas tarifas"
+          },
+          "tier_id": {
+            "name": "Pakopos ID"
+          },
+          "start_value": {
+            "name": "Pradinė vertė"
+          },
+          "end_value": {
+            "name": "Galutinė vertė"
+          },
+          "unbounded": {
+            "name": "Be viršutinės ribos"
+          },
+          "last_refresh_utc": {
+            "name": "Paskutinis atnaujinimas (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifo lokatorius"
+          },
+          "active_rate_name": {
+            "name": "Aktyvaus tarifo pavadinimas"
+          },
+          "configured_rates": {
+            "name": "Sukonfigūruoti tarifai"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Baterijos tvarkaraščio riba"
+      },
+      "tariff_import_rate_value": {
+        "name": "Importo tarifas {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifo struktura"
+          },
+          "variation_type": {
+            "name": "Variacijos tipas"
+          },
+          "source": {
+            "name": "Saltinis"
+          },
+          "currency": {
+            "name": "Valiuta"
+          },
+          "season_id": {
+            "name": "Sezono ID"
+          },
+          "start_month": {
+            "name": "Pradžios mėnuo"
+          },
+          "end_month": {
+            "name": "Pabaigos mėnuo"
+          },
+          "day_group_id": {
+            "name": "Dienų grupės ID"
+          },
+          "days": {
+            "name": "Dienos"
+          },
+          "period_id": {
+            "name": "Laikotarpio ID"
+          },
+          "period_type": {
+            "name": "Laikotarpio tipas"
+          },
+          "start_time": {
+            "name": "Pradžios laikas"
+          },
+          "end_time": {
+            "name": "Pabaigos laikas"
+          },
+          "rate": {
+            "name": "Tarifas"
+          },
+          "formatted_rate": {
+            "name": "Suformatuotas tarifas"
+          },
+          "tier_id": {
+            "name": "Pakopos ID"
+          },
+          "start_value": {
+            "name": "Pradinė vertė"
+          },
+          "end_value": {
+            "name": "Galutinė vertė"
+          },
+          "unbounded": {
+            "name": "Be viršutinės ribos"
+          },
+          "last_refresh_utc": {
+            "name": "Paskutinis atnaujinimas (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifo lokatorius"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Eksporto tarifas {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifo struktura"
+          },
+          "variation_type": {
+            "name": "Variacijos tipas"
+          },
+          "source": {
+            "name": "Saltinis"
+          },
+          "currency": {
+            "name": "Valiuta"
+          },
+          "export_plan": {
+            "name": "Eksporto planas"
+          },
+          "season_id": {
+            "name": "Sezono ID"
+          },
+          "start_month": {
+            "name": "Pradžios mėnuo"
+          },
+          "end_month": {
+            "name": "Pabaigos mėnuo"
+          },
+          "day_group_id": {
+            "name": "Dienų grupės ID"
+          },
+          "days": {
+            "name": "Dienos"
+          },
+          "period_id": {
+            "name": "Laikotarpio ID"
+          },
+          "period_type": {
+            "name": "Laikotarpio tipas"
+          },
+          "start_time": {
+            "name": "Pradžios laikas"
+          },
+          "end_time": {
+            "name": "Pabaigos laikas"
+          },
+          "rate": {
+            "name": "Tarifas"
+          },
+          "formatted_rate": {
+            "name": "Suformatuotas tarifas"
+          },
+          "tier_id": {
+            "name": "Pakopos ID"
+          },
+          "start_value": {
+            "name": "Pradinė vertė"
+          },
+          "end_value": {
+            "name": "Galutinė vertė"
+          },
+          "unbounded": {
+            "name": "Be viršutinės ribos"
+          },
+          "last_refresh_utc": {
+            "name": "Paskutinis atnaujinimas (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifo lokatorius"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Svetainės ID",
           "description": "Pasirenkamas svetainės identifikatorius; aptinkamas automatiškai pasirinkus svetainės įrenginį."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Nustatyti tarifo kainą",
+      "description": "Atnaujina vieną esamą Enphase importo arba eksporto tarifo kainą.",
+      "fields": {
+        "rate": {
+          "name": "Kaina",
+          "description": "Nauja neneigiama tarifo kaina."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Grafika atjauninājums konfliktē ar esošu akumulatora grafiku: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tarifa likmei jābūt nenegatīvam skaitlim."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Tarifa likmes mērķis netika atrasts jaunākajos tarifa datos."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Tarifa likmes mērķis nav derīgs."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "Tarifu rakstīšanas API nav pieejama."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Atlasiet tieši vienu tarifa likmes entītiju."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entītija nav Enphase tarifa likme: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Pedeja atjaunosana (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifa lokators"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Pedeja atjaunosana (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifa lokators"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Akumulatora grafiku kopsavilkums"
+      },
+      "tariff_current_import_rate": {
+        "name": "Pašreizējais importa tarifs",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifa struktura"
+          },
+          "variation_type": {
+            "name": "Variacijas tips"
+          },
+          "source": {
+            "name": "Avots"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Sezonas ID"
+          },
+          "start_month": {
+            "name": "Sākuma mēnesis"
+          },
+          "end_month": {
+            "name": "Beigu mēnesis"
+          },
+          "day_group_id": {
+            "name": "Dienu grupas ID"
+          },
+          "days": {
+            "name": "Dienas"
+          },
+          "period_id": {
+            "name": "Perioda ID"
+          },
+          "period_type": {
+            "name": "Perioda tips"
+          },
+          "start_time": {
+            "name": "Sākuma laiks"
+          },
+          "end_time": {
+            "name": "Beigu laiks"
+          },
+          "rate": {
+            "name": "Tarifs"
+          },
+          "formatted_rate": {
+            "name": "Formatēts tarifs"
+          },
+          "tier_id": {
+            "name": "Pakāpes ID"
+          },
+          "start_value": {
+            "name": "Sākuma vērtība"
+          },
+          "end_value": {
+            "name": "Beigu vērtība"
+          },
+          "unbounded": {
+            "name": "Bez augšējās robežas"
+          },
+          "last_refresh_utc": {
+            "name": "Pedeja atjaunosana (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifa lokators"
+          },
+          "active_rate_name": {
+            "name": "Aktīvā tarifa nosaukums"
+          },
+          "configured_rates": {
+            "name": "Konfigurētie tarifi"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Pašreizējais eksporta tarifs",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifa struktura"
+          },
+          "variation_type": {
+            "name": "Variacijas tips"
+          },
+          "source": {
+            "name": "Avots"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Eksporta plans"
+          },
+          "season_id": {
+            "name": "Sezonas ID"
+          },
+          "start_month": {
+            "name": "Sākuma mēnesis"
+          },
+          "end_month": {
+            "name": "Beigu mēnesis"
+          },
+          "day_group_id": {
+            "name": "Dienu grupas ID"
+          },
+          "days": {
+            "name": "Dienas"
+          },
+          "period_id": {
+            "name": "Perioda ID"
+          },
+          "period_type": {
+            "name": "Perioda tips"
+          },
+          "start_time": {
+            "name": "Sākuma laiks"
+          },
+          "end_time": {
+            "name": "Beigu laiks"
+          },
+          "rate": {
+            "name": "Tarifs"
+          },
+          "formatted_rate": {
+            "name": "Formatēts tarifs"
+          },
+          "tier_id": {
+            "name": "Pakāpes ID"
+          },
+          "start_value": {
+            "name": "Sākuma vērtība"
+          },
+          "end_value": {
+            "name": "Beigu vērtība"
+          },
+          "unbounded": {
+            "name": "Bez augšējās robežas"
+          },
+          "last_refresh_utc": {
+            "name": "Pedeja atjaunosana (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifa lokators"
+          },
+          "active_rate_name": {
+            "name": "Aktīvā tarifa nosaukums"
+          },
+          "configured_rates": {
+            "name": "Konfigurētie tarifi"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Akumulatora grafika limits"
+      },
+      "tariff_import_rate_value": {
+        "name": "Importa tarifs {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifa struktura"
+          },
+          "variation_type": {
+            "name": "Variacijas tips"
+          },
+          "source": {
+            "name": "Avots"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Sezonas ID"
+          },
+          "start_month": {
+            "name": "Sākuma mēnesis"
+          },
+          "end_month": {
+            "name": "Beigu mēnesis"
+          },
+          "day_group_id": {
+            "name": "Dienu grupas ID"
+          },
+          "days": {
+            "name": "Dienas"
+          },
+          "period_id": {
+            "name": "Perioda ID"
+          },
+          "period_type": {
+            "name": "Perioda tips"
+          },
+          "start_time": {
+            "name": "Sākuma laiks"
+          },
+          "end_time": {
+            "name": "Beigu laiks"
+          },
+          "rate": {
+            "name": "Tarifs"
+          },
+          "formatted_rate": {
+            "name": "Formatēts tarifs"
+          },
+          "tier_id": {
+            "name": "Pakāpes ID"
+          },
+          "start_value": {
+            "name": "Sākuma vērtība"
+          },
+          "end_value": {
+            "name": "Beigu vērtība"
+          },
+          "unbounded": {
+            "name": "Bez augšējās robežas"
+          },
+          "last_refresh_utc": {
+            "name": "Pedeja atjaunosana (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifa lokators"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Eksporta tarifs {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tarifa struktura"
+          },
+          "variation_type": {
+            "name": "Variacijas tips"
+          },
+          "source": {
+            "name": "Avots"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Eksporta plans"
+          },
+          "season_id": {
+            "name": "Sezonas ID"
+          },
+          "start_month": {
+            "name": "Sākuma mēnesis"
+          },
+          "end_month": {
+            "name": "Beigu mēnesis"
+          },
+          "day_group_id": {
+            "name": "Dienu grupas ID"
+          },
+          "days": {
+            "name": "Dienas"
+          },
+          "period_id": {
+            "name": "Perioda ID"
+          },
+          "period_type": {
+            "name": "Perioda tips"
+          },
+          "start_time": {
+            "name": "Sākuma laiks"
+          },
+          "end_time": {
+            "name": "Beigu laiks"
+          },
+          "rate": {
+            "name": "Tarifs"
+          },
+          "formatted_rate": {
+            "name": "Formatēts tarifs"
+          },
+          "tier_id": {
+            "name": "Pakāpes ID"
+          },
+          "start_value": {
+            "name": "Sākuma vērtība"
+          },
+          "end_value": {
+            "name": "Beigu vērtība"
+          },
+          "unbounded": {
+            "name": "Bez augšējās robežas"
+          },
+          "last_refresh_utc": {
+            "name": "Pedeja atjaunosana (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifa lokators"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Vietnes ID",
           "description": "Neobligāts vietnes identifikators; tiek noteikts automātiski, kad atlasīta vietnes ierīce."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Iestatīt tarifa likmi",
+      "description": "Atjaunina vienu esošu Enphase importa vai eksporta tarifa likmes vērtību.",
+      "fields": {
+        "rate": {
+          "name": "Likme",
+          "description": "Jauna nenegatīva tarifa likme."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Planoppdateringen er i konflikt med en eksisterende batteriplan: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tariffprisen må være et ikke-negativt tall."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Målet for tariffprisen ble ikke funnet i de nyeste tariffdataene."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Målet for tariffprisen er ugyldig."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "API for tariffskriving er ikke tilgjengelig."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Velg nøyaktig én tariffpris-entitet."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entiteten er ikke en Enphase-tariffpris: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Siste oppdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifflokator"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Siste oppdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifflokator"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Sammendrag av batteriplaner"
+      },
+      "tariff_current_import_rate": {
+        "name": "Gjeldende importtariff",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variasjonstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Sesong-ID"
+          },
+          "start_month": {
+            "name": "Startmåned"
+          },
+          "end_month": {
+            "name": "Sluttmåned"
+          },
+          "day_group_id": {
+            "name": "Daggruppe-ID"
+          },
+          "days": {
+            "name": "Dager"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Pris"
+          },
+          "formatted_rate": {
+            "name": "Formatert pris"
+          },
+          "tier_id": {
+            "name": "Trinn-ID"
+          },
+          "start_value": {
+            "name": "Startverdi"
+          },
+          "end_value": {
+            "name": "Sluttverdi"
+          },
+          "unbounded": {
+            "name": "Uten øvre grense"
+          },
+          "last_refresh_utc": {
+            "name": "Siste oppdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifflokator"
+          },
+          "active_rate_name": {
+            "name": "Navn på aktiv tariff"
+          },
+          "configured_rates": {
+            "name": "Konfigurerte tariffer"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Gjeldende eksporttariff",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variasjonstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Eksportplan"
+          },
+          "season_id": {
+            "name": "Sesong-ID"
+          },
+          "start_month": {
+            "name": "Startmåned"
+          },
+          "end_month": {
+            "name": "Sluttmåned"
+          },
+          "day_group_id": {
+            "name": "Daggruppe-ID"
+          },
+          "days": {
+            "name": "Dager"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Pris"
+          },
+          "formatted_rate": {
+            "name": "Formatert pris"
+          },
+          "tier_id": {
+            "name": "Trinn-ID"
+          },
+          "start_value": {
+            "name": "Startverdi"
+          },
+          "end_value": {
+            "name": "Sluttverdi"
+          },
+          "unbounded": {
+            "name": "Uten øvre grense"
+          },
+          "last_refresh_utc": {
+            "name": "Siste oppdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifflokator"
+          },
+          "active_rate_name": {
+            "name": "Navn på aktiv tariff"
+          },
+          "configured_rates": {
+            "name": "Konfigurerte tariffer"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Grense for batteriplan"
+      },
+      "tariff_import_rate_value": {
+        "name": "Importtariff {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variasjonstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Sesong-ID"
+          },
+          "start_month": {
+            "name": "Startmåned"
+          },
+          "end_month": {
+            "name": "Sluttmåned"
+          },
+          "day_group_id": {
+            "name": "Daggruppe-ID"
+          },
+          "days": {
+            "name": "Dager"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Pris"
+          },
+          "formatted_rate": {
+            "name": "Formatert pris"
+          },
+          "tier_id": {
+            "name": "Trinn-ID"
+          },
+          "start_value": {
+            "name": "Startverdi"
+          },
+          "end_value": {
+            "name": "Sluttverdi"
+          },
+          "unbounded": {
+            "name": "Uten øvre grense"
+          },
+          "last_refresh_utc": {
+            "name": "Siste oppdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifflokator"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Eksporttariff {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variasjonstype"
+          },
+          "source": {
+            "name": "Kilde"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Eksportplan"
+          },
+          "season_id": {
+            "name": "Sesong-ID"
+          },
+          "start_month": {
+            "name": "Startmåned"
+          },
+          "end_month": {
+            "name": "Sluttmåned"
+          },
+          "day_group_id": {
+            "name": "Daggruppe-ID"
+          },
+          "days": {
+            "name": "Dager"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Pris"
+          },
+          "formatted_rate": {
+            "name": "Formatert pris"
+          },
+          "tier_id": {
+            "name": "Trinn-ID"
+          },
+          "start_value": {
+            "name": "Startverdi"
+          },
+          "end_value": {
+            "name": "Sluttverdi"
+          },
+          "unbounded": {
+            "name": "Uten øvre grense"
+          },
+          "last_refresh_utc": {
+            "name": "Siste oppdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifflokator"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Anleggs-ID",
           "description": "Valgfri anleggsidentifikator; oppdages automatisk når en anleggsenhet velges."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Angi tariffpris",
+      "description": "Oppdaterer én eksisterende Enphase import- eller eksporttariffpris.",
+      "fields": {
+        "rate": {
+          "name": "Pris",
+          "description": "Ny ikke-negativ tariffpris."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Schema-update conflicteert met een bestaand batterijschema: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Het tarief moet een niet-negatief getal zijn."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Het doel van het tarief is niet gevonden in de nieuwste tariefgegevens."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Het doel van het tarief is ongeldig."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "De API voor het schrijven van tarieven is niet beschikbaar."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Selecteer precies één tariefentiteit."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "De entiteit is geen Enphase-tarief: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Laatst bijgewerkt (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariefzoeker"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Laatst bijgewerkt (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariefzoeker"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Samenvatting van het batterijschema"
+      },
+      "tariff_current_import_rate": {
+        "name": "Huidig importtarief",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariefstructuur"
+          },
+          "variation_type": {
+            "name": "Variatietype"
+          },
+          "source": {
+            "name": "Bron"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Seizoens-ID"
+          },
+          "start_month": {
+            "name": "Startmaand"
+          },
+          "end_month": {
+            "name": "Eindmaand"
+          },
+          "day_group_id": {
+            "name": "Daggroep-ID"
+          },
+          "days": {
+            "name": "Dagen"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttijd"
+          },
+          "end_time": {
+            "name": "Eindtijd"
+          },
+          "rate": {
+            "name": "Tarief"
+          },
+          "formatted_rate": {
+            "name": "Opgemaakt tarief"
+          },
+          "tier_id": {
+            "name": "Schijf-ID"
+          },
+          "start_value": {
+            "name": "Startwaarde"
+          },
+          "end_value": {
+            "name": "Eindwaarde"
+          },
+          "unbounded": {
+            "name": "Zonder bovengrens"
+          },
+          "last_refresh_utc": {
+            "name": "Laatst bijgewerkt (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariefzoeker"
+          },
+          "active_rate_name": {
+            "name": "Naam actief tarief"
+          },
+          "configured_rates": {
+            "name": "Geconfigureerde tarieven"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Huidig exporttarief",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariefstructuur"
+          },
+          "variation_type": {
+            "name": "Variatietype"
+          },
+          "source": {
+            "name": "Bron"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Exportplan"
+          },
+          "season_id": {
+            "name": "Seizoens-ID"
+          },
+          "start_month": {
+            "name": "Startmaand"
+          },
+          "end_month": {
+            "name": "Eindmaand"
+          },
+          "day_group_id": {
+            "name": "Daggroep-ID"
+          },
+          "days": {
+            "name": "Dagen"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttijd"
+          },
+          "end_time": {
+            "name": "Eindtijd"
+          },
+          "rate": {
+            "name": "Tarief"
+          },
+          "formatted_rate": {
+            "name": "Opgemaakt tarief"
+          },
+          "tier_id": {
+            "name": "Schijf-ID"
+          },
+          "start_value": {
+            "name": "Startwaarde"
+          },
+          "end_value": {
+            "name": "Eindwaarde"
+          },
+          "unbounded": {
+            "name": "Zonder bovengrens"
+          },
+          "last_refresh_utc": {
+            "name": "Laatst bijgewerkt (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariefzoeker"
+          },
+          "active_rate_name": {
+            "name": "Naam actief tarief"
+          },
+          "configured_rates": {
+            "name": "Geconfigureerde tarieven"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Limiet batterijschema"
+      },
+      "tariff_import_rate_value": {
+        "name": "Importtarief {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariefstructuur"
+          },
+          "variation_type": {
+            "name": "Variatietype"
+          },
+          "source": {
+            "name": "Bron"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Seizoens-ID"
+          },
+          "start_month": {
+            "name": "Startmaand"
+          },
+          "end_month": {
+            "name": "Eindmaand"
+          },
+          "day_group_id": {
+            "name": "Daggroep-ID"
+          },
+          "days": {
+            "name": "Dagen"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttijd"
+          },
+          "end_time": {
+            "name": "Eindtijd"
+          },
+          "rate": {
+            "name": "Tarief"
+          },
+          "formatted_rate": {
+            "name": "Opgemaakt tarief"
+          },
+          "tier_id": {
+            "name": "Schijf-ID"
+          },
+          "start_value": {
+            "name": "Startwaarde"
+          },
+          "end_value": {
+            "name": "Eindwaarde"
+          },
+          "unbounded": {
+            "name": "Zonder bovengrens"
+          },
+          "last_refresh_utc": {
+            "name": "Laatst bijgewerkt (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariefzoeker"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Exporttarief {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariefstructuur"
+          },
+          "variation_type": {
+            "name": "Variatietype"
+          },
+          "source": {
+            "name": "Bron"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Exportplan"
+          },
+          "season_id": {
+            "name": "Seizoens-ID"
+          },
+          "start_month": {
+            "name": "Startmaand"
+          },
+          "end_month": {
+            "name": "Eindmaand"
+          },
+          "day_group_id": {
+            "name": "Daggroep-ID"
+          },
+          "days": {
+            "name": "Dagen"
+          },
+          "period_id": {
+            "name": "Periode-ID"
+          },
+          "period_type": {
+            "name": "Periodetype"
+          },
+          "start_time": {
+            "name": "Starttijd"
+          },
+          "end_time": {
+            "name": "Eindtijd"
+          },
+          "rate": {
+            "name": "Tarief"
+          },
+          "formatted_rate": {
+            "name": "Opgemaakt tarief"
+          },
+          "tier_id": {
+            "name": "Schijf-ID"
+          },
+          "start_value": {
+            "name": "Startwaarde"
+          },
+          "end_value": {
+            "name": "Eindwaarde"
+          },
+          "unbounded": {
+            "name": "Zonder bovengrens"
+          },
+          "last_refresh_utc": {
+            "name": "Laatst bijgewerkt (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tariefzoeker"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Site-ID",
           "description": "Optionele site-id; wordt automatisch gedetecteerd wanneer een site-apparaat is geselecteerd."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Tarief instellen",
+      "description": "Werkt één bestaande Enphase import- of exporttariefwaarde bij.",
+      "fields": {
+        "rate": {
+          "name": "Tarief",
+          "description": "Nieuwe niet-negatieve tariefwaarde."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Aktualizacja harmonogramu koliduje z istniejącym harmonogramem baterii: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Stawka taryfy musi być liczbą nieujemną."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Cel stawki taryfy nie został znaleziony w najnowszych danych taryfy."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Cel stawki taryfy jest nieprawidłowy."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "API zapisu taryf jest niedostępne."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Wybierz dokładnie jedną encję stawki taryfy."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Encja nie jest stawką taryfy Enphase: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Ostatnie odswiezenie (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Lokalizator taryfy"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Ostatnie odswiezenie (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Lokalizator taryfy"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Podsumowanie harmonogramu baterii"
+      },
+      "tariff_current_import_rate": {
+        "name": "Bieżąca stawka importu",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura taryfy"
+          },
+          "variation_type": {
+            "name": "Typ wariantu"
+          },
+          "source": {
+            "name": "Zrodlo"
+          },
+          "currency": {
+            "name": "Waluta"
+          },
+          "season_id": {
+            "name": "ID sezonu"
+          },
+          "start_month": {
+            "name": "Miesiąc początkowy"
+          },
+          "end_month": {
+            "name": "Miesiąc końcowy"
+          },
+          "day_group_id": {
+            "name": "ID grupy dni"
+          },
+          "days": {
+            "name": "Dni"
+          },
+          "period_id": {
+            "name": "ID okresu"
+          },
+          "period_type": {
+            "name": "Typ okresu"
+          },
+          "start_time": {
+            "name": "Czas rozpoczęcia"
+          },
+          "end_time": {
+            "name": "Czas zakończenia"
+          },
+          "rate": {
+            "name": "Stawka"
+          },
+          "formatted_rate": {
+            "name": "Sformatowana stawka"
+          },
+          "tier_id": {
+            "name": "ID progu"
+          },
+          "start_value": {
+            "name": "Wartość początkowa"
+          },
+          "end_value": {
+            "name": "Wartość końcowa"
+          },
+          "unbounded": {
+            "name": "Bez górnego limitu"
+          },
+          "last_refresh_utc": {
+            "name": "Ostatnie odswiezenie (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Lokalizator taryfy"
+          },
+          "active_rate_name": {
+            "name": "Nazwa aktywnej stawki"
+          },
+          "configured_rates": {
+            "name": "Skonfigurowane stawki"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Bieżąca stawka eksportu",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura taryfy"
+          },
+          "variation_type": {
+            "name": "Typ wariantu"
+          },
+          "source": {
+            "name": "Zrodlo"
+          },
+          "currency": {
+            "name": "Waluta"
+          },
+          "export_plan": {
+            "name": "Plan eksportu"
+          },
+          "season_id": {
+            "name": "ID sezonu"
+          },
+          "start_month": {
+            "name": "Miesiąc początkowy"
+          },
+          "end_month": {
+            "name": "Miesiąc końcowy"
+          },
+          "day_group_id": {
+            "name": "ID grupy dni"
+          },
+          "days": {
+            "name": "Dni"
+          },
+          "period_id": {
+            "name": "ID okresu"
+          },
+          "period_type": {
+            "name": "Typ okresu"
+          },
+          "start_time": {
+            "name": "Czas rozpoczęcia"
+          },
+          "end_time": {
+            "name": "Czas zakończenia"
+          },
+          "rate": {
+            "name": "Stawka"
+          },
+          "formatted_rate": {
+            "name": "Sformatowana stawka"
+          },
+          "tier_id": {
+            "name": "ID progu"
+          },
+          "start_value": {
+            "name": "Wartość początkowa"
+          },
+          "end_value": {
+            "name": "Wartość końcowa"
+          },
+          "unbounded": {
+            "name": "Bez górnego limitu"
+          },
+          "last_refresh_utc": {
+            "name": "Ostatnie odswiezenie (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Lokalizator taryfy"
+          },
+          "active_rate_name": {
+            "name": "Nazwa aktywnej stawki"
+          },
+          "configured_rates": {
+            "name": "Skonfigurowane stawki"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Limit harmonogramu baterii"
+      },
+      "tariff_import_rate_value": {
+        "name": "Taryfa importu {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura taryfy"
+          },
+          "variation_type": {
+            "name": "Typ wariantu"
+          },
+          "source": {
+            "name": "Zrodlo"
+          },
+          "currency": {
+            "name": "Waluta"
+          },
+          "season_id": {
+            "name": "ID sezonu"
+          },
+          "start_month": {
+            "name": "Miesiąc początkowy"
+          },
+          "end_month": {
+            "name": "Miesiąc końcowy"
+          },
+          "day_group_id": {
+            "name": "ID grupy dni"
+          },
+          "days": {
+            "name": "Dni"
+          },
+          "period_id": {
+            "name": "ID okresu"
+          },
+          "period_type": {
+            "name": "Typ okresu"
+          },
+          "start_time": {
+            "name": "Czas rozpoczęcia"
+          },
+          "end_time": {
+            "name": "Czas zakończenia"
+          },
+          "rate": {
+            "name": "Stawka"
+          },
+          "formatted_rate": {
+            "name": "Sformatowana stawka"
+          },
+          "tier_id": {
+            "name": "ID progu"
+          },
+          "start_value": {
+            "name": "Wartość początkowa"
+          },
+          "end_value": {
+            "name": "Wartość końcowa"
+          },
+          "unbounded": {
+            "name": "Bez górnego limitu"
+          },
+          "last_refresh_utc": {
+            "name": "Ostatnie odswiezenie (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Lokalizator taryfy"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Taryfa eksportu {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Struktura taryfy"
+          },
+          "variation_type": {
+            "name": "Typ wariantu"
+          },
+          "source": {
+            "name": "Zrodlo"
+          },
+          "currency": {
+            "name": "Waluta"
+          },
+          "export_plan": {
+            "name": "Plan eksportu"
+          },
+          "season_id": {
+            "name": "ID sezonu"
+          },
+          "start_month": {
+            "name": "Miesiąc początkowy"
+          },
+          "end_month": {
+            "name": "Miesiąc końcowy"
+          },
+          "day_group_id": {
+            "name": "ID grupy dni"
+          },
+          "days": {
+            "name": "Dni"
+          },
+          "period_id": {
+            "name": "ID okresu"
+          },
+          "period_type": {
+            "name": "Typ okresu"
+          },
+          "start_time": {
+            "name": "Czas rozpoczęcia"
+          },
+          "end_time": {
+            "name": "Czas zakończenia"
+          },
+          "rate": {
+            "name": "Stawka"
+          },
+          "formatted_rate": {
+            "name": "Sformatowana stawka"
+          },
+          "tier_id": {
+            "name": "ID progu"
+          },
+          "start_value": {
+            "name": "Wartość początkowa"
+          },
+          "end_value": {
+            "name": "Wartość końcowa"
+          },
+          "unbounded": {
+            "name": "Bez górnego limitu"
+          },
+          "last_refresh_utc": {
+            "name": "Ostatnie odswiezenie (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Lokalizator taryfy"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "ID lokalizacji",
           "description": "Opcjonalny identyfikator lokalizacji; wykrywany automatycznie po wybraniu urządzenia lokalizacji."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Ustaw stawkę taryfy",
+      "description": "Aktualizuje jedną istniejącą wartość stawki importu lub eksportu Enphase.",
+      "fields": {
+        "rate": {
+          "name": "Stawka",
+          "description": "Nowa nieujemna wartość stawki taryfy."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "A atualização do agendamento entra em conflito com um agendamento de bateria existente: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "A tarifa deve ser um número não negativo."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "O destino da tarifa não foi encontrado nos dados de tarifa mais recentes."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "O destino da tarifa é inválido."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "A API de gravação de tarifas não está disponível."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Selecione exatamente uma entidade de tarifa."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "A entidade não é uma tarifa da Enphase: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Ultima atualizacao (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizador de tarifa"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Ultima atualizacao (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizador de tarifa"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Resumo dos agendamentos da bateria"
+      },
+      "tariff_current_import_rate": {
+        "name": "Tarifa atual de importação",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estrutura da tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacao"
+          },
+          "source": {
+            "name": "Fonte"
+          },
+          "currency": {
+            "name": "Moeda"
+          },
+          "season_id": {
+            "name": "ID da temporada"
+          },
+          "start_month": {
+            "name": "Mês inicial"
+          },
+          "end_month": {
+            "name": "Mês final"
+          },
+          "day_group_id": {
+            "name": "ID do grupo de dias"
+          },
+          "days": {
+            "name": "Dias"
+          },
+          "period_id": {
+            "name": "ID do período"
+          },
+          "period_type": {
+            "name": "Tipo de período"
+          },
+          "start_time": {
+            "name": "Hora de início"
+          },
+          "end_time": {
+            "name": "Hora de término"
+          },
+          "rate": {
+            "name": "Tarifa"
+          },
+          "formatted_rate": {
+            "name": "Tarifa formatada"
+          },
+          "tier_id": {
+            "name": "ID da faixa"
+          },
+          "start_value": {
+            "name": "Valor inicial"
+          },
+          "end_value": {
+            "name": "Valor final"
+          },
+          "unbounded": {
+            "name": "Sem limite superior"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima atualizacao (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizador de tarifa"
+          },
+          "active_rate_name": {
+            "name": "Nome da tarifa ativa"
+          },
+          "configured_rates": {
+            "name": "Tarifas configuradas"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Tarifa atual de exportação",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estrutura da tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacao"
+          },
+          "source": {
+            "name": "Fonte"
+          },
+          "currency": {
+            "name": "Moeda"
+          },
+          "export_plan": {
+            "name": "Plano de exportacao"
+          },
+          "season_id": {
+            "name": "ID da temporada"
+          },
+          "start_month": {
+            "name": "Mês inicial"
+          },
+          "end_month": {
+            "name": "Mês final"
+          },
+          "day_group_id": {
+            "name": "ID do grupo de dias"
+          },
+          "days": {
+            "name": "Dias"
+          },
+          "period_id": {
+            "name": "ID do período"
+          },
+          "period_type": {
+            "name": "Tipo de período"
+          },
+          "start_time": {
+            "name": "Hora de início"
+          },
+          "end_time": {
+            "name": "Hora de término"
+          },
+          "rate": {
+            "name": "Tarifa"
+          },
+          "formatted_rate": {
+            "name": "Tarifa formatada"
+          },
+          "tier_id": {
+            "name": "ID da faixa"
+          },
+          "start_value": {
+            "name": "Valor inicial"
+          },
+          "end_value": {
+            "name": "Valor final"
+          },
+          "unbounded": {
+            "name": "Sem limite superior"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima atualizacao (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizador de tarifa"
+          },
+          "active_rate_name": {
+            "name": "Nome da tarifa ativa"
+          },
+          "configured_rates": {
+            "name": "Tarifas configuradas"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Limite de agendamento da bateria"
+      },
+      "tariff_import_rate_value": {
+        "name": "Tarifa de importacao {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estrutura da tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacao"
+          },
+          "source": {
+            "name": "Fonte"
+          },
+          "currency": {
+            "name": "Moeda"
+          },
+          "season_id": {
+            "name": "ID da temporada"
+          },
+          "start_month": {
+            "name": "Mês inicial"
+          },
+          "end_month": {
+            "name": "Mês final"
+          },
+          "day_group_id": {
+            "name": "ID do grupo de dias"
+          },
+          "days": {
+            "name": "Dias"
+          },
+          "period_id": {
+            "name": "ID do período"
+          },
+          "period_type": {
+            "name": "Tipo de período"
+          },
+          "start_time": {
+            "name": "Hora de início"
+          },
+          "end_time": {
+            "name": "Hora de término"
+          },
+          "rate": {
+            "name": "Tarifa"
+          },
+          "formatted_rate": {
+            "name": "Tarifa formatada"
+          },
+          "tier_id": {
+            "name": "ID da faixa"
+          },
+          "start_value": {
+            "name": "Valor inicial"
+          },
+          "end_value": {
+            "name": "Valor final"
+          },
+          "unbounded": {
+            "name": "Sem limite superior"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima atualizacao (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizador de tarifa"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Tarifa de exportacao {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Estrutura da tarifa"
+          },
+          "variation_type": {
+            "name": "Tipo de variacao"
+          },
+          "source": {
+            "name": "Fonte"
+          },
+          "currency": {
+            "name": "Moeda"
+          },
+          "export_plan": {
+            "name": "Plano de exportacao"
+          },
+          "season_id": {
+            "name": "ID da temporada"
+          },
+          "start_month": {
+            "name": "Mês inicial"
+          },
+          "end_month": {
+            "name": "Mês final"
+          },
+          "day_group_id": {
+            "name": "ID do grupo de dias"
+          },
+          "days": {
+            "name": "Dias"
+          },
+          "period_id": {
+            "name": "ID do período"
+          },
+          "period_type": {
+            "name": "Tipo de período"
+          },
+          "start_time": {
+            "name": "Hora de início"
+          },
+          "end_time": {
+            "name": "Hora de término"
+          },
+          "rate": {
+            "name": "Tarifa"
+          },
+          "formatted_rate": {
+            "name": "Tarifa formatada"
+          },
+          "tier_id": {
+            "name": "ID da faixa"
+          },
+          "start_value": {
+            "name": "Valor inicial"
+          },
+          "end_value": {
+            "name": "Valor final"
+          },
+          "unbounded": {
+            "name": "Sem limite superior"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima atualizacao (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizador de tarifa"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "ID do local",
           "description": "Identificador opcional do local; detectado automaticamente quando um dispositivo do local é selecionado."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Definir tarifa",
+      "description": "Atualiza um valor existente de tarifa de importação ou exportação da Enphase.",
+      "fields": {
+        "rate": {
+          "name": "Tarifa",
+          "description": "Novo valor de tarifa não negativo."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Actualizarea planificării intră în conflict cu o planificare existentă a bateriei: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tariful trebuie să fie un număr nenegativ."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Ținta tarifului nu a fost găsită în cele mai recente date tarifare."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Ținta tarifului nu este validă."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "API-ul de scriere a tarifelor nu este disponibil."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Selectați exact o entitate de tarif."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entitatea nu este un tarif Enphase: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Ultima actualizare (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizator tarif"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Ultima actualizare (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizator tarif"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Rezumatul planificărilor bateriei"
+      },
+      "tariff_current_import_rate": {
+        "name": "Tarif curent de import",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structura tarifului"
+          },
+          "variation_type": {
+            "name": "Tip variatie"
+          },
+          "source": {
+            "name": "Sursa"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "season_id": {
+            "name": "ID sezon"
+          },
+          "start_month": {
+            "name": "Luna de început"
+          },
+          "end_month": {
+            "name": "Luna de sfârșit"
+          },
+          "day_group_id": {
+            "name": "ID grup de zile"
+          },
+          "days": {
+            "name": "Zile"
+          },
+          "period_id": {
+            "name": "ID perioadă"
+          },
+          "period_type": {
+            "name": "Tip perioadă"
+          },
+          "start_time": {
+            "name": "Ora de început"
+          },
+          "end_time": {
+            "name": "Ora de sfârșit"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Tarif formatat"
+          },
+          "tier_id": {
+            "name": "ID nivel"
+          },
+          "start_value": {
+            "name": "Valoare inițială"
+          },
+          "end_value": {
+            "name": "Valoare finală"
+          },
+          "unbounded": {
+            "name": "Fără limită superioară"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizare (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizator tarif"
+          },
+          "active_rate_name": {
+            "name": "Numele tarifului activ"
+          },
+          "configured_rates": {
+            "name": "Tarife configurate"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Tarif curent de export",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structura tarifului"
+          },
+          "variation_type": {
+            "name": "Tip variatie"
+          },
+          "source": {
+            "name": "Sursa"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "export_plan": {
+            "name": "Plan de export"
+          },
+          "season_id": {
+            "name": "ID sezon"
+          },
+          "start_month": {
+            "name": "Luna de început"
+          },
+          "end_month": {
+            "name": "Luna de sfârșit"
+          },
+          "day_group_id": {
+            "name": "ID grup de zile"
+          },
+          "days": {
+            "name": "Zile"
+          },
+          "period_id": {
+            "name": "ID perioadă"
+          },
+          "period_type": {
+            "name": "Tip perioadă"
+          },
+          "start_time": {
+            "name": "Ora de început"
+          },
+          "end_time": {
+            "name": "Ora de sfârșit"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Tarif formatat"
+          },
+          "tier_id": {
+            "name": "ID nivel"
+          },
+          "start_value": {
+            "name": "Valoare inițială"
+          },
+          "end_value": {
+            "name": "Valoare finală"
+          },
+          "unbounded": {
+            "name": "Fără limită superioară"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizare (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizator tarif"
+          },
+          "active_rate_name": {
+            "name": "Numele tarifului activ"
+          },
+          "configured_rates": {
+            "name": "Tarife configurate"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Limită de planificare a bateriei"
+      },
+      "tariff_import_rate_value": {
+        "name": "Tarif de import {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structura tarifului"
+          },
+          "variation_type": {
+            "name": "Tip variatie"
+          },
+          "source": {
+            "name": "Sursa"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "season_id": {
+            "name": "ID sezon"
+          },
+          "start_month": {
+            "name": "Luna de început"
+          },
+          "end_month": {
+            "name": "Luna de sfârșit"
+          },
+          "day_group_id": {
+            "name": "ID grup de zile"
+          },
+          "days": {
+            "name": "Zile"
+          },
+          "period_id": {
+            "name": "ID perioadă"
+          },
+          "period_type": {
+            "name": "Tip perioadă"
+          },
+          "start_time": {
+            "name": "Ora de început"
+          },
+          "end_time": {
+            "name": "Ora de sfârșit"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Tarif formatat"
+          },
+          "tier_id": {
+            "name": "ID nivel"
+          },
+          "start_value": {
+            "name": "Valoare inițială"
+          },
+          "end_value": {
+            "name": "Valoare finală"
+          },
+          "unbounded": {
+            "name": "Fără limită superioară"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizare (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizator tarif"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Tarif de export {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Structura tarifului"
+          },
+          "variation_type": {
+            "name": "Tip variatie"
+          },
+          "source": {
+            "name": "Sursa"
+          },
+          "currency": {
+            "name": "Moneda"
+          },
+          "export_plan": {
+            "name": "Plan de export"
+          },
+          "season_id": {
+            "name": "ID sezon"
+          },
+          "start_month": {
+            "name": "Luna de început"
+          },
+          "end_month": {
+            "name": "Luna de sfârșit"
+          },
+          "day_group_id": {
+            "name": "ID grup de zile"
+          },
+          "days": {
+            "name": "Zile"
+          },
+          "period_id": {
+            "name": "ID perioadă"
+          },
+          "period_type": {
+            "name": "Tip perioadă"
+          },
+          "start_time": {
+            "name": "Ora de început"
+          },
+          "end_time": {
+            "name": "Ora de sfârșit"
+          },
+          "rate": {
+            "name": "Tarif"
+          },
+          "formatted_rate": {
+            "name": "Tarif formatat"
+          },
+          "tier_id": {
+            "name": "ID nivel"
+          },
+          "start_value": {
+            "name": "Valoare inițială"
+          },
+          "end_value": {
+            "name": "Valoare finală"
+          },
+          "unbounded": {
+            "name": "Fără limită superioară"
+          },
+          "last_refresh_utc": {
+            "name": "Ultima actualizare (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Localizator tarif"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "ID site",
           "description": "Identificator opțional al site-ului; detectat automat când este selectat un dispozitiv de site."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Setează tariful",
+      "description": "Actualizează o valoare existentă a tarifului de import sau export Enphase.",
+      "fields": {
+        "rate": {
+          "name": "Tarif",
+          "description": "Valoare nouă de tarif nenegativă."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -393,6 +393,24 @@
     },
     "schedule_update_conflict_detail": {
       "message": "Schemauppdateringen konflikterar med ett befintligt batterischema: {message}"
+    },
+    "tariff_rate_invalid": {
+      "message": "Tariffpriset måste vara ett icke-negativt tal."
+    },
+    "tariff_rate_target_not_found": {
+      "message": "Målet för tariffpriset hittades inte i de senaste tariffuppgifterna."
+    },
+    "tariff_rate_target_invalid": {
+      "message": "Målet för tariffpriset är ogiltigt."
+    },
+    "tariff_rate_api_unavailable": {
+      "message": "API för tariffskrivning är inte tillgängligt."
+    },
+    "tariff_rate_entity_required": {
+      "message": "Välj exakt en tariffprisentitet."
+    },
+    "tariff_rate_entity_invalid": {
+      "message": "Entiteten är inte ett Enphase-tariffpris: {entity_id}"
     }
   },
   "options": {
@@ -1244,6 +1262,9 @@
           },
           "last_refresh_utc": {
             "name": "Senaste uppdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifflokaliserare"
           }
         }
       },
@@ -1338,6 +1359,9 @@
           },
           "last_refresh_utc": {
             "name": "Senaste uppdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifflokaliserare"
           }
         }
       },
@@ -1496,6 +1520,157 @@
       },
       "battery_schedule_summary": {
         "name": "Sammanfattning av batterischeman"
+      },
+      "tariff_current_import_rate": {
+        "name": "Aktuell importtariff",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Kaella"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Säsongs-ID"
+          },
+          "start_month": {
+            "name": "Startmånad"
+          },
+          "end_month": {
+            "name": "Slutmånad"
+          },
+          "day_group_id": {
+            "name": "Daggrupps-ID"
+          },
+          "days": {
+            "name": "Dagar"
+          },
+          "period_id": {
+            "name": "Period-ID"
+          },
+          "period_type": {
+            "name": "Periodtyp"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Pris"
+          },
+          "formatted_rate": {
+            "name": "Formaterat pris"
+          },
+          "tier_id": {
+            "name": "Nivå-ID"
+          },
+          "start_value": {
+            "name": "Startvärde"
+          },
+          "end_value": {
+            "name": "Slutvärde"
+          },
+          "unbounded": {
+            "name": "Utan övre gräns"
+          },
+          "last_refresh_utc": {
+            "name": "Senaste uppdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifflokaliserare"
+          },
+          "active_rate_name": {
+            "name": "Namn på aktiv tariff"
+          },
+          "configured_rates": {
+            "name": "Konfigurerade tariffer"
+          }
+        }
+      },
+      "tariff_current_export_rate": {
+        "name": "Aktuell exporttariff",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Kaella"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Exportplan"
+          },
+          "season_id": {
+            "name": "Säsongs-ID"
+          },
+          "start_month": {
+            "name": "Startmånad"
+          },
+          "end_month": {
+            "name": "Slutmånad"
+          },
+          "day_group_id": {
+            "name": "Daggrupps-ID"
+          },
+          "days": {
+            "name": "Dagar"
+          },
+          "period_id": {
+            "name": "Period-ID"
+          },
+          "period_type": {
+            "name": "Periodtyp"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Pris"
+          },
+          "formatted_rate": {
+            "name": "Formaterat pris"
+          },
+          "tier_id": {
+            "name": "Nivå-ID"
+          },
+          "start_value": {
+            "name": "Startvärde"
+          },
+          "end_value": {
+            "name": "Slutvärde"
+          },
+          "unbounded": {
+            "name": "Utan övre gräns"
+          },
+          "last_refresh_utc": {
+            "name": "Senaste uppdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifflokaliserare"
+          },
+          "active_rate_name": {
+            "name": "Namn på aktiv tariff"
+          },
+          "configured_rates": {
+            "name": "Konfigurerade tariffer"
+          }
+        }
       }
     },
     "number": {
@@ -1522,6 +1697,145 @@
       },
       "battery_schedule_edit_limit": {
         "name": "Gräns för batterischema"
+      },
+      "tariff_import_rate_value": {
+        "name": "Importtariff {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Kaella"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "season_id": {
+            "name": "Säsongs-ID"
+          },
+          "start_month": {
+            "name": "Startmånad"
+          },
+          "end_month": {
+            "name": "Slutmånad"
+          },
+          "day_group_id": {
+            "name": "Daggrupps-ID"
+          },
+          "days": {
+            "name": "Dagar"
+          },
+          "period_id": {
+            "name": "Period-ID"
+          },
+          "period_type": {
+            "name": "Periodtyp"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Pris"
+          },
+          "formatted_rate": {
+            "name": "Formaterat pris"
+          },
+          "tier_id": {
+            "name": "Nivå-ID"
+          },
+          "start_value": {
+            "name": "Startvärde"
+          },
+          "end_value": {
+            "name": "Slutvärde"
+          },
+          "unbounded": {
+            "name": "Utan övre gräns"
+          },
+          "last_refresh_utc": {
+            "name": "Senaste uppdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifflokaliserare"
+          }
+        }
+      },
+      "tariff_export_rate_value": {
+        "name": "Exporttariff {detail}",
+        "state_attributes": {
+          "rate_structure": {
+            "name": "Tariffstruktur"
+          },
+          "variation_type": {
+            "name": "Variationstyp"
+          },
+          "source": {
+            "name": "Kaella"
+          },
+          "currency": {
+            "name": "Valuta"
+          },
+          "export_plan": {
+            "name": "Exportplan"
+          },
+          "season_id": {
+            "name": "Säsongs-ID"
+          },
+          "start_month": {
+            "name": "Startmånad"
+          },
+          "end_month": {
+            "name": "Slutmånad"
+          },
+          "day_group_id": {
+            "name": "Daggrupps-ID"
+          },
+          "days": {
+            "name": "Dagar"
+          },
+          "period_id": {
+            "name": "Period-ID"
+          },
+          "period_type": {
+            "name": "Periodtyp"
+          },
+          "start_time": {
+            "name": "Starttid"
+          },
+          "end_time": {
+            "name": "Sluttid"
+          },
+          "rate": {
+            "name": "Pris"
+          },
+          "formatted_rate": {
+            "name": "Formaterat pris"
+          },
+          "tier_id": {
+            "name": "Nivå-ID"
+          },
+          "start_value": {
+            "name": "Startvärde"
+          },
+          "end_value": {
+            "name": "Slutvärde"
+          },
+          "unbounded": {
+            "name": "Utan övre gräns"
+          },
+          "last_refresh_utc": {
+            "name": "Senaste uppdatering (UTC)"
+          },
+          "tariff_locator": {
+            "name": "Tarifflokaliserare"
+          }
+        }
       }
     },
     "binary_sensor": {
@@ -2195,6 +2509,16 @@
         "site_id": {
           "name": "Plats-ID",
           "description": "Valfri platsidentifierare; identifieras automatiskt när en platsenhet väljs."
+        }
+      }
+    },
+    "set_tariff_rate": {
+      "name": "Ange tariffpris",
+      "description": "Uppdaterar ett befintligt Enphase import- eller exporttariffvärde.",
+      "fields": {
+        "rate": {
+          "name": "Pris",
+          "description": "Nytt icke-negativt tariffvärde."
         }
       }
     }

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3788,6 +3788,45 @@ async def test_site_tariff_bundle_fetches_billing_and_tariff() -> None:
 
 
 @pytest.mark.asyncio
+async def test_site_tariff_update_passes_user_id_and_write_headers() -> None:
+    token = _make_token({"user_id": "77"})
+    client = _make_client()
+    client.update_credentials(
+        eauth=token,
+        cookie="session=1; XSRF-TOKEN=xsrf-token; other=1",
+    )
+    client._json = AsyncMock(return_value={"message": "success"})
+
+    out = await client.site_tariff_update({"purchase": {"typeId": "flat"}})
+
+    assert out == {"message": "success"}
+    args, kwargs = client._json.await_args
+    assert args[0] == "PUT"
+    assert "/service/tariff/tariff-ms/systems/SITE/tariff" in args[1]
+    assert kwargs["params"] == {"user-id": "77"}
+    assert kwargs["json"] == {"purchase": {"typeId": "flat"}}
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+    assert kwargs["headers"]["e-auth-token"] == token
+    assert kwargs["headers"]["Username"] == "77"
+    assert kwargs["headers"]["x-xsrf-token"] == "xsrf-token"
+
+
+@pytest.mark.asyncio
+async def test_notify_tariff_change_uses_scheduler_endpoint() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value={"data": "Request Accepted"})
+
+    out = await client.notify_tariff_change()
+
+    assert out == {"data": "Request Accepted"}
+    args, kwargs = client._json.await_args
+    assert args[0] == "PUT"
+    assert "/service/evse_scheduler/api/v1/siteConfig/SITE/tariff_change" in args[1]
+    assert kwargs["json"] is None
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
 async def test_battery_settings_details_passes_params_and_headers() -> None:
     token = _make_token({"user_id": "99"})
     client = _make_client()

--- a/tests/components/enphase_ev/test_number_module.py
+++ b/tests/components/enphase_ev/test_number_module.py
@@ -14,9 +14,15 @@ from custom_components.enphase_ev.number import (
     BatteryScheduleEditLimitNumber,
     BatteryShutdownLevelNumber,
     ChargingAmpsNumber,
+    EnphaseTariffRateNumber,
     async_setup_entry,
 )
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
+from custom_components.enphase_ev.tariff import (
+    TariffRateSnapshot,
+    parse_tariff_rate,
+    tariff_rate_sensor_specs,
+)
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
 
 
@@ -517,3 +523,235 @@ def test_battery_schedule_edit_limit_number_unavailable_without_editor(
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
 
     assert BatteryScheduleEditLimitNumber(coord, config_entry).available is False
+
+
+def test_tariff_rate_number_exposes_value_unit_attributes_and_device_info(
+    hass, config_entry
+) -> None:
+    coord = _make_coordinator(hass, config_entry, {RANDOM_SERIAL: {}})
+    coord.client.site_tariff = AsyncMock()
+    coord.client.site_tariff_update = AsyncMock()
+    envoy_info = {"identifiers": {("enphase_ev", "envoy")}}
+    coord.inventory_view.type_device_info = lambda type_key: (
+        envoy_info if type_key == "envoy" else None
+    )
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "id": "peak-1",
+                                        "type": "peak",
+                                        "rate": "0.31",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    spec = tariff_rate_sensor_specs(coord.tariff_import_rate)[0]
+
+    number = EnphaseTariffRateNumber(coord, spec, is_import=True)
+
+    assert number.available is True
+    assert number.native_value == 0.31
+    assert number.native_unit_of_measurement == "$/kWh"
+    assert number.extra_state_attributes["tariff_locator"]["branch"] == "purchase"
+    assert number.entity_category == "config"
+    assert number.device_info is envoy_info
+
+    cloud_info = {"identifiers": {("enphase_ev", "cloud")}}
+    coord.inventory_view.type_device_info = lambda type_key: (
+        cloud_info if type_key == "cloud" else None
+    )
+    assert number.device_info is cloud_info
+
+
+def test_tariff_rate_number_fallback_paths(hass, config_entry) -> None:
+    from custom_components.enphase_ev import number as number_mod
+
+    coord = _make_coordinator(hass, config_entry, {RANDOM_SERIAL: {}})
+    coord.client.site_tariff = AsyncMock()
+    coord.client.site_tariff_update = AsyncMock()
+    coord.inventory_runtime._set_type_device_buckets({}, [])  # noqa: SLF001
+    coord.inventory_view.type_device_info = lambda *_args, **_kwargs: None
+    coord.tariff_import_rate = TariffRateSnapshot(
+        state="Flat",
+        rate_structure="Flat",
+        variation_type="Single",
+        source="manual",
+        currency=None,
+        export_plan=None,
+        seasons=(
+            {
+                "id": "default",
+                "days": [{"id": "week", "periods": [{"rate": "0.18"}]}],
+            },
+        ),
+    )
+    assert number_mod._tariff_rate_number_entities(coord) == {}
+
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "flat",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [{"id": "off-peak", "rate": "0.18"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    spec = tariff_rate_sensor_specs(coord.tariff_import_rate)[0]
+    number = EnphaseTariffRateNumber(coord, spec, is_import=True)
+    number._detail_key = "missing"  # noqa: SLF001
+
+    assert number.available is False
+    assert number.native_value is None
+    assert number.native_unit_of_measurement is None
+    assert number.extra_state_attributes == {}
+    assert number.device_info["identifiers"] == {
+        ("enphase_ev", f"site:{coord.site_id}")
+    }
+
+
+def test_tariff_rate_number_uses_home_assistant_currency(hass, config_entry) -> None:
+    coord = _make_coordinator(hass, config_entry, {RANDOM_SERIAL: {}})
+    coord.client.site_tariff = AsyncMock()
+    coord.client.site_tariff_update = AsyncMock()
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "flat",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [{"id": "off-peak", "rate": "0.18"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    spec = tariff_rate_sensor_specs(coord.tariff_import_rate)[0]
+    number = EnphaseTariffRateNumber(coord, spec, is_import=True)
+    number.hass = hass
+    hass.config.currency = "EUR"
+
+    assert number.native_unit_of_measurement == "EUR/kWh"
+
+
+@pytest.mark.asyncio
+async def test_tariff_rate_number_sets_value(hass, config_entry) -> None:
+    coord = _make_coordinator(hass, config_entry, {RANDOM_SERIAL: {}})
+    coord.tariff_runtime.async_set_tariff_rate = AsyncMock()
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "flat",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [{"id": "off-peak", "rate": "0.18"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    spec = tariff_rate_sensor_specs(coord.tariff_import_rate)[0]
+
+    await EnphaseTariffRateNumber(coord, spec, is_import=True).async_set_native_value(
+        0.22
+    )
+
+    coord.tariff_runtime.async_set_tariff_rate.assert_awaited_once_with(
+        spec["attributes"]["tariff_locator"], 0.22
+    )
+
+
+@pytest.mark.asyncio
+async def test_tariff_rate_numbers_are_created_and_stale_entries_pruned(
+    hass, config_entry
+) -> None:
+    from homeassistant.helpers import entity_registry as er
+
+    coord = _make_coordinator(hass, config_entry, {})
+    coord._devices_inventory_ready = True  # noqa: SLF001
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "flat",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [{"id": "off-peak", "rate": "0.18"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    ent_reg = er.async_get(hass)
+    stale_unique_id = f"enphase_ev_site_{coord.site_id}_tariff_import_rate_old_number"
+    ent_reg.async_get_or_create(
+        "number",
+        "enphase_ev",
+        stale_unique_id,
+        config_entry=config_entry,
+    )
+    added = []
+
+    await async_setup_entry(
+        hass, config_entry, lambda entities, **_: added.extend(entities)
+    )
+
+    tariff_numbers = [
+        entity.unique_id for entity in added if "tariff_import_rate" in entity.unique_id
+    ]
+    assert tariff_numbers == [
+        f"enphase_ev_site_{coord.site_id}_tariff_import_rate_default_week_off_peak_number"
+    ]
+    assert ent_reg.async_get_entity_id("number", "enphase_ev", stale_unique_id) is None

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -346,11 +346,17 @@ def test_tariff_entity_strings_exist_for_all_locales() -> None:
         "end_time",
         "rate",
         "formatted_rate",
+        "tariff_locator",
         "tier_id",
         "start_value",
         "end_value",
         "unbounded",
         "last_refresh_utc",
+    ]
+    current_rate_attrs = [
+        *rate_value_attrs,
+        "active_rate_name",
+        "configured_rates",
     ]
     paths = [
         "entity.sensor.tariff_billing_cycle.name",
@@ -377,12 +383,20 @@ def test_tariff_entity_strings_exist_for_all_locales() -> None:
     ]
     for family in ("import", "export"):
         key = f"tariff_{family}_rate_value"
+        current_key = f"tariff_current_{family}_rate"
         paths.append(f"entity.sensor.{key}.name")
+        paths.append(f"entity.sensor.{current_key}.name")
+        paths.append(f"entity.number.{key}.name")
         attrs = list(rate_value_attrs)
+        current_attrs = list(current_rate_attrs)
         if family == "export":
             attrs.append("export_plan")
+            current_attrs.append("export_plan")
         for attr in attrs:
             paths.append(f"entity.sensor.{key}.state_attributes.{attr}.name")
+            paths.append(f"entity.number.{key}.state_attributes.{attr}.name")
+        for attr in current_attrs:
+            paths.append(f"entity.sensor.{current_key}.state_attributes.{attr}.name")
     for locale in translations_dir.glob("*.json"):
         data = json.loads(locale.read_text(encoding="utf-8"))
         for path in paths:
@@ -406,13 +420,22 @@ def test_tariff_entity_strings_localized_for_non_english_locales() -> None:
         "entity.sensor.tariff_billing_cycle.state_attributes.billing_cycle.name",
         "entity.sensor.tariff_import_rate.name",
         "entity.sensor.tariff_import_rate.state_attributes.rate_structure.name",
+        "entity.sensor.tariff_current_import_rate.name",
+        "entity.sensor.tariff_current_import_rate.state_attributes.active_rate_name.name",
+        "entity.sensor.tariff_current_import_rate.state_attributes.configured_rates.name",
         "entity.sensor.tariff_import_rate_value.name",
         "entity.sensor.tariff_import_rate_value.state_attributes.period_type.name",
         "entity.sensor.tariff_import_rate_value.state_attributes.formatted_rate.name",
+        "entity.sensor.tariff_import_rate_value.state_attributes.tariff_locator.name",
+        "entity.number.tariff_import_rate_value.name",
         "entity.sensor.tariff_export_rate.name",
         "entity.sensor.tariff_export_rate.state_attributes.export_plan.name",
+        "entity.sensor.tariff_current_export_rate.name",
+        "entity.sensor.tariff_current_export_rate.state_attributes.active_rate_name.name",
+        "entity.sensor.tariff_current_export_rate.state_attributes.configured_rates.name",
         "entity.sensor.tariff_export_rate_value.name",
         "entity.sensor.tariff_export_rate_value.state_attributes.rate.name",
+        "entity.number.tariff_export_rate_value.name",
     ]
     for locale in translations_dir.glob("*.json"):
         name = locale.name

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -9,6 +9,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import entity_registry as er
 
 from custom_components.enphase_ev.const import CONF_SITE_ID, CONF_SITE_ONLY, DOMAIN
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
@@ -330,3 +331,234 @@ async def test_try_reauth_now_reports_manual_retry_cooldown(
     coord.async_start_streaming.assert_not_awaited()
     coord.async_stop_streaming.assert_not_awaited()
     coord.schedule_sync.async_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_set_tariff_rate_targets_tariff_entity(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    handlers = _register_service_handlers(hass, monkeypatch)
+    coord = _fake_service_coordinator(site_id="tariff-site", serials=set())
+    coord.tariff_runtime = SimpleNamespace(async_set_tariff_rate=AsyncMock())
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "tariff-site", CONF_SITE_ONLY: True},
+        title="Tariff Site",
+        unique_id="tariff-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    locator = {
+        "branch": "purchase",
+        "kind": "period",
+        "season_index": 1,
+        "day_index": 1,
+        "period_index": 1,
+    }
+    reg_entry = er.async_get(hass).async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_tariff-site_tariff_import_rate_default_week_peak",
+        config_entry=entry,
+    )
+    hass.states.async_set(reg_entry.entity_id, 0.18, {"tariff_locator": locator})
+
+    await handlers[(DOMAIN, "set_tariff_rate")](
+        SimpleNamespace(data={"entity_id": [reg_entry.entity_id], "rate": 0.25})
+    )
+
+    coord.tariff_runtime.async_set_tariff_rate.assert_awaited_once_with(locator, 0.25)
+
+
+@pytest.mark.asyncio
+async def test_set_tariff_rate_targets_current_tariff_sensor(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    handlers = _register_service_handlers(hass, monkeypatch)
+    coord = _fake_service_coordinator(site_id="tariff-site", serials=set())
+    coord.tariff_runtime = SimpleNamespace(async_set_tariff_rate=AsyncMock())
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "tariff-site", CONF_SITE_ONLY: True},
+        title="Tariff Site",
+        unique_id="tariff-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    locator = {
+        "branch": "purchase",
+        "kind": "period",
+        "season_index": 1,
+        "day_index": 1,
+        "period_index": 1,
+    }
+    reg_entry = er.async_get(hass).async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_tariff-site_tariff_current_import_rate",
+        config_entry=entry,
+    )
+    hass.states.async_set(reg_entry.entity_id, 0.18, {"tariff_locator": locator})
+
+    await handlers[(DOMAIN, "set_tariff_rate")](
+        SimpleNamespace(data={"entity_id": [reg_entry.entity_id], "rate": 0.25})
+    )
+
+    coord.tariff_runtime.async_set_tariff_rate.assert_awaited_once_with(locator, 0.25)
+
+
+@pytest.mark.asyncio
+async def test_set_tariff_rate_rejects_invalid_targets(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    handlers = _register_service_handlers(hass, monkeypatch)
+    coord = _fake_service_coordinator(site_id="tariff-site", serials=set())
+    coord.tariff_runtime = SimpleNamespace(async_set_tariff_rate=AsyncMock())
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "tariff-site", CONF_SITE_ONLY: True},
+        title="Tariff Site",
+        unique_id="tariff-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    ent_reg = er.async_get(hass)
+
+    with pytest.raises(ServiceValidationError):
+        await handlers[(DOMAIN, "set_tariff_rate")](
+            SimpleNamespace(data={"rate": 0.25})
+        )
+
+    with pytest.raises(ServiceValidationError):
+        await handlers[(DOMAIN, "set_tariff_rate")](
+            SimpleNamespace(
+                data={"entity_id": ["sensor.one", "sensor.two"], "rate": 0.25}
+            )
+        )
+
+    hass.states.async_set("sensor.not_tariff", 1)
+    with pytest.raises(ServiceValidationError):
+        await handlers[(DOMAIN, "set_tariff_rate")](
+            SimpleNamespace(data={"entity_id": ["sensor.not_tariff"], "rate": 0.25})
+        )
+
+    other_entry = ent_reg.async_get_or_create(
+        "sensor",
+        "other_platform",
+        "external_tariff_import_rate",
+        config_entry=entry,
+    )
+    with pytest.raises(ServiceValidationError):
+        await handlers[(DOMAIN, "set_tariff_rate")](
+            SimpleNamespace(data={"entity_id": [other_entry.entity_id], "rate": 0.25})
+        )
+
+    non_tariff_entry = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_tariff-site_grid_import",
+        config_entry=entry,
+    )
+    with pytest.raises(ServiceValidationError):
+        await handlers[(DOMAIN, "set_tariff_rate")](
+            SimpleNamespace(
+                data={"entity_id": [non_tariff_entry.entity_id], "rate": 0.25}
+            )
+        )
+
+    missing_locator = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_tariff-site_tariff_import_rate_default_week_peak",
+        config_entry=entry,
+    )
+    hass.states.async_set(missing_locator.entity_id, 0.18)
+    with pytest.raises(ServiceValidationError):
+        await handlers[(DOMAIN, "set_tariff_rate")](
+            SimpleNamespace(
+                data={"entity_id": [missing_locator.entity_id], "rate": 0.25}
+            )
+        )
+
+    wrong_site = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_other-site_tariff_import_rate_default_week_peak",
+    )
+    hass.states.async_set(wrong_site.entity_id, 0.18, {"tariff_locator": {}})
+    with pytest.raises(ServiceValidationError):
+        await handlers[(DOMAIN, "set_tariff_rate")](
+            SimpleNamespace(data={"entity_id": [wrong_site.entity_id], "rate": 0.25})
+        )
+
+
+@pytest.mark.asyncio
+async def test_set_tariff_rate_falls_back_to_tariff_entity_unique_id(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    handlers = _register_service_handlers(hass, monkeypatch)
+    coord = _fake_service_coordinator(site_id="tariff-site", serials=set())
+    coord.tariff_runtime = SimpleNamespace(async_set_tariff_rate=AsyncMock())
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "tariff-site", CONF_SITE_ONLY: True},
+        title="Tariff Site",
+        unique_id="tariff-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    locator = {
+        "branch": "purchase",
+        "kind": "period",
+        "season_index": 1,
+        "day_index": 1,
+        "period_index": 1,
+    }
+    reg_entry = er.async_get(hass).async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_tariff-site_tariff_import_rate_default_week_peak",
+    )
+    hass.states.async_set(reg_entry.entity_id, 0.18, {"tariff_locator": locator})
+
+    await handlers[(DOMAIN, "set_tariff_rate")](
+        SimpleNamespace(data={"entity_id": reg_entry.entity_id, "rate": 0.25})
+    )
+
+    coord.tariff_runtime.async_set_tariff_rate.assert_awaited_once_with(locator, 0.25)
+
+
+@pytest.mark.asyncio
+async def test_set_tariff_rate_uses_legacy_entity_target_extractor(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from custom_components.enphase_ev import services as services_mod
+
+    monkeypatch.setattr(
+        services_mod.ha_target,
+        "async_extract_referenced_entity_ids",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        services_mod.ha_service,
+        "async_extract_referenced_entity_ids",
+        lambda _hass, _call: {"sensor.missing"},
+    )
+    handlers = _register_service_handlers(hass, monkeypatch)
+
+    with pytest.raises(ServiceValidationError):
+        await handlers[(DOMAIN, "set_tariff_rate")](SimpleNamespace(data={"rate": 1}))
+
+    def _raise(*_args, **_kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(
+        services_mod.ha_service,
+        "async_extract_referenced_entity_ids",
+        _raise,
+    )
+    handlers = _register_service_handlers(hass, monkeypatch)
+
+    with pytest.raises(ServiceValidationError):
+        await handlers[(DOMAIN, "set_tariff_rate")](SimpleNamespace(data={"rate": 1}))

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -6,11 +6,14 @@ from unittest.mock import AsyncMock, MagicMock
 
 import aiohttp
 import pytest
+from homeassistant.exceptions import ServiceValidationError
 
+from custom_components.enphase_ev import sensor as sensor_mod
 from custom_components.enphase_ev.api import OptionalEndpointUnavailable
 from custom_components.enphase_ev.const import DOMAIN
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
 from custom_components.enphase_ev.sensor import (
+    EnphaseCurrentTariffRateSensor,
     EnphaseTariffBillingSensor,
     EnphaseTariffExportRateValueSensor,
     EnphaseTariffRateSensor,
@@ -19,12 +22,16 @@ from custom_components.enphase_ev.sensor import (
 )
 from custom_components.enphase_ev.tariff import (
     TARIFF_ENDPOINT_FAMILY,
+    TariffRateLocator,
     TariffRateSnapshot,
     TariffRuntime,
     _clean_text,
     _format_rate,
+    _locate_tariff_rate,
+    current_tariff_rate_sensor_spec,
     export_rate_sensor_specs,
     next_billing_date,
+    next_tariff_rate_change,
     parse_tariff_billing,
     parse_tariff_rate,
     tariff_rate_sensor_specs,
@@ -228,6 +235,17 @@ def test_tariff_rate_sensor_specs_for_tou_and_tiered_rates() -> None:
     assert [spec["unit"] for spec in import_specs] == ["$/kWh", "$/kWh"]
     assert import_specs[0]["attributes"]["formatted_rate"] == "$0.18"
     assert import_specs[0]["attributes"]["source"] == "manual"
+    assert import_specs[0]["attributes"]["tariff_locator"] == {
+        "branch": "purchase",
+        "kind": "period",
+        "season_index": 1,
+        "season_id": "default",
+        "day_index": 1,
+        "day_group_id": "week",
+        "period_index": 1,
+        "period_id": "off-peak",
+        "period_type": "off-peak",
+    }
 
     export_tou = parse_tariff_rate(
         {
@@ -306,6 +324,38 @@ def test_tariff_rate_sensor_specs_for_tou_and_tiered_rates() -> None:
     assert [spec["state"] for spec in tier_specs] == [0.04, 0.10]
     assert [spec["unit"] for spec in tier_specs] == ["AUD/kWh", "AUD/kWh"]
     assert tier_specs[1]["attributes"]["unbounded"] is True
+
+    tiered_with_off_peak = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tiered",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "offPeak": "0.03",
+                        "tiers": [{"id": "tier-1", "rate": "0.06"}],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+
+    off_peak_specs = tariff_rate_sensor_specs(tiered_with_off_peak)
+
+    assert [spec["key"] for spec in off_peak_specs] == [
+        "default_off_peak",
+        "default_tier_1",
+    ]
+    assert [spec["state"] for spec in off_peak_specs] == [0.03, 0.06]
+    assert off_peak_specs[0]["attributes"]["tariff_locator"] == {
+        "branch": "purchase",
+        "kind": "off_peak",
+        "season_index": 1,
+        "season_id": "default",
+    }
 
 
 def test_export_rate_sensor_specs_handles_sparse_and_duplicate_rows() -> None:
@@ -403,6 +453,261 @@ def test_export_rate_sensor_specs_handles_sparse_and_duplicate_rows() -> None:
     )
 
 
+def test_current_tariff_rate_sensor_spec_selects_active_period() -> None:
+    snapshot = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "seasonal-and-weekends",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "summer",
+                        "startMonth": "12",
+                        "endMonth": "2",
+                        "days": [
+                            {
+                                "id": "weekday",
+                                "days": [1, 2, 3, 4, 5],
+                                "periods": [
+                                    {
+                                        "type": "off-peak",
+                                        "rate": "0.18",
+                                        "startTime": "1320",
+                                        "endTime": "420",
+                                    },
+                                    {
+                                        "type": "peak",
+                                        "rate": "0.42",
+                                        "startTime": "420",
+                                        "endTime": "1320",
+                                    },
+                                ],
+                            },
+                            {
+                                "id": "weekend",
+                                "days": [6, 7],
+                                "periods": [{"type": "shoulder", "rate": "0.24"}],
+                            },
+                        ],
+                    },
+                    {
+                        "id": "winter",
+                        "startMonth": "3",
+                        "endMonth": "11",
+                        "days": [{"id": "all", "periods": [{"rate": "0.30"}]}],
+                    },
+                ],
+            },
+        },
+        "purchase",
+    )
+
+    peak = current_tariff_rate_sensor_spec(
+        snapshot,
+        datetime(2026, 1, 5, 9, 0, tzinfo=timezone.utc),
+    )
+    off_peak = current_tariff_rate_sensor_spec(
+        snapshot,
+        datetime(2026, 1, 5, 23, 30, tzinfo=timezone.utc),
+    )
+    weekend = current_tariff_rate_sensor_spec(
+        snapshot,
+        datetime(2026, 1, 10, 9, 0, tzinfo=timezone.utc),
+    )
+    winter = current_tariff_rate_sensor_spec(
+        snapshot,
+        datetime(2026, 6, 5, 9, 0, tzinfo=timezone.utc),
+    )
+
+    assert peak is not None
+    assert peak["name"] == "Peak"
+    assert peak["state"] == 0.42
+    assert off_peak is not None
+    assert off_peak["name"] == "Off-Peak"
+    assert weekend is not None
+    assert weekend["name"] == "Shoulder"
+    assert winter is not None
+    assert winter["state"] == 0.30
+
+
+def test_next_tariff_rate_change_finds_time_and_season_boundaries() -> None:
+    snapshot = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "seasonal-and-weekends",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "summer",
+                        "startMonth": "12",
+                        "endMonth": "2",
+                        "days": [
+                            {
+                                "id": "weekday",
+                                "days": [1, 2, 3, 4, 5],
+                                "periods": [
+                                    {
+                                        "type": "off-peak",
+                                        "rate": "0.18",
+                                        "startTime": "1320",
+                                        "endTime": "420",
+                                    },
+                                    {
+                                        "type": "peak",
+                                        "rate": "0.42",
+                                        "startTime": "420",
+                                        "endTime": "1320",
+                                    },
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "id": "winter",
+                        "startMonth": "3",
+                        "endMonth": "11",
+                        "days": [{"id": "all", "periods": [{"rate": "0.30"}]}],
+                    },
+                ],
+            },
+        },
+        "purchase",
+    )
+
+    assert next_tariff_rate_change(
+        snapshot,
+        datetime(2026, 1, 5, 6, 59, tzinfo=timezone.utc),
+    ) == datetime(2026, 1, 5, 7, 0, tzinfo=timezone.utc)
+    assert next_tariff_rate_change(
+        snapshot,
+        datetime(2026, 1, 5, 21, 59, tzinfo=timezone.utc),
+    ) == datetime(2026, 1, 5, 22, 0, tzinfo=timezone.utc)
+    assert next_tariff_rate_change(
+        snapshot,
+        datetime(2026, 2, 28, 23, 30, tzinfo=timezone.utc),
+    ) == datetime(2026, 3, 1, 0, 0, tzinfo=timezone.utc)
+
+
+def test_next_tariff_rate_change_handles_missing_naive_and_unchanged_rates() -> None:
+    snapshot = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "all",
+                                "periods": [{"type": "flat", "rate": "0.20"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+
+    assert next_tariff_rate_change(None, datetime(2026, 1, 1, 12, 0)) is None
+    assert (
+        next_tariff_rate_change(
+            snapshot,
+            datetime(2026, 1, 1, 12, 0),
+        )
+        is None
+    )
+
+
+def test_current_tariff_rate_sensor_spec_rejects_ambiguous_tiers() -> None:
+    snapshot = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tiered",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "tiers": [
+                            {"id": "tier-1", "rate": "0.10"},
+                            {"id": "tier-2", "rate": "0.20"},
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+
+    assert (
+        current_tariff_rate_sensor_spec(
+            snapshot,
+            datetime(2026, 1, 5, 9, 0, tzinfo=timezone.utc),
+        )
+        is None
+    )
+
+
+def test_current_tariff_rate_sensor_spec_handles_invalid_metadata() -> None:
+    invalid_month = TariffRateSnapshot(
+        state="Time of use",
+        rate_structure="Time of use",
+        variation_type=None,
+        source=None,
+        currency="$",
+        export_plan=None,
+        seasons=(
+            {
+                "start_month": 13,
+                "end_month": 14,
+                "days": [{"periods": [{"rate": "0.10"}]}],
+            },
+        ),
+    )
+    missing_separator = TariffRateSnapshot(
+        state="Time of use",
+        rate_structure="Time of use",
+        variation_type=None,
+        source=None,
+        currency="$",
+        export_plan=None,
+        seasons=({"days": [{"periods": [{"rate": "0.11", "start_time": "bad"}]}]},),
+    )
+    invalid_numbers = TariffRateSnapshot(
+        state="Time of use",
+        rate_structure="Time of use",
+        variation_type=None,
+        source=None,
+        currency="$",
+        export_plan=None,
+        seasons=({"days": [{"periods": [{"rate": "0.12", "start_time": "aa:00"}]}]},),
+    )
+    out_of_range = TariffRateSnapshot(
+        state="Time of use",
+        rate_structure="Time of use",
+        variation_type=None,
+        source=None,
+        currency="$",
+        export_plan=None,
+        seasons=({"days": [{"periods": [{"rate": "0.13", "start_time": "24:00"}]}]},),
+    )
+
+    when = datetime(2026, 1, 5, 9, 0)
+
+    assert current_tariff_rate_sensor_spec(invalid_month, when)["state"] == 0.10
+    assert current_tariff_rate_sensor_spec(missing_separator, when)["state"] == 0.11
+    assert current_tariff_rate_sensor_spec(invalid_numbers, when)["state"] == 0.12
+    assert current_tariff_rate_sensor_spec(out_of_range, when)["state"] == 0.13
+
+
 def test_parse_tariff_rate_rejects_empty_or_bad_branches() -> None:
     class BadString:
         def __str__(self) -> str:
@@ -436,6 +741,107 @@ def test_parse_tariff_rate_rejects_empty_or_bad_branches() -> None:
         },
         "purchase",
     ).attributes["seasons"] == [{"days": [{}], "tiers": [{"end_value": "bad"}]}]
+
+
+def test_tariff_rate_locator_rejects_invalid_objects() -> None:
+    assert TariffRateLocator.from_object(None) is None
+    assert TariffRateLocator.from_object({"branch": "bad", "kind": "period"}) is None
+    assert (
+        TariffRateLocator.from_object(
+            {"branch": "purchase", "kind": "period", "season_index": 0}
+        )
+        is None
+    )
+
+
+def test_locate_tariff_rate_covers_guard_paths() -> None:
+    with pytest.raises(ServiceValidationError):
+        _locate_tariff_rate(
+            {},
+            TariffRateLocator(branch="purchase", kind="period", season_index=1),
+        )
+    with pytest.raises(ServiceValidationError):
+        _locate_tariff_rate(
+            {"purchase": {"seasons": "bad"}},
+            TariffRateLocator(branch="purchase", kind="period", season_index=1),
+        )
+    with pytest.raises(ServiceValidationError):
+        _locate_tariff_rate(
+            {"purchase": {"seasons": [{"id": "default"}]}},
+            TariffRateLocator(
+                branch="purchase",
+                kind="off_peak",
+                season_index=1,
+                season_id="default",
+            ),
+        )
+    with pytest.raises(ServiceValidationError):
+        _locate_tariff_rate(
+            {"purchase": {"seasons": [{"id": "default", "days": []}]}},
+            TariffRateLocator(
+                branch="purchase",
+                kind="period",
+                season_index=1,
+                season_id="default",
+                day_index=1,
+            ),
+        )
+    with pytest.raises(ServiceValidationError):
+        _locate_tariff_rate(
+            {
+                "purchase": {
+                    "seasons": [
+                        {
+                            "id": "default",
+                            "days": [{"id": "week", "periods": []}],
+                        }
+                    ]
+                }
+            },
+            TariffRateLocator(
+                branch="purchase",
+                kind="period",
+                season_index=1,
+                season_id="default",
+                day_index=1,
+                day_group_id="week",
+                period_index=1,
+            ),
+        )
+    tier, field = _locate_tariff_rate(
+        {
+            "purchase": {
+                "seasons": [
+                    {"id": "default", "tiers": [{"id": "tier-1", "rate": "0.1"}]}
+                ]
+            }
+        },
+        TariffRateLocator(
+            branch="purchase",
+            kind="tier",
+            season_index=1,
+            season_id="default",
+            tier_index=1,
+            tier_id="tier-1",
+        ),
+    )
+    assert (tier, field) == ({"id": "tier-1", "rate": "0.1"}, "rate")
+    with pytest.raises(ServiceValidationError):
+        _locate_tariff_rate(
+            {"purchase": {"seasons": [{"id": "default", "tiers": []}]}},
+            TariffRateLocator(
+                branch="purchase",
+                kind="tier",
+                season_index=1,
+                season_id="default",
+                tier_index=1,
+            ),
+        )
+    with pytest.raises(ServiceValidationError):
+        _locate_tariff_rate(
+            {"purchase": {"seasons": [{"id": "default"}]}},
+            TariffRateLocator(branch="purchase", kind="bad", season_index=1),
+        )
 
 
 @pytest.mark.asyncio
@@ -501,6 +907,199 @@ async def test_tariff_runtime_refreshes_snapshots(coordinator_factory) -> None:
     assert coord.tariff_last_refresh_utc is not None
     assert coord.tariff_rates_last_refresh_utc is coord.tariff_last_refresh_utc
     assert coord._endpoint_family_state("tariff").support_state == "supported"
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_updates_single_rate_and_preserves_payload(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff = AsyncMock(
+        return_value={
+            "site_id": 123,
+            "unknown": {"kept": True},
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "id": "off-peak",
+                                        "type": "off-peak",
+                                        "rate": "0.18",
+                                    },
+                                    {
+                                        "id": "peak-1",
+                                        "type": "peak",
+                                        "rate": "0.31",
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+            "buyback": {"typeId": "flat", "seasons": []},
+        }
+    )
+    coord.client.site_tariff_update = AsyncMock(return_value={"message": "success"})
+    coord.client.notify_tariff_change = AsyncMock(return_value={"data": "ok"})
+    coord.tariff_runtime.async_refresh = AsyncMock()
+    locator = TariffRateLocator(
+        branch="purchase",
+        kind="period",
+        season_index=1,
+        season_id="default",
+        day_index=1,
+        day_group_id="week",
+        period_index=2,
+        period_id="peak-1",
+        period_type="peak",
+    )
+
+    out = await TariffRuntime(coord).async_set_tariff_rate(locator, 0.42)
+
+    assert out == {"message": "success"}
+    update_payload = coord.client.site_tariff_update.await_args.args[0]
+    assert update_payload["unknown"] == {"kept": True}
+    assert update_payload["purchase"]["typeId"] == "tou"
+    assert (
+        update_payload["purchase"]["seasons"][0]["days"][0]["periods"][0]["rate"]
+        == "0.18"
+    )
+    assert (
+        update_payload["purchase"]["seasons"][0]["days"][0]["periods"][1]["rate"]
+        == "0.42"
+    )
+    coord.client.notify_tariff_change.assert_awaited_once_with()
+    coord.tariff_runtime.async_refresh.assert_awaited_once_with(force=True)
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_updates_tiered_off_peak_and_ignores_notify_failure(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff = AsyncMock(
+        return_value={
+            "purchase": {
+                "typeId": "tiered",
+                "seasons": [{"id": "default", "offPeak": "0.03", "tiers": []}],
+            }
+        }
+    )
+    coord.client.site_tariff_update = AsyncMock(return_value={"message": "success"})
+    coord.client.notify_tariff_change = AsyncMock(
+        side_effect=aiohttp.ClientError("boom")
+    )
+    coord.tariff_runtime.async_refresh = AsyncMock()
+
+    await TariffRuntime(coord).async_set_tariff_rate(
+        {
+            "branch": "purchase",
+            "kind": "off_peak",
+            "season_index": 1,
+            "season_id": "default",
+        },
+        0.05,
+    )
+
+    update_payload = coord.client.site_tariff_update.await_args.args[0]
+    assert update_payload["purchase"]["seasons"][0]["offPeak"] == "0.05"
+    coord.tariff_runtime.async_refresh.assert_awaited_once_with(force=True)
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_rejects_invalid_and_stale_targets(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff = AsyncMock(
+        return_value={"purchase": {"typeId": "tou", "seasons": []}}
+    )
+    coord.client.site_tariff_update = AsyncMock()
+
+    with pytest.raises(ServiceValidationError):
+        await TariffRuntime(coord).async_set_tariff_rate(
+            {
+                "branch": "purchase",
+                "kind": "period",
+                "season_index": 1,
+                "day_index": 1,
+                "period_index": 1,
+            },
+            0.1,
+        )
+
+    with pytest.raises(ServiceValidationError):
+        await TariffRuntime(coord).async_set_tariff_rate(
+            {
+                "branch": "purchase",
+                "kind": "period",
+                "season_index": 1,
+                "day_index": 1,
+                "period_index": 1,
+            },
+            -1,
+        )
+    coord.client.site_tariff_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_rejects_invalid_input_and_unavailable_api(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    with pytest.raises(ServiceValidationError):
+        await TariffRuntime(coord).async_set_tariff_rate(None, 0.1)
+
+    coord.client.site_tariff = AsyncMock(return_value=[])
+    coord.client.site_tariff_update = AsyncMock()
+    with pytest.raises(ServiceValidationError):
+        await TariffRuntime(coord).async_set_tariff_rate(
+            {
+                "branch": "purchase",
+                "kind": "period",
+                "season_index": 1,
+                "day_index": 1,
+                "period_index": 1,
+            },
+            "bad",
+        )
+
+    coord.client.site_tariff = None
+    with pytest.raises(ServiceValidationError):
+        await TariffRuntime(coord).async_set_tariff_rate(
+            {
+                "branch": "purchase",
+                "kind": "period",
+                "season_index": 1,
+                "day_index": 1,
+                "period_index": 1,
+            },
+            0.1,
+        )
+
+    coord.client.site_tariff = AsyncMock(return_value=[])
+    with pytest.raises(ServiceValidationError):
+        await TariffRuntime(coord).async_set_tariff_rate(
+            {
+                "branch": "purchase",
+                "kind": "period",
+                "season_index": 1,
+                "day_index": 1,
+                "period_index": 1,
+            },
+            0.1,
+        )
 
 
 @pytest.mark.asyncio
@@ -834,6 +1433,314 @@ def test_import_rate_value_sensor_exposes_rate_state_and_attributes(
     assert sensor.available is True
     assert sensor.extra_state_attributes["rate_structure"] == "Time of use"
     assert sensor.extra_state_attributes["period_type"] == "off-peak"
+    assert sensor.entity_registry_enabled_default is False
+
+
+def test_current_import_rate_sensor_exposes_energy_price_state(
+    hass,
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.tariff_last_refresh_utc = datetime(2026, 4, 26, tzinfo=timezone.utc)
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "id": "peak",
+                                        "type": "peak",
+                                        "rate": "0.31",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    sensor = EnphaseCurrentTariffRateSensor(coord, is_import=True)
+    sensor.hass = hass
+
+    assert sensor.native_value == 0.31
+    assert sensor.native_unit_of_measurement == f"{hass.config.currency}/kWh"
+    assert sensor.state_class == "measurement"
+    assert sensor.suggested_display_precision == 4
+    assert sensor.icon == "mdi:cash-minus"
+    assert sensor.translation_key == "tariff_current_import_rate"
+    assert sensor.available is True
+    attrs = sensor.extra_state_attributes
+    assert attrs["period_type"] == "peak"
+    assert attrs["active_rate_name"] == "Peak"
+    assert attrs["configured_rates"] == [
+        {
+            "name": "Peak",
+            "rate": "0.31",
+            "formatted_rate": "$0.31",
+            "unit": "$/kWh",
+            "season_id": "default",
+            "day_group_id": "week",
+            "period_type": "peak",
+            "tariff_locator": {
+                "branch": "purchase",
+                "kind": "period",
+                "season_index": 1,
+                "season_id": "default",
+                "day_index": 1,
+                "day_group_id": "week",
+                "period_index": 1,
+                "period_id": "peak",
+                "period_type": "peak",
+            },
+        }
+    ]
+    assert attrs["last_refresh_utc"] == "2026-04-26T00:00:00+00:00"
+    assert "configured_rates" in sensor._unrecorded_attributes
+    fallback_unit_sensor = EnphaseCurrentTariffRateSensor(coord, is_import=True)
+    assert fallback_unit_sensor.native_unit_of_measurement == "$/kWh"
+
+    coord.tariff_import_rate = None
+
+    assert sensor.available is False
+    assert sensor.native_value is None
+    assert sensor.native_unit_of_measurement is None
+    assert sensor.extra_state_attributes == {}
+
+
+def test_current_rate_sensor_uses_home_assistant_timezone_fallback(
+    hass,
+    coordinator_factory,
+    monkeypatch,
+) -> None:
+    coord = coordinator_factory()
+    monkeypatch.setattr(coord, "_site_timezone_name", lambda: "", raising=False)
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [{"type": "peak", "rate": "0.31"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    sensor = EnphaseCurrentTariffRateSensor(coord, is_import=True)
+    sensor.hass = hass
+
+    assert sensor.native_value == 0.31
+
+
+def test_current_rate_sensor_schedules_next_tariff_boundary(
+    hass, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    coord.last_success_utc = datetime(2026, 1, 5, 6, 59, tzinfo=timezone.utc)
+    coord._site_timezone_name = lambda: "UTC"  # noqa: SLF001
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "weekends",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "id": "off_peak",
+                                        "type": "off-peak",
+                                        "rate": "0.11",
+                                        "startTime": "1320",
+                                        "endTime": "420",
+                                    },
+                                    {
+                                        "id": "peak",
+                                        "type": "peak",
+                                        "rate": "0.31",
+                                        "startTime": "420",
+                                        "endTime": "1320",
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    now = datetime(2026, 1, 5, 6, 59, tzinfo=timezone.utc)
+    scheduled: list[datetime] = []
+    callbacks = []
+    cancelled = 0
+
+    def _track(_hass, callback, fire_at):
+        callbacks.append(callback)
+        scheduled.append(fire_at)
+
+        def _cancel():
+            nonlocal cancelled
+            cancelled += 1
+
+        return _cancel
+
+    monkeypatch.setattr(sensor_mod, "async_track_point_in_utc_time", _track)
+    monkeypatch.setattr(
+        sensor_mod.dt_util,
+        "now",
+        lambda tz=None: now.astimezone(tz) if tz is not None else now,
+    )
+    monkeypatch.setattr(
+        sensor_mod.dt_util,
+        "utcnow",
+        lambda: now,
+    )
+    sensor = EnphaseCurrentTariffRateSensor(coord, is_import=True)
+    sensor.hass = hass
+    sensor.async_write_ha_state = MagicMock()
+
+    sensor._ensure_tariff_boundary_timer()  # noqa: SLF001
+
+    assert scheduled == [datetime(2026, 1, 5, 7, 0, tzinfo=timezone.utc)]
+    now = datetime(2026, 1, 5, 7, 0, tzinfo=timezone.utc)
+    callbacks[0](now)
+
+    sensor.async_write_ha_state.assert_called_once_with()
+    assert scheduled == [
+        datetime(2026, 1, 5, 7, 0, tzinfo=timezone.utc),
+        datetime(2026, 1, 5, 22, 0, tzinfo=timezone.utc),
+    ]
+    assert cancelled == 1
+    sensor._cancel_tariff_boundary_timer()  # noqa: SLF001
+    assert cancelled == 2
+
+
+@pytest.mark.asyncio
+async def test_current_rate_sensor_timer_lifecycle_and_guard_branches(
+    hass, coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    coord.last_success_utc = datetime(2026, 1, 5, 7, 0, tzinfo=timezone.utc)
+    coord._site_timezone_name = lambda: "UTC"  # noqa: SLF001
+    scheduled: list[datetime] = []
+
+    def _track(_hass, _callback, fire_at):
+        scheduled.append(fire_at)
+        return lambda: None
+
+    monkeypatch.setattr(sensor_mod, "async_track_point_in_utc_time", _track)
+    monkeypatch.setattr(
+        sensor_mod.dt_util,
+        "now",
+        lambda tz=None: datetime(2026, 1, 5, 7, 0, tzinfo=tz or timezone.utc),
+    )
+    monkeypatch.setattr(
+        sensor_mod.dt_util,
+        "utcnow",
+        lambda: datetime(2026, 1, 5, 7, 1, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(
+        sensor_mod.CoordinatorEntity,
+        "async_added_to_hass",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        sensor_mod.CoordinatorEntity,
+        "async_will_remove_from_hass",
+        AsyncMock(),
+    )
+    monkeypatch.setattr(
+        sensor_mod.CoordinatorEntity,
+        "_handle_coordinator_update",
+        MagicMock(),
+    )
+
+    sensor = EnphaseCurrentTariffRateSensor(coord, is_import=True)
+    sensor._ensure_tariff_boundary_timer()  # noqa: SLF001
+    assert scheduled == []
+
+    sensor.hass = hass
+    sensor._ensure_tariff_boundary_timer()  # noqa: SLF001
+    assert scheduled == []
+
+    sensor._tariff_boundary_cancel = MagicMock(side_effect=RuntimeError("boom"))
+    sensor._cancel_tariff_boundary_timer()  # noqa: SLF001
+    assert sensor._tariff_boundary_cancel is None
+
+    coord.tariff_import_rate = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "weekends",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "id": "off_peak",
+                                        "type": "off-peak",
+                                        "rate": "0.11",
+                                        "startTime": "1320",
+                                        "endTime": "420",
+                                    },
+                                    {
+                                        "id": "peak",
+                                        "type": "peak",
+                                        "rate": "0.31",
+                                        "startTime": "420",
+                                        "endTime": "1320",
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+    monkeypatch.setattr(
+        sensor_mod,
+        "next_tariff_rate_change",
+        lambda _snapshot, _when: datetime(2026, 1, 5, 7, 0, tzinfo=timezone.utc),
+    )
+
+    await sensor.async_added_to_hass()
+    assert scheduled == [datetime(2026, 1, 5, 7, 1, 1, tzinfo=timezone.utc)]
+    sensor._handle_coordinator_update()  # noqa: SLF001
+    assert scheduled[-1] == datetime(2026, 1, 5, 7, 1, 1, tzinfo=timezone.utc)
+    await sensor.async_will_remove_from_hass()
 
 
 def test_rate_value_sensor_uses_home_assistant_currency_for_unit(
@@ -1023,7 +1930,18 @@ async def test_tariff_dynamic_rate_entities_removed_when_branch_removed(
     old_export_unique_id = (
         f"{DOMAIN}_site_{coord.site_id}_tariff_export_rate_default_week_peak"
     )
-    for unique_id in (old_import_unique_id, old_export_unique_id):
+    old_current_import_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_current_import_rate"
+    )
+    old_current_export_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_current_export_rate"
+    )
+    for unique_id in (
+        old_import_unique_id,
+        old_export_unique_id,
+        old_current_import_unique_id,
+        old_current_export_unique_id,
+    ):
         ent_reg.async_get_or_create(
             "sensor",
             DOMAIN,
@@ -1038,11 +1956,15 @@ async def test_tariff_dynamic_rate_entities_removed_when_branch_removed(
 
     assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_import_unique_id) is None
     assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_export_unique_id) is None
+    assert (
+        ent_reg.async_get_entity_id("sensor", DOMAIN, old_current_export_unique_id)
+        is None
+    )
     assert [
         entity.unique_id for entity in added if "tariff" in str(entity.unique_id)
     ] == [
         f"{DOMAIN}_site_{coord.site_id}_tariff_billing_cycle",
-        f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate",
+        f"{DOMAIN}_site_{coord.site_id}_tariff_current_import_rate",
     ]
 
 
@@ -1075,7 +1997,18 @@ async def test_tariff_dynamic_rate_entities_removed_when_rates_unconfigured(
     old_export_unique_id = (
         f"{DOMAIN}_site_{coord.site_id}_tariff_export_rate_default_week_peak"
     )
-    for unique_id in (old_import_unique_id, old_export_unique_id):
+    old_current_import_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_current_import_rate"
+    )
+    old_current_export_unique_id = (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_current_export_rate"
+    )
+    for unique_id in (
+        old_import_unique_id,
+        old_export_unique_id,
+        old_current_import_unique_id,
+        old_current_export_unique_id,
+    ):
         ent_reg.async_get_or_create(
             "sensor",
             DOMAIN,
@@ -1090,13 +2023,21 @@ async def test_tariff_dynamic_rate_entities_removed_when_rates_unconfigured(
 
     assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_import_unique_id) is None
     assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_export_unique_id) is None
+    assert (
+        ent_reg.async_get_entity_id("sensor", DOMAIN, old_current_import_unique_id)
+        is None
+    )
+    assert (
+        ent_reg.async_get_entity_id("sensor", DOMAIN, old_current_export_unique_id)
+        is None
+    )
     assert [
         entity.unique_id for entity in added if "tariff" in str(entity.unique_id)
     ] == [f"{DOMAIN}_site_{coord.site_id}_tariff_billing_cycle"]
 
 
 @pytest.mark.asyncio
-async def test_tariff_dynamic_rate_entities_preserved_without_current_context(
+async def test_tariff_dynamic_rate_entities_removed_without_current_context(
     hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:
     from homeassistant.helpers import entity_registry as er
@@ -1136,12 +2077,8 @@ async def test_tariff_dynamic_rate_entities_preserved_without_current_context(
         hass, config_entry, lambda entities, **_: added.extend(entities)
     )
 
-    assert (
-        ent_reg.async_get_entity_id("sensor", DOMAIN, old_import_unique_id) is not None
-    )
-    assert (
-        ent_reg.async_get_entity_id("sensor", DOMAIN, old_export_unique_id) is not None
-    )
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_import_unique_id) is None
+    assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_export_unique_id) is None
     assert [
         entity.unique_id for entity in added if "tariff" in str(entity.unique_id)
     ] == [f"{DOMAIN}_site_{coord.site_id}_tariff_billing_cycle"]
@@ -1182,9 +2119,10 @@ async def test_tariff_setup_registry_filter_branches(
         },
         "purchase",
     )
-    current_unique_id = (
+    old_unique_id = (
         f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate_default_week_peak"
     )
+    current_unique_id = f"{DOMAIN}_site_{coord.site_id}_tariff_current_import_rate"
     fake_registry = SimpleNamespace(
         entities={
             "binary_sensor.skip": SimpleNamespace(
@@ -1192,28 +2130,28 @@ async def test_tariff_setup_registry_filter_branches(
                 entity_id="binary_sensor.skip",
                 platform=DOMAIN,
                 config_entry_id=config_entry.entry_id,
-                unique_id=current_unique_id,
+                unique_id=old_unique_id,
             ),
             "sensor.other_platform": SimpleNamespace(
                 domain="sensor",
                 entity_id="sensor.other_platform",
                 platform="other",
                 config_entry_id=config_entry.entry_id,
-                unique_id=current_unique_id,
+                unique_id=old_unique_id,
             ),
             "sensor.other_entry": SimpleNamespace(
                 domain="sensor",
                 entity_id="sensor.other_entry",
                 platform=DOMAIN,
                 config_entry_id="other-entry",
-                unique_id=current_unique_id,
+                unique_id=old_unique_id,
             ),
             "sensor.current": SimpleNamespace(
                 domain="sensor",
                 entity_id="sensor.current",
                 platform=DOMAIN,
                 config_entry_id=config_entry.entry_id,
-                unique_id=current_unique_id,
+                unique_id=old_unique_id,
             ),
         },
         async_get_entity_id=MagicMock(return_value=None),
@@ -1228,7 +2166,8 @@ async def test_tariff_setup_registry_filter_branches(
     )
 
     assert current_unique_id in {entity.unique_id for entity in added}
-    fake_registry.async_remove.assert_not_called()
+    assert old_unique_id not in {entity.unique_id for entity in added}
+    fake_registry.async_remove.assert_called_once_with("sensor.current")
 
 
 @pytest.mark.asyncio
@@ -1275,7 +2214,9 @@ async def test_tariff_setup_handles_registry_without_values(
         hass, config_entry, lambda entities, **_: added.extend(entities)
     )
 
-    assert any("tariff_import_rate" in str(entity.unique_id) for entity in added)
+    assert any(
+        "tariff_current_import_rate" in str(entity.unique_id) for entity in added
+    )
     fake_registry.entities = object()
     for listener in listeners:
         listener()
@@ -1283,7 +2224,7 @@ async def test_tariff_setup_handles_registry_without_values(
 
 
 @pytest.mark.asyncio
-async def test_tariff_setup_adds_export_value_sensor(
+async def test_tariff_setup_adds_current_export_rate_sensor(
     hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:
     coord = coordinator_factory()
@@ -1322,9 +2263,13 @@ async def test_tariff_setup_adds_export_value_sensor(
         hass, config_entry, lambda entities, **_: added.extend(entities)
     )
 
-    assert f"{DOMAIN}_site_{coord.site_id}_tariff_export_rate_default_week_peak" in {
+    assert f"{DOMAIN}_site_{coord.site_id}_tariff_current_export_rate" in {
         entity.unique_id for entity in added
     }
+    assert (
+        f"{DOMAIN}_site_{coord.site_id}_tariff_export_rate_default_week_peak"
+        not in {entity.unique_id for entity in added}
+    )
 
 
 @pytest.mark.asyncio
@@ -1367,7 +2312,7 @@ async def test_tariff_setup_prunes_dynamic_export_for_summary_snapshot(
     )
 
     assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_export_unique_id) is None
-    assert f"{DOMAIN}_site_{coord.site_id}_tariff_export_rate" in {
+    assert f"{DOMAIN}_site_{coord.site_id}_tariff_current_export_rate" in {
         entity.unique_id for entity in added
     }
 
@@ -1424,7 +2369,9 @@ async def test_tariff_rate_sensor_entities_resync_when_structure_changes(
     old_unique_id = (
         f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate_default_week_off_peak"
     )
-    assert old_unique_id in {entity.unique_id for entity in added}
+    current_unique_id = f"{DOMAIN}_site_{coord.site_id}_tariff_current_import_rate"
+    assert current_unique_id in {entity.unique_id for entity in added}
+    assert old_unique_id not in {entity.unique_id for entity in added}
     ent_reg = er.async_get(hass)
     ent_reg.async_get_or_create(
         "sensor",
@@ -1461,5 +2408,5 @@ async def test_tariff_rate_sensor_entities_resync_when_structure_changes(
     new_unique_id = (
         f"{DOMAIN}_site_{coord.site_id}_tariff_import_rate_default_week_peak"
     )
-    assert new_unique_id in {entity.unique_id for entity in added}
+    assert new_unique_id not in {entity.unique_id for entity in added}
     assert ent_reg.async_get_entity_id("sensor", DOMAIN, old_unique_id) is None


### PR DESCRIPTION
## Summary

Adds editable tariff rate control for existing Enphase tariff values while keeping tariff structure editing out of scope. The change includes:

- `enphase_ev.set_tariff_rate` service for targeting one existing tariff sensor or number entity.
- Editable config `number` entities for import/export tariff rows.
- Energy-dashboard-ready current import/export tariff price sensors with configured-rate attributes.
- Current price sensor boundary timers so TOU prices update when the active tariff window changes, without waiting for the next coordinator poll.
- Tariff write API support, scheduler tariff-change notification, translations, docs, and changelog updates.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/number.py custom_components/enphase_ev/sensor.py custom_components/enphase_ev/services.py custom_components/enphase_ev/tariff.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_number_module.py tests/components/enphase_ev/test_service_translations.py tests/components/enphase_ev/test_services.py tests/components/enphase_ev/test_tariff.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/number.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/services.py,custom_components/enphase_ev/tariff.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_tariff.py tests/components/enphase_ev/test_services.py tests/components/enphase_ev/test_number_module.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py && pre-commit run --all-files"
git diff --check
```

Rebased-branch results:

- `ruff check .`: passed.
- Targeted tariff/service/number/API/translation tests: `581 passed`.
- Full pytest: `3142 passed`.
- Targeted coverage for touched source modules: 100% for `api.py`, `number.py`, `sensor.py`, `services.py`, and `tariff.py`.
- Quality scale validation: passed.
- `pre-commit run --all-files`: passed.
- `git diff --check`: passed.

Manual validation:

- Started local `ha-runtime` and verified the device page only exposes current import/export rate sensors plus editable tariff number controls.
- Changed Import Rate Off-Peak from `0.1` to `0.101`, verified Current Import Rate became `0.1010 AUD/kWh`, restored the value to `0.1`, and verified Current Import Rate returned to `0.1000 AUD/kWh`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The implementation intentionally supports only editing existing tariff values. Tariff type, seasons, days, time windows, tier thresholds, source, export plan, and billing details remain read-only.
