### PR TITLE
Fix firmware update catalog handling

### DIFF
--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -261,18 +261,20 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
 
         raw_latest = _text(entry.get("version"))
         normalized_latest = normalize_version_token(raw_latest)
-        comparable_update = compare_versions(normalized_latest, normalized_installed)
 
         self._raw_latest_version = raw_latest
-        if comparable_update is None:
-            # Conservative fallback: avoid false-positive update state.
-            self._attr_latest_version = None
-        else:
-            self._attr_latest_version = normalized_latest
+        self._attr_latest_version = _latest_version_for_state(
+            latest=normalized_latest,
+            installed=normalized_installed,
+        )
+        release_metadata_matches = _release_metadata_matches_state(
+            catalog_version=normalized_latest,
+            latest_version=self._attr_latest_version,
+        )
 
         urls = entry.get("urls_by_locale")
         release_url = None
-        if isinstance(urls, dict):
+        if release_metadata_matches and isinstance(urls, dict):
             chosen_key = (
                 self._locale_used
                 if self._locale_used in urls
@@ -283,7 +285,9 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
                 self._locale_used = chosen_key
 
         self._attr_release_url = release_url
-        self._attr_release_summary = _text(entry.get("summary"))
+        self._attr_release_summary = (
+            _text(entry.get("summary")) if release_metadata_matches else None
+        )
         _reconcile_skipped_version(self)
 
 
@@ -323,6 +327,7 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
         self._locale_used: str = "en"
         self._source_scope: str | None = None
         self._catalog_generated_at: str | None = None
+        self._catalog_latest_version: str | None = None
 
         self._refresh_from_details(self._manager.cached_details)
         self._refresh_from_catalog(self._catalog_manager.cached_catalog)
@@ -457,12 +462,12 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
 
         raw_latest = _text(details.get("targetFwVersion")) if details else None
         normalized_latest = normalize_version_token(raw_latest)
-        comparable_update = compare_versions(normalized_latest, normalized_installed)
         self._raw_latest_version = raw_latest
-        if comparable_update is None:
-            self._attr_latest_version = None
-        else:
-            self._attr_latest_version = normalized_latest
+        self._attr_latest_version = _latest_version_for_state(
+            latest=normalized_latest,
+            installed=normalized_installed,
+        )
+        self._clear_release_metadata_if_mismatch()
 
         self._upgrade_status = (
             _as_int(details.get("upgradeStatus")) if details else None
@@ -498,16 +503,20 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
             if isinstance(catalog, dict) and catalog.get("generated_at") is not None
             else None
         )
+        self._catalog_latest_version = None
 
         entry = selected.entry if isinstance(selected.entry, dict) else None
         if entry is None:
             self._attr_release_url = None
             self._attr_release_summary = None
             return
+        self._catalog_latest_version = normalize_version_token(
+            _text(entry.get("version"))
+        )
 
         urls = entry.get("urls_by_locale")
         release_url = None
-        if isinstance(urls, dict):
+        if self._release_metadata_matches_state() and isinstance(urls, dict):
             chosen_key = (
                 self._locale_used
                 if self._locale_used in urls
@@ -518,7 +527,23 @@ class ChargerFirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateE
                 self._locale_used = chosen_key
 
         self._attr_release_url = release_url
-        self._attr_release_summary = _text(entry.get("summary"))
+        self._attr_release_summary = (
+            _text(entry.get("summary"))
+            if self._release_metadata_matches_state()
+            else None
+        )
+
+    def _release_metadata_matches_state(self) -> bool:
+        return _release_metadata_matches_state(
+            catalog_version=self._catalog_latest_version,
+            latest_version=self.latest_version,
+        )
+
+    def _clear_release_metadata_if_mismatch(self) -> None:
+        if self._release_metadata_matches_state():
+            return
+        self._attr_release_url = None
+        self._attr_release_summary = None
 
 
 def _charger_serials(coord: EnphaseCoordinator) -> list[str]:
@@ -624,6 +649,24 @@ def _evse_firmware_rollout_enabled(
         return feature_flag_enabled("iqevse_itk_fw_upgrade_status", serial)
     except Exception:  # noqa: BLE001
         return None
+
+
+def _latest_version_for_state(
+    *, latest: str | None, installed: str | None
+) -> str | None:
+    comparable_update = compare_versions(latest, installed)
+    if comparable_update is None:
+        # Conservative fallback: avoid false-positive update state.
+        return None
+    if comparable_update:
+        return latest
+    return installed
+
+
+def _release_metadata_matches_state(
+    *, catalog_version: str | None, latest_version: str | None
+) -> bool:
+    return catalog_version is not None and catalog_version == latest_version
 
 
 def _reconcile_skipped_version(entity: UpdateEntity) -> None:

--- a/scripts/firmware_catalog.py
+++ b/scripts/firmware_catalog.py
@@ -30,14 +30,16 @@ TARGET_CATEGORY_PATH = "/installers/resources/documentation/apps"
 COMMUNICATION_CATEGORY_PATH = "/installers/resources/documentation/communication"
 DEFAULT_PRODUCT_TYPE = "216"
 
-TARGET_PRODUCTS: dict[str, dict[str, str]] = {
+TARGET_PRODUCTS: dict[str, dict[str, Any]] = {
     "envoy": {
         "label": "IQ Gateway software",
         "docs_path": COMMUNICATION_CATEGORY_PATH,
+        "required": True,
     },
     "iqevse": {
         "label": "IQ EV Charger software",
         "docs_path": TARGET_CATEGORY_PATH,
+        "required": False,
     },
 }
 
@@ -1354,6 +1356,31 @@ def fetch_previous_runtime_catalog(
     return payload
 
 
+def _previous_catalog_device(
+    previous_catalog: dict[str, Any] | None, device_key: str
+) -> dict[str, Any] | None:
+    devices = (
+        previous_catalog.get("devices") if isinstance(previous_catalog, dict) else None
+    )
+    if not isinstance(devices, dict):
+        return None
+    device = devices.get(device_key)
+    return device if isinstance(device, dict) else None
+
+
+def _previous_catalog_source_device(
+    previous_catalog: dict[str, Any] | None, device_key: str
+) -> dict[str, Any] | None:
+    source = (
+        previous_catalog.get("source") if isinstance(previous_catalog, dict) else None
+    )
+    source_devices = source.get("devices") if isinstance(source, dict) else None
+    if not isinstance(source_devices, dict):
+        return None
+    source_device = source_devices.get(device_key)
+    return source_device if isinstance(source_device, dict) else None
+
+
 def _bootstrap_target(
     target: dict[str, Any], *, timeout: int, docs_path: str
 ) -> dict[str, Any]:
@@ -1469,6 +1496,7 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
     global_product_facets: dict[str, Any] = {}
     language_options: dict[str, str] = {}
     alt_language_options: dict[str, str] = {}
+    previous_runtime_catalog = fetch_previous_runtime_catalog(timeout=timeout)
 
     for device_key, product_meta in TARGET_PRODUCTS.items():
         device_targets = [dict(target) for target in crawl_targets]
@@ -1482,6 +1510,43 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
             _bootstrap_target(global_target, timeout=timeout, docs_path=docs_path)
         )
         global_target["bootstrap_error"] = None
+
+        global_product_id_raw = global_target["product_ids"].get(device_key)
+        if global_product_id_raw is None:
+            missing_message = (
+                f"Could not discover product id for '{product_meta['label']}'"
+            )
+            if bool(product_meta.get("required")):
+                raise RuntimeError(missing_message)
+            previous_device = _previous_catalog_device(
+                previous_runtime_catalog, device_key
+            )
+            if isinstance(previous_device, dict):
+                devices_catalog[device_key] = previous_device
+            previous_source_device = _previous_catalog_source_device(
+                previous_runtime_catalog, device_key
+            )
+            if isinstance(previous_source_device, dict):
+                source_devices[device_key] = previous_source_device
+            crawl_meta[device_key] = {
+                "count": 0,
+                "targets": {},
+                "missing_product_media_id_targets": [global_target_key],
+                "used_global_product_media_id_targets": [],
+                "empty_release_targets": [],
+                "bootstrap_error_targets": [],
+                "crawl_error_targets": [],
+                "skipped": True,
+                "skip_reason": missing_message,
+                "using_previous_catalog_device": isinstance(previous_device, dict),
+            }
+            _LOGGER.warning(
+                "Firmware catalog skipping device %s: %s",
+                device_key,
+                missing_message,
+            )
+            continue
+        global_product_id = int(global_product_id_raw)
 
         for target in device_targets:
             if str(target["key"]) == global_target_key:
@@ -1514,12 +1579,6 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
                     err,
                 )
 
-        global_product_id_raw = global_target["product_ids"].get(device_key)
-        if global_product_id_raw is None:
-            raise RuntimeError(
-                f"Could not discover product id for '{product_meta['label']}'"
-            )
-        global_product_id = int(global_product_id_raw)
         global_topic_id = int(global_target["topic_id"])
         global_product_type = str(global_target["product_type"])
         global_apps_url = str(global_target["apps_url"])
@@ -1708,7 +1767,6 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
         },
         "devices": devices_catalog,
     }
-    previous_runtime_catalog = fetch_previous_runtime_catalog(timeout=timeout)
     generated_at = choose_generated_at(
         current_catalog=runtime_catalog,
         previous_catalog=previous_runtime_catalog,
@@ -1757,6 +1815,7 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
                     ),
                 }
                 for key in TARGET_PRODUCTS
