### PR TITLE
Fix EV charger safe-limit amps display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ All notable changes to this project will be documented in this file.
 - Smoothed idle heat-pump power over existing low-load energy samples so whole-Wh cloud readings no longer flicker between `0 W` and standby load, while exposing the raw short-window value in diagnostics.
 - Reduced unnecessary EV charger post-status follow-up lookups, kept idle session-history catch-up off the main refresh path when cached data is still usable, and aligned HEMS preflight/device refresh cadence with fast polling to lower steady-state cloud overhead.
 - Hardened setup, polling, and EV charger service inputs by bounding scan/runtime intervals, restricting OCPP trigger messages to supported values, requiring confirmation for advanced trigger messages, and keeping raw Enphase error bodies out of raised exceptions.
+- Reported the charger-specific minimum amp value during EV charger safe-limit charging instead of always showing 8A.
 
 ### 🔧 Improvements
 - Clarified the Enphase authentication-block repair message and added a manual stored-credential reauthentication service for trying one immediate unblock attempt.

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -88,7 +88,6 @@ from .const import (
     PHASE_SWITCH_CONFIG_SETTING,
     SAVINGS_OPERATION_MODE_SUBTYPE,
     DEFAULT_SESSION_HISTORY_INTERVAL_MIN,
-    SAFE_LIMIT_AMPS,
 )
 from .battery_runtime import BatteryRuntime
 from .coordinator_diagnostics import CoordinatorDiagnostics
@@ -3454,8 +3453,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             safe_limit_active = (
                 safe_limit_state is not None and int(safe_limit_state) != 0
             )
