### PR TITLE
Improve cloud error handling and backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Bug fixes
 - Detected Enphase "too many active sessions" authentication failures explicitly, paused automatic login retries, and surfaced localized config-flow and repair messages that tell users to clear other Enphase sessions.
+- Localized cloud diagnostic error states for rate limits, temporary authentication blocks, authentication failures, invalid payloads, service outages, DNS failures, and network errors; rate-limit repairs now include retry timing, de-duplicate repeated reports, and clear after a successful refresh.
 - Bounded the `Current Production Power` live-sample cache so stale values are not reused indefinitely when the latest-power endpoint stops returning valid samples.
 - Smoothed idle heat-pump power over existing low-load energy samples so whole-Wh cloud readings no longer flicker between `0 W` and standby load, while exposing the raw short-window value in diagnostics.
 - Reduced unnecessary EV charger post-status follow-up lookups, kept idle session-history catch-up off the main refresh path when cached data is still usable, and aligned HEMS preflight/device refresh cadence with fast polling to lower steady-state cloud overhead.

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -786,6 +786,30 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             return int(err.status) if isinstance(err.status, int) else None
         return None
 
+    @staticmethod
+    def _retry_after_delay(err: Exception) -> float | None:
+        """Return a Retry-After delay in seconds when an HTTP error provides one."""
+
+        if not isinstance(err, aiohttp.ClientResponseError) or not err.headers:
+            return None
+        retry_after = err.headers.get("Retry-After")
+        if not retry_after:
+            return None
+        try:
+            return max(0.0, float(int(retry_after)))
+        except Exception:
+            retry_dt = None
+            try:
+                retry_dt = parsedate_to_datetime(str(retry_after))
+            except Exception:
+                retry_dt = None
+            if retry_dt is None:
+                return None
+            if retry_dt.tzinfo is None:
+                retry_dt = retry_dt.replace(tzinfo=_tz.utc)
+            retry_dt = retry_dt.astimezone(_tz.utc)
+            return max(0.0, (retry_dt - dt_util.utcnow()).total_seconds())
+
     def _endpoint_family_backoff_delay(
         self,
         family: str,
@@ -919,6 +943,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         health.last_status = status
         health.last_error = redact_text(err, site_ids=(self.site_id,))
         delay = self._endpoint_family_backoff_delay(family, health.consecutive_failures)
+        retry_after_delay = self._retry_after_delay(err)
+        if retry_after_delay is not None:
+            delay = max(delay, retry_after_delay)
         if policy.suppress_after_failures is not None and (
             health.consecutive_failures >= int(policy.suppress_after_failures)
         ):
@@ -2392,6 +2419,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self.diagnostics.clear_network_issue()
         self.diagnostics.clear_cloud_issue()
         self.diagnostics.clear_dns_issue()
+        self.diagnostics.clear_rate_limited_issue()
         self._unauth_errors = 0
         self._rate_limit_hits = 0
         self._http_errors = 0
@@ -2443,6 +2471,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._rate_limit_hits = 0
         self._http_errors = 0
         self._payload_errors = 0
+        self.diagnostics.clear_rate_limited_issue()
         self.diagnostics.clear_network_issue()
         self._network_errors = 0
         self.diagnostics.clear_cloud_issue()
@@ -2818,28 +2847,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._network_errors = 0
             self._payload_errors = 0
             self._http_errors += 1
-            retry_after = err.headers.get("Retry-After") if err.headers else None
-            delay = 0
-            if retry_after:
-                try:
-                    delay = int(retry_after)
-                except Exception:
-                    retry_dt = None
-                    try:
-                        retry_dt = parsedate_to_datetime(str(retry_after))
-                    except Exception:
-                        retry_dt = None
-                    if retry_dt is not None:
-                        if retry_dt.tzinfo is None:
-                            retry_dt = retry_dt.replace(tzinfo=_tz.utc)
-                        retry_dt = retry_dt.astimezone(_tz.utc)
-                        now_utc = dt_util.utcnow()
-                        delay = max(
-                            0,
-                            (retry_dt - now_utc).total_seconds(),
-                        )
-                    else:
-                        delay = 0
+            delay = self._retry_after_delay(err) or 0.0
             # Exponential backoff anchored to configured slow poll interval
             jitter = random.uniform(1.0, 3.0)
             backoff_multiplier = 2 ** min(self._http_errors - 1, 3)

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -911,6 +911,9 @@ class CoordinatorDiagnostics:
         blocked_until = metrics.get("auth_blocked_until")
         if blocked_until:
             placeholders["blocked_until"] = str(blocked_until)
+        backoff_ends = metrics.get("backoff_ends_utc")
+        if backoff_ends:
+            placeholders["backoff_ends"] = str(backoff_ends)
         return placeholders
 
     def issue_context(self) -> tuple[dict[str, object], dict[str, str]]:
@@ -1305,10 +1308,30 @@ class CoordinatorDiagnostics:
         )
 
     def create_rate_limited_issue(self) -> None:
-        self._create_site_metrics_issue(
+        placeholders: dict[str, str] = {}
+        backoff_ends = self.coordinator._format_auth_blocked_until(
+            getattr(self.coordinator, "backoff_ends_utc", None)
+        )
+        if backoff_ends:
+            placeholders["backoff_ends"] = backoff_ends
+        self._report_flagged_issue(
+            "_rate_limit_issue_reported",
             ISSUE_RATE_LIMITED,
             severity=ir.IssueSeverity.WARNING,
+            placeholders=placeholders,
         )
+
+    def clear_rate_limited_issue(self) -> None:
+        coord = self.coordinator
+        if getattr(coord, "_rate_limit_issue_reported", False):
+            self._delete_issue(ISSUE_RATE_LIMITED)
+            coord._rate_limit_issue_reported = False
+            coord._rate_limit_issue_clear_checked = True
+            return
+        if getattr(coord, "_rate_limit_issue_clear_checked", False):
+            return
+        self._delete_issue(ISSUE_RATE_LIMITED)
+        coord._rate_limit_issue_clear_checked = True
 
     def clear_scheduler_issue(self) -> None:
         self._clear_reported_issue(

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -79,6 +79,17 @@ from .evse_runtime import evse_power_is_actively_charging
 PARALLEL_UPDATES = 0
 
 STATE_NONE = "none"
+CLOUD_ERROR_CODE_STATES: tuple[str, ...] = (
+    STATE_NONE,
+    "rate_limited",
+    "auth_blocked",
+    "authentication_error",
+    "request_error",
+    "service_unavailable",
+    "invalid_payload",
+    "dns_error",
+    "network_error",
+)
 BATTERY_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = (
     "_charge_level",
     "_status",
@@ -6620,9 +6631,21 @@ class EnphaseCurrentPowerConsumptionSensor(_SiteBaseEntity, RestoreSensor):
 class EnphaseSiteLastErrorCodeSensor(_SiteBaseEntity):
     _attr_translation_key = "cloud_error_code"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = list(CLOUD_ERROR_CODE_STATES)
 
     def __init__(self, coord: EnphaseCoordinator):
         super().__init__(coord, "last_error_code", "Cloud Error Code", type_key=None)
+
+    def _auth_block_is_active(self) -> bool:
+        """Return True when auth is currently blocked without mutating coordinator state."""
+
+        if getattr(self._coord, "_last_error", None) == "auth_blocked":
+            return True
+        blocked_until = getattr(self._coord, "_auth_blocked_until_utc", None)
+        if isinstance(blocked_until, datetime):
+            return blocked_until > dt_util.utcnow()
+        return False
 
     @property
     def native_value(self):
@@ -6633,10 +6656,22 @@ class EnphaseSiteLastErrorCodeSensor(_SiteBaseEntity):
         )
         if not failure_active:
             return STATE_NONE
-        code = self._coord.last_failure_status
+        failure_source = getattr(self._coord, "last_failure_source", None)
+        if (
+            failure_source == "payload"
+            or getattr(self._coord, "payload_failure_kind", None) is not None
+        ):
+            return "invalid_payload"
+        if failure_source == "auth" and self._auth_block_is_active():
+            return "auth_blocked"
+        code = getattr(self._coord, "last_failure_status", None)
         if code is None:
-            description = (self._coord.last_failure_description or "").lower()
-            if self._coord.last_failure_source == "network":
+            if failure_source == "auth":
+                return "authentication_error"
+            description = (
+                getattr(self._coord, "last_failure_description", None) or ""
+            ).lower()
+            if failure_source == "network":
                 dns_tokens = (
                     "dns",
                     "name or service not known",
@@ -6647,7 +6682,17 @@ class EnphaseSiteLastErrorCodeSensor(_SiteBaseEntity):
                     return "dns_error"
                 return "network_error"
             return STATE_NONE
-        return str(code)
+        try:
+            status = int(code)
+        except (TypeError, ValueError):
+            return "request_error"
+        if status == 429:
+            return "rate_limited"
+        if status in (401, 403):
+            return "authentication_error"
+        if 500 <= status < 600:
+            return "service_unavailable"
+        return "request_error"
 
     @property
     def extra_state_attributes(self):

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -106,6 +106,8 @@ class RefreshHealthState:
     _network_issue_reported: bool = False
     _dns_failures: int = 0
     _dns_issue_reported: bool = False
+    _rate_limit_issue_reported: bool = False
+    _rate_limit_issue_clear_checked: bool = False
     _scheduler_available: bool = True
     _scheduler_failures: int = 0
     _scheduler_last_error: str | None = None

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -817,6 +817,12 @@
         "name": "Cloud Error Code",
         "state": {
           "none": "None",
+          "rate_limited": "Rate limited",
+          "auth_blocked": "Authentication temporarily blocked",
+          "authentication_error": "Authentication error",
+          "request_error": "Request error",
+          "service_unavailable": "Service unavailable",
+          "invalid_payload": "Invalid cloud response",
           "dns_error": "DNS error",
           "network_error": "Network error"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy is rate limited",
-      "description": "The cloud API returned rate limiting. Polling will slow temporarily."
+      "description": "The cloud API returned rate limiting. Polling will slow until {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy cloud unreachable",

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -814,6 +814,12 @@
         "name": "Код на грешка в облака",
         "state": {
           "none": "Няма",
+          "rate_limited": "Ограничена честота",
+          "auth_blocked": "Удостоверяването е временно блокирано",
+          "authentication_error": "Грешка при удостоверяване",
+          "request_error": "Грешка в заявката",
+          "service_unavailable": "Услугата е недостъпна",
+          "invalid_payload": "Невалиден отговор от облака",
           "dns_error": "DNS грешка",
           "network_error": "Мрежова грешка"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy е с ограничение на заявките",
-      "description": "Cloud API върна ограничение на заявките. Опресняването временно ще се забави."
+      "description": "Облачният API върна ограничение на честотата. Опросът ще се забави до {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Облакът Enphase Energy е недостъпен",

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -814,8 +814,14 @@
         "name": "Kód chyby cloudu",
         "state": {
           "none": "Žádné",
+          "rate_limited": "Omezení četnosti",
+          "auth_blocked": "Ověření je dočasně blokováno",
+          "authentication_error": "Chyba ověření",
+          "request_error": "Chyba požadavku",
+          "service_unavailable": "Služba není dostupná",
+          "invalid_payload": "Neplatná odpověď cloudu",
           "dns_error": "Chyba DNS",
-          "network_error": "Síťová chyba"
+          "network_error": "Chyba sítě"
         }
       },
       "cloud_backoff_ends": {
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy je omezeno limitem",
-      "description": "Cloud API vrátilo omezení rychlosti. Dotazování se dočasně zpomalí."
+      "description": "Cloudové API vrátilo omezení četnosti. Dotazování se zpomalí do {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Cloud Enphase Energy nedostupný",

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -814,6 +814,12 @@
         "name": "Cloud-fejlkode",
         "state": {
           "none": "Ingen",
+          "rate_limited": "Frekvensbegrænset",
+          "auth_blocked": "Godkendelse midlertidigt blokeret",
+          "authentication_error": "Godkendelsesfejl",
+          "request_error": "Forespørgselsfejl",
+          "service_unavailable": "Tjenesten er utilgængelig",
+          "invalid_payload": "Ugyldigt cloudsvar",
           "dns_error": "DNS-fejl",
           "network_error": "Netværksfejl"
         }
@@ -2105,8 +2111,8 @@
       "description": "Enphase afviste godkendelse for stedet {site_id}, fordi der er for mange aktive kontosessioner. Automatiske forsøg er sat på pause indtil {blocked_until}. Log ud af andre Enphase app- eller browsersessioner, og prøv derefter at godkende igen."
     },
     "rate_limited": {
-      "title": "Enphase Energy er rate-begrænset",
-      "description": "Cloud-API'et returnerede rate limiting. Polling vil midlertidigt blive langsommere."
+      "title": "Enphase Energy er frekvensbegrænset",
+      "description": "Cloud-API’et returnerede en frekvensbegrænsning. Forespørgsler sænkes indtil {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy cloud ikke tilgængelig",

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -814,6 +814,12 @@
         "name": "Cloud-Fehlercode",
         "state": {
           "none": "Keiner",
+          "rate_limited": "Durch Ratenlimit begrenzt",
+          "auth_blocked": "Authentifizierung vorübergehend blockiert",
+          "authentication_error": "Authentifizierungsfehler",
+          "request_error": "Anfragefehler",
+          "service_unavailable": "Dienst nicht verfügbar",
+          "invalid_payload": "Ungültige Cloud-Antwort",
           "dns_error": "DNS-Fehler",
           "network_error": "Netzwerkfehler"
         }
@@ -2105,8 +2111,8 @@
       "description": "Enphase hat die Authentifizierung für Standort {site_id} abgelehnt, weil zu viele Kontositzungen aktiv sind. Automatische Wiederholungen sind bis {blocked_until} pausiert. Melden Sie sich von anderen Enphase-App- oder Browser-Sitzungen ab und versuchen Sie die erneute Authentifizierung danach erneut."
     },
     "rate_limited": {
-      "title": "Enphase Energy ist rate-limitiert",
-      "description": "Die Cloud-API hat eine Limitierung gemeldet. Die Abfrage wird vorübergehend langsamer."
+      "title": "Enphase Energy ist durch ein Ratenlimit begrenzt",
+      "description": "Die Cloud-API hat ein Ratenlimit gemeldet. Die Abfrage wird bis {backoff_ends} verlangsamt."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy-Cloud nicht erreichbar",

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -814,6 +814,12 @@
         "name": "Κωδικός σφάλματος cloud",
         "state": {
           "none": "Κανένα",
+          "rate_limited": "Περιορισμός ρυθμού",
+          "auth_blocked": "Ο έλεγχος ταυτότητας έχει προσωρινά αποκλειστεί",
+          "authentication_error": "Σφάλμα ελέγχου ταυτότητας",
+          "request_error": "Σφάλμα αιτήματος",
+          "service_unavailable": "Η υπηρεσία δεν είναι διαθέσιμη",
+          "invalid_payload": "Μη έγκυρη απόκριση cloud",
           "dns_error": "Σφάλμα DNS",
           "network_error": "Σφάλμα δικτύου"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Το Enphase Energy έχει περιορισμό ρυθμού",
-      "description": "Το API cloud επέστρεψε περιορισμό ρυθμού. Το polling θα επιβραδυνθεί προσωρινά."
+      "description": "Το API cloud επέστρεψε περιορισμό ρυθμού. Η περιοδική ενημέρωση θα επιβραδυνθεί έως {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Το cloud Enphase Energy δεν είναι προσβάσιμο",

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -817,6 +817,12 @@
         "name": "Cloud Error Code",
         "state": {
           "none": "None",
+          "rate_limited": "Rate limited",
+          "auth_blocked": "Authentication temporarily blocked",
+          "authentication_error": "Authentication error",
+          "request_error": "Request error",
+          "service_unavailable": "Service unavailable",
+          "invalid_payload": "Invalid cloud response",
           "dns_error": "DNS error",
           "network_error": "Network error"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy is rate limited",
-      "description": "The cloud API returned rate limiting. Polling will slow temporarily."
+      "description": "The cloud API returned rate limiting. Polling will slow until {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy cloud unreachable",

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -817,6 +817,12 @@
         "name": "Cloud Error Code",
         "state": {
           "none": "None",
+          "rate_limited": "Rate limited",
+          "auth_blocked": "Authentication temporarily blocked",
+          "authentication_error": "Authentication error",
+          "request_error": "Request error",
+          "service_unavailable": "Service unavailable",
+          "invalid_payload": "Invalid cloud response",
           "dns_error": "DNS error",
           "network_error": "Network error"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy is rate limited",
-      "description": "The cloud API returned rate limiting. Polling will slow temporarily."
+      "description": "The cloud API returned rate limiting. Polling will slow until {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy cloud unreachable",

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -817,6 +817,12 @@
         "name": "Cloud Error Code",
         "state": {
           "none": "None",
+          "rate_limited": "Rate limited",
+          "auth_blocked": "Authentication temporarily blocked",
+          "authentication_error": "Authentication error",
+          "request_error": "Request error",
+          "service_unavailable": "Service unavailable",
+          "invalid_payload": "Invalid cloud response",
           "dns_error": "DNS error",
           "network_error": "Network error"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy is rate limited",
-      "description": "The cloud API returned rate limiting. Polling will slow temporarily."
+      "description": "The cloud API returned rate limiting. Polling will slow until {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy cloud unreachable",

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -817,6 +817,12 @@
         "name": "Cloud Error Code",
         "state": {
           "none": "None",
+          "rate_limited": "Rate limited",
+          "auth_blocked": "Authentication temporarily blocked",
+          "authentication_error": "Authentication error",
+          "request_error": "Request error",
+          "service_unavailable": "Service unavailable",
+          "invalid_payload": "Invalid cloud response",
           "dns_error": "DNS error",
           "network_error": "Network error"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy is rate limited",
-      "description": "The cloud API returned rate limiting. Polling will slow temporarily."
+      "description": "The cloud API returned rate limiting. Polling will slow until {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy cloud unreachable",

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -817,6 +817,12 @@
         "name": "Cloud Error Code",
         "state": {
           "none": "None",
+          "rate_limited": "Rate limited",
+          "auth_blocked": "Authentication temporarily blocked",
+          "authentication_error": "Authentication error",
+          "request_error": "Request error",
+          "service_unavailable": "Service unavailable",
+          "invalid_payload": "Invalid cloud response",
           "dns_error": "DNS error",
           "network_error": "Network error"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy is rate limited",
-      "description": "The cloud API returned rate limiting. Polling will slow temporarily."
+      "description": "The cloud API returned rate limiting. Polling will slow until {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy cloud unreachable",

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -817,6 +817,12 @@
         "name": "Cloud Error Code",
         "state": {
           "none": "None",
+          "rate_limited": "Rate limited",
+          "auth_blocked": "Authentication temporarily blocked",
+          "authentication_error": "Authentication error",
+          "request_error": "Request error",
+          "service_unavailable": "Service unavailable",
+          "invalid_payload": "Invalid cloud response",
           "dns_error": "DNS error",
           "network_error": "Network error"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy is rate limited",
-      "description": "The cloud API returned rate limiting. Polling will slow temporarily."
+      "description": "The cloud API returned rate limiting. Polling will slow until {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy cloud unreachable",

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -814,6 +814,12 @@
         "name": "Código de error en la nube",
         "state": {
           "none": "Ninguno",
+          "rate_limited": "Frecuencia limitada",
+          "auth_blocked": "Autenticación bloqueada temporalmente",
+          "authentication_error": "Error de autenticación",
+          "request_error": "Error de solicitud",
+          "service_unavailable": "Servicio no disponible",
+          "invalid_payload": "Respuesta de la nube no válida",
           "dns_error": "Error de DNS",
           "network_error": "Error de red"
         }
@@ -2105,8 +2111,8 @@
       "description": "Enphase rechazó la autenticación del sitio {site_id} porque hay demasiadas sesiones de cuenta activas. Los reintentos automáticos están pausados hasta {blocked_until}. Cierre sesión en otras sesiones de la aplicación o del navegador de Enphase y vuelva a intentar la reautenticación."
     },
     "rate_limited": {
-      "title": "Enphase Energy tiene limitación",
-      "description": "La API en la nube devolvió limitación. El sondeo se ralentizará temporalmente."
+      "title": "Enphase Energy tiene frecuencia limitada",
+      "description": "La API en la nube devolvió una limitación de frecuencia. El sondeo se ralentizará hasta {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "La nube de Enphase Energy no es accesible",

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -814,8 +814,14 @@
         "name": "Pilve veakood",
         "state": {
           "none": "Puudub",
-          "dns_error": "DNS viga",
-          "network_error": "Võrguviga"
+          "rate_limited": "Sagedus piiratud",
+          "auth_blocked": "Autentimine on ajutiselt blokeeritud",
+          "authentication_error": "Autentimise viga",
+          "request_error": "Päringu viga",
+          "service_unavailable": "Teenus pole saadaval",
+          "invalid_payload": "Vigane pilvevastus",
+          "dns_error": "DNS-i viga",
+          "network_error": "Võrgu viga"
         }
       },
       "cloud_backoff_ends": {
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy on piiratud",
-      "description": "Pilve API tagastas piirangu. Küsitlus aeglustub ajutiselt."
+      "description": "Pilve API tagastas sageduspiirangu. Pollimine aeglustub kuni {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy pilv pole kättesaadav",

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -814,6 +814,12 @@
         "name": "Pilvivirhekoodi",
         "state": {
           "none": "Ei mitään",
+          "rate_limited": "Kutsutiheyttä rajoitettu",
+          "auth_blocked": "Todennus on tilapäisesti estetty",
+          "authentication_error": "Todennusvirhe",
+          "request_error": "Pyyntövirhe",
+          "service_unavailable": "Palvelu ei ole käytettävissä",
+          "invalid_payload": "Virheellinen pilvivastaus",
           "dns_error": "DNS-virhe",
           "network_error": "Verkkovirhe"
         }
@@ -2105,8 +2111,8 @@
       "description": "Enphase hylkäsi sivuston {site_id} todennuksen, koska tilillä on liian monta aktiivista istuntoa. Automaattiset uudelleenyritykset on keskeytetty aikaan {blocked_until} asti. Kirjaudu ulos muista Enphase-sovelluksen tai selaimen istunnoista ja yritä sitten todennusta uudelleen."
     },
     "rate_limited": {
-      "title": "Enphase Energy:n nopeus on rajoitettu",
-      "description": "Pilvisovellusliittymä palautti nopeusrajoituksen. Äänestys hidastuu väliaikaisesti."
+      "title": "Enphase Energyn kutsutiheyttä on rajoitettu",
+      "description": "Pilvi-API palautti kutsutiheyden rajoituksen. Kyselyt hidastuvat aikaan {backoff_ends} asti."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy -pilvi ei ole tavoitettavissa",

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -814,6 +814,12 @@
         "name": "Code d'erreur cloud",
         "state": {
           "none": "Aucune",
+          "rate_limited": "Débit limité",
+          "auth_blocked": "Authentification temporairement bloquée",
+          "authentication_error": "Erreur d'authentification",
+          "request_error": "Erreur de requête",
+          "service_unavailable": "Service indisponible",
+          "invalid_payload": "Réponse cloud non valide",
           "dns_error": "Erreur DNS",
           "network_error": "Erreur réseau"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy est limité en débit",
-      "description": "L'API cloud a retourné une limitation de débit. La scrutation ralentira temporairement."
+      "description": "L’API cloud a renvoyé une limitation de débit. La scrutation ralentira jusqu’à {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Cloud Enphase Energy inaccessible",

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -814,6 +814,12 @@
         "name": "Cloud hibakód",
         "state": {
           "none": "Nincs",
+          "rate_limited": "Kérésszám korlátozva",
+          "auth_blocked": "A hitelesítés ideiglenesen blokkolva",
+          "authentication_error": "Hitelesítési hiba",
+          "request_error": "Kérési hiba",
+          "service_unavailable": "A szolgáltatás nem érhető el",
+          "invalid_payload": "Érvénytelen felhőválasz",
           "dns_error": "DNS-hiba",
           "network_error": "Hálózati hiba"
         }
@@ -2105,8 +2111,8 @@
       "description": "Az Enphase elutasította a(z) {site_id} hely hitelesítését, mert túl sok aktív fiókmunkamenet van. Az automatikus újrapróbálkozások {blocked_until} időpontig szünetelnek. Jelentkezzen ki a többi Enphase alkalmazás- vagy böngészőmunkamenetből, majd próbálja meg újra a hitelesítést."
     },
     "rate_limited": {
-      "title": "Enphase Energy korlátozott",
-      "description": "A cloud API rate limitinget adott vissza. A lekérdezés ideiglenesen lassul."
+      "title": "Az Enphase Energy kérésszáma korlátozva van",
+      "description": "A felhő API kérésszám-korlátozást jelzett. A lekérdezés {backoff_ends} időpontig lassul."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy cloud nem érhető el",

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -814,6 +814,12 @@
         "name": "Codice errore cloud",
         "state": {
           "none": "Nessuno",
+          "rate_limited": "Limite di frequenza",
+          "auth_blocked": "Autenticazione temporaneamente bloccata",
+          "authentication_error": "Errore di autenticazione",
+          "request_error": "Errore di richiesta",
+          "service_unavailable": "Servizio non disponibile",
+          "invalid_payload": "Risposta cloud non valida",
           "dns_error": "Errore DNS",
           "network_error": "Errore di rete"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy ha limitazione di frequenza",
-      "description": "L'API cloud ha restituito limitazione di frequenza. Il polling rallenterà temporaneamente."
+      "description": "L’API cloud ha restituito un limite di frequenza. Il polling rallenterà fino a {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Cloud Enphase Energy non raggiungibile",

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -814,6 +814,12 @@
         "name": "Debesies klaidos kodas",
         "state": {
           "none": "Nėra",
+          "rate_limited": "Ribojamas užklausų dažnis",
+          "auth_blocked": "Autentifikavimas laikinai užblokuotas",
+          "authentication_error": "Autentifikavimo klaida",
+          "request_error": "Užklausos klaida",
+          "service_unavailable": "Paslauga nepasiekiama",
+          "invalid_payload": "Netinkamas debesijos atsakymas",
           "dns_error": "DNS klaida",
           "network_error": "Tinklo klaida"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy ribojamas",
-      "description": "Debesies API grąžino greičio ribojimą. Apklausa laikinai sulėtės."
+      "description": "Debesijos API grąžino užklausų dažnio ribojimą. Apklausos bus sulėtintos iki {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy debesis nepasiekiamas",

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -814,6 +814,12 @@
         "name": "Mākoņa kļūdas kods",
         "state": {
           "none": "Nav",
+          "rate_limited": "Ierobežots pieprasījumu biežums",
+          "auth_blocked": "Autentifikācija īslaicīgi bloķēta",
+          "authentication_error": "Autentifikācijas kļūda",
+          "request_error": "Pieprasījuma kļūda",
+          "service_unavailable": "Pakalpojums nav pieejams",
+          "invalid_payload": "Nederīga mākoņa atbilde",
           "dns_error": "DNS kļūda",
           "network_error": "Tīkla kļūda"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy ir ierobežots",
-      "description": "Mākoņa API atgrieza ātruma ierobežojumu. Aptauja uz laiku palēnināsies."
+      "description": "Mākoņa API atgrieza pieprasījumu biežuma ierobežojumu. Aptauja tiks palēnināta līdz {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy mākonis nav sasniedzams",

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -814,6 +814,12 @@
         "name": "Sky-feilkode",
         "state": {
           "none": "Ingen",
+          "rate_limited": "Frekvensbegrenset",
+          "auth_blocked": "Autentisering midlertidig blokkert",
+          "authentication_error": "Autentiseringsfeil",
+          "request_error": "Forespørselsfeil",
+          "service_unavailable": "Tjenesten er utilgjengelig",
+          "invalid_payload": "Ugyldig skysvar",
           "dns_error": "DNS-feil",
           "network_error": "Nettverksfeil"
         }
@@ -2105,8 +2111,8 @@
       "description": "Enphase avviste autentisering for stedet {site_id} fordi kontoen har for mange aktive økter. Automatiske forsøk er satt på pause til {blocked_until}. Logg ut av andre Enphase-app- eller nettleserøkter, og prøv deretter å autentisere på nytt."
     },
     "rate_limited": {
-      "title": "Enphase Energy er ratebegrenset",
-      "description": "Sky-API-et returnerte rate limiting. Oppdatering vil midlertidig gå saktere."
+      "title": "Enphase Energy er frekvensbegrenset",
+      "description": "Sky-API-et returnerte frekvensbegrensning. Spørringer bremses til {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy sky utilgjengelig",

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -814,6 +814,12 @@
         "name": "Cloud-foutcode",
         "state": {
           "none": "Geen",
+          "rate_limited": "Verzoekfrequentie beperkt",
+          "auth_blocked": "Authenticatie tijdelijk geblokkeerd",
+          "authentication_error": "Authenticatiefout",
+          "request_error": "Aanvraagfout",
+          "service_unavailable": "Service niet beschikbaar",
+          "invalid_payload": "Ongeldig cloudantwoord",
           "dns_error": "DNS-fout",
           "network_error": "Netwerkfout"
         }
@@ -2105,8 +2111,8 @@
       "description": "Enphase heeft de authenticatie voor locatie {site_id} geweigerd omdat er te veel accountsessies actief zijn. Automatische pogingen zijn gepauzeerd tot {blocked_until}. Meld u af bij andere Enphase-app- of browsersessies en probeer daarna opnieuw te authenticeren."
     },
     "rate_limited": {
-      "title": "Enphase Energy is beperkt door rate limiting",
-      "description": "De cloud-API gaf rate limiting terug. Polling zal tijdelijk vertragen."
+      "title": "Enphase Energy is door een snelheidslimiet beperkt",
+      "description": "De cloud-API gaf een verzoekfrequentielimiet terug. Polling wordt vertraagd tot {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy cloud onbereikbaar",

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -814,6 +814,12 @@
         "name": "Kod błędu chmury",
         "state": {
           "none": "Brak",
+          "rate_limited": "Ograniczenie częstotliwości",
+          "auth_blocked": "Uwierzytelnianie tymczasowo zablokowane",
+          "authentication_error": "Błąd uwierzytelniania",
+          "request_error": "Błąd żądania",
+          "service_unavailable": "Usługa niedostępna",
+          "invalid_payload": "Nieprawidłowa odpowiedź chmury",
           "dns_error": "Błąd DNS",
           "network_error": "Błąd sieci"
         }
@@ -2106,7 +2112,7 @@
     },
     "rate_limited": {
       "title": "Enphase Energy ma ograniczenie zapytań",
-      "description": "API chmury zwróciło ograniczenie zapytań. Odpytywanie tymczasowo zwolni."
+      "description": "Interfejs API chmury zwrócił ograniczenie częstotliwości. Odpytywanie zostanie spowolnione do {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Chmura Enphase Energy nieosiągalna",

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -814,6 +814,12 @@
         "name": "Código de erro da nuvem",
         "state": {
           "none": "Nenhum",
+          "rate_limited": "Limite de requisições",
+          "auth_blocked": "Autenticação temporariamente bloqueada",
+          "authentication_error": "Erro de autenticação",
+          "request_error": "Erro de solicitação",
+          "service_unavailable": "Serviço indisponível",
+          "invalid_payload": "Resposta da nuvem inválida",
           "dns_error": "Erro de DNS",
           "network_error": "Erro de rede"
         }
@@ -2105,8 +2111,8 @@
       "description": "A Enphase rejeitou a autenticação do local {site_id} porque há muitas sessões da conta ativas. As novas tentativas automáticas estão pausadas até {blocked_until}. Saia de outras sessões do aplicativo ou navegador Enphase e tente autenticar novamente."
     },
     "rate_limited": {
-      "title": "Enphase Energy com limitação de taxa",
-      "description": "A API da nuvem retornou limitação. O polling será reduzido temporariamente."
+      "title": "Enphase Energy com limite de requisições",
+      "description": "A API da nuvem retornou limite de requisições. A sondagem ficará mais lenta até {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Nuvem do Enphase Energy inacessível",

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -814,6 +814,12 @@
         "name": "Cod de eroare cloud",
         "state": {
           "none": "Niciunul",
+          "rate_limited": "Frecvență limitată",
+          "auth_blocked": "Autentificare blocată temporar",
+          "authentication_error": "Eroare de autentificare",
+          "request_error": "Eroare de solicitare",
+          "service_unavailable": "Serviciu indisponibil",
+          "invalid_payload": "Răspuns cloud nevalid",
           "dns_error": "Eroare DNS",
           "network_error": "Eroare de rețea"
         }
@@ -2105,8 +2111,8 @@
       "description": "Enphase a respins autentificarea pentru site-ul {site_id} deoarece există prea multe sesiuni active ale contului. Reîncercările automate sunt suspendate până la {blocked_until}. Deconectați-vă din alte sesiuni ale aplicației sau browserului Enphase, apoi reîncercați autentificarea."
     },
     "rate_limited": {
-      "title": "Enphase Energy are limitare de rată",
-      "description": "API-ul cloud a returnat limitare de rată. Interogarea va încetini temporar."
+      "title": "Enphase Energy are frecvența limitată",
+      "description": "API-ul cloud a returnat o limitare de frecvență. Interogarea va fi încetinită până la {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Cloud Enphase Energy inaccesibil",

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -814,6 +814,12 @@
         "name": "Molnfelkod",
         "state": {
           "none": "Ingen",
+          "rate_limited": "Frekvensbegränsad",
+          "auth_blocked": "Autentisering tillfälligt blockerad",
+          "authentication_error": "Autentiseringsfel",
+          "request_error": "Begäransfel",
+          "service_unavailable": "Tjänsten är otillgänglig",
+          "invalid_payload": "Ogiltigt molnsvar",
           "dns_error": "DNS-fel",
           "network_error": "Nätverksfel"
         }
@@ -2105,8 +2111,8 @@
       "description": "Enphase avvisade autentisering för platsen {site_id} eftersom kontot har för många aktiva sessioner. Automatiska försök är pausade till {blocked_until}. Logga ut från andra Enphase-app- eller webbläsarsessioner och försök sedan autentisera igen."
     },
     "rate_limited": {
-      "title": "Enphase Energy är hastighetsbegränsad",
-      "description": "Moln-API:et returnerade rate limiting. Pollningen kommer tillfälligt att sakta ner."
+      "title": "Enphase Energy är frekvensbegränsad",
+      "description": "Moln-API:t returnerade frekvensbegränsning. Avfrågningen saktas ned till {backoff_ends}."
     },
     "cloud_unreachable": {
       "title": "Enphase Energy-moln inte nåbart",

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -1581,6 +1581,7 @@ def test_collect_site_metrics_serializes_dates(coordinator_factory):
         "site_name": "Garage",
         "last_error": "boom",
         "last_status": "500",
+        "backoff_ends": "backoff",
     }
 
 

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1532,6 +1532,7 @@ async def test_site_only_clears_issues_and_counters(
     coord._network_issue_reported = True
     coord._cloud_issue_reported = True
     coord._dns_issue_reported = True
+    coord._rate_limit_issue_reported = True
     coord._unauth_errors = 3
     coord._rate_limit_hits = 2
     coord._http_errors = 4
@@ -1560,6 +1561,7 @@ async def test_site_only_clears_issues_and_counters(
     assert ("enphase_ev", "cloud_unreachable") in mock_issue_registry.deleted
     assert ("enphase_ev", "cloud_service_unavailable") in mock_issue_registry.deleted
     assert ("enphase_ev", "cloud_dns_resolution") in mock_issue_registry.deleted
+    assert ("enphase_ev", "rate_limited") in mock_issue_registry.deleted
 
 
 @pytest.mark.asyncio
@@ -5406,6 +5408,7 @@ async def test_timeout_backoff_issue_recovery(hass, monkeypatch):
         "reauth_required",
         "auth_blocked",
         "too_many_active_sessions",
+        "rate_limited",
         ISSUE_NETWORK_UNREACHABLE,
     ]
     assert coord._backoff_until is None

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -132,6 +132,76 @@ def test_endpoint_family_failure_classification_and_core_backoff(
     assert coord._endpoint_family_should_run("core_realtime") is False  # noqa: SLF001
 
 
+def test_endpoint_family_retry_after_numeric_overrides_policy_cap(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    now = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(coord_mod.time, "monotonic", lambda: 1_000.0)
+    monkeypatch.setattr(coord_mod.dt_util, "utcnow", lambda: now)
+    monkeypatch.setattr(coord_mod.random, "uniform", lambda _a, _b: 1.0)
+
+    err = aiohttp.ClientResponseError(
+        _request_info(),
+        (),
+        status=429,
+        message="Too Many Requests",
+        headers={"Retry-After": "120"},
+    )
+
+    assert coord._note_endpoint_family_failure("tariff", err) is True  # noqa: SLF001
+
+    health = coord._endpoint_family_state("tariff")  # noqa: SLF001
+    assert health.next_retry_mono == pytest.approx(1_120.0)
+    assert health.next_retry_utc == now + timedelta(seconds=120)
+
+
+def test_endpoint_family_retry_after_http_date_and_invalid_fallback(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    now = datetime(2025, 1, 1, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(coord_mod.time, "monotonic", lambda: 2_000.0)
+    monkeypatch.setattr(coord_mod.dt_util, "utcnow", lambda: now)
+    monkeypatch.setattr(coord_mod.random, "uniform", lambda _a, _b: 1.0)
+
+    dated_err = aiohttp.ClientResponseError(
+        _request_info(),
+        (),
+        status=503,
+        message="Service Unavailable",
+        headers={"Retry-After": "Wed, 01 Jan 2025 12:01:30 GMT"},
+    )
+
+    assert (
+        coord._note_endpoint_family_failure("core_realtime", dated_err) is True
+    )  # noqa: SLF001
+    health = coord._endpoint_family_state("core_realtime")  # noqa: SLF001
+    assert health.next_retry_mono == pytest.approx(2_090.0)
+    assert health.next_retry_utc == now + timedelta(seconds=90)
+
+    invalid_err = aiohttp.ClientResponseError(
+        _request_info(),
+        (),
+        status=503,
+        message="Service Unavailable",
+        headers={"Retry-After": "invalid"},
+    )
+    missing_retry_after_err = aiohttp.ClientResponseError(
+        _request_info(),
+        (),
+        status=503,
+        message="Service Unavailable",
+        headers={"Date": "Wed, 01 Jan 2025 12:00:00 GMT"},
+    )
+    assert coord._retry_after_delay(missing_retry_after_err) is None  # noqa: SLF001
+    assert (
+        coord._note_endpoint_family_failure("battery_status", invalid_err) is True
+    )  # noqa: SLF001
+    battery_health = coord._endpoint_family_state("battery_status")  # noqa: SLF001
+    assert battery_health.next_retry_mono == pytest.approx(2_300.0)
+
+
 def test_endpoint_family_suppression_recovery_and_metrics(
     coordinator_factory, monkeypatch
 ) -> None:

--- a/tests/components/enphase_ev/test_latency_and_connectivity.py
+++ b/tests/components/enphase_ev/test_latency_and_connectivity.py
@@ -411,8 +411,24 @@ def test_site_error_code_sensor_state_and_attributes():
     coord.payload_using_stale = True
     coord.payload_failure_kind = "json_decode"
 
-    assert sensor.native_value == "429"
+    assert sensor.native_value == "invalid_payload"
+    assert "rate_limited" in sensor.options
     assert sensor.extra_state_attributes == {}
+
+    coord.payload_failure_kind = None
+    assert sensor.native_value == "rate_limited"
+
+    coord.last_failure_status = 401
+    assert sensor.native_value == "authentication_error"
+
+    coord.last_failure_status = 404
+    assert sensor.native_value == "request_error"
+
+    coord.last_failure_status = "unavailable"
+    assert sensor.native_value == "request_error"
+
+    coord.last_failure_status = 503
+    assert sensor.native_value == "service_unavailable"
 
     coord.last_success_utc = failure_time + timedelta(seconds=1)
     assert sensor.native_value == "none"
@@ -436,6 +452,20 @@ def test_site_error_code_sensor_state_and_attributes():
     # Non-network failures without status fall back to none
     coord.last_failure_source = "other"
     assert sensor.native_value == "none"
+
+    coord.last_failure_source = "auth"
+    assert sensor.native_value == "authentication_error"
+
+    coord._last_error = "auth_blocked"
+    assert sensor.native_value == "auth_blocked"
+
+    coord._last_error = None
+    coord.last_failure_status = 401
+    coord._auth_blocked_until_utc = datetime.now(timezone.utc) + timedelta(hours=1)
+    assert sensor.native_value == "auth_blocked"
+
+    coord._auth_blocked_until_utc = datetime.now(timezone.utc) - timedelta(minutes=1)
+    assert sensor.native_value == "authentication_error"
 
 
 def test_site_backoff_sensor_handles_none_and_datetime(monkeypatch):

--- a/tests/components/enphase_ev/test_rate_limit_and_switch_kick.py
+++ b/tests/components/enphase_ev/test_rate_limit_and_switch_kick.py
@@ -1,3 +1,5 @@
+from types import SimpleNamespace
+
 import aiohttp
 import pytest
 
@@ -63,10 +65,16 @@ async def test_rate_limit_issue_created_on_repeated_429(hass, monkeypatch):
 
     # Capture issue creation calls
     created = []
+    deleted = []
     monkeypatch.setattr(
         diag_mod.ir,
         "async_create_issue",
         lambda *args, **kwargs: created.append(kwargs),
+    )
+    monkeypatch.setattr(
+        diag_mod.ir,
+        "async_delete_issue",
+        lambda _hass, _domain, issue_id: deleted.append(issue_id),
     )
 
     # First 429 -> backoff, no issue yet
@@ -79,7 +87,36 @@ async def test_rate_limit_issue_created_on_repeated_429(hass, monkeypatch):
     coord._backoff_until = None
     with pytest.raises(UpdateFailed):
         await coord._async_update_data()
-    assert any(k.get("translation_key") == "rate_limited" for k in created)
+    rate_limit_issues = [
+        kwargs for kwargs in created if kwargs.get("translation_key") == "rate_limited"
+    ]
+    assert len(rate_limit_issues) == 1
+    assert coord._rate_limit_issue_reported is True
+    assert "backoff_ends" in rate_limit_issues[0]["translation_placeholders"]
+
+    coord._backoff_until = None
+    with pytest.raises(UpdateFailed):
+        await coord._async_update_data()
+    rate_limit_issues = [
+        kwargs for kwargs in created if kwargs.get("translation_key") == "rate_limited"
+    ]
+    assert len(rate_limit_issues) == 1
+
+    coord._record_status_refresh_success(SimpleNamespace(status_used_stale=False))
+    assert "rate_limited" in deleted
+    assert coord._rate_limit_issue_reported is False
+
+    coord._record_status_refresh_success(SimpleNamespace(status_used_stale=False))
+    assert deleted.count("rate_limited") == 1
+
+    deleted.clear()
+    coord._rate_limit_issue_clear_checked = False
+    coord._record_status_refresh_success(SimpleNamespace(status_used_stale=False))
+    assert deleted == ["rate_limited"]
+    assert coord._rate_limit_issue_clear_checked is True
+
+    coord._record_status_refresh_success(SimpleNamespace(status_used_stale=False))
+    assert deleted == ["rate_limited"]
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -86,6 +86,62 @@ def test_try_reauth_now_strings_exist_for_all_locales() -> None:
         ), f"{name} missing {{blocked_until}} placeholder"
 
 
+def test_cloud_error_code_states_exist_for_all_locales() -> None:
+    """Ensure cloud diagnostic error states can be translated in the UI."""
+
+    from custom_components.enphase_ev.sensor import CLOUD_ERROR_CODE_STATES
+
+    root = (
+        pathlib.Path(__file__).resolve().parents[3] / "custom_components" / "enphase_ev"
+    )
+    translations_dir = root / "translations"
+    paths = [
+        "entity.sensor.cloud_error_code.state.none",
+        "entity.sensor.cloud_error_code.state.rate_limited",
+        "entity.sensor.cloud_error_code.state.auth_blocked",
+        "entity.sensor.cloud_error_code.state.authentication_error",
+        "entity.sensor.cloud_error_code.state.request_error",
+        "entity.sensor.cloud_error_code.state.service_unavailable",
+        "entity.sensor.cloud_error_code.state.invalid_payload",
+        "entity.sensor.cloud_error_code.state.dns_error",
+        "entity.sensor.cloud_error_code.state.network_error",
+    ]
+    strings_data = json.loads((root / "strings.json").read_text(encoding="utf-8"))
+    en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
+    assert set(strings_data["entity"]["sensor"]["cloud_error_code"]["state"]) == set(
+        CLOUD_ERROR_CODE_STATES
+    )
+    for path in paths:
+        value = _at_path(strings_data, path)
+        assert value.strip(), f"strings.json missing value for {path}"
+    rate_limited_issue = _at_path(strings_data, "issues.rate_limited.description")
+    assert "{backoff_ends}" in rate_limited_issue
+    for locale in translations_dir.glob("*.json"):
+        name = locale.name
+        data = json.loads(locale.read_text(encoding="utf-8"))
+        assert set(data["entity"]["sensor"]["cloud_error_code"]["state"]) == set(
+            CLOUD_ERROR_CODE_STATES
+        ), f"{name} cloud error states differ from sensor options"
+        for path in paths:
+            value = _at_path(data, path)
+            assert value.strip(), f"{name} missing value for {path}"
+            if name != "en.json" and not name.startswith("en-"):
+                assert value != _at_path(
+                    en_data, path
+                ), f"{name} should localize {path} (still matches English)"
+        rate_limited_issue = _at_path(data, "issues.rate_limited.description")
+        assert (
+            "{backoff_ends}" in rate_limited_issue
+        ), f"{name} missing {{backoff_ends}} placeholder"
+        if name != "en.json" and not name.startswith("en-"):
+            assert rate_limited_issue != _at_path(
+                en_data, "issues.rate_limited.description"
+            ), f"{name} should localize issues.rate_limited.description"
+            assert _at_path(data, "issues.rate_limited.title") != _at_path(
+                en_data, "issues.rate_limited.title"
+            ), f"{name} should localize issues.rate_limited.title"
+
+
 def _at_path(data: dict, path: str) -> str:
     cur = data
     for part in path.split("."):


### PR DESCRIPTION
## Summary

Improve Enphase cloud error handling so users see localized diagnostic states for rate limits, temporary auth blocks, authentication errors, request failures, service outages, invalid payloads, DNS failures, and network failures. The change also honors `Retry-After` headers for endpoint-family backoff, de-duplicates repeated rate-limit repair issues, and clears stale rate-limit repairs after successful recovery.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py && pytest tests/components/enphase_ev/test_service_translations.py -q"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "git config --global --add safe.directory /workspace && pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/state_models.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Coverage for touched Python modules:

```text
custom_components/enphase_ev/coordinator.py                100%
custom_components/enphase_ev/coordinator_diagnostics.py    100%
custom_components/enphase_ev/sensor.py                     100%
custom_components/enphase_ev/state_models.py               100%
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Local validation passed. GitHub Actions results are pending after PR creation.