+                if key in devices_catalog
             },
         },
     )

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -389,6 +389,14 @@ async def test_gateway_update_entity_states_and_release_url_selection(hass) -> N
     assert entity.state_attributes["release_url"] == "https://example.test/envoy/fr"
     assert entity.state_attributes["skipped_version"] is None
 
+    coord._gateway_version = "8.3.5286"
+    entity._refresh_from_catalog(manager.cached_catalog)
+    assert entity.installed_version == "8.3.5286"
+    assert entity.latest_version == "8.3.5286"
+    assert entity.state == "off"
+    assert entity.release_url is None
+    assert entity.release_summary is None
+
     coord._gateway_version = "8.2.4300"
     entity._refresh_from_catalog(manager.cached_catalog)
     await entity.async_skip()
@@ -502,9 +510,19 @@ async def test_charger_update_entity_uses_fw_details_payload(hass) -> None:
     assert entity.state_attributes["release_url"] == "https://example.test/charger/fr"
     assert entity.state_attributes["skipped_version"] is None
 
+    manager.cached_details[TEST_EVSE_SERIAL]["currentFwVersion"] = "25.37.1.15"
+    manager.cached_details[TEST_EVSE_SERIAL]["targetFwVersion"] = "25.37.1.14"
+    entity._refresh_from_details(manager.cached_details)
+    assert entity.installed_version == "25.37.1.15"
+    assert entity.latest_version == "25.37.1.15"
+    assert entity.state == "off"
+    assert entity.release_url is None
+    assert entity.release_summary is None
+
     manager.cached_details[TEST_EVSE_SERIAL]["currentFwVersion"] = "25.37.1.13"
     manager.cached_details[TEST_EVSE_SERIAL]["targetFwVersion"] = "25.37.1.14"
     entity._refresh_from_details(manager.cached_details)
