### PR TITLE
Reject unresolved charger service targets

### DIFF
--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -730,11 +730,6 @@ def async_setup_services(
                 )
             targets.append((device_id, sn, coord))
 
-        if not targets:
-            raise ServiceValidationError(
-                translation_domain=DOMAIN,
-                translation_key="exceptions.grid_site_required",
-            )
         return targets
 
     async def _svc_force_refresh(call: ServiceCall) -> None:

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -713,7 +713,10 @@ def async_setup_services(
         for device_id in device_ids:
             routing_context = await _resolve_device_routing_context(device_id)
             if routing_context is None:
-                continue
+                raise ServiceValidationError(
+                    translation_domain=DOMAIN,
+                    translation_key="exceptions.grid_site_required",
+                )
             sn, site_id, config_entry_ids = routing_context
             coord = await _get_coordinator_for_sn(
                 sn,

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -1431,12 +1431,13 @@ async def test_registered_services_cover_branches(
     class FakeHAService:
         def __init__(self) -> None:
             self.calls = 0
+            self.referenced_device_ids: list[str] = []
 
         def async_extract_referenced_device_ids(self, hass_, call):
             self.calls += 1
             if self.calls == 1:
                 raise RuntimeError("boom")
-            return ["ref-device"]
+            return list(self.referenced_device_ids)
 
     fake_service_helper = FakeHAService()
     monkeypatch.setattr(
@@ -1622,12 +1623,16 @@ async def test_registered_services_cover_branches(
             )
         )
 
-    await svc_sync(
-        SimpleNamespace(data={"device_id": [charger_two.id, site_device.id]})
-    )
+    await svc_sync(SimpleNamespace(data={"device_id": [charger_two.id]}))
     assert call(reason="service", serials=[second_serial]) in (
         coord_primary.schedule_sync.async_refresh.await_args_list
     )
+    fake_service_helper.referenced_device_ids = ["missing-device-id"]
+    with pytest.raises(ServiceValidationError):
+        await svc_sync(
+            SimpleNamespace(data={"device_id": [charger_two.id, site_device.id]})
+        )
+    fake_service_helper.referenced_device_ids = []
     with pytest.raises(ServiceValidationError):
         await svc_sync(SimpleNamespace(data={"device_id": [lonely_device.id]}))
     await svc_request_grid_otp(SimpleNamespace(data={"site_id": site_id}))
@@ -1658,7 +1663,7 @@ async def test_registered_services_cover_branches(
 
     start_call = SimpleNamespace(
         data={
-            "device_id": [charger_one.id, site_device.id, charger_two.id],
+            "device_id": [charger_one.id, charger_two.id],
             "charging_level": 30,
             "connector_id": 2,
         }
@@ -1670,6 +1675,18 @@ async def test_registered_services_cover_branches(
     assert call(second_serial, requested_amps=30, connector_id=2) in await_args
     assert coord_primary.async_start_charging.await_count == 2
     coord_site_only.async_start_charging.assert_not_awaited()
+    fake_service_helper.referenced_device_ids = ["missing-device-id"]
+    with pytest.raises(ServiceValidationError):
+        await svc_start(
+            SimpleNamespace(
+                data={
+                    "device_id": [charger_one.id, site_device.id, charger_two.id],
+                    "charging_level": 30,
+                    "connector_id": 2,
+                }
+            )
+        )
+    fake_service_helper.referenced_device_ids = []
 
     stop_call = SimpleNamespace(data={"device_id": charger_one.id})
     await svc_stop(stop_call)
@@ -2276,6 +2293,7 @@ async def test_service_helper_resolve_functions_cover_none_branches(
 
     dev_reg = dr.async_get(hass)
     assert await resolve_device_routing_context("does-not-exist") is None
+    assert await resolve_site("does-not-exist") is None
 
     site_device = dev_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -364,6 +364,63 @@ async def test_targeted_services_raise_without_target_or_owner(
 
 
 @pytest.mark.asyncio
+async def test_targeted_services_reject_mixed_valid_and_unknown_devices(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Targeted services should fail when any requested device cannot be resolved."""
+
+    handlers = _register_service_handlers(hass, monkeypatch)
+    coord = _fake_service_coordinator(site_id="evse-site", serials={"EVSE123"})
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "evse-site", CONF_SITE_ONLY: False},
+        title="EVSE Site",
+        unique_id="evse-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    device_registry = dr.async_get(hass)
+    device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "site:evse-site")},
+        manufacturer="Enphase",
+        name="EVSE Site Device",
+    )
+    charger = device_registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "EVSE123")},
+        manufacturer="Enphase",
+        name="Garage Charger",
+        via_device=(DOMAIN, "site:evse-site"),
+    )
+    unknown_device_id = "missing-device-id"
+
+    for service, data in (
+        (
+            "start_charging",
+            {"device_id": [charger.id, unknown_device_id], "charging_level": 24},
+        ),
+        ("stop_charging", {"device_id": [charger.id, unknown_device_id]}),
+        (
+            "trigger_message",
+            {
+                "device_id": [charger.id, unknown_device_id],
+                "requested_message": "MeterValues",
+            },
+        ),
+        ("sync_schedules", {"device_id": [charger.id, unknown_device_id]}),
+    ):
+        with pytest.raises(ServiceValidationError):
+            await handlers[(DOMAIN, service)](SimpleNamespace(data=data))
+
+    coord.async_start_charging.assert_not_awaited()
+    coord.async_stop_charging.assert_not_awaited()
+    coord.async_trigger_ocpp_message.assert_not_awaited()
+    coord.schedule_sync.async_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_try_reauth_now_uses_stored_credentials_for_selected_site(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- reject unresolved charger service targets instead of silently skipping them when mixed with valid devices
- add regression coverage for mixed valid and unknown charger device targets across targeted services

## Testing
- docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_services.py"