-            safe_limit_level = _as_int(charging_level)
-            skip_seed = safe_limit_active and safe_limit_level == SAFE_LIMIT_AMPS
+            skip_seed = safe_limit_active and charging_level_source == "status_payload"
             if (
                 sn not in self.last_set_amps
                 and charging_level is not None

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -341,6 +341,22 @@ class ChargingAmpsNumber(EnphaseBaseEntity, NumberEntity):
             return False
         return False
 
+    @staticmethod
+    def _coerce_amp(value) -> int | None:
+        if value in (None, ""):
+            return None
+        try:
+            return int(float(str(value).strip()))
+        except Exception:  # noqa: BLE001
+            return None
+
+    @classmethod
+    def _safe_limit_amps(cls, data) -> int:
+        min_amp = cls._coerce_amp(data.get("min_amp"))
+        if min_amp is not None and min_amp > 0:
+            return min_amp
+        return SAFE_LIMIT_AMPS
+
     @property
     def native_value(self) -> float | None:
         data = self.data
@@ -349,7 +365,7 @@ class ChargingAmpsNumber(EnphaseBaseEntity, NumberEntity):
         if self._safe_limit_active(
             data.get("safe_limit_state")
         ) and self._charging_active(data.get("charging")):
-            return float(SAFE_LIMIT_AMPS)
+            return float(self._safe_limit_amps(data))
         lvl = data.get("charging_level")
         if lvl is None:
             # Let coordinator choose a safe default within charger limits
@@ -361,19 +377,13 @@ class ChargingAmpsNumber(EnphaseBaseEntity, NumberEntity):
 
     @property
     def native_min_value(self) -> float:
-        v = self.data.get("min_amp")
-        try:
-            return float(int(v)) if v is not None else 6.0
-        except Exception:
-            return 6.0
+        v = self._coerce_amp(self.data.get("min_amp"))
+        return float(v) if v is not None else 6.0
 
     @property
     def native_max_value(self) -> float:
-        v = self.data.get("max_amp")
-        try:
-            return float(int(v)) if v is not None else 40.0
-        except Exception:
-            return 40.0
+        v = self._coerce_amp(self.data.get("max_amp"))
+        return float(v) if v is not None else 40.0
 
     @property
     def native_step(self) -> float:

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -2698,7 +2698,7 @@ class EnphaseChargingLevelSensor(EnphaseBaseEntity, SensorEntity):
         if self._safe_limit_active(
             data.get("safe_limit_state")
         ) and self._charging_active(data.get("charging")):
-            return SAFE_LIMIT_AMPS
+            return self._safe_limit_amps(data)
         lvl = data.get("charging_level")
         if lvl is None:
             # Fall back to coordinator helper which respects charger limits
@@ -2713,9 +2713,16 @@ class EnphaseChargingLevelSensor(EnphaseBaseEntity, SensorEntity):
         if value in (None, ""):
             return None
         try:
-            return int(str(value).strip())
+            return int(float(str(value).strip()))
         except Exception:  # noqa: BLE001
             return None
+
+    @classmethod
+    def _safe_limit_amps(cls, data):
+        min_amp = cls._coerce_amp(data.get("min_amp"))
+        if min_amp is not None and min_amp > 0:
+            return min_amp
+        return SAFE_LIMIT_AMPS
 
     @property
     def extra_state_attributes(self):

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -6082,7 +6082,7 @@ There is no single universal header set; the implementation varies headers by en
 | `maxCurrent` | Hardware max amp rating |
 | `operatingVoltage` | Nominal voltage per summary v2 |
 | `dlbEnabled` | Dynamic Load Balancing flag |
-| `safeLimitState` | DLB safe-mode indicator within `connectors[]`. Observed: `1` when DLB is enabled and the charger cannot reach the gateway, forcing a safe 8A limit. |
+| `safeLimitState` | Safe-limit indicator within `connectors[]`. Observed: `1` when the charger reverts to its lowest charge-current level; the effective limit follows the charger capability, for example 8A on some single-phase chargers and 16A on an IQ-EVSE-80R with `chargeLevelDetails.min=16`. |
 | `supportsUseBattery` | Summary v2 flag for green-mode "Use Battery" support |
 | `hoControl` | Homeowner-control capability flag from summary v2; observed value so far: `true` |
 | `activeConnection` | Active network transport label from summary v2; observed value so far: `ethernet` |

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -806,7 +806,7 @@ async def test_async_update_data_success_handles_edge_payloads(
         "pluggedIn": True,
         "charging": False,
         "faulted": False,
-        "chargingLevel": 8,
+        "chargingLevel": 16,
         "session_d": {
             "e_c": 500.0,
             "miles": " ",
@@ -958,6 +958,7 @@ async def test_async_update_data_success_handles_edge_payloads(
     assert main["status"] == "ONLINE"
     assert main["charge_mode"] == "IDLE"
     assert main["energy_today_sessions_kwh"] == 0.0
+    assert main["charging_level"] == 16
     assert main["safe_limit_state"] == 1
     assert RANDOM_SERIAL not in coord.last_set_amps
     aux = snapshot_data["AUX"]

--- a/tests/components/enphase_ev/test_number_module.py
+++ b/tests/components/enphase_ev/test_number_module.py
@@ -325,6 +325,8 @@ def test_charging_number_helper_coercions_cover_edge_inputs() -> None:
     assert ChargingAmpsNumber._charging_active("off") is False
     assert ChargingAmpsNumber._charging_active("mystery") is False
     assert ChargingAmpsNumber._charging_active(object()) is False
+    assert ChargingAmpsNumber._coerce_amp("16.0") == 16
+    assert ChargingAmpsNumber._coerce_amp("bad") is None
 
 
 @pytest.mark.asyncio
@@ -369,6 +371,8 @@ def test_charging_number_uses_pick_start_for_non_applicable_and_safe_limit(
     assert number.native_value == 26.0
     coord.data[RANDOM_SERIAL]["charge_mode_pref"] = "MANUAL"
     assert number.native_value == 8.0
+    coord.data[RANDOM_SERIAL]["min_amp"] = "16"
+    assert number.native_value == 16.0
     assert number.native_max_value == 40.0
 
 

--- a/tests/components/enphase_ev/test_sensors.py
+++ b/tests/components/enphase_ev/test_sensors.py
@@ -135,6 +135,9 @@ def test_charging_level_invalid_value_falls_back():
     coord.data[sn]["charging"] = True
     assert sensor.native_value == SAFE_LIMIT_AMPS
 
+    coord.data[sn]["min_amp"] = 16
+    assert sensor.native_value == 16
+
     coord.data[sn]["charging"] = False
     assert sensor.native_value == 32
 
@@ -143,7 +146,7 @@ def test_charging_level_invalid_value_falls_back():
 
     coord.data[sn]["safe_limit_state"] = True
     coord.data[sn]["charging"] = True
-    assert sensor.native_value == SAFE_LIMIT_AMPS
+    assert sensor.native_value == 16
 
     class BadStr:
         def __str__(self):


### PR DESCRIPTION
## Summary

Fixes #601.

When an IQ EV Charger reports `safeLimitState=1`, show the charger-specific minimum amp value instead of always showing the legacy 8A fallback. This keeps IQ-EVSE-80R chargers with `min_amp=16` from reporting impossible 8A values while safe-limit charging is active.

The coordinator also avoids seeding `last_set_amps` from status-payload amp values while safe limit is active, so a temporary safe-limit value does not replace the user's desired setpoint.

## Related Issues

Fixes #601

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/number.py custom_components/enphase_ev/sensor.py tests/components/enphase_ev/test_coordinator_remaining_coverage.py tests/components/enphase_ev/test_number_module.py tests/components/enphase_ev/test_sensors.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "pre-commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/number.py,custom_components/enphase_ev/sensor.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Issue diagnostics showed an IQ-EVSE-80R reporting `safeLimitState=1`, `min_amp=16`, `max_amp=64`, `amp_granularity=16`, and `session_charge_level=16`; the integration previously displayed 8A because the safe-limit fallback was hardcoded.