+    entity._refresh_from_catalog(catalog_manager.cached_catalog)
     await entity.async_skip()
     manager.cached_details[TEST_EVSE_SERIAL]["currentFwVersion"] = "25.37.1.13"
     manager.cached_details[TEST_EVSE_SERIAL]["targetFwVersion"] = "25.37.1.15"

--- a/tests/scripts/test_firmware_catalog.py
+++ b/tests/scripts/test_firmware_catalog.py
@@ -460,6 +460,13 @@ def test_helper_edge_branches(
     assert firmware_catalog_module.fetch_previous_runtime_catalog() == {
         "schema_version": 1
     }
+    assert firmware_catalog_module._previous_catalog_device(None, "envoy") is None
+    assert (
+        firmware_catalog_module._previous_catalog_source_device(
+            {"source": {"type": "x"}}, "envoy"
+        )
+        is None
+    )
 
     assert (
         firmware_catalog_module.choose_generated_at(
@@ -716,6 +723,191 @@ def test_build_catalog_success_and_error_paths(
             {"Release notes": 217} if alias == "document" else {}
         ),
     )
+    with pytest.raises(RuntimeError, match="IQ Gateway software"):
+        firmware_catalog_module.build_catalog(tmp_path, timeout=5, max_pages=1)
+
+
+def test_build_catalog_skips_later_missing_product_id(
+    firmware_catalog_module,
+    fixture_dir: Path,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    root_html = (fixture_dir / "enphase_root.html").read_text(encoding="utf-8")
+    apps_html = (fixture_dir / "enphase_apps_facets.html").read_text(encoding="utf-8")
+    gateway_card = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (8.3.5286)",
+        version="8.3.5286",
+        release_date="2026-04-20",
+        media_id="24000",
+        langcode="und",
+        summary="Gateway release",
+        countries_text=None,
+    )
+
+    monkeypatch.setattr(
+        firmware_catalog_module, "_now_utc_iso", lambda: "2026-04-29T00:00:00Z"
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "REGION_SITE_ROUTE_ROWS",
+        [
+            {
+                "label": "United States",
+                "country_code": "US",
+                "locale": "en",
+                "site_url": "https://enphase.com/",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "fetch_text",
+        lambda url, timeout=30: (
+            root_html
+            if url.endswith("/installers/resources/documentation")
+            else apps_html
+        ),
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "parse_facet_values",
+        lambda _html, alias: (
+            {"Release notes": 217}
+            if alias == "document"
+            else {"IQ Gateway software": 5002}
+        ),
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "crawl_release_cards",
+        lambda **kwargs: (
+            [gateway_card] if kwargs["product_media_name_id"] == 5002 else [],
+            ["https://example.test/p0"],
+        ),
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "fetch_previous_runtime_catalog",
+        lambda timeout=30: {
+            "schema_version": 1,
+            "generated_at": "2026-04-28T00:00:00Z",
+            "source": {
+                "devices": {
+                    "iqevse": {
+                        "docs_url": "https://enphase.com/installers/resources/documentation/apps",
+                        "docs_path": "/installers/resources/documentation/apps",
+                        "product_type": 216,
+                        "document_topic_id": 217,
+                        "product_media_name_id": 6001,
+                    }
+                }
+            },
+            "devices": {
+                "iqevse": {
+                    "product_media_name_id": 6001,
+                    "document_topic_id": 217,
+                    "latest_by_locale": {
+                        "en": {
+                            "version": "25.37.1.14",
+                            "urls_by_locale": {"en": "https://example.test/charger"},
+                        }
+                    },
+                    "latest_by_country": {},
+                    "latest_global": {
+                        "version": "25.37.1.14",
+                        "urls_by_locale": {"en": "https://example.test/charger"},
+                    },
+                }
+            },
+        },
+    )
+
+    firmware_catalog_module.build_catalog(tmp_path, timeout=5, max_pages=1)
+    runtime = json.loads(
+        (tmp_path / "catalog" / "v1" / "runtime_catalog.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    product_sources = json.loads(
+        (
+            tmp_path / "sources" / "enphase_doc_center" / "product_media_name_ids.json"
+        ).read_text(encoding="utf-8")
+    )
+
+    assert runtime["devices"]["envoy"]["latest_global"]["version"] == "8.3.5286"
+    assert runtime["devices"]["iqevse"]["latest_global"]["version"] == "25.37.1.14"
+    assert runtime["source"]["crawl"]["iqevse"]["skipped"] is True
+    assert runtime["source"]["crawl"]["iqevse"]["using_previous_catalog_device"] is True
+    assert (
+        "IQ EV Charger software" in runtime["source"]["crawl"]["iqevse"]["skip_reason"]
+    )
+    assert product_sources["targets"] == {
+        "envoy": {"label": "IQ Gateway software", "product_media_name_id": 5002},
+        "iqevse": {"label": "IQ EV Charger software", "product_media_name_id": 6001},
+    }
+
+
+def test_build_catalog_required_product_is_explicit(
+    firmware_catalog_module,
+    fixture_dir: Path,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    root_html = (fixture_dir / "enphase_root.html").read_text(encoding="utf-8")
+    apps_html = (fixture_dir / "enphase_apps_facets.html").read_text(encoding="utf-8")
+
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "TARGET_PRODUCTS",
+        {
+            "iqevse": {
+                "label": "IQ EV Charger software",
+                "docs_path": firmware_catalog_module.TARGET_CATEGORY_PATH,
+                "required": False,
+            },
+            "envoy": {
+                "label": "IQ Gateway software",
+                "docs_path": firmware_catalog_module.COMMUNICATION_CATEGORY_PATH,
+                "required": True,
+            },
+        },
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "REGION_SITE_ROUTE_ROWS",
+        [
+            {
+                "label": "United States",
+                "country_code": "US",
+                "locale": "en",
+                "site_url": "https://enphase.com/",
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "fetch_text",
+        lambda url, timeout=30: (
+            root_html
+            if url.endswith("/installers/resources/documentation")
+            else apps_html
+        ),
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "parse_facet_values",
+        lambda _html, alias: {"Release notes": 217} if alias == "document" else {},
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "fetch_previous_runtime_catalog",
+        lambda timeout=30: {
+            "devices": {"iqevse": {"product_media_name_id": 6001}},
+            "source": {"devices": {"iqevse": {"product_media_name_id": 6001}}},
+        },
+    )
+
     with pytest.raises(RuntimeError, match="IQ Gateway software"):
         firmware_catalog_module.build_catalog(tmp_path, timeout=5, max_pages=1)
 


### PR DESCRIPTION
## Summary

Fixes #626.

Correct firmware update entities when a gateway or charger already reports a newer firmware version than the advisory catalog target, so Home Assistant does not show an older catalog version as the latest available firmware.

Also hardens firmware catalog generation when Enphase temporarily removes optional EV charger release-note metadata. Gateway catalog generation remains required, while skipped optional devices carry forward their previous catalog payload and record skipped/stale crawl metadata.

## Related Issues

Fixes #626

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev tests/components/enphase_ev scripts/firmware_catalog.py tests/scripts/test_firmware_catalog.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc 'git config --global --add safe.directory /workspace && python3 -m pre_commit run --all-files'"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev tests/scripts/test_firmware_catalog.py -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/update.py,scripts/firmware_catalog.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Targeted coverage confirmed 100% for:

```text
custom_components/enphase_ev/update.py     368      0   100%
scripts/firmware_catalog.py                719      0   100%
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The final pre-commit run used an extra `.git` mount because this checkout is a Git worktree and the pinned Docker container otherwise cannot resolve the host absolute gitdir recorded in `.git`.
