### PR TITLE
Add unified tariff editing service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ New features
 - Added site tariff sensors for next billing date and Energy-dashboard-ready current import/export prices, attached to the IQ Gateway device when available.
-- Added editable tariff rate number entities and a `set_tariff_rate` service for updating existing Enphase import/export tariff values.
+- Added editable tariff rate number entities and an `update_tariff` service for updating billing-cycle details, guided tariff structures, and one or more Enphase import/export tariff rate values in one call.
 - Tariff sensors now refresh with normal sensor polling and keep their last known values while the Enphase tariff backend is degraded.
 
 ### 🐛 Bug fixes

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Cloud-based Home Assistant integration for Enphase Energy systems.
 - Advisory firmware update entities for gateway and EV charger devices with locale-aware release-note links
 - Heat-pump runtime status, connectivity, SG-Ready mode, power, and current-day consumption details sourced from HEMS endpoints
 - Site and battery energy telemetry, including derived grid-import, grid-export, and battery power sensors for Home Assistant Energy Dashboard use
-- Site tariff visibility for next billing date, Energy-dashboard-ready current import/export price sensors, and editable tariff rate number entities when Enphase exposes tariff data
+- Site tariff visibility for next billing date, Energy-dashboard-ready current import/export price sensors, editable tariff rate number entities, and a service for billing-cycle, rate, and guided structural tariff updates when Enphase exposes tariff data
 - Health diagnostics, service-availability tracking, and actionable repair issues
 - Detailed diagnostic and inventory entities remain available but are disabled by default when they are mainly useful for troubleshooting
 - Broad localization support across all user-facing integration strings

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -5103,6 +5103,33 @@ class EnphaseEVClient:
         )
         return await self._json("GET", url, headers=self._tariff_headers())
 
+    async def site_tariff_billing_update(
+        self,
+        payload: dict[str, Any],
+        *,
+        request_date: date | datetime | str | None = None,
+    ) -> dict:
+        """Update site tariff billing-cycle details."""
+
+        if request_date is None:
+            request_date_text = date.today().isoformat()
+        elif isinstance(request_date, datetime):
+            request_date_text = request_date.date().isoformat()
+        elif isinstance(request_date, date):
+            request_date_text = request_date.isoformat()
+        else:
+            request_date_text = str(request_date)
+        url = (
+            f"{BASE_URL}/service/tariff/tariff-ms/systems/{self._site}/billing-details"
+        )
+        return await self._json(
+            "POST",
+            url,
+            json=payload,
+            params={"date": request_date_text},
+            headers=self._tariff_headers(write=True),
+        )
+
     async def site_tariff(self) -> dict:
         """Return site import/export tariff configuration."""
 

--- a/custom_components/enphase_ev/services.py
+++ b/custom_components/enphase_ev/services.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+from datetime import date
 from typing import TYPE_CHECKING
 
 import aiohttp
@@ -58,7 +59,7 @@ REGISTERED_SERVICES = (
     "delete_schedule",
     "validate_schedule",
     "update_cfg_schedule",
-    "set_tariff_rate",
+    "update_tariff",
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -580,11 +581,122 @@ def async_setup_services(
         ),
         _validate_cfg_schedule,
     )
-    SET_TARIFF_RATE_SCHEMA = vol.Schema(
-        {
-            vol.Optional("entity_id"): cv.entity_ids,
-            vol.Required("rate"): vol.All(vol.Coerce(float), vol.Range(min=0)),
-        }
+    TARIFF_BILLING_FIELDS = frozenset(
+        {"billing_start_date", "billing_frequency", "billing_interval_value"}
+    )
+    FRIENDLY_RATE_VALUE_FIELDS = frozenset({"rate", "import_rate", "export_rate"})
+    TARIFF_STRUCTURE_FIELDS = frozenset(
+        {"tariff_payload", "purchase_tariff", "buyback_tariff"}
+    )
+    TARIFF_TYPE_SCHEMA = vol.In(("flat", "tou", "tiered"))
+    TARIFF_VARIATION_SCHEMA = vol.In(
+        ("single", "seasonal", "weekends", "seasonal-and-weekends")
+    )
+    TARIFF_EXPORT_PLAN_SCHEMA = vol.In(("netFit", "grossFit", "nem"))
+
+    def _validate_tariff_billing_start_date(value: object) -> str:
+        text = str(value).strip()
+        try:
+            date.fromisoformat(text)
+        except ValueError as err:
+            raise vol.Invalid("billing_start_date must be a valid ISO date") from err
+        return text
+
+    def _validate_update_tariff(data: dict) -> dict:
+        rates = data.get("rates") or []
+        has_rates = bool(rates) or bool(FRIENDLY_RATE_VALUE_FIELDS.intersection(data))
+        provided_billing = TARIFF_BILLING_FIELDS.intersection(data)
+        has_structure = bool(
+            TARIFF_STRUCTURE_FIELDS.intersection(data)
+            or data.get("configure_import_tariff")
+            or data.get("configure_export_tariff")
+        )
+        if "rate_entity" in data and "rate" not in data:
+            raise vol.Invalid("Provide both rate_entity and rate")
+        for rate_key, entity_key in (
+            ("import_rate", "import_rate_entity"),
+            ("export_rate", "export_rate_entity"),
+        ):
+            if (rate_key in data) != (entity_key in data):
+                raise vol.Invalid(f"Provide both {entity_key} and {rate_key}")
+        if not has_rates and not provided_billing and not has_structure:
+            raise vol.Invalid("Provide billing details or at least one rate update")
+        if provided_billing and provided_billing != TARIFF_BILLING_FIELDS:
+            raise vol.Invalid("Provide all billing fields")
+        if provided_billing:
+            frequency = data["billing_frequency"]
+            interval = data["billing_interval_value"]
+            maximum = 24 if frequency == "MONTH" else 100
+            if interval > maximum:
+                raise vol.Invalid(
+                    f"billing_interval_value must be between 1 and {maximum}"
+                )
+        return data
+
+    UPDATE_TARIFF_SCHEMA = vol.All(
+        vol.Schema(
+            {
+                vol.Optional("entity_id"): cv.entity_ids,
+                vol.Optional("device_id"): DEVICE_ID_LIST,
+                vol.Optional("site_id"): cv.string,
+                vol.Optional("config_entry_id"): cv.string,
+                vol.Optional("billing_start_date"): _validate_tariff_billing_start_date,
+                vol.Optional("billing_frequency"): vol.In(("MONTH", "DAY")),
+                vol.Optional("billing_interval_value"): vol.All(
+                    vol.Coerce(int), vol.Range(min=1)
+                ),
+                vol.Optional("rate_entity"): cv.entity_id,
+                vol.Optional("rate"): vol.All(vol.Coerce(float), vol.Range(min=0)),
+                vol.Optional("import_rate_entity"): cv.entity_id,
+                vol.Optional("import_rate"): vol.All(
+                    vol.Coerce(float), vol.Range(min=0)
+                ),
+                vol.Optional("export_rate_entity"): cv.entity_id,
+                vol.Optional("export_rate"): vol.All(
+                    vol.Coerce(float), vol.Range(min=0)
+                ),
+                vol.Optional("tariff_payload"): dict,
+                vol.Optional("purchase_tariff"): dict,
+                vol.Optional("buyback_tariff"): dict,
+                vol.Optional("configure_import_tariff"): cv.boolean,
+                vol.Optional("import_tariff_type"): TARIFF_TYPE_SCHEMA,
+                vol.Optional("import_variation"): TARIFF_VARIATION_SCHEMA,
+                vol.Optional("import_flat_rate"): vol.All(
+                    vol.Coerce(float), vol.Range(min=0)
+                ),
+                vol.Optional("import_periods"): vol.All(cv.ensure_list, [dict]),
+                vol.Optional("import_tiers"): vol.All(cv.ensure_list, [dict]),
+                vol.Optional("import_off_peak_rate"): vol.All(
+                    vol.Coerce(float), vol.Range(min=0)
+                ),
+                vol.Optional("configure_export_tariff"): cv.boolean,
+                vol.Optional("export_tariff_type"): TARIFF_TYPE_SCHEMA,
+                vol.Optional("export_variation"): TARIFF_VARIATION_SCHEMA,
+                vol.Optional("export_plan"): TARIFF_EXPORT_PLAN_SCHEMA,
+                vol.Optional("export_flat_rate"): vol.All(
+                    vol.Coerce(float), vol.Range(min=0)
+                ),
+                vol.Optional("export_periods"): vol.All(cv.ensure_list, [dict]),
+                vol.Optional("export_tiers"): vol.All(cv.ensure_list, [dict]),
+                vol.Optional("export_off_peak_rate"): vol.All(
+                    vol.Coerce(float), vol.Range(min=0)
+                ),
+                vol.Optional("rates"): vol.All(
+                    cv.ensure_list,
+                    [
+                        vol.Schema(
+                            {
+                                vol.Required("entity_id"): cv.entity_id,
+                                vol.Required("rate"): vol.All(
+                                    vol.Coerce(float), vol.Range(min=0)
+                                ),
+                            }
+                        )
+                    ],
+                ),
+            }
+        ),
+        _validate_update_tariff,
     )
 
     def _extract_device_ids(call: ServiceCall) -> list[str]:
@@ -698,6 +810,277 @@ def async_setup_services(
             if f"{DOMAIN}_site_{coord.site_id}_" in unique_id:
                 return coord
         return None
+
+    def _tariff_rate_update_from_entity(
+        entity_id: str,
+        rate: float,
+        *,
+        branch: str | None = None,
+    ) -> tuple[EnphaseCoordinator, dict[str, object]]:
+        coord = _coordinator_from_tariff_entity(entity_id)
+        if coord is None:
+            _raise_service_validation(
+                "tariff_rate_entity_invalid",
+                placeholders={"entity_id": entity_id},
+                message=f"Entity is not an Enphase tariff rate entity: {entity_id}",
+            )
+        state = hass.states.get(entity_id)
+        locator = None if state is None else state.attributes.get("tariff_locator")
+        if not isinstance(locator, dict):
+            _raise_service_validation(
+                "tariff_rate_target_invalid",
+                message="Tariff rate target is invalid.",
+            )
+        if branch is not None and locator.get("branch") != branch:
+            _raise_service_validation(
+                "tariff_rate_entity_invalid",
+                placeholders={"entity_id": entity_id},
+                message=f"Entity is not an Enphase tariff rate entity: {entity_id}",
+            )
+        return coord, {"locator": locator, "rate": rate}
+
+    def _format_tariff_rate(value: object) -> str:
+        try:
+            rate = float(value)
+        except (TypeError, ValueError):
+            _raise_service_validation(
+                "tariff_rate_invalid",
+                message="Tariff rate must be a non-negative number.",
+            )
+        if rate < 0:
+            _raise_service_validation(
+                "tariff_rate_invalid",
+                message="Tariff rate must be a non-negative number.",
+            )
+        return f"{rate:.10f}".rstrip("0").rstrip(".") or "0"
+
+    def _tariff_month(value: object, default: int) -> int:
+        if value in (None, ""):
+            return default
+        try:
+            month = int(float(str(value).strip()))
+        except (TypeError, ValueError):
+            _raise_service_validation(
+                "tariff_structure_invalid",
+                message="Tariff structure is invalid.",
+            )
+        if month < 1 or month > 12:
+            _raise_service_validation(
+                "tariff_structure_invalid",
+                message="Tariff structure is invalid.",
+            )
+        return month
+
+    def _tariff_minutes(value: object) -> int | str:
+        if value in (None, ""):
+            return ""
+        if isinstance(value, str) and ":" in value:
+            parts = value.strip().split(":", 1)
+            try:
+                hour = int(parts[0])
+                minute = int(parts[1])
+            except (TypeError, ValueError):
+                _raise_service_validation(
+                    "tariff_structure_invalid",
+                    message="Tariff structure is invalid.",
+                )
+            minutes = hour * 60 + minute
+        else:
+            try:
+                minutes = int(float(str(value).strip()))
+            except (TypeError, ValueError):
+                _raise_service_validation(
+                    "tariff_structure_invalid",
+                    message="Tariff structure is invalid.",
+                )
+        if minutes < 0 or minutes > 24 * 60:
+            _raise_service_validation(
+                "tariff_structure_invalid",
+                message="Tariff structure is invalid.",
+            )
+        return minutes
+
+    def _tariff_days(value: object, day_group_id: str) -> list[int]:
+        if value in (None, ""):
+            if day_group_id == "weekday":
+                return [1, 2, 3, 4, 5]
+            if day_group_id == "weekend":
+                return [6, 7]
+            return [1, 2, 3, 4, 5, 6, 7]
+        raw_days = value if isinstance(value, list) else cv.ensure_list(value)
+        days: list[int] = []
+        for raw_day in raw_days:
+            try:
+                day = int(float(str(raw_day).strip()))
+            except (TypeError, ValueError):
+                _raise_service_validation(
+                    "tariff_structure_invalid",
+                    message="Tariff structure is invalid.",
+                )
+            if day < 1 or day > 7:
+                _raise_service_validation(
+                    "tariff_structure_invalid",
+                    message="Tariff structure is invalid.",
+                )
+            days.append(day)
+        return sorted(dict.fromkeys(days))
+
+    def _season_key(row: dict[str, object]) -> tuple[str, int, int]:
+        return (
+            str(row.get("season_id") or row.get("season") or "default"),
+            _tariff_month(row.get("start_month"), 1),
+            _tariff_month(row.get("end_month"), 12),
+        )
+
+    def _guided_tou_seasons(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+        if not rows:
+            _raise_service_validation(
+                "tariff_structure_invalid",
+                message="Tariff structure is invalid.",
+            )
+        seasons: dict[tuple[str, int, int], dict[str, object]] = {}
+        day_groups: dict[tuple[str, int, int], dict[str, dict[str, object]]] = {}
+        for index, row in enumerate(rows, start=1):
+            if not isinstance(row, dict):
+                _raise_service_validation(
+                    "tariff_structure_invalid",
+                    message="Tariff structure is invalid.",
+                )
+            season_key = _season_key(row)
+            season = seasons.setdefault(
+                season_key,
+                {
+                    "id": season_key[0],
+                    "startMonth": str(season_key[1]),
+                    "endMonth": str(season_key[2]),
+                    "days": [],
+                },
+            )
+            groups = day_groups.setdefault(season_key, {})
+            day_group_id = str(
+                row.get("day_group_id") or row.get("day_group") or "week"
+            )
+            day_group = groups.get(day_group_id)
+            if day_group is None:
+                day_group = {
+                    "id": day_group_id,
+                    "days": _tariff_days(row.get("days"), day_group_id),
+                    "periods": [],
+                    "updatedValue": "",
+                }
+                groups[day_group_id] = day_group
+                season["days"].append(day_group)
+            period_id = str(row.get("period_id") or row.get("id") or f"period-{index}")
+            day_group["periods"].append(
+                {
+                    "id": period_id,
+                    "type": str(
+                        row.get("period_type") or row.get("type") or "off-peak"
+                    ),
+                    "rate": _format_tariff_rate(row.get("rate")),
+                    "startTime": _tariff_minutes(row.get("start_time")),
+                    "endTime": _tariff_minutes(row.get("end_time")),
+                    "rateComponents": [],
+                }
+            )
+        return list(seasons.values())
+
+    def _guided_tiered_seasons(
+        rows: list[dict[str, object]], off_peak_rate: object | None
+    ) -> list[dict[str, object]]:
+        if not rows:
+            _raise_service_validation(
+                "tariff_structure_invalid",
+                message="Tariff structure is invalid.",
+            )
+        seasons: dict[tuple[str, int, int], dict[str, object]] = {}
+        for index, row in enumerate(rows, start=1):
+            if not isinstance(row, dict):
+                _raise_service_validation(
+                    "tariff_structure_invalid",
+                    message="Tariff structure is invalid.",
+                )
+            season_key = _season_key(row)
+            season = seasons.setdefault(
+                season_key,
+                {
+                    "id": season_key[0],
+                    "startMonth": str(season_key[1]),
+                    "endMonth": str(season_key[2]),
+                    "offPeak": _format_tariff_rate(
+                        row.get(
+                            "off_peak_rate",
+                            off_peak_rate if off_peak_rate is not None else 0,
+                        )
+                    ),
+                    "tiers": [],
+                },
+            )
+            end_value = row.get("end_value", row.get("endValue", -1))
+            season["tiers"].append(
+                {
+                    "id": str(row.get("tier_id") or row.get("id") or f"tier-{index}"),
+                    "rate": _format_tariff_rate(row.get("rate")),
+                    "startValue": str(row.get("start_value", row.get("startValue", 0))),
+                    "endValue": (
+                        -1
+                        if end_value in (None, "", -1, "-1")
+                        else str(row.get("end_value", row.get("endValue")))
+                    ),
+                }
+            )
+        return list(seasons.values())
+
+    def _guided_tariff_branch(
+        data: dict[str, object],
+        *,
+        prefix: str,
+        export: bool = False,
+    ) -> dict[str, object] | None:
+        if not data.get(f"configure_{prefix}_tariff"):
+            return None
+        tariff_type = data.get(f"{prefix}_tariff_type")
+        if tariff_type is None:
+            _raise_service_validation(
+                "tariff_structure_invalid",
+                message="Tariff structure is invalid.",
+            )
+        variation = str(data.get(f"{prefix}_variation", "single"))
+        branch: dict[str, object] = {
+            "typeKind": variation,
+            "typeId": str(tariff_type),
+            "source": "manual",
+        }
+        if export:
+            branch["exportPlan"] = str(data.get("export_plan", "netFit"))
+        if tariff_type == "tiered":
+            branch["seasons"] = _guided_tiered_seasons(
+                list(data.get(f"{prefix}_tiers") or []),
+                data.get(f"{prefix}_off_peak_rate"),
+            )
+        else:
+            periods = list(data.get(f"{prefix}_periods") or [])
+            if not periods and tariff_type == "flat":
+                flat_rate = data.get(f"{prefix}_flat_rate")
+                if flat_rate is None:
+                    _raise_service_validation(
+                        "tariff_structure_invalid",
+                        message="Tariff structure is invalid.",
+                    )
+                periods = [
+                    {
+                        "season_id": "default",
+                        "day_group_id": "week",
+                        "days": [1, 2, 3, 4, 5, 6, 7],
+                        "period_id": "off-peak",
+                        "period_type": "off-peak",
+                        "rate": flat_rate,
+                        "start_time": "",
+                        "end_time": "",
+                    }
+                ]
+            branch["seasons"] = _guided_tou_seasons(periods)
+        return branch
 
     async def _resolve_charger_targets(
         call: ServiceCall,
@@ -1107,36 +1490,123 @@ def async_setup_services(
         for _device_id, sn, coord in await _resolve_charger_targets(call):
             await coord.schedule_sync.async_refresh(reason="service", serials=[sn])
 
-    async def _svc_set_tariff_rate(call: ServiceCall) -> None:
-        entity_ids = _extract_entity_ids(call)
-        if not entity_ids:
-            _raise_service_validation(
-                "tariff_rate_entity_required",
-                message="Select exactly one tariff rate entity.",
+    async def _svc_update_tariff(call: ServiceCall) -> None:
+        rates = list(call.data.get("rates") or [])
+        if "rate" in call.data:
+            entity_ids = list(_extract_entity_ids(call))
+            rate_entity = call.data.get("rate_entity")
+            if rate_entity:
+                entity_ids.append(str(rate_entity))
+            entity_ids = list(dict.fromkeys(entity_ids))
+            if len(entity_ids) != 1:
+                _raise_service_validation(
+                    "tariff_rate_entity_required",
+                    message="Select exactly one tariff rate entity.",
+                )
+            rates.append({"entity_id": entity_ids[0], "rate": call.data["rate"]})
+        if "import_rate" in call.data:
+            rates.append(
+                {
+                    "entity_id": call.data["import_rate_entity"],
+                    "rate": call.data["import_rate"],
+                    "branch": "purchase",
+                }
             )
-        if len(entity_ids) != 1:
-            _raise_service_validation(
-                "tariff_rate_entity_required",
-                message="Select exactly one tariff rate entity.",
+        if "export_rate" in call.data:
+            rates.append(
+                {
+                    "entity_id": call.data["export_rate_entity"],
+                    "rate": call.data["export_rate"],
+                    "branch": "buyback",
+                }
             )
-        entity_id = entity_ids[0]
-        coord = _coordinator_from_tariff_entity(entity_id)
-        if coord is None:
-            _raise_service_validation(
-                "tariff_rate_entity_invalid",
-                placeholders={"entity_id": entity_id},
-                message=f"Entity is not an Enphase tariff rate entity: {entity_id}",
-            )
-        state = hass.states.get(entity_id)
-        locator = None if state is None else state.attributes.get("tariff_locator")
-        if not isinstance(locator, dict):
-            _raise_service_validation(
-                "tariff_rate_target_invalid",
-                message="Tariff rate target is invalid.",
-            )
-        await coord.tariff_runtime.async_set_tariff_rate(
-            locator, float(call.data["rate"])
+        billing_requested = bool(TARIFF_BILLING_FIELDS.intersection(call.data))
+        guided_purchase_tariff = _guided_tariff_branch(call.data, prefix="import")
+        guided_buyback_tariff = _guided_tariff_branch(
+            call.data, prefix="export", export=True
         )
+        structure_requested = bool(
+            TARIFF_STRUCTURE_FIELDS.intersection(call.data)
+            or guided_purchase_tariff is not None
+            or guided_buyback_tariff is not None
+        )
+        if not rates and not billing_requested and not structure_requested:
+            _raise_service_validation(
+                "tariff_update_required",
+                message="Provide billing details or at least one tariff rate update.",
+            )
+        if billing_requested and not TARIFF_BILLING_FIELDS.issubset(call.data):
+            _raise_service_validation(
+                "tariff_billing_incomplete",
+                message="Provide billing start date, frequency, and interval.",
+            )
+
+        rate_updates: list[dict[str, object]] = []
+        rate_coord: EnphaseCoordinator | None = None
+        seen_entities: set[str] = set()
+        for item in rates:
+            entity_id = str(item.get("entity_id", "")).strip()
+            if entity_id in seen_entities:
+                _raise_service_validation(
+                    "tariff_rate_entity_duplicate",
+                    placeholders={"entity_id": entity_id},
+                    message=f"Duplicate tariff rate entity: {entity_id}",
+                )
+            seen_entities.add(entity_id)
+            coord, update = _tariff_rate_update_from_entity(
+                entity_id,
+                float(item["rate"]),
+                branch=item.get("branch"),
+            )
+            if rate_coord is None:
+                rate_coord = coord
+            elif coord is not rate_coord:
+                _raise_service_validation(
+                    "tariff_site_mismatch",
+                    message="All tariff updates must target the same Enphase site.",
+                )
+            rate_updates.append(update)
+
+        billing: dict[str, object] | None = None
+        if billing_requested:
+            billing = {
+                "billing_start_date": str(call.data["billing_start_date"]),
+                "billing_frequency": str(call.data["billing_frequency"]),
+                "billing_interval_value": int(call.data["billing_interval_value"]),
+            }
+        tariff_payload = call.data.get("tariff_payload")
+        purchase_tariff = call.data.get("purchase_tariff") or guided_purchase_tariff
+        buyback_tariff = call.data.get("buyback_tariff") or guided_buyback_tariff
+
+        target_coord: EnphaseCoordinator
+        has_explicit_site_target = bool(
+            call.data.get("config_entry_id")
+            or call.data.get("site_id")
+            or _extract_device_ids(call)
+        )
+        if (billing_requested or structure_requested) and (
+            has_explicit_site_target or rate_coord is None
+        ):
+            target_coord = await _resolve_single_site_coordinator(call)
+            if rate_coord is not None and str(target_coord.site_id) != str(
+                rate_coord.site_id
+            ):
+                _raise_service_validation(
+                    "tariff_site_mismatch",
+                    message="All tariff updates must target the same Enphase site.",
+                )
+        else:
+            assert rate_coord is not None
+            target_coord = rate_coord
+
+        kwargs: dict[str, object] = {"billing": billing, "rate_updates": rate_updates}
+        if tariff_payload is not None:
+            kwargs["tariff_payload"] = tariff_payload
+        if purchase_tariff is not None:
+            kwargs["purchase_tariff"] = purchase_tariff
+        if buyback_tariff is not None:
+            kwargs["buyback_tariff"] = buyback_tariff
+        await target_coord.tariff_runtime.async_update_tariff(**kwargs)
 
     hass.services.async_register(
         DOMAIN, "force_refresh", _svc_force_refresh, schema=FORCE_REFRESH_SCHEMA
@@ -1202,9 +1672,9 @@ def async_setup_services(
     )
     hass.services.async_register(
         DOMAIN,
-        "set_tariff_rate",
-        _svc_set_tariff_rate,
-        schema=SET_TARIFF_RATE_SCHEMA,
+        "update_tariff",
+        _svc_update_tariff,
+        schema=UPDATE_TARIFF_SCHEMA,
     )
 
 

--- a/custom_components/enphase_ev/services.yaml
+++ b/custom_components/enphase_ev/services.yaml
@@ -183,8 +183,6 @@ update_tariff:
   target:
     entity:
       integration: enphase_ev
-    device:
-      integration: enphase_ev
   fields:
     rate:
       required: false
@@ -466,6 +464,12 @@ update_tariff:
     advanced:
       collapsed: true
       fields:
+        device_id:
+          required: false
+          selector:
+            device:
+              integration: enphase_ev
+              multiple: true
         site_id:
           required: false
           selector:

--- a/custom_components/enphase_ev/services.yaml
+++ b/custom_components/enphase_ev/services.yaml
@@ -177,19 +177,306 @@ force_refresh:
             text:
               multiline: false
 
-set_tariff_rate:
-  name: Set Tariff Rate
-  description: Update one existing Enphase import or export tariff rate value.
+update_tariff:
+  name: Update Tariff
+  description: Update Enphase billing-cycle details, guided tariff structures, and one or more existing import or export tariff rate values.
   target:
     entity:
       integration: enphase_ev
+    device:
+      integration: enphase_ev
   fields:
     rate:
-      required: true
+      required: false
       selector:
         number:
           min: 0
           step: any
+    rate_entity:
+      required: false
+      selector:
+        entity:
+          integration: enphase_ev
+      example: number.iq_gateway_import_rate_peak
+    import_rate:
+      required: false
+      selector:
+        number:
+          min: 0
+          step: any
+    import_rate_entity:
+      required: false
+      selector:
+        entity:
+          integration: enphase_ev
+      example: number.iq_gateway_import_rate_peak
+    export_rate:
+      required: false
+      selector:
+        number:
+          min: 0
+          step: any
+    export_rate_entity:
+      required: false
+      selector:
+        entity:
+          integration: enphase_ev
+      example: number.iq_gateway_export_rate_peak
+    configure_import_tariff:
+      required: false
+      default: false
+      selector:
+        boolean:
+    import_tariff_type:
+      required: false
+      selector:
+        select:
+          options:
+            - label: Flat
+              value: flat
+            - label: Time of use
+              value: tou
+            - label: Tiered
+              value: tiered
+    import_variation:
+      required: false
+      default: single
+      selector:
+        select:
+          options:
+            - label: Same all year
+              value: single
+            - label: Seasonal
+              value: seasonal
+            - label: Weekdays and weekends
+              value: weekends
+            - label: Seasonal weekdays and weekends
+              value: seasonal-and-weekends
+    import_flat_rate:
+      required: false
+      selector:
+        number:
+          min: 0
+          step: any
+    import_periods:
+      required: false
+      selector:
+        object:
+      example:
+        - season_id: default
+          start_month: 1
+          end_month: 12
+          day_group_id: weekday
+          days: [1, 2, 3, 4, 5]
+          period_id: peak
+          period_type: peak
+          start_time: "15:00"
+          end_time: "21:00"
+          rate: 0.42
+        - season_id: default
+          day_group_id: weekend
+          days: [6, 7]
+          period_id: off-peak
+          period_type: off-peak
+          start_time: ""
+          end_time: ""
+          rate: 0.24
+    import_off_peak_rate:
+      required: false
+      selector:
+        number:
+          min: 0
+          step: any
+    import_tiers:
+      required: false
+      selector:
+        object:
+      example:
+        - season_id: default
+          start_month: 1
+          end_month: 12
+          tier_id: tier-1
+          start_value: 0
+          end_value: 10
+          rate: 0.18
+        - season_id: default
+          tier_id: tier-2
+          start_value: 10
+          end_value: -1
+          rate: 0.27
+    configure_export_tariff:
+      required: false
+      default: false
+      selector:
+        boolean:
+    export_tariff_type:
+      required: false
+      selector:
+        select:
+          options:
+            - label: Flat
+              value: flat
+            - label: Time of use
+              value: tou
+            - label: Tiered
+              value: tiered
+    export_variation:
+      required: false
+      default: single
+      selector:
+        select:
+          options:
+            - label: Same all year
+              value: single
+            - label: Seasonal
+              value: seasonal
+            - label: Weekdays and weekends
+              value: weekends
+            - label: Seasonal weekdays and weekends
+              value: seasonal-and-weekends
+    export_plan:
+      required: false
+      default: netFit
+      selector:
+        select:
+          options:
+            - label: Net feed-in
+              value: netFit
+            - label: Gross feed-in
+              value: grossFit
+            - label: NEM
+              value: nem
+    export_flat_rate:
+      required: false
+      selector:
+        number:
+          min: 0
+          step: any
+    export_periods:
+      required: false
+      selector:
+        object:
+      example:
+        - season_id: default
+          day_group_id: week
+          days: [1, 2, 3, 4, 5, 6, 7]
+          period_id: solar-peak
+          period_type: peak
+          start_time: "10:00"
+          end_time: "15:00"
+          rate: 0.11
+    export_off_peak_rate:
+      required: false
+      selector:
+        number:
+          min: 0
+          step: any
+    export_tiers:
+      required: false
+      selector:
+        object:
+      example:
+        - season_id: default
+          tier_id: tier-1
+          start_value: 0
+          end_value: -1
+          rate: 0.08
+    tariff_payload:
+      required: false
+      selector:
+        object:
+      example:
+        purchase:
+          typeKind: single
+          typeId: tou
+          source: manual
+          seasons:
+            - id: default
+              days:
+                - id: week
+                  periods:
+                    - id: peak
+                      type: peak
+                      rate: "0.31"
+                      startTime: 900
+                      endTime: 1260
+    purchase_tariff:
+      required: false
+      selector:
+        object:
+      example:
+        typeKind: single
+        typeId: flat
+        source: manual
+        seasons:
+          - id: default
+            days:
+              - id: week
+                periods:
+                  - id: off-peak
+                    type: off-peak
+                    rate: "0.25"
+                    startTime: ""
+                    endTime: ""
+    buyback_tariff:
+      required: false
+      selector:
+        object:
+      example:
+        typeKind: single
+        typeId: flat
+        source: manual
+        exportPlan: netFit
+        seasons:
+          - id: default
+            days:
+              - id: week
+                periods:
+                  - id: off-peak
+                    type: off-peak
+                    rate: "0.08"
+                    startTime: ""
+                    endTime: ""
+    billing_start_date:
+      required: false
+      selector:
+        date:
+      example: "2026-04-01"
+    billing_frequency:
+      required: false
+      selector:
+        select:
+          options:
+            - MONTH
+            - DAY
+    billing_interval_value:
+      required: false
+      selector:
+        number:
+          min: 1
+          max: 100
+          step: 1
+    rates:
+      required: false
+      selector:
+        object:
+      example:
+        - entity_id: number.import_rate_peak
+          rate: 0.31
+    advanced:
+      collapsed: true
+      fields:
+        site_id:
+          required: false
+          selector:
+            text:
+              multiline: false
+          example: "1234567"
+        config_entry_id:
+          required: false
+          selector:
+            text:
+              multiline: false
 
 add_schedule:
   name: Add Battery Schedule

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Export Off-Peak Baseline",
           "description": "Baseline off-peak export rate for tiered tariffs."
+        },
+        "device_id": {
+          "name": "Device",
+          "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
         }
       }
     }

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Enable advanced confirmation to send {message}."
+    },
+    "tariff_update_required": {
+      "message": "Provide billing details or at least one tariff rate update."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Provide billing start date, frequency, and interval."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Tariff billing start date must be a valid ISO date."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Tariff billing frequency must be MONTH or DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Tariff billing interval must be between {minimum} and {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Tariff billing write API is unavailable."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Duplicate tariff rate targets are not allowed."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Duplicate tariff rate entity: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "All tariff updates must target the same Enphase site."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tariff structure is invalid."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Set Tariff Rate",
-      "description": "Update one existing Enphase import or export tariff rate value.",
+    "update_tariff": {
+      "name": "Update Tariff",
+      "description": "Update Enphase billing-cycle details, guided tariff structures, and one or more existing import or export tariff rate values.",
       "fields": {
         "rate": {
           "name": "Rate",
-          "description": "New non-negative tariff rate value."
+          "description": "New non-negative tariff rate value for the selected tariff rate entity."
+        },
+        "rate_entity": {
+          "name": "Rate Entity",
+          "description": "Optional tariff rate entity to update when not using the action target."
+        },
+        "import_rate": {
+          "name": "Import Rate",
+          "description": "New non-negative import tariff rate value."
+        },
+        "import_rate_entity": {
+          "name": "Import Rate Entity",
+          "description": "Import tariff rate entity to update."
+        },
+        "export_rate": {
+          "name": "Export Rate",
+          "description": "New non-negative export tariff rate value."
+        },
+        "export_rate_entity": {
+          "name": "Export Rate Entity",
+          "description": "Export tariff rate entity to update."
+        },
+        "billing_start_date": {
+          "name": "Billing Start Date",
+          "description": "Bill period start date in ISO format."
+        },
+        "billing_frequency": {
+          "name": "Billing Frequency",
+          "description": "Billing interval unit: MONTH or DAY."
+        },
+        "billing_interval_value": {
+          "name": "Billing Interval",
+          "description": "Billing interval count. Use 1-24 for months or 1-100 for days."
+        },
+        "rates": {
+          "name": "Rates",
+          "description": "List of tariff rate entity IDs and non-negative rate values to update."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier for billing updates."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        },
+        "tariff_payload": {
+          "name": "Tariff Payload",
+          "description": "Complete Enphase tariff payload to write. Use this for advanced structural edits."
+        },
+        "purchase_tariff": {
+          "name": "Import Tariff Structure",
+          "description": "Replacement import tariff branch with type, seasons, periods, tiers, and rates."
+        },
+        "buyback_tariff": {
+          "name": "Export Tariff Structure",
+          "description": "Replacement export tariff branch with type, export plan, seasons, periods, tiers, and rates."
+        },
+        "configure_import_tariff": {
+          "name": "Configure Import Tariff",
+          "description": "Enable this to build a replacement import tariff from the guided fields below."
+        },
+        "import_tariff_type": {
+          "name": "Import Tariff Type",
+          "description": "Choose whether import pricing is flat, time of use, or tiered."
+        },
+        "import_variation": {
+          "name": "Import Variation",
+          "description": "Choose whether import pricing changes by season or weekday/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Import Flat Rate",
+          "description": "Single import rate used when the import tariff type is flat and no period rows are provided."
+        },
+        "import_periods": {
+          "name": "Import Period Rows",
+          "description": "Rows for flat or time-of-use import pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "import_tiers": {
+          "name": "Import Tier Rows",
+          "description": "Rows for tiered import pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "import_off_peak_rate": {
+          "name": "Import Off-Peak Baseline",
+          "description": "Baseline off-peak import rate for tiered tariffs."
+        },
+        "configure_export_tariff": {
+          "name": "Configure Export Tariff",
+          "description": "Enable this to build a replacement export tariff from the guided fields below."
+        },
+        "export_tariff_type": {
+          "name": "Export Tariff Type",
+          "description": "Choose whether export compensation is flat, time of use, or tiered."
+        },
+        "export_variation": {
+          "name": "Export Variation",
+          "description": "Choose whether export pricing changes by season or weekday/weekend."
+        },
+        "export_plan": {
+          "name": "Export Plan",
+          "description": "Choose the Enphase export plan label to write with the export tariff."
+        },
+        "export_flat_rate": {
+          "name": "Export Flat Rate",
+          "description": "Single export rate used when the export tariff type is flat and no period rows are provided."
+        },
+        "export_periods": {
+          "name": "Export Period Rows",
+          "description": "Rows for flat or time-of-use export pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "export_tiers": {
+          "name": "Export Tier Rows",
+          "description": "Rows for tiered export pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "export_off_peak_rate": {
+          "name": "Export Off-Peak Baseline",
+          "description": "Baseline off-peak export rate for tiered tariffs."
         }
       }
     }

--- a/custom_components/enphase_ev/tariff.py
+++ b/custom_components/enphase_ev/tariff.py
@@ -22,6 +22,11 @@ if TYPE_CHECKING:
     from .coordinator import EnphaseCoordinator
 
 TARIFF_ENDPOINT_FAMILY = "tariff"
+TARIFF_BRANCH_KEYS = frozenset({"purchase", "buyback"})
+TARIFF_TYPE_IDS = frozenset({"flat", "tou", "tiered"})
+TARIFF_TYPE_KINDS = frozenset(
+    {"single", "seasonal", "weekends", "seasonal-and-weekends"}
+)
 _EXPORT_RATE_KEY_RE = re.compile(r"[^a-z0-9]+")
 _LOGGER = logging.getLogger(__name__)
 
@@ -125,6 +130,83 @@ class TariffBillingSnapshot:
 
 
 @dataclass(slots=True, frozen=True)
+class TariffBillingUpdate:
+    """Validated tariff billing-cycle update payload."""
+
+    start_date: str
+    billing_frequency: str
+    billing_interval_value: int
+
+    @property
+    def payload(self) -> dict[str, object]:
+        """Return the Enphase billing-details write payload."""
+
+        return {
+            "anyBillPeriodStartDate": self.start_date,
+            "billingFrequency": self.billing_frequency,
+            "billingIntervalValue": self.billing_interval_value,
+        }
+
+    @classmethod
+    def from_object(cls, value: object) -> "TariffBillingUpdate | None":
+        """Parse and validate a billing-cycle update."""
+
+        if isinstance(value, cls):
+            return value
+        if not isinstance(value, dict):
+            return None
+        start_date = _clean_text(
+            value.get("anyBillPeriodStartDate")
+            if "anyBillPeriodStartDate" in value
+            else value.get("billing_start_date")
+        )
+        frequency = (
+            _clean_text(
+                value.get("billingFrequency")
+                if "billingFrequency" in value
+                else value.get("billing_frequency")
+            )
+            or ""
+        ).upper()
+        interval = _int_or_none(
+            value.get("billingIntervalValue")
+            if "billingIntervalValue" in value
+            else value.get("billing_interval_value")
+        )
+        if start_date is None:
+            _raise_tariff_validation(
+                "tariff_billing_start_date_invalid",
+                message="Tariff billing start date must be a valid ISO date.",
+            )
+        try:
+            date.fromisoformat(start_date)
+        except ValueError:
+            _raise_tariff_validation(
+                "tariff_billing_start_date_invalid",
+                message="Tariff billing start date must be a valid ISO date.",
+            )
+        if frequency not in {"MONTH", "DAY"}:
+            _raise_tariff_validation(
+                "tariff_billing_frequency_invalid",
+                message="Tariff billing frequency must be MONTH or DAY.",
+            )
+        max_interval = 24 if frequency == "MONTH" else 100
+        if interval is None or interval < 1 or interval > max_interval:
+            _raise_tariff_validation(
+                "tariff_billing_interval_invalid",
+                placeholders={"minimum": "1", "maximum": str(max_interval)},
+                message=(
+                    "Tariff billing interval must be between " f"1 and {max_interval}."
+                ),
+            )
+        return cls(
+            start_date=start_date,
+            billing_frequency=frequency,
+            billing_interval_value=interval,
+        )
+
+
+@dataclass(slots=True, frozen=True)
 class TariffRateSnapshot:
     """Normalized tariff branch metadata."""
 
@@ -151,6 +233,39 @@ class TariffRateSnapshot:
         if self.export_plan is not None:
             attrs["export_plan"] = self.export_plan
         return attrs
+
+
+@dataclass(slots=True, frozen=True)
+class TariffRateUpdate:
+    """Validated tariff rate update request."""
+
+    locator: TariffRateLocator
+    rate: float
+
+    @classmethod
+    def from_object(cls, value: object) -> "TariffRateUpdate | None":
+        """Parse a rate update from service/runtime input."""
+
+        if isinstance(value, cls):
+            return value
+        if isinstance(value, tuple) and len(value) == 2:
+            locator_raw, rate_raw = value
+        elif isinstance(value, dict):
+            locator_raw = value.get("locator", value.get("tariff_locator"))
+            rate_raw = value.get("rate")
+        else:
+            return None
+        locator = TariffRateLocator.from_object(locator_raw)
+        if locator is None:
+            return None
+        try:
+            rate = float(rate_raw)
+        except (TypeError, ValueError):
+            _raise_tariff_validation(
+                "tariff_rate_invalid",
+                message="Tariff rate must be a non-negative number.",
+            )
+        return cls(locator=locator, rate=rate)
 
 
 def _clean_text(value: object) -> str | None:
@@ -755,6 +870,170 @@ def _format_write_rate(value: float) -> str:
     return f"{value:.10f}".rstrip("0").rstrip(".") or "0"
 
 
+def _validate_write_rate(value: object) -> None:
+    try:
+        _format_write_rate(float(value))
+    except (TypeError, ValueError):
+        _raise_tariff_validation(
+            "tariff_rate_invalid",
+            message="Tariff rate must be a non-negative number.",
+        )
+
+
+def _minutes_or_empty(value: object) -> int | None:
+    if value == "":
+        return None
+    minutes = _int_or_none(value)
+    if minutes is None or minutes < 0 or minutes > 24 * 60:
+        _raise_tariff_validation(
+            "tariff_structure_invalid",
+            message="Tariff structure is invalid.",
+        )
+    return minutes
+
+
+def _validate_tariff_period(period: object) -> None:
+    if not isinstance(period, dict):
+        _raise_tariff_validation(
+            "tariff_structure_invalid",
+            message="Tariff structure is invalid.",
+        )
+    _validate_write_rate(period.get("rate"))
+    start = _minutes_or_empty(period.get("startTime", ""))
+    end = _minutes_or_empty(period.get("endTime", ""))
+    if (start is None) != (end is None) or (
+        start is not None and end is not None and start >= end
+    ):
+        _raise_tariff_validation(
+            "tariff_structure_invalid",
+            message="Tariff structure is invalid.",
+        )
+
+
+def _validate_tariff_tier(tier: object) -> None:
+    if not isinstance(tier, dict):
+        _raise_tariff_validation(
+            "tariff_structure_invalid",
+            message="Tariff structure is invalid.",
+        )
+    _validate_write_rate(tier.get("rate"))
+    for key in ("startValue", "endValue"):
+        value = tier.get(key)
+        if value in (None, "") or (key == "endValue" and _clean_text(value) == "-1"):
+            continue
+        try:
+            numeric = float(str(value).strip())
+        except (TypeError, ValueError):
+            _raise_tariff_validation(
+                "tariff_structure_invalid",
+                message="Tariff structure is invalid.",
+            )
+        if not math.isfinite(numeric) or numeric < 0:
+            _raise_tariff_validation(
+                "tariff_structure_invalid",
+                message="Tariff structure is invalid.",
+            )
+
+
+def _validate_tariff_season(season: object, *, type_id: str) -> None:
+    if not isinstance(season, dict):
+        _raise_tariff_validation(
+            "tariff_structure_invalid",
+            message="Tariff structure is invalid.",
+        )
+    for key in ("startMonth", "endMonth"):
+        value = season.get(key)
+        if value in (None, ""):
+            continue
+        month = _int_or_none(value)
+        if month is None or month < 1 or month > 12:
+            _raise_tariff_validation(
+                "tariff_structure_invalid",
+                message="Tariff structure is invalid.",
+            )
+    if type_id == "tiered":
+        tiers = season.get("tiers")
+        if not isinstance(tiers, list):
+            _raise_tariff_validation(
+                "tariff_structure_invalid",
+                message="Tariff structure is invalid.",
+            )
+        for tier in tiers:
+            _validate_tariff_tier(tier)
+        if "offPeak" in season:
+            _validate_write_rate(season.get("offPeak"))
+        return
+    days = season.get("days")
+    if not isinstance(days, list) or not days:
+        _raise_tariff_validation(
+            "tariff_structure_invalid",
+            message="Tariff structure is invalid.",
+        )
+    for day_group in days:
+        if not isinstance(day_group, dict):
+            _raise_tariff_validation(
+                "tariff_structure_invalid",
+                message="Tariff structure is invalid.",
+            )
+        periods = day_group.get("periods")
+        if not isinstance(periods, list) or not periods:
+            _raise_tariff_validation(
+                "tariff_structure_invalid",
+                message="Tariff structure is invalid.",
+            )
+        for period in periods:
+            _validate_tariff_period(period)
+
+
+def _validated_tariff_branch(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        _raise_tariff_validation(
+            "tariff_structure_invalid",
+            message="Tariff structure is invalid.",
+        )
+    branch = copy.deepcopy(value)
+    type_id = (_clean_text(branch.get("typeId")) or "").lower()
+    type_kind = (_clean_text(branch.get("typeKind")) or "").lower()
+    seasons = branch.get("seasons")
+    if (
+        type_id not in TARIFF_TYPE_IDS
+        or type_kind not in TARIFF_TYPE_KINDS
+        or not isinstance(seasons, list)
+        or not seasons
+    ):
+        _raise_tariff_validation(
+            "tariff_structure_invalid",
+            message="Tariff structure is invalid.",
+        )
+    for season in seasons:
+        _validate_tariff_season(season, type_id=type_id)
+    return branch
+
+
+def _validated_tariff_payload(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        _raise_tariff_validation(
+            "tariff_structure_invalid",
+            message="Tariff structure is invalid.",
+        )
+    payload = copy.deepcopy(value)
+    if not any(branch in payload for branch in TARIFF_BRANCH_KEYS):
+        _raise_tariff_validation(
+            "tariff_structure_invalid",
+            message="Tariff structure is invalid.",
+        )
+    for branch_key in TARIFF_BRANCH_KEYS:
+        if branch_key in payload:
+            payload[branch_key] = _validated_tariff_branch(payload[branch_key])
+    return payload
+
+
+def _locator_key(locator: TariffRateLocator) -> tuple[tuple[str, object], ...]:
+    """Return a stable hashable key for a tariff locator."""
+
+    return tuple(locator.as_dict().items())
+
+
 def _raise_tariff_validation(
     key: str,
     *,
@@ -910,38 +1189,128 @@ class TariffRuntime:
     ) -> dict:
         """Update one existing tariff rate value."""
 
-        parsed_locator = TariffRateLocator.from_object(locator)
-        if parsed_locator is None:
-            _raise_tariff_validation(
-                "tariff_rate_target_invalid",
-                message="Tariff rate target is invalid.",
+        result = await self.async_update_tariff(
+            rate_updates=({"locator": locator, "rate": value},)
+        )
+        return result.get("tariff") or {}
+
+    async def async_update_tariff(
+        self,
+        *,
+        billing: TariffBillingUpdate | dict[str, object] | None = None,
+        rate_updates: (
+            tuple[TariffRateUpdate | dict[str, object], ...]
+            | list[TariffRateUpdate | dict[str, object]]
+        ) = (),
+        tariff_payload: dict[str, object] | None = None,
+        purchase_tariff: dict[str, object] | None = None,
+        buyback_tariff: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        """Update tariff billing details and/or existing rate values."""
+
+        billing_update = TariffBillingUpdate.from_object(billing) if billing else None
+        payload_update = (
+            _validated_tariff_payload(tariff_payload)
+            if tariff_payload is not None
+            else None
+        )
+        purchase_update = (
+            _validated_tariff_branch(purchase_tariff)
+            if purchase_tariff is not None
+            else None
+        )
+        buyback_update = (
+            _validated_tariff_branch(buyback_tariff)
+            if buyback_tariff is not None
+            else None
+        )
+        parsed_rate_updates: list[TariffRateUpdate] = []
+        seen_locators: set[tuple[tuple[str, object], ...]] = set()
+        for update in rate_updates:
+            parsed_update = TariffRateUpdate.from_object(update)
+            if parsed_update is None:
+                _raise_tariff_validation(
+                    "tariff_rate_target_invalid",
+                    message="Tariff rate target is invalid.",
+                )
+            locator_key = _locator_key(parsed_update.locator)
+            if locator_key in seen_locators:
+                _raise_tariff_validation(
+                    "tariff_rate_target_duplicate",
+                    message="Duplicate tariff rate targets are not allowed.",
+                )
+            seen_locators.add(locator_key)
+            parsed_rate_updates.append(parsed_update)
+
+        tariff_write_requested = any(
+            (
+                parsed_rate_updates,
+                payload_update is not None,
+                purchase_update is not None,
+                buyback_update is not None,
             )
-        try:
-            rate_value = float(value)
-        except (TypeError, ValueError):
+        )
+        if billing_update is None and not tariff_write_requested:
             _raise_tariff_validation(
-                "tariff_rate_invalid",
-                message="Tariff rate must be a non-negative number.",
+                "tariff_update_required",
+                message="Provide billing details or at least one tariff rate update.",
             )
-        rate = _format_write_rate(rate_value)
+
         coord = self.coordinator
         site_tariff = getattr(coord.client, "site_tariff", None)
         site_tariff_update = getattr(coord.client, "site_tariff_update", None)
-        if not callable(site_tariff) or not callable(site_tariff_update):
+        needs_current_tariff = payload_update is None and (
+            parsed_rate_updates
+            or purchase_update is not None
+            or buyback_update is not None
+        )
+        if tariff_write_requested and not callable(site_tariff_update):
             _raise_tariff_validation(
                 "tariff_rate_api_unavailable",
                 message="Tariff write API is unavailable.",
             )
-        payload = await site_tariff()
-        if not isinstance(payload, dict):
+        if needs_current_tariff and not callable(site_tariff):
             _raise_tariff_validation(
                 "tariff_rate_api_unavailable",
                 message="Tariff write API is unavailable.",
             )
-        update_payload = copy.deepcopy(payload)
-        target, field = _locate_tariff_rate(update_payload, parsed_locator)
-        target[field] = rate
-        result = await site_tariff_update(update_payload)
+        site_tariff_billing_update = getattr(
+            coord.client, "site_tariff_billing_update", None
+        )
+        if billing_update is not None and not callable(site_tariff_billing_update):
+            _raise_tariff_validation(
+                "tariff_billing_api_unavailable",
+                message="Tariff billing write API is unavailable.",
+            )
+
+        tariff_result: dict | None = None
+        billing_result: dict | None = None
+        if tariff_write_requested:
+            if payload_update is not None:
+                update_payload = payload_update
+            else:
+                payload = await site_tariff()
+                if not isinstance(payload, dict):
+                    _raise_tariff_validation(
+                        "tariff_rate_api_unavailable",
+                        message="Tariff write API is unavailable.",
+                    )
+                update_payload = copy.deepcopy(payload)
+            if purchase_update is not None:
+                update_payload["purchase"] = purchase_update
+            if buyback_update is not None:
+                update_payload["buyback"] = buyback_update
+            located_updates: list[tuple[dict[str, object], str, str]] = []
+            for update in parsed_rate_updates:
+                rate = _format_write_rate(update.rate)
+                target, field = _locate_tariff_rate(update_payload, update.locator)
+                located_updates.append((target, field, rate))
+            for target, field, rate in located_updates:
+                target[field] = rate
+            tariff_result = await site_tariff_update(update_payload)
+
+        if billing_update is not None:
+            billing_result = await site_tariff_billing_update(billing_update.payload)
 
         notifier = getattr(coord.client, "notify_tariff_change", None)
         if callable(notifier):
@@ -954,7 +1323,7 @@ class TariffRuntime:
                     err,
                 )
         await coord.tariff_runtime.async_refresh(force=True)
-        return result
+        return {"tariff": tariff_result, "billing": billing_result}
 
     def _has_stale_data(self) -> bool:
         """Return whether a prior tariff snapshot can stay visible."""

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Включете разширеното потвърждение, за да изпратите {message}."
+    },
+    "tariff_update_required": {
+      "message": "Посочете данни за фактуриране или поне една актуализация на тарифна ставка."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Посочете начална дата, честота и интервал за фактуриране."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Началната дата за тарифно фактуриране трябва да е валидна ISO дата."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Честотата на тарифното фактуриране трябва да е MONTH или DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Интервалът за тарифно фактуриране трябва да е между {minimum} и {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "API за запис на тарифното фактуриране не е наличен."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Дублирани цели за тарифни ставки не са разрешени."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Дублирана същност за тарифна ставка: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Всички актуализации на тарифата трябва да са за един и същ сайт на Enphase."
+    },
+    "tariff_structure_invalid": {
+      "message": "Структурата на тарифата е невалидна."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Задаване на тарифна ставка",
-      "description": "Актуализира една съществуваща стойност на тарифна ставка за импорт или експорт на Enphase.",
+    "update_tariff": {
+      "name": "Актуализиране на тарифа",
+      "description": "Актуализирайте данните за цикъла на фактуриране на Enphase и една или повече съществуващи импортни или експортни тарифни ставки.",
       "fields": {
         "rate": {
           "name": "Ставка",
-          "description": "Нова неотрицателна стойност на тарифната ставка."
+          "description": "Нова неотрицателна стойност за избраната тарифна ставка."
+        },
+        "rate_entity": {
+          "name": "Същност на ставка",
+          "description": "Незадължителна същност на тарифна ставка за актуализиране, когато не се използва целта на действието."
+        },
+        "import_rate": {
+          "name": "Импортна ставка",
+          "description": "Нова неотрицателна стойност на импортната тарифна ставка."
+        },
+        "import_rate_entity": {
+          "name": "Същност на импортна ставка",
+          "description": "Същност на импортна тарифна ставка за актуализиране."
+        },
+        "export_rate": {
+          "name": "Експортна ставка",
+          "description": "Нова неотрицателна стойност на експортната тарифна ставка."
+        },
+        "export_rate_entity": {
+          "name": "Същност на експортна ставка",
+          "description": "Същност на експортна тарифна ставка за актуализиране."
+        },
+        "billing_start_date": {
+          "name": "Начална дата на фактуриране",
+          "description": "Начална дата на периода за фактуриране в ISO формат."
+        },
+        "billing_frequency": {
+          "name": "Честота на фактуриране",
+          "description": "Единица за интервала на фактуриране: MONTH или DAY."
+        },
+        "billing_interval_value": {
+          "name": "Интервал на фактуриране",
+          "description": "Брой интервали за фактуриране. Използвайте 1-24 за месеци или 1-100 за дни."
+        },
+        "rates": {
+          "name": "Ставки",
+          "description": "Списък с ID на същности за тарифни ставки и неотрицателни стойности за актуализиране."
+        },
+        "site_id": {
+          "name": "ID на сайт",
+          "description": "Незадължителен идентификатор на сайт за актуализации на фактуриране."
+        },
+        "config_entry_id": {
+          "name": "ID на запис за конфигурация",
+          "description": "Незадължителен идентификатор на запис за конфигурация за един сайт на Enphase."
+        },
+        "tariff_payload": {
+          "name": "Тарифен payload",
+          "description": "Пълен Enphase тарифен payload за запис. Използвайте го за разширени структурни редакции."
+        },
+        "purchase_tariff": {
+          "name": "Структура на тарифата за внос",
+          "description": "Заместващ клон за тарифата за внос с тип, сезони, периоди, стъпала и цени."
+        },
+        "buyback_tariff": {
+          "name": "Структура на тарифата за износ",
+          "description": "Заместващ клон за тарифата за износ с тип, план за износ, сезони, периоди, стъпала и цени."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Chcete-li odeslat {message}, povolte pokročilé potvrzení."
+    },
+    "tariff_update_required": {
+      "message": "Zadejte fakturační údaje nebo alespoň jednu aktualizaci tarifní sazby."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Zadejte počáteční datum, četnost a interval fakturace."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Počáteční datum fakturace tarifu musí být platné datum ISO."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Četnost fakturace tarifu musí být MONTH nebo DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Interval fakturace tarifu musí být mezi {minimum} a {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "API pro zápis fakturace tarifu není k dispozici."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Duplicitní cíle tarifních sazeb nejsou povoleny."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Duplicitní entita tarifní sazby: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Všechny aktualizace tarifu musí cílit na stejný web Enphase."
+    },
+    "tariff_structure_invalid": {
+      "message": "Struktura tarifu je neplatná."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Nastavit tarifní sazbu",
-      "description": "Aktualizuje jednu existující hodnotu importní nebo exportní tarifní sazby Enphase.",
+    "update_tariff": {
+      "name": "Aktualizovat tarif",
+      "description": "Aktualizuje fakturační cyklus Enphase a jednu nebo více existujících importních nebo exportních tarifních sazeb.",
       "fields": {
         "rate": {
           "name": "Sazba",
-          "description": "Nová nezáporná hodnota tarifní sazby."
+          "description": "Nová nezáporná hodnota tarifní sazby pro vybranou entitu."
+        },
+        "rate_entity": {
+          "name": "Entita sazby",
+          "description": "Volitelná entita tarifní sazby k aktualizaci, pokud se nepoužívá cíl akce."
+        },
+        "import_rate": {
+          "name": "Importní sazba",
+          "description": "Nová nezáporná hodnota importní tarifní sazby."
+        },
+        "import_rate_entity": {
+          "name": "Entita importní sazby",
+          "description": "Entita importní tarifní sazby k aktualizaci."
+        },
+        "export_rate": {
+          "name": "Exportní sazba",
+          "description": "Nová nezáporná hodnota exportní tarifní sazby."
+        },
+        "export_rate_entity": {
+          "name": "Entita exportní sazby",
+          "description": "Entita exportní tarifní sazby k aktualizaci."
+        },
+        "billing_start_date": {
+          "name": "Počáteční datum fakturace",
+          "description": "Počáteční datum fakturačního období ve formátu ISO."
+        },
+        "billing_frequency": {
+          "name": "Četnost fakturace",
+          "description": "Jednotka fakturačního intervalu: MONTH nebo DAY."
+        },
+        "billing_interval_value": {
+          "name": "Fakturační interval",
+          "description": "Počet fakturačních intervalů. Použijte 1-24 pro měsíce nebo 1-100 pro dny."
+        },
+        "rates": {
+          "name": "Sazby",
+          "description": "Seznam ID entit tarifních sazeb a nezáporných hodnot sazeb k aktualizaci."
+        },
+        "site_id": {
+          "name": "ID webu",
+          "description": "Volitelný identifikátor webu pro aktualizace fakturace."
+        },
+        "config_entry_id": {
+          "name": "ID položky konfigurace",
+          "description": "Volitelný identifikátor položky konfigurace pro jeden web Enphase."
+        },
+        "tariff_payload": {
+          "name": "Datová část tarifu",
+          "description": "Úplná datová část tarifu Enphase k zápisu. Použijte pro pokročilé strukturální úpravy."
+        },
+        "purchase_tariff": {
+          "name": "Struktura importního tarifu",
+          "description": "Náhradní větev importního tarifu s typem, sezónami, obdobími, pásmy a sazbami."
+        },
+        "buyback_tariff": {
+          "name": "Struktura exportního tarifu",
+          "description": "Náhradní větev exportního tarifu s typem, exportním plánem, sezónami, obdobími, pásmy a sazbami."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Aktivér avanceret bekræftelse for at sende {message}."
+    },
+    "tariff_update_required": {
+      "message": "Angiv faktureringsoplysninger eller mindst en opdatering af en tariffsats."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Angiv startdato, frekvens og interval for fakturering."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Startdatoen for tarifffakturering skal være en gyldig ISO-dato."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Faktureringsfrekvensen for tariffen skal være MONTH eller DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Faktureringsintervallet for tariffen skal være mellem {minimum} og {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "API til skrivning af tarifffakturering er ikke tilgængelig."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Dublerede mål for tariffsatser er ikke tilladt."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Dubleret tariffsats-entitet: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Alle tarifopdateringer skal pege på det samme Enphase-anlæg."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tarifstrukturen er ugyldig."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Indstil tarifpris",
-      "description": "Opdaterer én eksisterende Enphase import- eller eksporttarifpris.",
+    "update_tariff": {
+      "name": "Opdater tarif",
+      "description": "Opdater Enphase-faktureringscyklus og en eller flere eksisterende import- eller eksporttarifsatser.",
       "fields": {
         "rate": {
-          "name": "Pris",
-          "description": "Ny ikke-negativ tarifpris."
+          "name": "Sats",
+          "description": "Ny ikke-negativ tariffsatsværdi for den valgte tariffsats-entitet."
+        },
+        "rate_entity": {
+          "name": "Satsentitet",
+          "description": "Valgfri tariffsats-entitet, der skal opdateres, når handlingens mål ikke bruges."
+        },
+        "import_rate": {
+          "name": "Importsats",
+          "description": "Ny ikke-negativ importtariffsats."
+        },
+        "import_rate_entity": {
+          "name": "Import­satsentitet",
+          "description": "Importtariffsats-entitet, der skal opdateres."
+        },
+        "export_rate": {
+          "name": "Eksportsats",
+          "description": "Ny ikke-negativ eksporttariffsats."
+        },
+        "export_rate_entity": {
+          "name": "Eksport­satsentitet",
+          "description": "Eksporttariffsats-entitet, der skal opdateres."
+        },
+        "billing_start_date": {
+          "name": "Startdato for fakturering",
+          "description": "Startdato for faktureringsperioden i ISO-format."
+        },
+        "billing_frequency": {
+          "name": "Faktureringsfrekvens",
+          "description": "Enhed for faktureringsinterval: MONTH eller DAY."
+        },
+        "billing_interval_value": {
+          "name": "Faktureringsinterval",
+          "description": "Antal faktureringsintervaller. Brug 1-24 for måneder eller 1-100 for dage."
+        },
+        "rates": {
+          "name": "Satser",
+          "description": "Liste over entitets-ID’er for tariffsatser og ikke-negative satsværdier, der skal opdateres."
+        },
+        "site_id": {
+          "name": "Anlægs-ID",
+          "description": "Valgfrit anlægs-ID til faktureringsopdateringer."
+        },
+        "config_entry_id": {
+          "name": "Konfigurationspost-ID",
+          "description": "Valgfrit konfigurationspost-ID for et enkelt Enphase-anlæg."
+        },
+        "tariff_payload": {
+          "name": "Tarif-payload",
+          "description": "Komplet Enphase-tarifpayload til skrivning. Bruges til avancerede strukturændringer."
+        },
+        "purchase_tariff": {
+          "name": "Importtarifstruktur",
+          "description": "Erstatningsgren for importtarif med type, sæsoner, perioder, trin og satser."
+        },
+        "buyback_tariff": {
+          "name": "Eksporttarifstruktur",
+          "description": "Erstatningsgren for eksporttarif med type, eksportplan, sæsoner, perioder, trin og satser."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Aktivieren Sie die erweiterte Bestätigung, um {message} zu senden."
+    },
+    "tariff_update_required": {
+      "message": "Gib Abrechnungsdetails oder mindestens eine Aktualisierung eines Tarifsatzes an."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Gib Startdatum, Häufigkeit und Intervall der Abrechnung an."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Das Startdatum der Tarifabrechnung muss ein gültiges ISO-Datum sein."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Die Häufigkeit der Tarifabrechnung muss MONTH oder DAY sein."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Das Intervall der Tarifabrechnung muss zwischen {minimum} und {maximum} liegen."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Die API zum Schreiben der Tarifabrechnung ist nicht verfügbar."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Doppelte Ziele für Tarifsätze sind nicht erlaubt."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Doppelte Tarifsatz-Entität: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Alle Tarifaktualisierungen müssen dieselbe Enphase-Anlage betreffen."
+    },
+    "tariff_structure_invalid": {
+      "message": "Die Tarifstruktur ist ungültig."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Tarifsatz festlegen",
-      "description": "Aktualisiert einen vorhandenen Enphase Import- oder Exporttarifsatz.",
+    "update_tariff": {
+      "name": "Tarif aktualisieren",
+      "description": "Aktualisiert Enphase-Abrechnungszyklusdetails und einen oder mehrere bestehende Import- oder Exporttarifsätze.",
       "fields": {
         "rate": {
-          "name": "Satz",
-          "description": "Neuer nicht negativer Tarifsatz."
+          "name": "Tarifsatz",
+          "description": "Neuer nicht negativer Tarifsatzwert für die ausgewählte Tarifsatz-Entität."
+        },
+        "rate_entity": {
+          "name": "Tarifsatz-Entität",
+          "description": "Optionale Tarifsatz-Entität zum Aktualisieren, wenn kein Aktionsziel verwendet wird."
+        },
+        "import_rate": {
+          "name": "Importtarif",
+          "description": "Neuer nicht negativer Importtarifsatz."
+        },
+        "import_rate_entity": {
+          "name": "Importtarif-Entität",
+          "description": "Zu aktualisierende Importtarifsatz-Entität."
+        },
+        "export_rate": {
+          "name": "Exporttarif",
+          "description": "Neuer nicht negativer Exporttarifsatz."
+        },
+        "export_rate_entity": {
+          "name": "Exporttarif-Entität",
+          "description": "Zu aktualisierende Exporttarifsatz-Entität."
+        },
+        "billing_start_date": {
+          "name": "Startdatum der Abrechnung",
+          "description": "Startdatum des Abrechnungszeitraums im ISO-Format."
+        },
+        "billing_frequency": {
+          "name": "Abrechnungshäufigkeit",
+          "description": "Einheit des Abrechnungsintervalls: MONTH oder DAY."
+        },
+        "billing_interval_value": {
+          "name": "Abrechnungsintervall",
+          "description": "Anzahl der Abrechnungsintervalle. Verwende 1-24 für Monate oder 1-100 für Tage."
+        },
+        "rates": {
+          "name": "Tarifsätze",
+          "description": "Liste der Entitäts-IDs von Tarifsätzen und nicht negativer Werte, die aktualisiert werden sollen."
+        },
+        "site_id": {
+          "name": "Anlagen-ID",
+          "description": "Optionale Anlagenkennung für Abrechnungsaktualisierungen."
+        },
+        "config_entry_id": {
+          "name": "Konfigurationseintrags-ID",
+          "description": "Optionale Konfigurationseintragskennung für eine einzelne Enphase-Anlage."
+        },
+        "tariff_payload": {
+          "name": "Tarif-Nutzdaten",
+          "description": "Vollständige Enphase-Tarifnutzdaten zum Schreiben. Für erweiterte Strukturänderungen verwenden."
+        },
+        "purchase_tariff": {
+          "name": "Importtarifstruktur",
+          "description": "Ersatz für den Importtarif-Zweig mit Typ, Saisons, Zeiträumen, Stufen und Preisen."
+        },
+        "buyback_tariff": {
+          "name": "Exporttarifstruktur",
+          "description": "Ersatz für den Exporttarif-Zweig mit Typ, Exportplan, Saisons, Zeiträumen, Stufen und Preisen."
+        },
+        "configure_import_tariff": {
+          "name": "Importtarif konfigurieren",
+          "description": "Aktivieren, um mit den geführten Feldern einen Ersatz-Importtarif zu erstellen."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftyp",
+          "description": "Wählen Sie Flat, zeitabhängig oder gestaffelt."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Wählen Sie saisonale oder Werktag/Wochenende-Änderungen."
+        },
+        "import_flat_rate": {
+          "name": "Flacher Importpreis",
+          "description": "Ein Importpreis für Flat-Tarife, wenn keine Periodenzeilen angegeben sind."
+        },
+        "import_periods": {
+          "name": "Import-Periodenzeilen",
+          "description": "Zeilen für Flat- oder zeitabhängige Importpreise. Tage 1-7 sind Montag-Sonntag; Zeiten HH:MM oder Minuten nach Mitternacht."
+        },
+        "import_tiers": {
+          "name": "Import-Stufenzeilen",
+          "description": "Zeilen für gestaffelte Importpreise. end_value -1 bedeutet letzte unbegrenzte Stufe."
+        },
+        "import_off_peak_rate": {
+          "name": "Import-Off-Peak-Basis",
+          "description": "Off-Peak-Basispreis für gestaffelte Importtarife."
+        },
+        "configure_export_tariff": {
+          "name": "Exporttarif konfigurieren",
+          "description": "Aktivieren, um mit den geführten Feldern einen Ersatz-Exporttarif zu erstellen."
+        },
+        "export_tariff_type": {
+          "name": "Exporttariftyp",
+          "description": "Wählen Sie Flat, zeitabhängig oder gestaffelt."
+        },
+        "export_variation": {
+          "name": "Exportvariation",
+          "description": "Wählen Sie saisonale oder Werktag/Wochenende-Änderungen."
+        },
+        "export_plan": {
+          "name": "Exportplan",
+          "description": "Wählen Sie den Enphase-Exportplan für den Exporttarif."
+        },
+        "export_flat_rate": {
+          "name": "Flacher Exportpreis",
+          "description": "Ein Exportpreis für Flat-Tarife, wenn keine Periodenzeilen angegeben sind."
+        },
+        "export_periods": {
+          "name": "Export-Periodenzeilen",
+          "description": "Zeilen für Flat- oder zeitabhängige Exportpreise. Tage 1-7 sind Montag-Sonntag; Zeiten HH:MM oder Minuten nach Mitternacht."
+        },
+        "export_tiers": {
+          "name": "Export-Stufenzeilen",
+          "description": "Zeilen für gestaffelte Exportpreise. end_value -1 bedeutet letzte unbegrenzte Stufe."
+        },
+        "export_off_peak_rate": {
+          "name": "Export-Off-Peak-Basis",
+          "description": "Off-Peak-Basispreis für gestaffelte Exporttarife."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Export-Off-Peak-Basis",
           "description": "Off-Peak-Basispreis für gestaffelte Exporttarife."
+        },
+        "device_id": {
+          "name": "Gerät",
+          "description": "Optionales Enphase-Gerät zur Auswahl des Standorts für Abrechnungs- oder Tarifstruktur-Updates."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Ενεργοποιήστε την επιβεβαίωση για προχωρημένους για να στείλετε το {message}."
+    },
+    "tariff_update_required": {
+      "message": "Δώστε στοιχεία χρέωσης ή τουλάχιστον μία ενημέρωση τιμής τιμολογίου."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Δώστε ημερομηνία έναρξης, συχνότητα και διάστημα χρέωσης."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Η ημερομηνία έναρξης χρέωσης τιμολογίου πρέπει να είναι έγκυρη ημερομηνία ISO."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Η συχνότητα χρέωσης τιμολογίου πρέπει να είναι MONTH ή DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Το διάστημα χρέωσης τιμολογίου πρέπει να είναι μεταξύ {minimum} και {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Το API εγγραφής χρέωσης τιμολογίου δεν είναι διαθέσιμο."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Δεν επιτρέπονται διπλοί στόχοι τιμών τιμολογίου."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Διπλή οντότητα τιμής τιμολογίου: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Όλες οι ενημερώσεις τιμολογίου πρέπει να αφορούν τον ίδιο ιστότοπο Enphase."
+    },
+    "tariff_structure_invalid": {
+      "message": "Η δομή τιμολογίου δεν είναι έγκυρη."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Ορισμός τιμής τιμολογίου",
-      "description": "Ενημερώνει μία υπάρχουσα τιμή εισαγωγής ή εξαγωγής Enphase.",
+    "update_tariff": {
+      "name": "Ενημέρωση τιμολογίου",
+      "description": "Ενημερώνει τα στοιχεία κύκλου χρέωσης Enphase και μία ή περισσότερες υπάρχουσες τιμές εισαγωγής ή εξαγωγής.",
       "fields": {
         "rate": {
           "name": "Τιμή",
-          "description": "Νέα μη αρνητική τιμή τιμολογίου."
+          "description": "Νέα μη αρνητική τιμή τιμολογίου για την επιλεγμένη οντότητα."
+        },
+        "rate_entity": {
+          "name": "Οντότητα τιμής",
+          "description": "Προαιρετική οντότητα τιμής τιμολογίου για ενημέρωση όταν δεν χρησιμοποιείται ο στόχος ενέργειας."
+        },
+        "import_rate": {
+          "name": "Τιμή εισαγωγής",
+          "description": "Νέα μη αρνητική τιμή τιμολογίου εισαγωγής."
+        },
+        "import_rate_entity": {
+          "name": "Οντότητα τιμής εισαγωγής",
+          "description": "Οντότητα τιμής τιμολογίου εισαγωγής για ενημέρωση."
+        },
+        "export_rate": {
+          "name": "Τιμή εξαγωγής",
+          "description": "Νέα μη αρνητική τιμή τιμολογίου εξαγωγής."
+        },
+        "export_rate_entity": {
+          "name": "Οντότητα τιμής εξαγωγής",
+          "description": "Οντότητα τιμής τιμολογίου εξαγωγής για ενημέρωση."
+        },
+        "billing_start_date": {
+          "name": "Ημερομηνία έναρξης χρέωσης",
+          "description": "Ημερομηνία έναρξης περιόδου χρέωσης σε μορφή ISO."
+        },
+        "billing_frequency": {
+          "name": "Συχνότητα χρέωσης",
+          "description": "Μονάδα διαστήματος χρέωσης: MONTH ή DAY."
+        },
+        "billing_interval_value": {
+          "name": "Διάστημα χρέωσης",
+          "description": "Πλήθος διαστημάτων χρέωσης. Χρησιμοποιήστε 1-24 για μήνες ή 1-100 για ημέρες."
+        },
+        "rates": {
+          "name": "Τιμές",
+          "description": "Λίστα ID οντοτήτων τιμών τιμολογίου και μη αρνητικών τιμών για ενημέρωση."
+        },
+        "site_id": {
+          "name": "ID ιστότοπου",
+          "description": "Προαιρετικό αναγνωριστικό ιστότοπου για ενημερώσεις χρέωσης."
+        },
+        "config_entry_id": {
+          "name": "ID καταχώρισης ρύθμισης",
+          "description": "Προαιρετικό αναγνωριστικό καταχώρισης ρύθμισης για έναν ιστότοπο Enphase."
+        },
+        "tariff_payload": {
+          "name": "Payload τιμολογίου",
+          "description": "Πλήρες payload τιμολογίου Enphase για εγγραφή. Χρησιμοποιήστε το για προχωρημένες δομικές αλλαγές."
+        },
+        "purchase_tariff": {
+          "name": "Δομή τιμολογίου εισαγωγής",
+          "description": "Αντικατάσταση κλάδου τιμολογίου εισαγωγής με τύπο, εποχές, περιόδους, βαθμίδες και τιμές."
+        },
+        "buyback_tariff": {
+          "name": "Δομή τιμολογίου εξαγωγής",
+          "description": "Αντικατάσταση κλάδου τιμολογίου εξαγωγής με τύπο, σχέδιο εξαγωγής, εποχές, περιόδους, βαθμίδες και τιμές."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Export Off-Peak Baseline",
           "description": "Baseline off-peak export rate for tiered tariffs."
+        },
+        "device_id": {
+          "name": "Device",
+          "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Enable advanced confirmation to send {message}."
+    },
+    "tariff_update_required": {
+      "message": "Provide billing details or at least one tariff rate update."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Provide billing start date, frequency, and interval."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Tariff billing start date must be a valid ISO date."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Tariff billing frequency must be MONTH or DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Tariff billing interval must be between {minimum} and {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Tariff billing write API is unavailable."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Duplicate tariff rate targets are not allowed."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Duplicate tariff rate entity: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "All tariff updates must target the same Enphase site."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tariff structure is invalid."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Set Tariff Rate",
-      "description": "Update one existing Enphase import or export tariff rate value.",
+    "update_tariff": {
+      "name": "Update Tariff",
+      "description": "Update Enphase billing-cycle details, guided tariff structures, and one or more existing import or export tariff rate values.",
       "fields": {
         "rate": {
           "name": "Rate",
-          "description": "New non-negative tariff rate value."
+          "description": "New non-negative tariff rate value for the selected tariff rate entity."
+        },
+        "rate_entity": {
+          "name": "Rate Entity",
+          "description": "Optional tariff rate entity to update when not using the action target."
+        },
+        "import_rate": {
+          "name": "Import Rate",
+          "description": "New non-negative import tariff rate value."
+        },
+        "import_rate_entity": {
+          "name": "Import Rate Entity",
+          "description": "Import tariff rate entity to update."
+        },
+        "export_rate": {
+          "name": "Export Rate",
+          "description": "New non-negative export tariff rate value."
+        },
+        "export_rate_entity": {
+          "name": "Export Rate Entity",
+          "description": "Export tariff rate entity to update."
+        },
+        "billing_start_date": {
+          "name": "Billing Start Date",
+          "description": "Bill period start date in ISO format."
+        },
+        "billing_frequency": {
+          "name": "Billing Frequency",
+          "description": "Billing interval unit: MONTH or DAY."
+        },
+        "billing_interval_value": {
+          "name": "Billing Interval",
+          "description": "Billing interval count. Use 1-24 for months or 1-100 for days."
+        },
+        "rates": {
+          "name": "Rates",
+          "description": "List of tariff rate entity IDs and non-negative rate values to update."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier for billing updates."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        },
+        "tariff_payload": {
+          "name": "Tariff Payload",
+          "description": "Complete Enphase tariff payload to write. Use this for advanced structural edits."
+        },
+        "purchase_tariff": {
+          "name": "Import Tariff Structure",
+          "description": "Replacement import tariff branch with type, seasons, periods, tiers, and rates."
+        },
+        "buyback_tariff": {
+          "name": "Export Tariff Structure",
+          "description": "Replacement export tariff branch with type, export plan, seasons, periods, tiers, and rates."
+        },
+        "configure_import_tariff": {
+          "name": "Configure Import Tariff",
+          "description": "Enable this to build a replacement import tariff from the guided fields below."
+        },
+        "import_tariff_type": {
+          "name": "Import Tariff Type",
+          "description": "Choose whether import pricing is flat, time of use, or tiered."
+        },
+        "import_variation": {
+          "name": "Import Variation",
+          "description": "Choose whether import pricing changes by season or weekday/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Import Flat Rate",
+          "description": "Single import rate used when the import tariff type is flat and no period rows are provided."
+        },
+        "import_periods": {
+          "name": "Import Period Rows",
+          "description": "Rows for flat or time-of-use import pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "import_tiers": {
+          "name": "Import Tier Rows",
+          "description": "Rows for tiered import pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "import_off_peak_rate": {
+          "name": "Import Off-Peak Baseline",
+          "description": "Baseline off-peak import rate for tiered tariffs."
+        },
+        "configure_export_tariff": {
+          "name": "Configure Export Tariff",
+          "description": "Enable this to build a replacement export tariff from the guided fields below."
+        },
+        "export_tariff_type": {
+          "name": "Export Tariff Type",
+          "description": "Choose whether export compensation is flat, time of use, or tiered."
+        },
+        "export_variation": {
+          "name": "Export Variation",
+          "description": "Choose whether export pricing changes by season or weekday/weekend."
+        },
+        "export_plan": {
+          "name": "Export Plan",
+          "description": "Choose the Enphase export plan label to write with the export tariff."
+        },
+        "export_flat_rate": {
+          "name": "Export Flat Rate",
+          "description": "Single export rate used when the export tariff type is flat and no period rows are provided."
+        },
+        "export_periods": {
+          "name": "Export Period Rows",
+          "description": "Rows for flat or time-of-use export pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "export_tiers": {
+          "name": "Export Tier Rows",
+          "description": "Rows for tiered export pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "export_off_peak_rate": {
+          "name": "Export Off-Peak Baseline",
+          "description": "Baseline off-peak export rate for tiered tariffs."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Export Off-Peak Baseline",
           "description": "Baseline off-peak export rate for tiered tariffs."
+        },
+        "device_id": {
+          "name": "Device",
+          "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Enable advanced confirmation to send {message}."
+    },
+    "tariff_update_required": {
+      "message": "Provide billing details or at least one tariff rate update."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Provide billing start date, frequency, and interval."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Tariff billing start date must be a valid ISO date."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Tariff billing frequency must be MONTH or DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Tariff billing interval must be between {minimum} and {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Tariff billing write API is unavailable."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Duplicate tariff rate targets are not allowed."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Duplicate tariff rate entity: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "All tariff updates must target the same Enphase site."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tariff structure is invalid."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Set Tariff Rate",
-      "description": "Update one existing Enphase import or export tariff rate value.",
+    "update_tariff": {
+      "name": "Update Tariff",
+      "description": "Update Enphase billing-cycle details, guided tariff structures, and one or more existing import or export tariff rate values.",
       "fields": {
         "rate": {
           "name": "Rate",
-          "description": "New non-negative tariff rate value."
+          "description": "New non-negative tariff rate value for the selected tariff rate entity."
+        },
+        "rate_entity": {
+          "name": "Rate Entity",
+          "description": "Optional tariff rate entity to update when not using the action target."
+        },
+        "import_rate": {
+          "name": "Import Rate",
+          "description": "New non-negative import tariff rate value."
+        },
+        "import_rate_entity": {
+          "name": "Import Rate Entity",
+          "description": "Import tariff rate entity to update."
+        },
+        "export_rate": {
+          "name": "Export Rate",
+          "description": "New non-negative export tariff rate value."
+        },
+        "export_rate_entity": {
+          "name": "Export Rate Entity",
+          "description": "Export tariff rate entity to update."
+        },
+        "billing_start_date": {
+          "name": "Billing Start Date",
+          "description": "Bill period start date in ISO format."
+        },
+        "billing_frequency": {
+          "name": "Billing Frequency",
+          "description": "Billing interval unit: MONTH or DAY."
+        },
+        "billing_interval_value": {
+          "name": "Billing Interval",
+          "description": "Billing interval count. Use 1-24 for months or 1-100 for days."
+        },
+        "rates": {
+          "name": "Rates",
+          "description": "List of tariff rate entity IDs and non-negative rate values to update."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier for billing updates."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        },
+        "tariff_payload": {
+          "name": "Tariff Payload",
+          "description": "Complete Enphase tariff payload to write. Use this for advanced structural edits."
+        },
+        "purchase_tariff": {
+          "name": "Import Tariff Structure",
+          "description": "Replacement import tariff branch with type, seasons, periods, tiers, and rates."
+        },
+        "buyback_tariff": {
+          "name": "Export Tariff Structure",
+          "description": "Replacement export tariff branch with type, export plan, seasons, periods, tiers, and rates."
+        },
+        "configure_import_tariff": {
+          "name": "Configure Import Tariff",
+          "description": "Enable this to build a replacement import tariff from the guided fields below."
+        },
+        "import_tariff_type": {
+          "name": "Import Tariff Type",
+          "description": "Choose whether import pricing is flat, time of use, or tiered."
+        },
+        "import_variation": {
+          "name": "Import Variation",
+          "description": "Choose whether import pricing changes by season or weekday/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Import Flat Rate",
+          "description": "Single import rate used when the import tariff type is flat and no period rows are provided."
+        },
+        "import_periods": {
+          "name": "Import Period Rows",
+          "description": "Rows for flat or time-of-use import pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "import_tiers": {
+          "name": "Import Tier Rows",
+          "description": "Rows for tiered import pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "import_off_peak_rate": {
+          "name": "Import Off-Peak Baseline",
+          "description": "Baseline off-peak import rate for tiered tariffs."
+        },
+        "configure_export_tariff": {
+          "name": "Configure Export Tariff",
+          "description": "Enable this to build a replacement export tariff from the guided fields below."
+        },
+        "export_tariff_type": {
+          "name": "Export Tariff Type",
+          "description": "Choose whether export compensation is flat, time of use, or tiered."
+        },
+        "export_variation": {
+          "name": "Export Variation",
+          "description": "Choose whether export pricing changes by season or weekday/weekend."
+        },
+        "export_plan": {
+          "name": "Export Plan",
+          "description": "Choose the Enphase export plan label to write with the export tariff."
+        },
+        "export_flat_rate": {
+          "name": "Export Flat Rate",
+          "description": "Single export rate used when the export tariff type is flat and no period rows are provided."
+        },
+        "export_periods": {
+          "name": "Export Period Rows",
+          "description": "Rows for flat or time-of-use export pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "export_tiers": {
+          "name": "Export Tier Rows",
+          "description": "Rows for tiered export pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "export_off_peak_rate": {
+          "name": "Export Off-Peak Baseline",
+          "description": "Baseline off-peak export rate for tiered tariffs."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Export Off-Peak Baseline",
           "description": "Baseline off-peak export rate for tiered tariffs."
+        },
+        "device_id": {
+          "name": "Device",
+          "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Enable advanced confirmation to send {message}."
+    },
+    "tariff_update_required": {
+      "message": "Provide billing details or at least one tariff rate update."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Provide billing start date, frequency, and interval."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Tariff billing start date must be a valid ISO date."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Tariff billing frequency must be MONTH or DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Tariff billing interval must be between {minimum} and {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Tariff billing write API is unavailable."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Duplicate tariff rate targets are not allowed."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Duplicate tariff rate entity: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "All tariff updates must target the same Enphase site."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tariff structure is invalid."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Set Tariff Rate",
-      "description": "Update one existing Enphase import or export tariff rate value.",
+    "update_tariff": {
+      "name": "Update Tariff",
+      "description": "Update Enphase billing-cycle details, guided tariff structures, and one or more existing import or export tariff rate values.",
       "fields": {
         "rate": {
           "name": "Rate",
-          "description": "New non-negative tariff rate value."
+          "description": "New non-negative tariff rate value for the selected tariff rate entity."
+        },
+        "rate_entity": {
+          "name": "Rate Entity",
+          "description": "Optional tariff rate entity to update when not using the action target."
+        },
+        "import_rate": {
+          "name": "Import Rate",
+          "description": "New non-negative import tariff rate value."
+        },
+        "import_rate_entity": {
+          "name": "Import Rate Entity",
+          "description": "Import tariff rate entity to update."
+        },
+        "export_rate": {
+          "name": "Export Rate",
+          "description": "New non-negative export tariff rate value."
+        },
+        "export_rate_entity": {
+          "name": "Export Rate Entity",
+          "description": "Export tariff rate entity to update."
+        },
+        "billing_start_date": {
+          "name": "Billing Start Date",
+          "description": "Bill period start date in ISO format."
+        },
+        "billing_frequency": {
+          "name": "Billing Frequency",
+          "description": "Billing interval unit: MONTH or DAY."
+        },
+        "billing_interval_value": {
+          "name": "Billing Interval",
+          "description": "Billing interval count. Use 1-24 for months or 1-100 for days."
+        },
+        "rates": {
+          "name": "Rates",
+          "description": "List of tariff rate entity IDs and non-negative rate values to update."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier for billing updates."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        },
+        "tariff_payload": {
+          "name": "Tariff Payload",
+          "description": "Complete Enphase tariff payload to write. Use this for advanced structural edits."
+        },
+        "purchase_tariff": {
+          "name": "Import Tariff Structure",
+          "description": "Replacement import tariff branch with type, seasons, periods, tiers, and rates."
+        },
+        "buyback_tariff": {
+          "name": "Export Tariff Structure",
+          "description": "Replacement export tariff branch with type, export plan, seasons, periods, tiers, and rates."
+        },
+        "configure_import_tariff": {
+          "name": "Configure Import Tariff",
+          "description": "Enable this to build a replacement import tariff from the guided fields below."
+        },
+        "import_tariff_type": {
+          "name": "Import Tariff Type",
+          "description": "Choose whether import pricing is flat, time of use, or tiered."
+        },
+        "import_variation": {
+          "name": "Import Variation",
+          "description": "Choose whether import pricing changes by season or weekday/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Import Flat Rate",
+          "description": "Single import rate used when the import tariff type is flat and no period rows are provided."
+        },
+        "import_periods": {
+          "name": "Import Period Rows",
+          "description": "Rows for flat or time-of-use import pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "import_tiers": {
+          "name": "Import Tier Rows",
+          "description": "Rows for tiered import pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "import_off_peak_rate": {
+          "name": "Import Off-Peak Baseline",
+          "description": "Baseline off-peak import rate for tiered tariffs."
+        },
+        "configure_export_tariff": {
+          "name": "Configure Export Tariff",
+          "description": "Enable this to build a replacement export tariff from the guided fields below."
+        },
+        "export_tariff_type": {
+          "name": "Export Tariff Type",
+          "description": "Choose whether export compensation is flat, time of use, or tiered."
+        },
+        "export_variation": {
+          "name": "Export Variation",
+          "description": "Choose whether export pricing changes by season or weekday/weekend."
+        },
+        "export_plan": {
+          "name": "Export Plan",
+          "description": "Choose the Enphase export plan label to write with the export tariff."
+        },
+        "export_flat_rate": {
+          "name": "Export Flat Rate",
+          "description": "Single export rate used when the export tariff type is flat and no period rows are provided."
+        },
+        "export_periods": {
+          "name": "Export Period Rows",
+          "description": "Rows for flat or time-of-use export pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "export_tiers": {
+          "name": "Export Tier Rows",
+          "description": "Rows for tiered export pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "export_off_peak_rate": {
+          "name": "Export Off-Peak Baseline",
+          "description": "Baseline off-peak export rate for tiered tariffs."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Export Off-Peak Baseline",
           "description": "Baseline off-peak export rate for tiered tariffs."
+        },
+        "device_id": {
+          "name": "Device",
+          "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Enable advanced confirmation to send {message}."
+    },
+    "tariff_update_required": {
+      "message": "Provide billing details or at least one tariff rate update."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Provide billing start date, frequency, and interval."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Tariff billing start date must be a valid ISO date."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Tariff billing frequency must be MONTH or DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Tariff billing interval must be between {minimum} and {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Tariff billing write API is unavailable."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Duplicate tariff rate targets are not allowed."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Duplicate tariff rate entity: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "All tariff updates must target the same Enphase site."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tariff structure is invalid."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Set Tariff Rate",
-      "description": "Update one existing Enphase import or export tariff rate value.",
+    "update_tariff": {
+      "name": "Update Tariff",
+      "description": "Update Enphase billing-cycle details, guided tariff structures, and one or more existing import or export tariff rate values.",
       "fields": {
         "rate": {
           "name": "Rate",
-          "description": "New non-negative tariff rate value."
+          "description": "New non-negative tariff rate value for the selected tariff rate entity."
+        },
+        "rate_entity": {
+          "name": "Rate Entity",
+          "description": "Optional tariff rate entity to update when not using the action target."
+        },
+        "import_rate": {
+          "name": "Import Rate",
+          "description": "New non-negative import tariff rate value."
+        },
+        "import_rate_entity": {
+          "name": "Import Rate Entity",
+          "description": "Import tariff rate entity to update."
+        },
+        "export_rate": {
+          "name": "Export Rate",
+          "description": "New non-negative export tariff rate value."
+        },
+        "export_rate_entity": {
+          "name": "Export Rate Entity",
+          "description": "Export tariff rate entity to update."
+        },
+        "billing_start_date": {
+          "name": "Billing Start Date",
+          "description": "Bill period start date in ISO format."
+        },
+        "billing_frequency": {
+          "name": "Billing Frequency",
+          "description": "Billing interval unit: MONTH or DAY."
+        },
+        "billing_interval_value": {
+          "name": "Billing Interval",
+          "description": "Billing interval count. Use 1-24 for months or 1-100 for days."
+        },
+        "rates": {
+          "name": "Rates",
+          "description": "List of tariff rate entity IDs and non-negative rate values to update."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier for billing updates."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        },
+        "tariff_payload": {
+          "name": "Tariff Payload",
+          "description": "Complete Enphase tariff payload to write. Use this for advanced structural edits."
+        },
+        "purchase_tariff": {
+          "name": "Import Tariff Structure",
+          "description": "Replacement import tariff branch with type, seasons, periods, tiers, and rates."
+        },
+        "buyback_tariff": {
+          "name": "Export Tariff Structure",
+          "description": "Replacement export tariff branch with type, export plan, seasons, periods, tiers, and rates."
+        },
+        "configure_import_tariff": {
+          "name": "Configure Import Tariff",
+          "description": "Enable this to build a replacement import tariff from the guided fields below."
+        },
+        "import_tariff_type": {
+          "name": "Import Tariff Type",
+          "description": "Choose whether import pricing is flat, time of use, or tiered."
+        },
+        "import_variation": {
+          "name": "Import Variation",
+          "description": "Choose whether import pricing changes by season or weekday/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Import Flat Rate",
+          "description": "Single import rate used when the import tariff type is flat and no period rows are provided."
+        },
+        "import_periods": {
+          "name": "Import Period Rows",
+          "description": "Rows for flat or time-of-use import pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "import_tiers": {
+          "name": "Import Tier Rows",
+          "description": "Rows for tiered import pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "import_off_peak_rate": {
+          "name": "Import Off-Peak Baseline",
+          "description": "Baseline off-peak import rate for tiered tariffs."
+        },
+        "configure_export_tariff": {
+          "name": "Configure Export Tariff",
+          "description": "Enable this to build a replacement export tariff from the guided fields below."
+        },
+        "export_tariff_type": {
+          "name": "Export Tariff Type",
+          "description": "Choose whether export compensation is flat, time of use, or tiered."
+        },
+        "export_variation": {
+          "name": "Export Variation",
+          "description": "Choose whether export pricing changes by season or weekday/weekend."
+        },
+        "export_plan": {
+          "name": "Export Plan",
+          "description": "Choose the Enphase export plan label to write with the export tariff."
+        },
+        "export_flat_rate": {
+          "name": "Export Flat Rate",
+          "description": "Single export rate used when the export tariff type is flat and no period rows are provided."
+        },
+        "export_periods": {
+          "name": "Export Period Rows",
+          "description": "Rows for flat or time-of-use export pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "export_tiers": {
+          "name": "Export Tier Rows",
+          "description": "Rows for tiered export pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "export_off_peak_rate": {
+          "name": "Export Off-Peak Baseline",
+          "description": "Baseline off-peak export rate for tiered tariffs."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Export Off-Peak Baseline",
           "description": "Baseline off-peak export rate for tiered tariffs."
+        },
+        "device_id": {
+          "name": "Device",
+          "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Enable advanced confirmation to send {message}."
+    },
+    "tariff_update_required": {
+      "message": "Provide billing details or at least one tariff rate update."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Provide billing start date, frequency, and interval."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Tariff billing start date must be a valid ISO date."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Tariff billing frequency must be MONTH or DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Tariff billing interval must be between {minimum} and {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Tariff billing write API is unavailable."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Duplicate tariff rate targets are not allowed."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Duplicate tariff rate entity: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "All tariff updates must target the same Enphase site."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tariff structure is invalid."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Set Tariff Rate",
-      "description": "Update one existing Enphase import or export tariff rate value.",
+    "update_tariff": {
+      "name": "Update Tariff",
+      "description": "Update Enphase billing-cycle details, guided tariff structures, and one or more existing import or export tariff rate values.",
       "fields": {
         "rate": {
           "name": "Rate",
-          "description": "New non-negative tariff rate value."
+          "description": "New non-negative tariff rate value for the selected tariff rate entity."
+        },
+        "rate_entity": {
+          "name": "Rate Entity",
+          "description": "Optional tariff rate entity to update when not using the action target."
+        },
+        "import_rate": {
+          "name": "Import Rate",
+          "description": "New non-negative import tariff rate value."
+        },
+        "import_rate_entity": {
+          "name": "Import Rate Entity",
+          "description": "Import tariff rate entity to update."
+        },
+        "export_rate": {
+          "name": "Export Rate",
+          "description": "New non-negative export tariff rate value."
+        },
+        "export_rate_entity": {
+          "name": "Export Rate Entity",
+          "description": "Export tariff rate entity to update."
+        },
+        "billing_start_date": {
+          "name": "Billing Start Date",
+          "description": "Bill period start date in ISO format."
+        },
+        "billing_frequency": {
+          "name": "Billing Frequency",
+          "description": "Billing interval unit: MONTH or DAY."
+        },
+        "billing_interval_value": {
+          "name": "Billing Interval",
+          "description": "Billing interval count. Use 1-24 for months or 1-100 for days."
+        },
+        "rates": {
+          "name": "Rates",
+          "description": "List of tariff rate entity IDs and non-negative rate values to update."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier for billing updates."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        },
+        "tariff_payload": {
+          "name": "Tariff Payload",
+          "description": "Complete Enphase tariff payload to write. Use this for advanced structural edits."
+        },
+        "purchase_tariff": {
+          "name": "Import Tariff Structure",
+          "description": "Replacement import tariff branch with type, seasons, periods, tiers, and rates."
+        },
+        "buyback_tariff": {
+          "name": "Export Tariff Structure",
+          "description": "Replacement export tariff branch with type, export plan, seasons, periods, tiers, and rates."
+        },
+        "configure_import_tariff": {
+          "name": "Configure Import Tariff",
+          "description": "Enable this to build a replacement import tariff from the guided fields below."
+        },
+        "import_tariff_type": {
+          "name": "Import Tariff Type",
+          "description": "Choose whether import pricing is flat, time of use, or tiered."
+        },
+        "import_variation": {
+          "name": "Import Variation",
+          "description": "Choose whether import pricing changes by season or weekday/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Import Flat Rate",
+          "description": "Single import rate used when the import tariff type is flat and no period rows are provided."
+        },
+        "import_periods": {
+          "name": "Import Period Rows",
+          "description": "Rows for flat or time-of-use import pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "import_tiers": {
+          "name": "Import Tier Rows",
+          "description": "Rows for tiered import pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "import_off_peak_rate": {
+          "name": "Import Off-Peak Baseline",
+          "description": "Baseline off-peak import rate for tiered tariffs."
+        },
+        "configure_export_tariff": {
+          "name": "Configure Export Tariff",
+          "description": "Enable this to build a replacement export tariff from the guided fields below."
+        },
+        "export_tariff_type": {
+          "name": "Export Tariff Type",
+          "description": "Choose whether export compensation is flat, time of use, or tiered."
+        },
+        "export_variation": {
+          "name": "Export Variation",
+          "description": "Choose whether export pricing changes by season or weekday/weekend."
+        },
+        "export_plan": {
+          "name": "Export Plan",
+          "description": "Choose the Enphase export plan label to write with the export tariff."
+        },
+        "export_flat_rate": {
+          "name": "Export Flat Rate",
+          "description": "Single export rate used when the export tariff type is flat and no period rows are provided."
+        },
+        "export_periods": {
+          "name": "Export Period Rows",
+          "description": "Rows for flat or time-of-use export pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "export_tiers": {
+          "name": "Export Tier Rows",
+          "description": "Rows for tiered export pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "export_off_peak_rate": {
+          "name": "Export Off-Peak Baseline",
+          "description": "Baseline off-peak export rate for tiered tariffs."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Export Off-Peak Baseline",
           "description": "Baseline off-peak export rate for tiered tariffs."
+        },
+        "device_id": {
+          "name": "Device",
+          "description": "Optional Enphase device to choose the site for billing or structural tariff updates."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Enable advanced confirmation to send {message}."
+    },
+    "tariff_update_required": {
+      "message": "Provide billing details or at least one tariff rate update."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Provide billing start date, frequency, and interval."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Tariff billing start date must be a valid ISO date."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Tariff billing frequency must be MONTH or DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Tariff billing interval must be between {minimum} and {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Tariff billing write API is unavailable."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Duplicate tariff rate targets are not allowed."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Duplicate tariff rate entity: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "All tariff updates must target the same Enphase site."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tariff structure is invalid."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Set Tariff Rate",
-      "description": "Update one existing Enphase import or export tariff rate value.",
+    "update_tariff": {
+      "name": "Update Tariff",
+      "description": "Update Enphase billing-cycle details, guided tariff structures, and one or more existing import or export tariff rate values.",
       "fields": {
         "rate": {
           "name": "Rate",
-          "description": "New non-negative tariff rate value."
+          "description": "New non-negative tariff rate value for the selected tariff rate entity."
+        },
+        "rate_entity": {
+          "name": "Rate Entity",
+          "description": "Optional tariff rate entity to update when not using the action target."
+        },
+        "import_rate": {
+          "name": "Import Rate",
+          "description": "New non-negative import tariff rate value."
+        },
+        "import_rate_entity": {
+          "name": "Import Rate Entity",
+          "description": "Import tariff rate entity to update."
+        },
+        "export_rate": {
+          "name": "Export Rate",
+          "description": "New non-negative export tariff rate value."
+        },
+        "export_rate_entity": {
+          "name": "Export Rate Entity",
+          "description": "Export tariff rate entity to update."
+        },
+        "billing_start_date": {
+          "name": "Billing Start Date",
+          "description": "Bill period start date in ISO format."
+        },
+        "billing_frequency": {
+          "name": "Billing Frequency",
+          "description": "Billing interval unit: MONTH or DAY."
+        },
+        "billing_interval_value": {
+          "name": "Billing Interval",
+          "description": "Billing interval count. Use 1-24 for months or 1-100 for days."
+        },
+        "rates": {
+          "name": "Rates",
+          "description": "List of tariff rate entity IDs and non-negative rate values to update."
+        },
+        "site_id": {
+          "name": "Site ID",
+          "description": "Optional site identifier for billing updates."
+        },
+        "config_entry_id": {
+          "name": "Config Entry ID",
+          "description": "Optional config entry identifier for a single Enphase site entry."
+        },
+        "tariff_payload": {
+          "name": "Tariff Payload",
+          "description": "Complete Enphase tariff payload to write. Use this for advanced structural edits."
+        },
+        "purchase_tariff": {
+          "name": "Import Tariff Structure",
+          "description": "Replacement import tariff branch with type, seasons, periods, tiers, and rates."
+        },
+        "buyback_tariff": {
+          "name": "Export Tariff Structure",
+          "description": "Replacement export tariff branch with type, export plan, seasons, periods, tiers, and rates."
+        },
+        "configure_import_tariff": {
+          "name": "Configure Import Tariff",
+          "description": "Enable this to build a replacement import tariff from the guided fields below."
+        },
+        "import_tariff_type": {
+          "name": "Import Tariff Type",
+          "description": "Choose whether import pricing is flat, time of use, or tiered."
+        },
+        "import_variation": {
+          "name": "Import Variation",
+          "description": "Choose whether import pricing changes by season or weekday/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Import Flat Rate",
+          "description": "Single import rate used when the import tariff type is flat and no period rows are provided."
+        },
+        "import_periods": {
+          "name": "Import Period Rows",
+          "description": "Rows for flat or time-of-use import pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "import_tiers": {
+          "name": "Import Tier Rows",
+          "description": "Rows for tiered import pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "import_off_peak_rate": {
+          "name": "Import Off-Peak Baseline",
+          "description": "Baseline off-peak import rate for tiered tariffs."
+        },
+        "configure_export_tariff": {
+          "name": "Configure Export Tariff",
+          "description": "Enable this to build a replacement export tariff from the guided fields below."
+        },
+        "export_tariff_type": {
+          "name": "Export Tariff Type",
+          "description": "Choose whether export compensation is flat, time of use, or tiered."
+        },
+        "export_variation": {
+          "name": "Export Variation",
+          "description": "Choose whether export pricing changes by season or weekday/weekend."
+        },
+        "export_plan": {
+          "name": "Export Plan",
+          "description": "Choose the Enphase export plan label to write with the export tariff."
+        },
+        "export_flat_rate": {
+          "name": "Export Flat Rate",
+          "description": "Single export rate used when the export tariff type is flat and no period rows are provided."
+        },
+        "export_periods": {
+          "name": "Export Period Rows",
+          "description": "Rows for flat or time-of-use export pricing. Use days 1-7 for Monday-Sunday; times can be HH:MM or minutes after midnight."
+        },
+        "export_tiers": {
+          "name": "Export Tier Rows",
+          "description": "Rows for tiered export pricing. Use end_value -1 for the final unbounded tier."
+        },
+        "export_off_peak_rate": {
+          "name": "Export Off-Peak Baseline",
+          "description": "Baseline off-peak export rate for tiered tariffs."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Base valle de exportación",
           "description": "Tarifa valle base para tarifas de exportación por tramos."
+        },
+        "device_id": {
+          "name": "Dispositivo",
+          "description": "Dispositivo Enphase opcional para elegir el sitio de las actualizaciones de facturación o estructura tarifaria."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Activa la confirmación avanzada para enviar {message}."
+    },
+    "tariff_update_required": {
+      "message": "Proporciona detalles de facturación o al menos una actualización de tarifa."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Proporciona la fecha de inicio, la frecuencia y el intervalo de facturación."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "La fecha de inicio de facturación de la tarifa debe ser una fecha ISO válida."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "La frecuencia de facturación de la tarifa debe ser MONTH o DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "El intervalo de facturación de la tarifa debe estar entre {minimum} y {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "La API de escritura de facturación de tarifas no está disponible."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "No se permiten destinos de tarifa duplicados."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Entidad de tarifa duplicada: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Todas las actualizaciones de tarifa deben apuntar al mismo sitio de Enphase."
+    },
+    "tariff_structure_invalid": {
+      "message": "La estructura de la tarifa no es válida."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Establecer tarifa",
-      "description": "Actualiza un valor existente de tarifa de importación o exportación de Enphase.",
+    "update_tariff": {
+      "name": "Actualizar tarifa",
+      "description": "Actualiza los detalles del ciclo de facturación de Enphase y uno o más valores existentes de tarifa de importación o exportación.",
       "fields": {
         "rate": {
           "name": "Tarifa",
-          "description": "Nuevo valor de tarifa no negativo."
+          "description": "Nuevo valor de tarifa no negativo para la entidad de tarifa seleccionada."
+        },
+        "rate_entity": {
+          "name": "Entidad de tarifa",
+          "description": "Entidad de tarifa opcional para actualizar cuando no se usa el destino de la acción."
+        },
+        "import_rate": {
+          "name": "Tarifa de importación",
+          "description": "Nuevo valor no negativo de tarifa de importación."
+        },
+        "import_rate_entity": {
+          "name": "Entidad de tarifa de importación",
+          "description": "Entidad de tarifa de importación que se actualizará."
+        },
+        "export_rate": {
+          "name": "Tarifa de exportación",
+          "description": "Nuevo valor no negativo de tarifa de exportación."
+        },
+        "export_rate_entity": {
+          "name": "Entidad de tarifa de exportación",
+          "description": "Entidad de tarifa de exportación que se actualizará."
+        },
+        "billing_start_date": {
+          "name": "Fecha de inicio de facturación",
+          "description": "Fecha de inicio del periodo de facturación en formato ISO."
+        },
+        "billing_frequency": {
+          "name": "Frecuencia de facturación",
+          "description": "Unidad del intervalo de facturación: MONTH o DAY."
+        },
+        "billing_interval_value": {
+          "name": "Intervalo de facturación",
+          "description": "Cantidad de intervalos de facturación. Usa 1-24 para meses o 1-100 para días."
+        },
+        "rates": {
+          "name": "Tarifas",
+          "description": "Lista de IDs de entidades de tarifa y valores no negativos que se actualizarán."
+        },
+        "site_id": {
+          "name": "ID del sitio",
+          "description": "Identificador opcional del sitio para actualizaciones de facturación."
+        },
+        "config_entry_id": {
+          "name": "ID de entrada de configuración",
+          "description": "Identificador opcional de entrada de configuración para un único sitio de Enphase."
+        },
+        "tariff_payload": {
+          "name": "Carga útil de tarifa",
+          "description": "Carga útil completa de tarifa de Enphase para escribir. Úsela para ediciones estructurales avanzadas."
+        },
+        "purchase_tariff": {
+          "name": "Estructura de tarifa de importación",
+          "description": "Rama de reemplazo de la tarifa de importación con tipo, temporadas, periodos, tramos y precios."
+        },
+        "buyback_tariff": {
+          "name": "Estructura de tarifa de exportación",
+          "description": "Rama de reemplazo de la tarifa de exportación con tipo, plan de exportación, temporadas, periodos, tramos y precios."
+        },
+        "configure_import_tariff": {
+          "name": "Configurar tarifa de importación",
+          "description": "Actívelo para crear una tarifa de importación de reemplazo con los campos guiados."
+        },
+        "import_tariff_type": {
+          "name": "Tipo de tarifa de importación",
+          "description": "Elija tarifa plana, por horario o por tramos."
+        },
+        "import_variation": {
+          "name": "Variación de importación",
+          "description": "Elija si cambia por temporada o por días laborables/fines de semana."
+        },
+        "import_flat_rate": {
+          "name": "Tarifa plana de importación",
+          "description": "Tarifa única de importación para tipo plano sin filas de períodos."
+        },
+        "import_periods": {
+          "name": "Filas de períodos de importación",
+          "description": "Filas para precios planos o por horario. Los días 1-7 son lunes-domingo; horas HH:MM o minutos tras medianoche."
+        },
+        "import_tiers": {
+          "name": "Filas de tramos de importación",
+          "description": "Filas para precios de importación por tramos. end_value -1 indica el último tramo ilimitado."
+        },
+        "import_off_peak_rate": {
+          "name": "Base valle de importación",
+          "description": "Tarifa valle base para tarifas de importación por tramos."
+        },
+        "configure_export_tariff": {
+          "name": "Configurar tarifa de exportación",
+          "description": "Actívelo para crear una tarifa de exportación de reemplazo con los campos guiados."
+        },
+        "export_tariff_type": {
+          "name": "Tipo de tarifa de exportación",
+          "description": "Elija tarifa plana, por horario o por tramos."
+        },
+        "export_variation": {
+          "name": "Variación de exportación",
+          "description": "Elija si cambia por temporada o por días laborables/fines de semana."
+        },
+        "export_plan": {
+          "name": "Plan de exportación",
+          "description": "Elija la etiqueta de plan de exportación Enphase que se escribirá."
+        },
+        "export_flat_rate": {
+          "name": "Tarifa plana de exportación",
+          "description": "Tarifa única de exportación para tipo plano sin filas de períodos."
+        },
+        "export_periods": {
+          "name": "Filas de períodos de exportación",
+          "description": "Filas para precios planos o por horario. Los días 1-7 son lunes-domingo; horas HH:MM o minutos tras medianoche."
+        },
+        "export_tiers": {
+          "name": "Filas de tramos de exportación",
+          "description": "Filas para precios de exportación por tramos. end_value -1 indica el último tramo ilimitado."
+        },
+        "export_off_peak_rate": {
+          "name": "Base valle de exportación",
+          "description": "Tarifa valle base para tarifas de exportación por tramos."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Luba täpsem kinnitus, et saata {message}."
+    },
+    "tariff_update_required": {
+      "message": "Sisesta arveldusandmed või vähemalt üks tariifimäära uuendus."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Sisesta arvelduse alguskuupäev, sagedus ja intervall."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Tariifi arvelduse alguskuupäev peab olema kehtiv ISO-kuupäev."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Tariifi arveldussagedus peab olema MONTH või DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Tariifi arveldusintervall peab olema vahemikus {minimum} kuni {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Tariifi arvelduse kirjutamise API pole saadaval."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Topelt tariifimäära sihtmärgid pole lubatud."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Topelt tariifimäära olem: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Kõik tariifiuuendused peavad sihtima sama Enphase’i saiti."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tariifi struktuur on vigane."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Määra tariifimäär",
-      "description": "Uuendab ühte olemasolevat Enphase impordi- või eksporditariifi väärtust.",
+    "update_tariff": {
+      "name": "Uuenda tariifi",
+      "description": "Uuendab Enphase’i arveldustsükli andmeid ja üht või mitut olemasolevat impordi- või eksporditariifi määra.",
       "fields": {
         "rate": {
           "name": "Määr",
-          "description": "Uus mittenegatiivne tariifimäär."
+          "description": "Uus mittenegatiivne tariifimäär valitud tariifimäära olemile."
+        },
+        "rate_entity": {
+          "name": "Määra olem",
+          "description": "Valikuline tariifimäära olem uuendamiseks, kui toimingu sihtmärki ei kasutata."
+        },
+        "import_rate": {
+          "name": "Impordimäär",
+          "description": "Uus mittenegatiivne imporditariifi määr."
+        },
+        "import_rate_entity": {
+          "name": "Impordimäära olem",
+          "description": "Uuendatav imporditariifi määra olem."
+        },
+        "export_rate": {
+          "name": "Ekspordimäär",
+          "description": "Uus mittenegatiivne eksporditariifi määr."
+        },
+        "export_rate_entity": {
+          "name": "Ekspordimäära olem",
+          "description": "Uuendatav eksporditariifi määra olem."
+        },
+        "billing_start_date": {
+          "name": "Arvelduse alguskuupäev",
+          "description": "Arveldusperioodi alguskuupäev ISO-vormingus."
+        },
+        "billing_frequency": {
+          "name": "Arveldussagedus",
+          "description": "Arveldusintervalli ühik: MONTH või DAY."
+        },
+        "billing_interval_value": {
+          "name": "Arveldusintervall",
+          "description": "Arveldusintervallide arv. Kasuta kuude jaoks 1-24 või päevade jaoks 1-100."
+        },
+        "rates": {
+          "name": "Määrad",
+          "description": "Uuendatavate tariifimäära olemi ID-de ja mittenegatiivsete määrade loend."
+        },
+        "site_id": {
+          "name": "Saidi ID",
+          "description": "Valikuline saidi identifikaator arvelduse uuenduste jaoks."
+        },
+        "config_entry_id": {
+          "name": "Seadistuskirje ID",
+          "description": "Valikuline seadistuskirje identifikaator ühe Enphase’i saidi jaoks."
+        },
+        "tariff_payload": {
+          "name": "Tariifi payload",
+          "description": "Täielik Enphase tariifi payload kirjutamiseks. Kasutage seda täiustatud struktuurimuudatusteks."
+        },
+        "purchase_tariff": {
+          "name": "Imporditariifi struktuur",
+          "description": "Asendav imporditariifi haru tüübi, hooaegade, perioodide, astmete ja hindadega."
+        },
+        "buyback_tariff": {
+          "name": "Eksporditariifi struktuur",
+          "description": "Asendav eksporditariifi haru tüübi, ekspordiplaani, hooaegade, perioodide, astmete ja hindadega."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Ota lisävahvistus käyttöön lähettääksesi viestin {message}."
+    },
+    "tariff_update_required": {
+      "message": "Anna laskutustiedot tai vähintään yksi tariffihinnan päivitys."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Anna laskutuksen aloituspäivä, tiheys ja väli."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Tariffilaskutuksen aloituspäivän on oltava kelvollinen ISO-päivä."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Tariffilaskutuksen tiheyden on oltava MONTH tai DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Tariffilaskutuksen välin on oltava välillä {minimum} ja {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Tariffilaskutuksen kirjoitus-API ei ole käytettävissä."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Päällekkäisiä tariffihinnan kohteita ei sallita."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Päällekkäinen tariffihintaentiteetti: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Kaikkien tariffipäivitysten on kohdistuttava samaan Enphase-kohteeseen."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tariffirakenne on virheellinen."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Aseta tariffihinta",
-      "description": "Päivittää yhden olemassa olevan Enphase-tuonti- tai vientitariffin arvon.",
+    "update_tariff": {
+      "name": "Päivitä tariffi",
+      "description": "Päivitä Enphase-laskutusjakson tiedot ja yksi tai useampi olemassa oleva tuonti- tai vientitariffihinta.",
       "fields": {
         "rate": {
           "name": "Hinta",
-          "description": "Uusi ei-negatiivinen tariffihinta."
+          "description": "Uusi ei-negatiivinen tariffihinta valitulle tariffihintaentiteetille."
+        },
+        "rate_entity": {
+          "name": "Hintaentiteetti",
+          "description": "Valinnainen tariffihintaentiteetti päivitettäväksi, kun toiminnon kohdetta ei käytetä."
+        },
+        "import_rate": {
+          "name": "Tuontihinta",
+          "description": "Uusi ei-negatiivinen tuontitariffihinta."
+        },
+        "import_rate_entity": {
+          "name": "Tuontihintaentiteetti",
+          "description": "Päivitettävä tuontitariffihintaentiteetti."
+        },
+        "export_rate": {
+          "name": "Vientihinta",
+          "description": "Uusi ei-negatiivinen vientitariffihinta."
+        },
+        "export_rate_entity": {
+          "name": "Vientihintaentiteetti",
+          "description": "Päivitettävä vientitariffihintaentiteetti."
+        },
+        "billing_start_date": {
+          "name": "Laskutuksen aloituspäivä",
+          "description": "Laskutuskauden aloituspäivä ISO-muodossa."
+        },
+        "billing_frequency": {
+          "name": "Laskutustiheys",
+          "description": "Laskutusvälin yksikkö: MONTH tai DAY."
+        },
+        "billing_interval_value": {
+          "name": "Laskutusväli",
+          "description": "Laskutusvälien määrä. Käytä kuukausille 1-24 tai päiville 1-100."
+        },
+        "rates": {
+          "name": "Hinnat",
+          "description": "Luettelo päivitettävistä tariffihintaentiteettien ID:istä ja ei-negatiivisista hinnoista."
+        },
+        "site_id": {
+          "name": "Kohteen ID",
+          "description": "Valinnainen kohteen tunniste laskutuspäivityksille."
+        },
+        "config_entry_id": {
+          "name": "Määrityskirjauksen ID",
+          "description": "Valinnainen määrityskirjauksen tunniste yhdelle Enphase-kohteelle."
+        },
+        "tariff_payload": {
+          "name": "Tariffin payload",
+          "description": "Täydellinen kirjoitettava Enphase-tariffin payload. Käytä edistyneisiin rakennepäivityksiin."
+        },
+        "purchase_tariff": {
+          "name": "Tuontitariffin rakenne",
+          "description": "Korvaava tuontitariffin haara, jossa on tyyppi, kaudet, jaksot, portaat ja hinnat."
+        },
+        "buyback_tariff": {
+          "name": "Vientitariffin rakenne",
+          "description": "Korvaava vientitariffin haara, jossa on tyyppi, vientisuunnitelma, kaudet, jaksot, portaat ja hinnat."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Base hors pointe d’export",
           "description": "Tarif hors pointe de base pour les tarifs d’export par paliers."
+        },
+        "device_id": {
+          "name": "Appareil",
+          "description": "Appareil Enphase facultatif pour choisir le site des mises à jour de facturation ou de structure tarifaire."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Activez la confirmation avancée pour envoyer {message}."
+    },
+    "tariff_update_required": {
+      "message": "Fournissez les détails de facturation ou au moins une mise à jour de tarif."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Fournissez la date de début, la fréquence et l’intervalle de facturation."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "La date de début de facturation du tarif doit être une date ISO valide."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "La fréquence de facturation du tarif doit être MONTH ou DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "L’intervalle de facturation du tarif doit être compris entre {minimum} et {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "L’API d’écriture de facturation du tarif n’est pas disponible."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Les cibles de tarif en double ne sont pas autorisées."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Entité de tarif en double : {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Toutes les mises à jour de tarif doivent cibler le même site Enphase."
+    },
+    "tariff_structure_invalid": {
+      "message": "La structure tarifaire est invalide."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Définir le tarif",
-      "description": "Met à jour une valeur existante de tarif d’importation ou d’exportation Enphase.",
+    "update_tariff": {
+      "name": "Mettre à jour le tarif",
+      "description": "Met à jour les détails du cycle de facturation Enphase et une ou plusieurs valeurs de tarif d’importation ou d’exportation existantes.",
       "fields": {
         "rate": {
           "name": "Tarif",
-          "description": "Nouvelle valeur de tarif non négative."
+          "description": "Nouvelle valeur de tarif non négative pour l’entité de tarif sélectionnée."
+        },
+        "rate_entity": {
+          "name": "Entité de tarif",
+          "description": "Entité de tarif facultative à mettre à jour lorsque la cible de l’action n’est pas utilisée."
+        },
+        "import_rate": {
+          "name": "Tarif d’importation",
+          "description": "Nouvelle valeur non négative du tarif d’importation."
+        },
+        "import_rate_entity": {
+          "name": "Entité de tarif d’importation",
+          "description": "Entité de tarif d’importation à mettre à jour."
+        },
+        "export_rate": {
+          "name": "Tarif d’exportation",
+          "description": "Nouvelle valeur non négative du tarif d’exportation."
+        },
+        "export_rate_entity": {
+          "name": "Entité de tarif d’exportation",
+          "description": "Entité de tarif d’exportation à mettre à jour."
+        },
+        "billing_start_date": {
+          "name": "Date de début de facturation",
+          "description": "Date de début de la période de facturation au format ISO."
+        },
+        "billing_frequency": {
+          "name": "Fréquence de facturation",
+          "description": "Unité de l’intervalle de facturation : MONTH ou DAY."
+        },
+        "billing_interval_value": {
+          "name": "Intervalle de facturation",
+          "description": "Nombre d’intervalles de facturation. Utilisez 1-24 pour les mois ou 1-100 pour les jours."
+        },
+        "rates": {
+          "name": "Tarifs",
+          "description": "Liste des ID d’entité de tarif et des valeurs non négatives à mettre à jour."
+        },
+        "site_id": {
+          "name": "ID du site",
+          "description": "Identifiant de site facultatif pour les mises à jour de facturation."
+        },
+        "config_entry_id": {
+          "name": "ID d’entrée de configuration",
+          "description": "Identifiant facultatif d’entrée de configuration pour un seul site Enphase."
+        },
+        "tariff_payload": {
+          "name": "Charge utile tarifaire",
+          "description": "Charge utile tarifaire Enphase complète à écrire. À utiliser pour les modifications structurelles avancées."
+        },
+        "purchase_tariff": {
+          "name": "Structure du tarif d’import",
+          "description": "Branche de remplacement du tarif d’import avec type, saisons, périodes, paliers et tarifs."
+        },
+        "buyback_tariff": {
+          "name": "Structure du tarif d’export",
+          "description": "Branche de remplacement du tarif d’export avec type, plan d’export, saisons, périodes, paliers et tarifs."
+        },
+        "configure_import_tariff": {
+          "name": "Configurer le tarif d’import",
+          "description": "Activez pour créer un tarif d’import de remplacement avec les champs guidés."
+        },
+        "import_tariff_type": {
+          "name": "Type de tarif d’import",
+          "description": "Choisissez un tarif plat, heures d’utilisation ou par paliers."
+        },
+        "import_variation": {
+          "name": "Variation d’import",
+          "description": "Choisissez les variations par saison ou semaine/week-end."
+        },
+        "import_flat_rate": {
+          "name": "Tarif d’import plat",
+          "description": "Tarif d’import unique pour un tarif plat sans lignes de période."
+        },
+        "import_periods": {
+          "name": "Lignes de périodes d’import",
+          "description": "Lignes pour les tarifs plats ou horaires. Les jours 1-7 sont lundi-dimanche; heures HH:MM ou minutes après minuit."
+        },
+        "import_tiers": {
+          "name": "Lignes de paliers d’import",
+          "description": "Lignes pour les tarifs d’import par paliers. end_value -1 indique le dernier palier illimité."
+        },
+        "import_off_peak_rate": {
+          "name": "Base hors pointe d’import",
+          "description": "Tarif hors pointe de base pour les tarifs d’import par paliers."
+        },
+        "configure_export_tariff": {
+          "name": "Configurer le tarif d’export",
+          "description": "Activez pour créer un tarif d’export de remplacement avec les champs guidés."
+        },
+        "export_tariff_type": {
+          "name": "Type de tarif d’export",
+          "description": "Choisissez un tarif plat, heures d’utilisation ou par paliers."
+        },
+        "export_variation": {
+          "name": "Variation d’export",
+          "description": "Choisissez les variations par saison ou semaine/week-end."
+        },
+        "export_plan": {
+          "name": "Plan d’export",
+          "description": "Choisissez le libellé de plan d’export Enphase à écrire."
+        },
+        "export_flat_rate": {
+          "name": "Tarif d’export plat",
+          "description": "Tarif d’export unique pour un tarif plat sans lignes de période."
+        },
+        "export_periods": {
+          "name": "Lignes de périodes d’export",
+          "description": "Lignes pour les tarifs plats ou horaires. Les jours 1-7 sont lundi-dimanche; heures HH:MM ou minutes après minuit."
+        },
+        "export_tiers": {
+          "name": "Lignes de paliers d’export",
+          "description": "Lignes pour les tarifs d’export par paliers. end_value -1 indique le dernier palier illimité."
+        },
+        "export_off_peak_rate": {
+          "name": "Base hors pointe d’export",
+          "description": "Tarif hors pointe de base pour les tarifs d’export par paliers."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Engedélyezze a speciális megerősítést a(z) {message} küldéséhez."
+    },
+    "tariff_update_required": {
+      "message": "Adja meg a számlázási adatokat vagy legalább egy tarifaár-frissítést."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Adja meg a számlázás kezdő dátumát, gyakoriságát és intervallumát."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "A tarifa számlázási kezdő dátumának érvényes ISO-dátumnak kell lennie."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "A tarifa számlázási gyakorisága MONTH vagy DAY lehet."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "A tarifa számlázási intervalluma {minimum} és {maximum} között lehet."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "A tarifa számlázási írási API nem érhető el."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Ismétlődő tarifaár-célok nem engedélyezettek."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Ismétlődő tarifaár entitás: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Minden tarifafrissítésnek ugyanarra az Enphase helyre kell mutatnia."
+    },
+    "tariff_structure_invalid": {
+      "message": "A tarifa szerkezete érvénytelen."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Tarifadíj beállítása",
-      "description": "Frissít egy meglévő Enphase import- vagy exporttarifadíj értéket.",
+    "update_tariff": {
+      "name": "Tarifa frissítése",
+      "description": "Frissíti az Enphase számlázási ciklus adatait és egy vagy több meglévő import- vagy exporttarifa értékét.",
       "fields": {
         "rate": {
           "name": "Díj",
-          "description": "Új, nem negatív tarifadíj érték."
+          "description": "Új nem negatív tarifaérték a kiválasztott tarifaentitáshoz."
+        },
+        "rate_entity": {
+          "name": "Díjentitás",
+          "description": "Opcionális tarifaentitás frissítéshez, ha nem az akció célját használja."
+        },
+        "import_rate": {
+          "name": "Importdíj",
+          "description": "Új nem negatív importtarifa-érték."
+        },
+        "import_rate_entity": {
+          "name": "Importdíj entitás",
+          "description": "Frissítendő importtarifa-entitás."
+        },
+        "export_rate": {
+          "name": "Exportdíj",
+          "description": "Új nem negatív exporttarifa-érték."
+        },
+        "export_rate_entity": {
+          "name": "Exportdíj entitás",
+          "description": "Frissítendő exporttarifa-entitás."
+        },
+        "billing_start_date": {
+          "name": "Számlázás kezdő dátuma",
+          "description": "A számlázási időszak kezdő dátuma ISO formátumban."
+        },
+        "billing_frequency": {
+          "name": "Számlázási gyakoriság",
+          "description": "A számlázási intervallum egysége: MONTH vagy DAY."
+        },
+        "billing_interval_value": {
+          "name": "Számlázási intervallum",
+          "description": "A számlázási intervallumok száma. Hónapokhoz 1-24, napokhoz 1-100 használható."
+        },
+        "rates": {
+          "name": "Díjak",
+          "description": "Frissítendő tarifaár-entitásazonosítók és nem negatív értékek listája."
+        },
+        "site_id": {
+          "name": "Helyazonosító",
+          "description": "Opcionális helyazonosító számlázási frissítésekhez."
+        },
+        "config_entry_id": {
+          "name": "Konfigurációs bejegyzés azonosítója",
+          "description": "Opcionális konfigurációs bejegyzés azonosító egyetlen Enphase helyhez."
+        },
+        "tariff_payload": {
+          "name": "Tarifa payload",
+          "description": "Teljes írandó Enphase tarifa payload. Haladó szerkezeti módosításokhoz használja."
+        },
+        "purchase_tariff": {
+          "name": "Importtarifa szerkezete",
+          "description": "Csere importtarifa ág típussal, szezonokkal, időszakokkal, sávokkal és díjakkal."
+        },
+        "buyback_tariff": {
+          "name": "Exporttarifa szerkezete",
+          "description": "Csere exporttarifa ág típussal, exporttervvel, szezonokkal, időszakokkal, sávokkal és díjakkal."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Base fuori punta esportazione",
           "description": "Tariffa base fuori punta per tariffe di esportazione a scaglioni."
+        },
+        "device_id": {
+          "name": "Dispositivo",
+          "description": "Dispositivo Enphase opzionale per scegliere il sito degli aggiornamenti di fatturazione o struttura tariffaria."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Abilita la conferma avanzata per inviare {message}."
+    },
+    "tariff_update_required": {
+      "message": "Fornisci i dettagli di fatturazione o almeno un aggiornamento della tariffa."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Fornisci data di inizio, frequenza e intervallo di fatturazione."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "La data di inizio fatturazione della tariffa deve essere una data ISO valida."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "La frequenza di fatturazione della tariffa deve essere MONTH o DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "L’intervallo di fatturazione della tariffa deve essere compreso tra {minimum} e {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "L’API di scrittura della fatturazione tariffaria non è disponibile."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Non sono consentite destinazioni tariffarie duplicate."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Entità tariffaria duplicata: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Tutti gli aggiornamenti tariffari devono riguardare lo stesso sito Enphase."
+    },
+    "tariff_structure_invalid": {
+      "message": "La struttura tariffaria non è valida."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Imposta tariffa",
-      "description": "Aggiorna un valore esistente della tariffa di importazione o esportazione Enphase.",
+    "update_tariff": {
+      "name": "Aggiorna tariffa",
+      "description": "Aggiorna i dettagli del ciclo di fatturazione Enphase e uno o più valori tariffari di importazione o esportazione esistenti.",
       "fields": {
         "rate": {
           "name": "Tariffa",
-          "description": "Nuovo valore tariffario non negativo."
+          "description": "Nuovo valore tariffario non negativo per l’entità tariffaria selezionata."
+        },
+        "rate_entity": {
+          "name": "Entità tariffaria",
+          "description": "Entità tariffaria opzionale da aggiornare quando non si usa il target dell’azione."
+        },
+        "import_rate": {
+          "name": "Tariffa di importazione",
+          "description": "Nuovo valore non negativo della tariffa di importazione."
+        },
+        "import_rate_entity": {
+          "name": "Entità tariffa di importazione",
+          "description": "Entità della tariffa di importazione da aggiornare."
+        },
+        "export_rate": {
+          "name": "Tariffa di esportazione",
+          "description": "Nuovo valore non negativo della tariffa di esportazione."
+        },
+        "export_rate_entity": {
+          "name": "Entità tariffa di esportazione",
+          "description": "Entità della tariffa di esportazione da aggiornare."
+        },
+        "billing_start_date": {
+          "name": "Data di inizio fatturazione",
+          "description": "Data di inizio del periodo di fatturazione in formato ISO."
+        },
+        "billing_frequency": {
+          "name": "Frequenza di fatturazione",
+          "description": "Unità dell’intervallo di fatturazione: MONTH o DAY."
+        },
+        "billing_interval_value": {
+          "name": "Intervallo di fatturazione",
+          "description": "Numero di intervalli di fatturazione. Usa 1-24 per i mesi o 1-100 per i giorni."
+        },
+        "rates": {
+          "name": "Tariffe",
+          "description": "Elenco degli ID entità tariffarie e dei valori non negativi da aggiornare."
+        },
+        "site_id": {
+          "name": "ID sito",
+          "description": "Identificatore sito opzionale per aggiornamenti di fatturazione."
+        },
+        "config_entry_id": {
+          "name": "ID voce di configurazione",
+          "description": "Identificatore opzionale della voce di configurazione per un singolo sito Enphase."
+        },
+        "tariff_payload": {
+          "name": "Payload tariffario",
+          "description": "Payload tariffario Enphase completo da scrivere. Usalo per modifiche strutturali avanzate."
+        },
+        "purchase_tariff": {
+          "name": "Struttura tariffa di importazione",
+          "description": "Ramo sostitutivo della tariffa di importazione con tipo, stagioni, periodi, scaglioni e prezzi."
+        },
+        "buyback_tariff": {
+          "name": "Struttura tariffa di esportazione",
+          "description": "Ramo sostitutivo della tariffa di esportazione con tipo, piano di esportazione, stagioni, periodi, scaglioni e prezzi."
+        },
+        "configure_import_tariff": {
+          "name": "Configura tariffa di importazione",
+          "description": "Abilita per creare una tariffa di importazione sostitutiva con i campi guidati."
+        },
+        "import_tariff_type": {
+          "name": "Tipo tariffa di importazione",
+          "description": "Scegli piatta, a fasce orarie o a scaglioni."
+        },
+        "import_variation": {
+          "name": "Variazione importazione",
+          "description": "Scegli se varia per stagione o giorni feriali/fine settimana."
+        },
+        "import_flat_rate": {
+          "name": "Tariffa piatta di importazione",
+          "description": "Tariffa unica di importazione per tipo piatto senza righe periodo."
+        },
+        "import_periods": {
+          "name": "Righe periodi importazione",
+          "description": "Righe per prezzi piatti o a fasce orarie. Giorni 1-7 da lunedì a domenica; orari HH:MM o minuti dopo mezzanotte."
+        },
+        "import_tiers": {
+          "name": "Righe scaglioni importazione",
+          "description": "Righe per prezzi a scaglioni. end_value -1 indica lo scaglione finale illimitato."
+        },
+        "import_off_peak_rate": {
+          "name": "Base fuori punta importazione",
+          "description": "Tariffa base fuori punta per tariffe di importazione a scaglioni."
+        },
+        "configure_export_tariff": {
+          "name": "Configura tariffa di esportazione",
+          "description": "Abilita per creare una tariffa di esportazione sostitutiva con i campi guidati."
+        },
+        "export_tariff_type": {
+          "name": "Tipo tariffa di esportazione",
+          "description": "Scegli piatta, a fasce orarie o a scaglioni."
+        },
+        "export_variation": {
+          "name": "Variazione esportazione",
+          "description": "Scegli se varia per stagione o giorni feriali/fine settimana."
+        },
+        "export_plan": {
+          "name": "Piano di esportazione",
+          "description": "Scegli l’etichetta del piano di esportazione Enphase da scrivere."
+        },
+        "export_flat_rate": {
+          "name": "Tariffa piatta di esportazione",
+          "description": "Tariffa unica di esportazione per tipo piatto senza righe periodo."
+        },
+        "export_periods": {
+          "name": "Righe periodi esportazione",
+          "description": "Righe per prezzi piatti o a fasce orarie. Giorni 1-7 da lunedì a domenica; orari HH:MM o minuti dopo mezzanotte."
+        },
+        "export_tiers": {
+          "name": "Righe scaglioni esportazione",
+          "description": "Righe per prezzi di esportazione a scaglioni. end_value -1 indica lo scaglione finale illimitato."
+        },
+        "export_off_peak_rate": {
+          "name": "Base fuori punta esportazione",
+          "description": "Tariffa base fuori punta per tariffe di esportazione a scaglioni."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Įjunkite išplėstinį patvirtinimą, kad išsiųstumėte {message}."
+    },
+    "tariff_update_required": {
+      "message": "Pateikite atsiskaitymo duomenis arba bent vieną tarifo kainos atnaujinimą."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Pateikite atsiskaitymo pradžios datą, dažnį ir intervalą."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Tarifo atsiskaitymo pradžios data turi būti galiojanti ISO data."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Tarifo atsiskaitymo dažnis turi būti MONTH arba DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Tarifo atsiskaitymo intervalas turi būti nuo {minimum} iki {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Tarifo atsiskaitymo rašymo API nepasiekiama."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Pasikartojantys tarifo kainos tikslai neleidžiami."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Pasikartojantis tarifo kainos objektas: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Visi tarifo atnaujinimai turi būti skirti tai pačiai Enphase vietai."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tarifo struktūra netinkama."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Nustatyti tarifo kainą",
-      "description": "Atnaujina vieną esamą Enphase importo arba eksporto tarifo kainą.",
+    "update_tariff": {
+      "name": "Atnaujinti tarifą",
+      "description": "Atnaujina Enphase atsiskaitymo ciklo duomenis ir vieną ar daugiau esamų importo arba eksporto tarifų kainų.",
       "fields": {
         "rate": {
           "name": "Kaina",
-          "description": "Nauja neneigiama tarifo kaina."
+          "description": "Nauja neneigiama tarifo reikšmė pasirinktai tarifo entitetui."
+        },
+        "rate_entity": {
+          "name": "Tarifo entitetas",
+          "description": "Pasirenkamas tarifo entitetas atnaujinimui, kai nenaudojamas veiksmo tikslas."
+        },
+        "import_rate": {
+          "name": "Importo kaina",
+          "description": "Nauja neneigiama importo tarifo reikšmė."
+        },
+        "import_rate_entity": {
+          "name": "Importo tarifo entitetas",
+          "description": "Atnaujinamas importo tarifo entitetas."
+        },
+        "export_rate": {
+          "name": "Eksporto kaina",
+          "description": "Nauja neneigiama eksporto tarifo reikšmė."
+        },
+        "export_rate_entity": {
+          "name": "Eksporto tarifo entitetas",
+          "description": "Atnaujinamas eksporto tarifo entitetas."
+        },
+        "billing_start_date": {
+          "name": "Atsiskaitymo pradžios data",
+          "description": "Atsiskaitymo laikotarpio pradžios data ISO formatu."
+        },
+        "billing_frequency": {
+          "name": "Atsiskaitymo dažnis",
+          "description": "Atsiskaitymo intervalo vienetas: MONTH arba DAY."
+        },
+        "billing_interval_value": {
+          "name": "Atsiskaitymo intervalas",
+          "description": "Atsiskaitymo intervalų skaičius. Mėnesiams naudokite 1-24, dienoms 1-100."
+        },
+        "rates": {
+          "name": "Kainos",
+          "description": "Atnaujinamų tarifo kainos objektų ID ir neigiamų nebūnančių reikšmių sąrašas."
+        },
+        "site_id": {
+          "name": "Vietos ID",
+          "description": "Pasirenkamas vietos identifikatorius atsiskaitymo atnaujinimams."
+        },
+        "config_entry_id": {
+          "name": "Konfigūracijos įrašo ID",
+          "description": "Pasirenkamas vienos Enphase vietos konfigūracijos įrašo identifikatorius."
+        },
+        "tariff_payload": {
+          "name": "Tarifo payload",
+          "description": "Visas įrašomas Enphase tarifo payload. Naudokite išplėstiniams struktūros keitimams."
+        },
+        "purchase_tariff": {
+          "name": "Importo tarifo struktūra",
+          "description": "Pakaitinė importo tarifo šaka su tipu, sezonais, laikotarpiais, pakopomis ir kainomis."
+        },
+        "buyback_tariff": {
+          "name": "Eksporto tarifo struktūra",
+          "description": "Pakaitinė eksporto tarifo šaka su tipu, eksporto planu, sezonais, laikotarpiais, pakopomis ir kainomis."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Ieslēdziet papildu apstiprinājumu, lai nosūtītu {message}."
+    },
+    "tariff_update_required": {
+      "message": "Norādiet norēķinu datus vai vismaz vienu tarifa likmes atjauninājumu."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Norādiet norēķinu sākuma datumu, biežumu un intervālu."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Tarifa norēķinu sākuma datumam jābūt derīgam ISO datumam."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Tarifa norēķinu biežumam jābūt MONTH vai DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Tarifa norēķinu intervālam jābūt no {minimum} līdz {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "Tarifa norēķinu rakstīšanas API nav pieejama."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Dublēti tarifa likmes mērķi nav atļauti."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Dublēta tarifa likmes entītija: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Visiem tarifa atjauninājumiem jāattiecas uz vienu un to pašu Enphase vietni."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tarifa struktūra nav derīga."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Iestatīt tarifa likmi",
-      "description": "Atjaunina vienu esošu Enphase importa vai eksporta tarifa likmes vērtību.",
+    "update_tariff": {
+      "name": "Atjaunināt tarifu",
+      "description": "Atjaunina Enphase norēķinu cikla datus un vienu vai vairākas esošas importa vai eksporta tarifa likmes.",
       "fields": {
         "rate": {
           "name": "Likme",
-          "description": "Jauna nenegatīva tarifa likme."
+          "description": "Jauna nenegatīva tarifa likmes vērtība atlasītajai entītijai."
+        },
+        "rate_entity": {
+          "name": "Likmes entītija",
+          "description": "Neobligāta tarifa likmes entītija atjaunināšanai, ja netiek izmantots darbības mērķis."
+        },
+        "import_rate": {
+          "name": "Importa likme",
+          "description": "Jauna nenegatīva importa tarifa likme."
+        },
+        "import_rate_entity": {
+          "name": "Importa likmes entītija",
+          "description": "Atjaunināmā importa tarifa likmes entītija."
+        },
+        "export_rate": {
+          "name": "Eksporta likme",
+          "description": "Jauna nenegatīva eksporta tarifa likme."
+        },
+        "export_rate_entity": {
+          "name": "Eksporta likmes entītija",
+          "description": "Atjaunināmā eksporta tarifa likmes entītija."
+        },
+        "billing_start_date": {
+          "name": "Norēķinu sākuma datums",
+          "description": "Norēķinu perioda sākuma datums ISO formātā."
+        },
+        "billing_frequency": {
+          "name": "Norēķinu biežums",
+          "description": "Norēķinu intervāla vienība: MONTH vai DAY."
+        },
+        "billing_interval_value": {
+          "name": "Norēķinu intervāls",
+          "description": "Norēķinu intervālu skaits. Mēnešiem izmantojiet 1-24, dienām 1-100."
+        },
+        "rates": {
+          "name": "Likmes",
+          "description": "Atjaunināmo tarifa likmju entītiju ID un nenegatīvo vērtību saraksts."
+        },
+        "site_id": {
+          "name": "Vietnes ID",
+          "description": "Neobligāts vietnes identifikators norēķinu atjauninājumiem."
+        },
+        "config_entry_id": {
+          "name": "Konfigurācijas ieraksta ID",
+          "description": "Neobligāts konfigurācijas ieraksta identifikators vienai Enphase vietnei."
+        },
+        "tariff_payload": {
+          "name": "Tarifa payload",
+          "description": "Pilns rakstāmais Enphase tarifa payload. Izmantojiet paplašinātām struktūras izmaiņām."
+        },
+        "purchase_tariff": {
+          "name": "Importa tarifa struktūra",
+          "description": "Aizstājošs importa tarifa zars ar tipu, sezonām, periodiem, pakāpēm un cenām."
+        },
+        "buyback_tariff": {
+          "name": "Eksporta tarifa struktūra",
+          "description": "Aizstājošs eksporta tarifa zars ar tipu, eksporta plānu, sezonām, periodiem, pakāpēm un cenām."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Aktiver avansert bekreftelse for å sende {message}."
+    },
+    "tariff_update_required": {
+      "message": "Oppgi faktureringsdetaljer eller minst én oppdatering av tariffsats."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Oppgi startdato, frekvens og intervall for fakturering."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Startdatoen for tarifffakturering må være en gyldig ISO-dato."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Faktureringsfrekvensen for tariffen må være MONTH eller DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Faktureringsintervallet for tariffen må være mellom {minimum} og {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "API for skriving av tarifffakturering er ikke tilgjengelig."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Dupliserte mål for tariffsatser er ikke tillatt."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Duplisert tariffsats-entitet: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Alle tariffoppdateringer må gjelde samme Enphase-anlegg."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tariffstrukturen er ugyldig."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Angi tariffpris",
-      "description": "Oppdaterer én eksisterende Enphase import- eller eksporttariffpris.",
+    "update_tariff": {
+      "name": "Oppdater tariff",
+      "description": "Oppdater Enphase-faktureringssyklus og én eller flere eksisterende import- eller eksporttariffsatser.",
       "fields": {
         "rate": {
-          "name": "Pris",
-          "description": "Ny ikke-negativ tariffpris."
+          "name": "Sats",
+          "description": "Ny ikke-negativ tariffsatsverdi for valgt tariffsats-entitet."
+        },
+        "rate_entity": {
+          "name": "Satsentitet",
+          "description": "Valgfri tariffsats-entitet som skal oppdateres når handlingsmålet ikke brukes."
+        },
+        "import_rate": {
+          "name": "Importsats",
+          "description": "Ny ikke-negativ importtariffsats."
+        },
+        "import_rate_entity": {
+          "name": "Import­satsentitet",
+          "description": "Importtariffsats-entitet som skal oppdateres."
+        },
+        "export_rate": {
+          "name": "Eksportsats",
+          "description": "Ny ikke-negativ eksporttariffsats."
+        },
+        "export_rate_entity": {
+          "name": "Eksport­satsentitet",
+          "description": "Eksporttariffsats-entitet som skal oppdateres."
+        },
+        "billing_start_date": {
+          "name": "Startdato for fakturering",
+          "description": "Startdato for faktureringsperioden i ISO-format."
+        },
+        "billing_frequency": {
+          "name": "Faktureringsfrekvens",
+          "description": "Enhet for faktureringsintervall: MONTH eller DAY."
+        },
+        "billing_interval_value": {
+          "name": "Faktureringsintervall",
+          "description": "Antall faktureringsintervaller. Bruk 1-24 for måneder eller 1-100 for dager."
+        },
+        "rates": {
+          "name": "Satser",
+          "description": "Liste over entitets-ID-er for tariffsatser og ikke-negative satsverdier som skal oppdateres."
+        },
+        "site_id": {
+          "name": "Anleggs-ID",
+          "description": "Valgfri anleggsidentifikator for faktureringsoppdateringer."
+        },
+        "config_entry_id": {
+          "name": "Konfigurasjonsoppførings-ID",
+          "description": "Valgfri identifikator for konfigurasjonsoppføring for ett Enphase-anlegg."
+        },
+        "tariff_payload": {
+          "name": "Tariff-payload",
+          "description": "Fullstendig Enphase-tariffpayload som skal skrives. Brukes til avanserte strukturendringer."
+        },
+        "purchase_tariff": {
+          "name": "Importtariffstruktur",
+          "description": "Erstatningsgren for importtariff med type, sesonger, perioder, trinn og satser."
+        },
+        "buyback_tariff": {
+          "name": "Eksporttariffstruktur",
+          "description": "Erstatningsgren for eksporttariff med type, eksportplan, sesonger, perioder, trinn og satser."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Schakel geavanceerde bevestiging in om {message} te verzenden."
+    },
+    "tariff_update_required": {
+      "message": "Geef factureringsgegevens of ten minste één tariefupdate op."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Geef de startdatum, frequentie en interval van de facturering op."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "De startdatum voor tarieffacturering moet een geldige ISO-datum zijn."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "De factureringsfrequentie van het tarief moet MONTH of DAY zijn."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Het factureringsinterval van het tarief moet tussen {minimum} en {maximum} liggen."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "De API voor het schrijven van tarieffacturering is niet beschikbaar."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Dubbele tariefdoelen zijn niet toegestaan."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Dubbele tariefentiteit: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Alle tariefupdates moeten op dezelfde Enphase-site zijn gericht."
+    },
+    "tariff_structure_invalid": {
+      "message": "De tariefstructuur is ongeldig."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Tarief instellen",
-      "description": "Werkt één bestaande Enphase import- of exporttariefwaarde bij.",
+    "update_tariff": {
+      "name": "Tarief bijwerken",
+      "description": "Werk Enphase-factureringscyclusgegevens en één of meer bestaande import- of exporttarieven bij.",
       "fields": {
         "rate": {
           "name": "Tarief",
-          "description": "Nieuwe niet-negatieve tariefwaarde."
+          "description": "Nieuwe niet-negatieve tariefwaarde voor de geselecteerde tariefentiteit."
+        },
+        "rate_entity": {
+          "name": "Tariefentiteit",
+          "description": "Optionele tariefentiteit om bij te werken wanneer het actiedoel niet wordt gebruikt."
+        },
+        "import_rate": {
+          "name": "Importtarief",
+          "description": "Nieuwe niet-negatieve importtariefwaarde."
+        },
+        "import_rate_entity": {
+          "name": "Importtariefentiteit",
+          "description": "Importtariefentiteit om bij te werken."
+        },
+        "export_rate": {
+          "name": "Exporttarief",
+          "description": "Nieuwe niet-negatieve exporttariefwaarde."
+        },
+        "export_rate_entity": {
+          "name": "Exporttariefentiteit",
+          "description": "Exporttariefentiteit om bij te werken."
+        },
+        "billing_start_date": {
+          "name": "Startdatum facturering",
+          "description": "Startdatum van de factureringsperiode in ISO-formaat."
+        },
+        "billing_frequency": {
+          "name": "Factureringsfrequentie",
+          "description": "Eenheid van het factureringsinterval: MONTH of DAY."
+        },
+        "billing_interval_value": {
+          "name": "Factureringsinterval",
+          "description": "Aantal factureringsintervallen. Gebruik 1-24 voor maanden of 1-100 voor dagen."
+        },
+        "rates": {
+          "name": "Tarieven",
+          "description": "Lijst met entiteits-ID’s van tarieven en niet-negatieve tariefwaarden om bij te werken."
+        },
+        "site_id": {
+          "name": "Site-ID",
+          "description": "Optionele site-identificatie voor factureringsupdates."
+        },
+        "config_entry_id": {
+          "name": "Configuratie-item-ID",
+          "description": "Optionele configuratie-itemidentificatie voor één Enphase-site."
+        },
+        "tariff_payload": {
+          "name": "Tariefpayload",
+          "description": "Volledige Enphase-tariefpayload om te schrijven. Gebruik dit voor geavanceerde structuurwijzigingen."
+        },
+        "purchase_tariff": {
+          "name": "Importtariefstructuur",
+          "description": "Vervangende tak voor het importtarief met type, seizoenen, perioden, staffels en tarieven."
+        },
+        "buyback_tariff": {
+          "name": "Exporttariefstructuur",
+          "description": "Vervangende tak voor het exporttarief met type, exportplan, seizoenen, perioden, staffels en tarieven."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Włącz zaawansowane potwierdzenie, aby wysłać {message}."
+    },
+    "tariff_update_required": {
+      "message": "Podaj dane rozliczeniowe lub co najmniej jedną aktualizację stawki taryfy."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Podaj datę rozpoczęcia, częstotliwość i interwał rozliczeń."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Data rozpoczęcia rozliczeń taryfy musi być prawidłową datą ISO."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Częstotliwość rozliczeń taryfy musi mieć wartość MONTH lub DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Interwał rozliczeń taryfy musi być między {minimum} a {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "API zapisu rozliczeń taryfy jest niedostępne."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Zduplikowane cele stawek taryfy nie są dozwolone."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Zduplikowana encja stawki taryfy: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Wszystkie aktualizacje taryfy muszą dotyczyć tej samej instalacji Enphase."
+    },
+    "tariff_structure_invalid": {
+      "message": "Struktura taryfy jest nieprawidłowa."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Ustaw stawkę taryfy",
-      "description": "Aktualizuje jedną istniejącą wartość stawki importu lub eksportu Enphase.",
+    "update_tariff": {
+      "name": "Aktualizuj taryfę",
+      "description": "Aktualizuje szczegóły cyklu rozliczeniowego Enphase oraz jedną lub więcej istniejących stawek taryfy importu albo eksportu.",
       "fields": {
         "rate": {
           "name": "Stawka",
-          "description": "Nowa nieujemna wartość stawki taryfy."
+          "description": "Nowa nieujemna wartość stawki taryfy dla wybranej encji."
+        },
+        "rate_entity": {
+          "name": "Encja stawki",
+          "description": "Opcjonalna encja stawki taryfy do aktualizacji, gdy nie używasz celu akcji."
+        },
+        "import_rate": {
+          "name": "Stawka importu",
+          "description": "Nowa nieujemna wartość stawki taryfy importu."
+        },
+        "import_rate_entity": {
+          "name": "Encja stawki importu",
+          "description": "Encja stawki taryfy importu do aktualizacji."
+        },
+        "export_rate": {
+          "name": "Stawka eksportu",
+          "description": "Nowa nieujemna wartość stawki taryfy eksportu."
+        },
+        "export_rate_entity": {
+          "name": "Encja stawki eksportu",
+          "description": "Encja stawki taryfy eksportu do aktualizacji."
+        },
+        "billing_start_date": {
+          "name": "Data rozpoczęcia rozliczeń",
+          "description": "Data rozpoczęcia okresu rozliczeniowego w formacie ISO."
+        },
+        "billing_frequency": {
+          "name": "Częstotliwość rozliczeń",
+          "description": "Jednostka interwału rozliczeń: MONTH lub DAY."
+        },
+        "billing_interval_value": {
+          "name": "Interwał rozliczeń",
+          "description": "Liczba interwałów rozliczeniowych. Użyj 1-24 dla miesięcy lub 1-100 dla dni."
+        },
+        "rates": {
+          "name": "Stawki",
+          "description": "Lista ID encji stawek taryfy i nieujemnych wartości do zaktualizowania."
+        },
+        "site_id": {
+          "name": "ID instalacji",
+          "description": "Opcjonalny identyfikator instalacji dla aktualizacji rozliczeń."
+        },
+        "config_entry_id": {
+          "name": "ID wpisu konfiguracji",
+          "description": "Opcjonalny identyfikator wpisu konfiguracji dla jednej instalacji Enphase."
+        },
+        "tariff_payload": {
+          "name": "Payload taryfy",
+          "description": "Pełny payload taryfy Enphase do zapisania. Użyj do zaawansowanych zmian strukturalnych."
+        },
+        "purchase_tariff": {
+          "name": "Struktura taryfy importu",
+          "description": "Zastępcza gałąź taryfy importu z typem, sezonami, okresami, progami i stawkami."
+        },
+        "buyback_tariff": {
+          "name": "Struktura taryfy eksportu",
+          "description": "Zastępcza gałąź taryfy eksportu z typem, planem eksportu, sezonami, okresami, progami i stawkami."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Ative a confirmação avançada para enviar {message}."
+    },
+    "tariff_update_required": {
+      "message": "Forneça detalhes de faturamento ou pelo menos uma atualização de tarifa."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Forneça a data de início, a frequência e o intervalo de faturamento."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "A data de início do faturamento da tarifa deve ser uma data ISO válida."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "A frequência de faturamento da tarifa deve ser MONTH ou DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "O intervalo de faturamento da tarifa deve estar entre {minimum} e {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "A API de escrita do faturamento da tarifa não está disponível."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Destinos de tarifa duplicados não são permitidos."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Entidade de tarifa duplicada: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Todas as atualizações de tarifa devem apontar para o mesmo local Enphase."
+    },
+    "tariff_structure_invalid": {
+      "message": "A estrutura tarifária é inválida."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Definir tarifa",
-      "description": "Atualiza um valor existente de tarifa de importação ou exportação da Enphase.",
+    "update_tariff": {
+      "name": "Atualizar tarifa",
+      "description": "Atualiza os detalhes do ciclo de faturamento Enphase e um ou mais valores existentes de tarifa de importação ou exportação.",
       "fields": {
         "rate": {
           "name": "Tarifa",
-          "description": "Novo valor de tarifa não negativo."
+          "description": "Novo valor de tarifa não negativo para a entidade de tarifa selecionada."
+        },
+        "rate_entity": {
+          "name": "Entidade de tarifa",
+          "description": "Entidade de tarifa opcional para atualizar quando o alvo da ação não for usado."
+        },
+        "import_rate": {
+          "name": "Tarifa de importação",
+          "description": "Novo valor não negativo da tarifa de importação."
+        },
+        "import_rate_entity": {
+          "name": "Entidade de tarifa de importação",
+          "description": "Entidade de tarifa de importação a atualizar."
+        },
+        "export_rate": {
+          "name": "Tarifa de exportação",
+          "description": "Novo valor não negativo da tarifa de exportação."
+        },
+        "export_rate_entity": {
+          "name": "Entidade de tarifa de exportação",
+          "description": "Entidade de tarifa de exportação a atualizar."
+        },
+        "billing_start_date": {
+          "name": "Data de início do faturamento",
+          "description": "Data de início do período de faturamento em formato ISO."
+        },
+        "billing_frequency": {
+          "name": "Frequência de faturamento",
+          "description": "Unidade do intervalo de faturamento: MONTH ou DAY."
+        },
+        "billing_interval_value": {
+          "name": "Intervalo de faturamento",
+          "description": "Quantidade de intervalos de faturamento. Use 1-24 para meses ou 1-100 para dias."
+        },
+        "rates": {
+          "name": "Tarifas",
+          "description": "Lista de IDs de entidades de tarifa e valores não negativos a atualizar."
+        },
+        "site_id": {
+          "name": "ID do local",
+          "description": "Identificador opcional do local para atualizações de faturamento."
+        },
+        "config_entry_id": {
+          "name": "ID da entrada de configuração",
+          "description": "Identificador opcional da entrada de configuração para um único local Enphase."
+        },
+        "tariff_payload": {
+          "name": "Payload da tarifa",
+          "description": "Payload completo da tarifa Enphase para gravar. Use para edições estruturais avançadas."
+        },
+        "purchase_tariff": {
+          "name": "Estrutura da tarifa de importação",
+          "description": "Ramo substituto da tarifa de importação com tipo, temporadas, períodos, faixas e valores."
+        },
+        "buyback_tariff": {
+          "name": "Estrutura da tarifa de exportação",
+          "description": "Ramo substituto da tarifa de exportação com tipo, plano de exportação, temporadas, períodos, faixas e valores."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Activați confirmarea avansată pentru a trimite {message}."
+    },
+    "tariff_update_required": {
+      "message": "Furnizați detalii de facturare sau cel puțin o actualizare a tarifului."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Furnizați data de început, frecvența și intervalul de facturare."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Data de început a facturării tarifului trebuie să fie o dată ISO validă."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Frecvența de facturare a tarifului trebuie să fie MONTH sau DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Intervalul de facturare a tarifului trebuie să fie între {minimum} și {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "API-ul de scriere a facturării tarifului nu este disponibil."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Țintele duplicate pentru tarife nu sunt permise."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Entitate tarifară duplicată: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Toate actualizările tarifului trebuie să vizeze același site Enphase."
+    },
+    "tariff_structure_invalid": {
+      "message": "Structura tarifului este invalidă."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Setează tariful",
-      "description": "Actualizează o valoare existentă a tarifului de import sau export Enphase.",
+    "update_tariff": {
+      "name": "Actualizează tariful",
+      "description": "Actualizează detaliile ciclului de facturare Enphase și una sau mai multe valori existente ale tarifelor de import sau export.",
       "fields": {
         "rate": {
           "name": "Tarif",
-          "description": "Valoare nouă de tarif nenegativă."
+          "description": "Noua valoare nenegativă a tarifului pentru entitatea selectată."
+        },
+        "rate_entity": {
+          "name": "Entitate tarifară",
+          "description": "Entitate tarifară opțională de actualizat când nu se folosește ținta acțiunii."
+        },
+        "import_rate": {
+          "name": "Tarif de import",
+          "description": "Noua valoare nenegativă a tarifului de import."
+        },
+        "import_rate_entity": {
+          "name": "Entitate tarif de import",
+          "description": "Entitatea tarifului de import de actualizat."
+        },
+        "export_rate": {
+          "name": "Tarif de export",
+          "description": "Noua valoare nenegativă a tarifului de export."
+        },
+        "export_rate_entity": {
+          "name": "Entitate tarif de export",
+          "description": "Entitatea tarifului de export de actualizat."
+        },
+        "billing_start_date": {
+          "name": "Data de început a facturării",
+          "description": "Data de început a perioadei de facturare în format ISO."
+        },
+        "billing_frequency": {
+          "name": "Frecvența facturării",
+          "description": "Unitatea intervalului de facturare: MONTH sau DAY."
+        },
+        "billing_interval_value": {
+          "name": "Interval de facturare",
+          "description": "Numărul de intervale de facturare. Folosiți 1-24 pentru luni sau 1-100 pentru zile."
+        },
+        "rates": {
+          "name": "Tarife",
+          "description": "Lista ID-urilor entităților tarifare și a valorilor nenegative de actualizat."
+        },
+        "site_id": {
+          "name": "ID site",
+          "description": "Identificator opțional de site pentru actualizări de facturare."
+        },
+        "config_entry_id": {
+          "name": "ID intrare de configurare",
+          "description": "Identificator opțional al intrării de configurare pentru un singur site Enphase."
+        },
+        "tariff_payload": {
+          "name": "Payload tarifar",
+          "description": "Payload tarifar Enphase complet de scris. Folosește-l pentru editări structurale avansate."
+        },
+        "purchase_tariff": {
+          "name": "Structura tarifului de import",
+          "description": "Ramură de înlocuire pentru tariful de import cu tip, sezoane, perioade, trepte și tarife."
+        },
+        "buyback_tariff": {
+          "name": "Structura tarifului de export",
+          "description": "Ramură de înlocuire pentru tariful de export cu tip, plan de export, sezoane, perioade, trepte și tarife."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -2681,6 +2681,10 @@
         "export_off_peak_rate": {
           "name": "Eksport off-peak basis",
           "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
+        },
+        "device_id": {
+          "name": "Enphase-enhed",
+          "description": "Valgfri Enphase-enhed til at vælge stedet for fakturerings- eller tarifstrukturændringer."
         }
       }
     }

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -417,6 +417,36 @@
     },
     "trigger_message_confirmation_required": {
       "message": "Aktivera avancerad bekräftelse för att skicka {message}."
+    },
+    "tariff_update_required": {
+      "message": "Ange faktureringsuppgifter eller minst en uppdatering av en tariffavgift."
+    },
+    "tariff_billing_incomplete": {
+      "message": "Ange faktureringens startdatum, frekvens och intervall."
+    },
+    "tariff_billing_start_date_invalid": {
+      "message": "Startdatumet för tariffakturering måste vara ett giltigt ISO-datum."
+    },
+    "tariff_billing_frequency_invalid": {
+      "message": "Faktureringsfrekvensen för tariffen måste vara MONTH eller DAY."
+    },
+    "tariff_billing_interval_invalid": {
+      "message": "Faktureringsintervallet för tariffen måste vara mellan {minimum} och {maximum}."
+    },
+    "tariff_billing_api_unavailable": {
+      "message": "API för att skriva tariffakturering är inte tillgängligt."
+    },
+    "tariff_rate_target_duplicate": {
+      "message": "Dubbla mål för tariffavgifter är inte tillåtna."
+    },
+    "tariff_rate_entity_duplicate": {
+      "message": "Dubblett av tariffavgiftsentitet: {entity_id}"
+    },
+    "tariff_site_mismatch": {
+      "message": "Alla tariffuppdateringar måste rikta sig till samma Enphase-anläggning."
+    },
+    "tariff_structure_invalid": {
+      "message": "Tariffstrukturen är ogiltig."
     }
   },
   "options": {
@@ -2528,13 +2558,129 @@
         }
       }
     },
-    "set_tariff_rate": {
-      "name": "Ange tariffpris",
-      "description": "Uppdaterar ett befintligt Enphase import- eller exporttariffvärde.",
+    "update_tariff": {
+      "name": "Uppdatera tariff",
+      "description": "Uppdatera Enphase-faktureringscykel och en eller flera befintliga import- eller exporttariffavgifter.",
       "fields": {
         "rate": {
-          "name": "Pris",
-          "description": "Nytt icke-negativt tariffvärde."
+          "name": "Avgift",
+          "description": "Nytt icke-negativt tariffvärde för vald tariffentitet."
+        },
+        "rate_entity": {
+          "name": "Avgiftsentitet",
+          "description": "Valfri tariffentitet att uppdatera när åtgärdens mål inte används."
+        },
+        "import_rate": {
+          "name": "Importavgift",
+          "description": "Nytt icke-negativt importtariffvärde."
+        },
+        "import_rate_entity": {
+          "name": "Importavgiftsentitet",
+          "description": "Importtariffentitet att uppdatera."
+        },
+        "export_rate": {
+          "name": "Exportavgift",
+          "description": "Nytt icke-negativt exporttariffvärde."
+        },
+        "export_rate_entity": {
+          "name": "Exportavgiftsentitet",
+          "description": "Exporttariffentitet att uppdatera."
+        },
+        "billing_start_date": {
+          "name": "Startdatum för fakturering",
+          "description": "Startdatum för faktureringsperioden i ISO-format."
+        },
+        "billing_frequency": {
+          "name": "Faktureringsfrekvens",
+          "description": "Enhet för faktureringsintervall: MONTH eller DAY."
+        },
+        "billing_interval_value": {
+          "name": "Faktureringsintervall",
+          "description": "Antal faktureringsintervaller. Använd 1-24 för månader eller 1-100 för dagar."
+        },
+        "rates": {
+          "name": "Avgifter",
+          "description": "Lista över entitets-ID:n för tariffavgifter och icke-negativa värden som ska uppdateras."
+        },
+        "site_id": {
+          "name": "Anläggnings-ID",
+          "description": "Valfritt anläggnings-ID för faktureringsuppdateringar."
+        },
+        "config_entry_id": {
+          "name": "Konfigurationspost-ID",
+          "description": "Valfritt konfigurationspost-ID för en enda Enphase-anläggning."
+        },
+        "tariff_payload": {
+          "name": "Tariff-payload",
+          "description": "Fullständig Enphase-tariffpayload att skriva. Använd för avancerade strukturändringar."
+        },
+        "purchase_tariff": {
+          "name": "Importtariffstruktur",
+          "description": "Ersättningsgren för importtariff med typ, säsonger, perioder, nivåer och priser."
+        },
+        "buyback_tariff": {
+          "name": "Exporttariffstruktur",
+          "description": "Ersättningsgren för exporttariff med typ, exportplan, säsonger, perioder, nivåer och priser."
+        },
+        "configure_import_tariff": {
+          "name": "Guidet importtarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for importtariffen med de guidede felter."
+        },
+        "import_tariff_type": {
+          "name": "Importtariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt importpris."
+        },
+        "import_variation": {
+          "name": "Importvariation",
+          "description": "Vælg om importprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "import_flat_rate": {
+          "name": "Flad importpris",
+          "description": "En enkelt importpris for flad tarif uden periode-rækker."
+        },
+        "import_periods": {
+          "name": "Importperioder",
+          "description": "Rækker til flade eller tidsafhængige importpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "import_tiers": {
+          "name": "Importtrin",
+          "description": "Rækker til trindelte importpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "import_off_peak_rate": {
+          "name": "Import off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte importtariffer."
+        },
+        "configure_export_tariff": {
+          "name": "Guidet eksporttarif",
+          "description": "Aktiver dette felt for at opbygge en erstatning for eksporttariffen med de guidede felter."
+        },
+        "export_tariff_type": {
+          "name": "Eksporttariftype",
+          "description": "Vælg flad, tidsafhængig eller trindelt eksportpris."
+        },
+        "export_variation": {
+          "name": "Eksportvariation",
+          "description": "Vælg om eksportprisen varierer efter sæson eller hverdag/weekend."
+        },
+        "export_plan": {
+          "name": "Eksportplan",
+          "description": "Vælg Enphase-eksportplanen der skal skrives med eksporttariffen."
+        },
+        "export_flat_rate": {
+          "name": "Flad eksportpris",
+          "description": "En enkelt eksportpris for flad tarif uden periode-rækker."
+        },
+        "export_periods": {
+          "name": "Eksportperioder",
+          "description": "Rækker til flade eller tidsafhængige eksportpriser. Dage 1-7 er mandag-søndag; tider kan være HH:MM eller minutter efter midnat."
+        },
+        "export_tiers": {
+          "name": "Eksporttrin",
+          "description": "Rækker til trindelte eksportpriser. Brug end_value -1 for sidste ubegrænsede trin."
+        },
+        "export_off_peak_rate": {
+          "name": "Eksport off-peak basis",
+          "description": "Basispris uden for spidsbelastning for trindelte eksporttariffer."
         }
       }
     }

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -116,7 +116,7 @@ Status labels:
 | PowerMatch UI flags | `GET` | `/app-api/<site_id>/powermatch_details` | authenticated session cookies + `e-auth-token` | Browser capture only |
 | Site today snapshot | `GET` | `/pv/systems/<site_id>/today` | authenticated Enlighten session cookies | Runtime |
 | Legacy site tariff flags | `GET` | `/app-api/<site_id>/tariff.json?country=<country>` | authenticated session cookies + `e-auth-token` | Browser capture only |
-| Site billing-cycle details | `GET/POST` | `/service/tariff/tariff-ms/systems/<site_id>/billing-details[?date=<YYYY-MM-DD>]` | tariff web headers: authenticated cookies, `e-auth-token`, `Username`, `Requestid`; writes add `Origin`, `Content-Type`, and `x-xsrf-token` | Runtime (GET) |
+| Site billing-cycle details | `GET/POST` | `/service/tariff/tariff-ms/systems/<site_id>/billing-details[?date=<YYYY-MM-DD>]` | tariff web headers: authenticated cookies, `e-auth-token`, `Username`, `Requestid`; writes add `Origin`, `Content-Type`, and `x-xsrf-token` | Runtime |
 | Site tariff configuration | `GET/PUT` | `/service/tariff/tariff-ms/systems/<site_id>/tariff?include-site-details=true` and `/service/tariff/tariff-ms/systems/<site_id>/tariff?user-id=<user_id>` | tariff web headers: authenticated cookies, `e-auth-token`, `Username`, `Requestid`, `X-Requested-With`; writes add `Origin`, `Content-Type`, and `x-xsrf-token` | Runtime |
 | Tariff settings MQTT authorizer | `GET` | `/pv/aws_sigv4/tariff_settings_response_stream?serial_number=<gateway_sn>` | authenticated Enlighten session cookies + `e-auth-token` + `x-xsrf-token` | Browser capture only |
 | EVSE tariff-change notification | `PUT` | `/service/evse_scheduler/api/v1/siteConfig/<site_id>/tariff_change` | tariff web write headers + JSON `null` body | Runtime (best-effort) |
@@ -2445,8 +2445,12 @@ and notifies the EVSE scheduler service after billing or tariff changes.
 
 Implementation notes:
 - The active runtime reads a bundled billing/import/export snapshot and exposes billing-cycle plus current import/export tariff sensors.
-- Writes update one located `rate` or `offPeak` value in a copied full tariff payload, call `PUT /tariff`, then best-effort notify `/siteConfig/<site_id>/tariff_change`.
-- Billing `POST` and the tariff-settings MQTT response stream are documented browser flows, but they are not part of the active runtime write path.
+- Rate writes update located `rate` or `offPeak` values in a copied full tariff payload, call `PUT /tariff` once per batch, then best-effort notify `/siteConfig/<site_id>/tariff_change`.
+- Structural writes can replace the full tariff payload or replace the `purchase` and/or `buyback` branch on the latest payload before the single `PUT /tariff` call. This supports flat, time-of-use, and tiered structures, including seasons, weekday/weekend groups, periods, tiers, off-peak baselines, and export plans.
+- Guided structural service fields can build common import/export branches from tariff type, variation, flat-rate, period-row, tier-row, off-peak baseline, and export-plan inputs. The advanced object fields remain available for exact payload replacement.
+- Billing writes call `POST /billing-details` with `anyBillPeriodStartDate`, `billingFrequency`, and `billingIntervalValue`, then best-effort notify `/siteConfig/<site_id>/tariff_change`.
+- The `update_tariff` service can combine billing, structural, and rate writes, but the Enphase endpoints are not transactional; a remote failure after one endpoint succeeds can leave a partial cloud-side update.
+- The tariff-settings MQTT response stream is a documented browser flow, but it is not part of the active runtime write path.
 
 #### Billing Details
 ```

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3788,6 +3788,67 @@ async def test_site_tariff_billing_details_passes_tariff_headers() -> None:
 
 
 @pytest.mark.asyncio
+async def test_site_tariff_billing_update_posts_payload_with_today() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value={"billingFrequency": "MONTH"})
+    payload = {
+        "anyBillPeriodStartDate": "2026-04-01",
+        "billingFrequency": "MONTH",
+        "billingIntervalValue": 1,
+    }
+
+    out = await client.site_tariff_billing_update(payload)
+
+    assert out == {"billingFrequency": "MONTH"}
+    args, kwargs = client._json.await_args
+    assert args[0] == "POST"
+    assert "/service/tariff/tariff-ms/systems/SITE/billing-details" in args[1]
+    assert kwargs["json"] == payload
+    assert kwargs["params"] == {"date": datetime.date.today().isoformat()}
+    assert kwargs["headers"]["Content-Type"] == "application/json"
+
+
+@pytest.mark.asyncio
+async def test_site_tariff_billing_update_accepts_request_date_override() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value={"billingFrequency": "DAY"})
+
+    await client.site_tariff_billing_update(
+        {
+            "anyBillPeriodStartDate": "2026-04-01",
+            "billingFrequency": "DAY",
+            "billingIntervalValue": 30,
+        },
+        request_date=datetime.date(2026, 4, 29),
+    )
+
+    _args, kwargs = client._json.await_args
+    assert kwargs["params"] == {"date": "2026-04-29"}
+
+    await client.site_tariff_billing_update(
+        {
+            "anyBillPeriodStartDate": "2026-04-01",
+            "billingFrequency": "DAY",
+            "billingIntervalValue": 30,
+        },
+        request_date=datetime.datetime(2026, 4, 30, 12, 0),
+    )
+    _args, kwargs = client._json.await_args
+    assert kwargs["params"] == {"date": "2026-04-30"}
+
+    await client.site_tariff_billing_update(
+        {
+            "anyBillPeriodStartDate": "2026-04-01",
+            "billingFrequency": "DAY",
+            "billingIntervalValue": 30,
+        },
+        request_date="2026-05-01",
+    )
+    _args, kwargs = client._json.await_args
+    assert kwargs["params"] == {"date": "2026-05-01"}
+
+
+@pytest.mark.asyncio
 async def test_site_tariff_passes_include_site_details() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"purchase": {"typeId": "flat"}})

--- a/tests/components/enphase_ev/test_services.py
+++ b/tests/components/enphase_ev/test_services.py
@@ -121,6 +121,128 @@ def test_trigger_message_service_options_match_allowlist() -> None:
     assert OCPP_TRIGGER_MESSAGES_REQUIRING_CONFIRMATION < OCPP_TRIGGER_MESSAGES
 
 
+def test_update_tariff_schema_validates_billing_and_rates(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    registered = _register_service_metadata(hass, monkeypatch)
+    schema = registered[(DOMAIN, "update_tariff")]["schema"]
+
+    assert (DOMAIN, "set_tariff_rate") not in registered
+    assert schema(
+        {
+            "billing_start_date": "2026-04-01",
+            "billing_frequency": "MONTH",
+            "billing_interval_value": 24,
+            "rates": [{"entity_id": "number.import_peak", "rate": 0.25}],
+        }
+    ) == {
+        "billing_start_date": "2026-04-01",
+        "billing_frequency": "MONTH",
+        "billing_interval_value": 24,
+        "rates": [{"entity_id": "number.import_peak", "rate": 0.25}],
+    }
+    assert schema({"entity_id": ["number.import_peak"], "rate": "0.27"}) == {
+        "entity_id": ["number.import_peak"],
+        "rate": 0.27,
+    }
+    assert schema({"rate_entity": "number.import_peak", "rate": "0.28"}) == {
+        "rate_entity": "number.import_peak",
+        "rate": 0.28,
+    }
+    assert schema(
+        {
+            "import_rate_entity": "number.import_peak",
+            "import_rate": "0.29",
+            "export_rate_entity": "number.export_peak",
+            "export_rate": "0.08",
+        }
+    ) == {
+        "import_rate_entity": "number.import_peak",
+        "import_rate": 0.29,
+        "export_rate_entity": "number.export_peak",
+        "export_rate": 0.08,
+    }
+    assert schema(
+        {
+            "site_id": "tariff-site",
+            "purchase_tariff": {
+                "typeKind": "single",
+                "typeId": "flat",
+                "seasons": [],
+            },
+        }
+    ) == {
+        "site_id": "tariff-site",
+        "purchase_tariff": {
+            "typeKind": "single",
+            "typeId": "flat",
+            "seasons": [],
+        },
+    }
+    assert schema(
+        {
+            "site_id": "tariff-site",
+            "configure_import_tariff": True,
+            "import_tariff_type": "flat",
+            "import_flat_rate": "0.24",
+            "configure_export_tariff": True,
+            "export_tariff_type": "tou",
+            "export_variation": "weekends",
+            "export_plan": "grossFit",
+            "export_periods": [
+                {
+                    "day_group_id": "weekend",
+                    "period_type": "peak",
+                    "start_time": "10:00",
+                    "end_time": "15:00",
+                    "rate": 0.1,
+                }
+            ],
+        }
+    ) == {
+        "site_id": "tariff-site",
+        "configure_import_tariff": True,
+        "import_tariff_type": "flat",
+        "import_flat_rate": 0.24,
+        "configure_export_tariff": True,
+        "export_tariff_type": "tou",
+        "export_variation": "weekends",
+        "export_plan": "grossFit",
+        "export_periods": [
+            {
+                "day_group_id": "weekend",
+                "period_type": "peak",
+                "start_time": "10:00",
+                "end_time": "15:00",
+                "rate": 0.1,
+            }
+        ],
+    }
+
+    for data in (
+        {},
+        {"billing_start_date": "not-a-date"},
+        {"billing_start_date": "2026-04-01"},
+        {"rate_entity": "number.import_peak"},
+        {"import_rate": 0.29},
+        {"import_rate_entity": "number.import_peak"},
+        {"export_rate": 0.08},
+        {"export_rate_entity": "number.export_peak"},
+        {
+            "billing_start_date": "2026-04-01",
+            "billing_frequency": "MONTH",
+            "billing_interval_value": 25,
+        },
+        {
+            "billing_start_date": "2026-04-01",
+            "billing_frequency": "DAY",
+            "billing_interval_value": 101,
+        },
+    ):
+        with pytest.raises(vol.Invalid):
+            schema(data)
+
+
 @pytest.mark.asyncio
 async def test_trigger_message_handler_restricts_requested_message_without_schema(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
@@ -521,12 +643,12 @@ async def test_try_reauth_now_reports_manual_retry_cooldown(
 
 
 @pytest.mark.asyncio
-async def test_set_tariff_rate_targets_tariff_entity(
+async def test_update_tariff_accepts_rate_entities(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     handlers = _register_service_handlers(hass, monkeypatch)
     coord = _fake_service_coordinator(site_id="tariff-site", serials=set())
-    coord.tariff_runtime = SimpleNamespace(async_set_tariff_rate=AsyncMock())
+    coord.tariff_runtime = SimpleNamespace(async_update_tariff=AsyncMock())
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_SITE_ID: "tariff-site", CONF_SITE_ONLY: True},
@@ -543,27 +665,131 @@ async def test_set_tariff_rate_targets_tariff_entity(
         "period_index": 1,
     }
     reg_entry = er.async_get(hass).async_get_or_create(
-        "sensor",
+        "number",
         DOMAIN,
-        f"{DOMAIN}_site_tariff-site_tariff_import_rate_default_week_peak",
+        f"{DOMAIN}_site_tariff-site_tariff_import_rate_default_week_peak_number",
         config_entry=entry,
     )
     hass.states.async_set(reg_entry.entity_id, 0.18, {"tariff_locator": locator})
 
-    await handlers[(DOMAIN, "set_tariff_rate")](
-        SimpleNamespace(data={"entity_id": [reg_entry.entity_id], "rate": 0.25})
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(
+            data={"rates": [{"entity_id": reg_entry.entity_id, "rate": 0.25}]}
+        )
     )
 
-    coord.tariff_runtime.async_set_tariff_rate.assert_awaited_once_with(locator, 0.25)
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing=None,
+        rate_updates=[{"locator": locator, "rate": 0.25}],
+    )
 
 
 @pytest.mark.asyncio
-async def test_set_tariff_rate_targets_current_tariff_sensor(
+async def test_update_tariff_accepts_friendly_rate_fields(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     handlers = _register_service_handlers(hass, monkeypatch)
     coord = _fake_service_coordinator(site_id="tariff-site", serials=set())
-    coord.tariff_runtime = SimpleNamespace(async_set_tariff_rate=AsyncMock())
+    coord.tariff_runtime = SimpleNamespace(async_update_tariff=AsyncMock())
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "tariff-site", CONF_SITE_ONLY: True},
+        title="Tariff Site",
+        unique_id="tariff-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    import_locator = {
+        "branch": "purchase",
+        "kind": "period",
+        "season_index": 1,
+        "day_index": 1,
+        "period_index": 1,
+    }
+    export_locator = {
+        "branch": "buyback",
+        "kind": "period",
+        "season_index": 1,
+        "day_index": 1,
+        "period_index": 1,
+    }
+    ent_reg = er.async_get(hass)
+    import_entity = ent_reg.async_get_or_create(
+        "number",
+        DOMAIN,
+        f"{DOMAIN}_site_tariff-site_tariff_import_rate_default_week_peak_number",
+        config_entry=entry,
+    )
+    export_entity = ent_reg.async_get_or_create(
+        "number",
+        DOMAIN,
+        f"{DOMAIN}_site_tariff-site_tariff_export_rate_default_week_peak_number",
+        config_entry=entry,
+    )
+    hass.states.async_set(
+        import_entity.entity_id, 0.18, {"tariff_locator": import_locator}
+    )
+    hass.states.async_set(
+        export_entity.entity_id, 0.04, {"tariff_locator": export_locator}
+    )
+
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(data={"entity_id": [import_entity.entity_id], "rate": 0.25})
+    )
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing=None,
+        rate_updates=[{"locator": import_locator, "rate": 0.25}],
+    )
+    coord.tariff_runtime.async_update_tariff.reset_mock()
+
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(data={"rate_entity": import_entity.entity_id, "rate": 0.26})
+    )
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing=None,
+        rate_updates=[{"locator": import_locator, "rate": 0.26}],
+    )
+    coord.tariff_runtime.async_update_tariff.reset_mock()
+
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(
+            data={
+                "import_rate_entity": import_entity.entity_id,
+                "import_rate": 0.27,
+                "export_rate_entity": export_entity.entity_id,
+                "export_rate": 0.08,
+            }
+        )
+    )
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing=None,
+        rate_updates=[
+            {"locator": import_locator, "rate": 0.27},
+            {"locator": export_locator, "rate": 0.08},
+        ],
+    )
+    coord.tariff_runtime.async_update_tariff.reset_mock()
+
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(data={"entity_id": import_entity.entity_id, "rate": 0.28})
+    )
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing=None,
+        rate_updates=[{"locator": import_locator, "rate": 0.28}],
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_tariff_rate_entity_extractor_fallback(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    handlers = _register_service_handlers(hass, monkeypatch)
+    coord = _fake_service_coordinator(site_id="tariff-site", serials=set())
+    coord.tariff_runtime = SimpleNamespace(async_update_tariff=AsyncMock())
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_SITE_ID: "tariff-site", CONF_SITE_ONLY: True},
@@ -580,27 +806,57 @@ async def test_set_tariff_rate_targets_current_tariff_sensor(
         "period_index": 1,
     }
     reg_entry = er.async_get(hass).async_get_or_create(
-        "sensor",
+        "number",
         DOMAIN,
-        f"{DOMAIN}_site_tariff-site_tariff_current_import_rate",
+        f"{DOMAIN}_site_tariff-site_tariff_import_rate_default_week_fallback_number",
         config_entry=entry,
     )
     hass.states.async_set(reg_entry.entity_id, 0.18, {"tariff_locator": locator})
-
-    await handlers[(DOMAIN, "set_tariff_rate")](
-        SimpleNamespace(data={"entity_id": [reg_entry.entity_id], "rate": 0.25})
+    monkeypatch.setattr(
+        "homeassistant.helpers.target.async_extract_referenced_entity_ids",
+        None,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "homeassistant.helpers.service.async_extract_referenced_entity_ids",
+        lambda _hass, _call: [reg_entry.entity_id],
+        raising=False,
     )
 
-    coord.tariff_runtime.async_set_tariff_rate.assert_awaited_once_with(locator, 0.25)
+    await handlers[(DOMAIN, "update_tariff")](SimpleNamespace(data={"rate": 0.25}))
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing=None,
+        rate_updates=[{"locator": locator, "rate": 0.25}],
+    )
+    coord.tariff_runtime.async_update_tariff.reset_mock()
+
+    def raise_extract_error(_hass, _call):
+        raise RuntimeError("extract failed")
+
+    monkeypatch.setattr(
+        "homeassistant.helpers.service.async_extract_referenced_entity_ids",
+        raise_extract_error,
+        raising=False,
+    )
+
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(data={"entity_id": reg_entry.entity_id, "rate": 0.26})
+    )
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing=None,
+        rate_updates=[{"locator": locator, "rate": 0.26}],
+    )
 
 
 @pytest.mark.asyncio
-async def test_set_tariff_rate_rejects_invalid_targets(
+async def test_update_tariff_rejects_invalid_rate_entity_targets(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     handlers = _register_service_handlers(hass, monkeypatch)
     coord = _fake_service_coordinator(site_id="tariff-site", serials=set())
-    coord.tariff_runtime = SimpleNamespace(async_set_tariff_rate=AsyncMock())
+    coord.tariff_runtime = SimpleNamespace(async_update_tariff=AsyncMock())
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_SITE_ID: "tariff-site", CONF_SITE_ONLY: True},
@@ -610,82 +866,95 @@ async def test_set_tariff_rate_rejects_invalid_targets(
     entry.add_to_hass(hass)
     entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
     ent_reg = er.async_get(hass)
-
-    with pytest.raises(ServiceValidationError):
-        await handlers[(DOMAIN, "set_tariff_rate")](
-            SimpleNamespace(data={"rate": 0.25})
-        )
-
-    with pytest.raises(ServiceValidationError):
-        await handlers[(DOMAIN, "set_tariff_rate")](
-            SimpleNamespace(
-                data={"entity_id": ["sensor.one", "sensor.two"], "rate": 0.25}
-            )
-        )
-
-    hass.states.async_set("sensor.not_tariff", 1)
-    with pytest.raises(ServiceValidationError):
-        await handlers[(DOMAIN, "set_tariff_rate")](
-            SimpleNamespace(data={"entity_id": ["sensor.not_tariff"], "rate": 0.25})
-        )
-
-    other_entry = ent_reg.async_get_or_create(
-        "sensor",
+    other_platform = ent_reg.async_get_or_create(
+        "number",
         "other_platform",
-        "external_tariff_import_rate",
-        config_entry=entry,
+        "tariff_import_rate_other_platform",
     )
-    with pytest.raises(ServiceValidationError):
-        await handlers[(DOMAIN, "set_tariff_rate")](
-            SimpleNamespace(data={"entity_id": [other_entry.entity_id], "rate": 0.25})
-        )
-
-    non_tariff_entry = ent_reg.async_get_or_create(
-        "sensor",
+    wrong_unique_id = ent_reg.async_get_or_create(
+        "number",
         DOMAIN,
-        f"{DOMAIN}_site_tariff-site_grid_import",
+        f"{DOMAIN}_site_tariff-site_other_number",
         config_entry=entry,
     )
-    with pytest.raises(ServiceValidationError):
-        await handlers[(DOMAIN, "set_tariff_rate")](
-            SimpleNamespace(
-                data={"entity_id": [non_tariff_entry.entity_id], "rate": 0.25}
-            )
-        )
-
     missing_locator = ent_reg.async_get_or_create(
-        "sensor",
+        "number",
         DOMAIN,
-        f"{DOMAIN}_site_tariff-site_tariff_import_rate_default_week_peak",
+        f"{DOMAIN}_site_tariff-site_tariff_import_rate_missing_locator_number",
         config_entry=entry,
     )
-    hass.states.async_set(missing_locator.entity_id, 0.18)
-    with pytest.raises(ServiceValidationError):
-        await handlers[(DOMAIN, "set_tariff_rate")](
-            SimpleNamespace(
-                data={"entity_id": [missing_locator.entity_id], "rate": 0.25}
-            )
-        )
-
-    wrong_site = ent_reg.async_get_or_create(
-        "sensor",
+    fallback_entity = ent_reg.async_get_or_create(
+        "number",
         DOMAIN,
-        f"{DOMAIN}_site_other-site_tariff_import_rate_default_week_peak",
+        f"{DOMAIN}_site_tariff-site_tariff_import_rate_no_config_entry_number",
     )
-    hass.states.async_set(wrong_site.entity_id, 0.18, {"tariff_locator": {}})
-    with pytest.raises(ServiceValidationError):
-        await handlers[(DOMAIN, "set_tariff_rate")](
-            SimpleNamespace(data={"entity_id": [wrong_site.entity_id], "rate": 0.25})
-        )
+    unknown_site_entity = ent_reg.async_get_or_create(
+        "number",
+        DOMAIN,
+        f"{DOMAIN}_site_unknown-site_tariff_import_rate_no_config_entry_number",
+    )
+    locator = {
+        "branch": "purchase",
+        "kind": "period",
+        "season_index": 1,
+        "day_index": 1,
+        "period_index": 1,
+    }
+    hass.states.async_set(fallback_entity.entity_id, 0.18, {"tariff_locator": locator})
+    hass.states.async_set(
+        unknown_site_entity.entity_id, 0.18, {"tariff_locator": locator}
+    )
+
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(data={"rate_entity": fallback_entity.entity_id, "rate": 0.25})
+    )
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing=None,
+        rate_updates=[{"locator": locator, "rate": 0.25}],
+    )
+
+    for entity_id, translation_key in (
+        ("number.missing", "exceptions.tariff_rate_entity_invalid"),
+        (other_platform.entity_id, "exceptions.tariff_rate_entity_invalid"),
+        (wrong_unique_id.entity_id, "exceptions.tariff_rate_entity_invalid"),
+        (unknown_site_entity.entity_id, "exceptions.tariff_rate_entity_invalid"),
+        (missing_locator.entity_id, "exceptions.tariff_rate_target_invalid"),
+    ):
+        with pytest.raises(ServiceValidationError) as err:
+            await handlers[(DOMAIN, "update_tariff")](
+                SimpleNamespace(data={"rate_entity": entity_id, "rate": 0.2})
+            )
+        assert err.value.translation_key == translation_key
 
 
 @pytest.mark.asyncio
-async def test_set_tariff_rate_falls_back_to_tariff_entity_unique_id(
+async def test_update_tariff_rejects_missing_and_incomplete_updates(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    handlers = _register_service_handlers(hass, monkeypatch)
+
+    with pytest.raises(ServiceValidationError) as err:
+        await handlers[(DOMAIN, "update_tariff")](SimpleNamespace(data={}))
+    assert err.value.translation_key == "exceptions.tariff_update_required"
+
+    with pytest.raises(ServiceValidationError) as err:
+        await handlers[(DOMAIN, "update_tariff")](
+            SimpleNamespace(data={"billing_start_date": "2026-04-01"})
+        )
+    assert err.value.translation_key == "exceptions.tariff_billing_incomplete"
+
+    with pytest.raises(ServiceValidationError) as err:
+        await handlers[(DOMAIN, "update_tariff")](SimpleNamespace(data={"rate": 0.2}))
+    assert err.value.translation_key == "exceptions.tariff_rate_entity_required"
+
+
+@pytest.mark.asyncio
+async def test_update_tariff_billing_only_resolves_site_targets(
     hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     handlers = _register_service_handlers(hass, monkeypatch)
     coord = _fake_service_coordinator(site_id="tariff-site", serials=set())
-    coord.tariff_runtime = SimpleNamespace(async_set_tariff_rate=AsyncMock())
+    coord.tariff_runtime = SimpleNamespace(async_update_tariff=AsyncMock())
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={CONF_SITE_ID: "tariff-site", CONF_SITE_ONLY: True},
@@ -694,6 +963,425 @@ async def test_set_tariff_rate_falls_back_to_tariff_entity_unique_id(
     )
     entry.add_to_hass(hass)
     entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(
+            data={
+                "site_id": "tariff-site",
+                "billing_start_date": "2026-04-01",
+                "billing_frequency": "MONTH",
+                "billing_interval_value": 1,
+            }
+        )
+    )
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing={
+            "billing_start_date": "2026-04-01",
+            "billing_frequency": "MONTH",
+            "billing_interval_value": 1,
+        },
+        rate_updates=[],
+    )
+    coord.tariff_runtime.async_update_tariff.reset_mock()
+
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(
+            data={
+                "config_entry_id": entry.entry_id,
+                "billing_start_date": "2026-04-02",
+                "billing_frequency": "DAY",
+                "billing_interval_value": 30,
+            }
+        )
+    )
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once()
+    coord.tariff_runtime.async_update_tariff.reset_mock()
+
+    site_device = dr.async_get(hass).async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "site:tariff-site")},
+        manufacturer="Enphase",
+        name="Tariff Site",
+    )
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(
+            data={
+                "device_id": [site_device.id],
+                "billing_start_date": "2026-04-03",
+                "billing_frequency": "MONTH",
+                "billing_interval_value": 2,
+            }
+        )
+    )
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_update_tariff_structural_updates_resolve_site_targets(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    handlers = _register_service_handlers(hass, monkeypatch)
+    coord = _fake_service_coordinator(site_id="tariff-site", serials=set())
+    coord.tariff_runtime = SimpleNamespace(async_update_tariff=AsyncMock())
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "tariff-site", CONF_SITE_ONLY: True},
+        title="Tariff Site",
+        unique_id="tariff-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    purchase = {
+        "typeKind": "single",
+        "typeId": "flat",
+        "source": "manual",
+        "seasons": [
+            {
+                "id": "default",
+                "days": [
+                    {
+                        "id": "week",
+                        "periods": [
+                            {
+                                "id": "off-peak",
+                                "type": "off-peak",
+                                "rate": "0.25",
+                                "startTime": "",
+                                "endTime": "",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    buyback = {
+        "typeKind": "single",
+        "typeId": "flat",
+        "source": "manual",
+        "exportPlan": "netFit",
+        "seasons": [
+            {
+                "id": "default",
+                "days": [
+                    {
+                        "id": "week",
+                        "periods": [
+                            {
+                                "id": "off-peak",
+                                "type": "off-peak",
+                                "rate": "0.08",
+                                "startTime": "",
+                                "endTime": "",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(
+            data={
+                "site_id": "tariff-site",
+                "purchase_tariff": purchase,
+                "buyback_tariff": buyback,
+            }
+        )
+    )
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing=None,
+        rate_updates=[],
+        purchase_tariff=purchase,
+        buyback_tariff=buyback,
+    )
+    coord.tariff_runtime.async_update_tariff.reset_mock()
+
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(
+            data={
+                "config_entry_id": entry.entry_id,
+                "tariff_payload": {"purchase": purchase, "buyback": buyback},
+            }
+        )
+    )
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once_with(
+        billing=None,
+        rate_updates=[],
+        tariff_payload={"purchase": purchase, "buyback": buyback},
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_tariff_guided_structural_fields_build_tariffs(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    handlers = _register_service_handlers(hass, monkeypatch)
+    coord = _fake_service_coordinator(site_id="tariff-site", serials=set())
+    coord.tariff_runtime = SimpleNamespace(async_update_tariff=AsyncMock())
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "tariff-site", CONF_SITE_ONLY: True},
+        title="Tariff Site",
+        unique_id="tariff-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(
+            data={
+                "site_id": "tariff-site",
+                "configure_import_tariff": True,
+                "import_tariff_type": "flat",
+                "import_flat_rate": 0.24,
+                "configure_export_tariff": True,
+                "export_tariff_type": "tou",
+                "export_variation": "weekends",
+                "export_plan": "grossFit",
+                "export_periods": [
+                    {
+                        "season_id": "summer",
+                        "start_month": 1,
+                        "end_month": 3,
+                        "day_group_id": "weekday",
+                        "period_id": "solar-peak",
+                        "period_type": "peak",
+                        "start_time": "10:00",
+                        "end_time": "15:00",
+                        "rate": 0.11,
+                    },
+                    {
+                        "season_id": "summer",
+                        "start_month": 1,
+                        "end_month": 3,
+                        "day_group_id": "weekend",
+                        "id": "off-peak",
+                        "type": "off-peak",
+                        "rate": 0.04,
+                    },
+                ],
+            }
+        )
+    )
+
+    coord.tariff_runtime.async_update_tariff.assert_awaited_once()
+    kwargs = coord.tariff_runtime.async_update_tariff.await_args.kwargs
+    assert kwargs["billing"] is None
+    assert kwargs["rate_updates"] == []
+    assert kwargs["purchase_tariff"] == {
+        "typeKind": "single",
+        "typeId": "flat",
+        "source": "manual",
+        "seasons": [
+            {
+                "id": "default",
+                "startMonth": "1",
+                "endMonth": "12",
+                "days": [
+                    {
+                        "id": "week",
+                        "days": [1, 2, 3, 4, 5, 6, 7],
+                        "periods": [
+                            {
+                                "id": "off-peak",
+                                "type": "off-peak",
+                                "rate": "0.24",
+                                "startTime": "",
+                                "endTime": "",
+                                "rateComponents": [],
+                            }
+                        ],
+                        "updatedValue": "",
+                    }
+                ],
+            }
+        ],
+    }
+    assert kwargs["buyback_tariff"]["typeKind"] == "weekends"
+    assert kwargs["buyback_tariff"]["typeId"] == "tou"
+    assert kwargs["buyback_tariff"]["exportPlan"] == "grossFit"
+    day_groups = kwargs["buyback_tariff"]["seasons"][0]["days"]
+    assert day_groups[0]["days"] == [1, 2, 3, 4, 5]
+    assert day_groups[0]["periods"][0]["startTime"] == 600
+    assert day_groups[0]["periods"][0]["endTime"] == 900
+    assert day_groups[1]["days"] == [6, 7]
+
+    coord.tariff_runtime.async_update_tariff.reset_mock()
+    await handlers[(DOMAIN, "update_tariff")](
+        SimpleNamespace(
+            data={
+                "site_id": "tariff-site",
+                "configure_import_tariff": True,
+                "import_tariff_type": "tiered",
+                "import_variation": "seasonal",
+                "import_off_peak_rate": 0.04,
+                "import_tiers": [
+                    {
+                        "season": "winter",
+                        "start_month": 4,
+                        "end_month": 9,
+                        "tier_id": "tier-1",
+                        "start_value": 0,
+                        "end_value": 10,
+                        "rate": 0.18,
+                    },
+                    {
+                        "season": "winter",
+                        "start_month": 4,
+                        "end_month": 9,
+                        "id": "tier-2",
+                        "startValue": 10,
+                        "endValue": "",
+                        "rate": 0.27,
+                    },
+                ],
+            }
+        )
+    )
+
+    tiered = coord.tariff_runtime.async_update_tariff.await_args.kwargs[
+        "purchase_tariff"
+    ]
+    assert tiered["typeKind"] == "seasonal"
+    assert tiered["typeId"] == "tiered"
+    assert tiered["seasons"][0]["offPeak"] == "0.04"
+    assert tiered["seasons"][0]["tiers"][1]["endValue"] == -1
+
+
+@pytest.mark.asyncio
+async def test_update_tariff_guided_structural_fields_validate_inputs(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    handlers = _register_service_handlers(hass, monkeypatch)
+    coord = _fake_service_coordinator(site_id="tariff-site", serials=set())
+    coord.tariff_runtime = SimpleNamespace(async_update_tariff=AsyncMock())
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "tariff-site", CONF_SITE_ONLY: True},
+        title="Tariff Site",
+        unique_id="tariff-site",
+    )
+    entry.add_to_hass(hass)
+    entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    invalid_inputs = (
+        {"configure_import_tariff": True},
+        {"configure_import_tariff": True, "import_tariff_type": "flat"},
+        {"configure_import_tariff": True, "import_tariff_type": "tou"},
+        {"configure_import_tariff": True, "import_tariff_type": "tiered"},
+        {
+            "configure_import_tariff": True,
+            "import_tariff_type": "tou",
+            "import_periods": ["bad"],
+        },
+        {
+            "configure_import_tariff": True,
+            "import_tariff_type": "tou",
+            "import_periods": [{"rate": "bad"}],
+        },
+        {
+            "configure_import_tariff": True,
+            "import_tariff_type": "tou",
+            "import_periods": [{"rate": -0.2}],
+        },
+        {
+            "configure_import_tariff": True,
+            "import_tariff_type": "tou",
+            "import_periods": [{"rate": 0.2, "start_month": "bad"}],
+        },
+        {
+            "configure_import_tariff": True,
+            "import_tariff_type": "tou",
+            "import_periods": [{"rate": 0.2, "start_month": 13}],
+        },
+        {
+            "configure_import_tariff": True,
+            "import_tariff_type": "tou",
+            "import_periods": [{"rate": 0.2, "start_time": "bad"}],
+        },
+        {
+            "configure_import_tariff": True,
+            "import_tariff_type": "tou",
+            "import_periods": [{"rate": 0.2, "start_time": "bad:time"}],
+        },
+        {
+            "configure_import_tariff": True,
+            "import_tariff_type": "tou",
+            "import_periods": [{"rate": 0.2, "start_time": 1500}],
+        },
+        {
+            "configure_import_tariff": True,
+            "import_tariff_type": "tou",
+            "import_periods": [{"rate": 0.2, "days": ["bad"]}],
+        },
+        {
+            "configure_import_tariff": True,
+            "import_tariff_type": "tou",
+            "import_periods": [{"rate": 0.2, "days": [0]}],
+        },
+        {
+            "configure_import_tariff": True,
+            "import_tariff_type": "tiered",
+            "import_tiers": ["bad"],
+        },
+    )
+    for data in invalid_inputs:
+        with pytest.raises(ServiceValidationError) as err:
+            await handlers[(DOMAIN, "update_tariff")](
+                SimpleNamespace(data={"site_id": "tariff-site", **data})
+            )
+        assert err.value.translation_key in {
+            "exceptions.tariff_structure_invalid",
+            "exceptions.tariff_rate_invalid",
+        }
+    coord.tariff_runtime.async_update_tariff.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_update_tariff_rejects_duplicate_and_cross_site_rates(
+    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    handlers = _register_service_handlers(hass, monkeypatch)
+    first = _fake_service_coordinator(site_id="first-site", serials=set())
+    first.tariff_runtime = SimpleNamespace(async_update_tariff=AsyncMock())
+    second = _fake_service_coordinator(site_id="second-site", serials=set())
+    second.tariff_runtime = SimpleNamespace(async_update_tariff=AsyncMock())
+    first_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "first-site", CONF_SITE_ONLY: True},
+        title="First Site",
+        unique_id="first-site",
+    )
+    second_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_SITE_ID: "second-site", CONF_SITE_ONLY: True},
+        title="Second Site",
+        unique_id="second-site",
+    )
+    first_entry.add_to_hass(hass)
+    second_entry.add_to_hass(hass)
+    first_entry.runtime_data = EnphaseRuntimeData(coordinator=first)
+    second_entry.runtime_data = EnphaseRuntimeData(coordinator=second)
+    ent_reg = er.async_get(hass)
+    first_entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_first-site_tariff_import_rate_default_week_peak",
+        config_entry=first_entry,
+    )
+    second_entity = ent_reg.async_get_or_create(
+        "sensor",
+        DOMAIN,
+        f"{DOMAIN}_site_second-site_tariff_import_rate_default_week_peak",
+        config_entry=second_entry,
+    )
     locator = {
         "branch": "purchase",
         "kind": "period",
@@ -701,51 +1389,56 @@ async def test_set_tariff_rate_falls_back_to_tariff_entity_unique_id(
         "day_index": 1,
         "period_index": 1,
     }
-    reg_entry = er.async_get(hass).async_get_or_create(
-        "sensor",
-        DOMAIN,
-        f"{DOMAIN}_site_tariff-site_tariff_import_rate_default_week_peak",
-    )
-    hass.states.async_set(reg_entry.entity_id, 0.18, {"tariff_locator": locator})
+    hass.states.async_set(first_entity.entity_id, 0.18, {"tariff_locator": locator})
+    hass.states.async_set(second_entity.entity_id, 0.19, {"tariff_locator": locator})
 
-    await handlers[(DOMAIN, "set_tariff_rate")](
-        SimpleNamespace(data={"entity_id": reg_entry.entity_id, "rate": 0.25})
-    )
+    with pytest.raises(ServiceValidationError) as err:
+        await handlers[(DOMAIN, "update_tariff")](
+            SimpleNamespace(
+                data={
+                    "rates": [
+                        {"entity_id": first_entity.entity_id, "rate": 0.25},
+                        {"entity_id": first_entity.entity_id, "rate": 0.26},
+                    ]
+                }
+            )
+        )
+    assert err.value.translation_key == "exceptions.tariff_rate_entity_duplicate"
 
-    coord.tariff_runtime.async_set_tariff_rate.assert_awaited_once_with(locator, 0.25)
+    with pytest.raises(ServiceValidationError) as err:
+        await handlers[(DOMAIN, "update_tariff")](
+            SimpleNamespace(
+                data={
+                    "rates": [
+                        {"entity_id": first_entity.entity_id, "rate": 0.25},
+                        {"entity_id": second_entity.entity_id, "rate": 0.26},
+                    ]
+                }
+            )
+        )
+    assert err.value.translation_key == "exceptions.tariff_site_mismatch"
 
+    with pytest.raises(ServiceValidationError) as err:
+        await handlers[(DOMAIN, "update_tariff")](
+            SimpleNamespace(
+                data={
+                    "site_id": "second-site",
+                    "billing_start_date": "2026-04-01",
+                    "billing_frequency": "MONTH",
+                    "billing_interval_value": 1,
+                    "rates": [{"entity_id": first_entity.entity_id, "rate": 0.25}],
+                }
+            )
+        )
+    assert err.value.translation_key == "exceptions.tariff_site_mismatch"
 
-@pytest.mark.asyncio
-async def test_set_tariff_rate_uses_legacy_entity_target_extractor(
-    hass: HomeAssistant, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    from custom_components.enphase_ev import services as services_mod
-
-    monkeypatch.setattr(
-        services_mod.ha_target,
-        "async_extract_referenced_entity_ids",
-        None,
-        raising=False,
-    )
-    monkeypatch.setattr(
-        services_mod.ha_service,
-        "async_extract_referenced_entity_ids",
-        lambda _hass, _call: {"sensor.missing"},
-    )
-    handlers = _register_service_handlers(hass, monkeypatch)
-
-    with pytest.raises(ServiceValidationError):
-        await handlers[(DOMAIN, "set_tariff_rate")](SimpleNamespace(data={"rate": 1}))
-
-    def _raise(*_args, **_kwargs):
-        raise RuntimeError("boom")
-
-    monkeypatch.setattr(
-        services_mod.ha_service,
-        "async_extract_referenced_entity_ids",
-        _raise,
-    )
-    handlers = _register_service_handlers(hass, monkeypatch)
-
-    with pytest.raises(ServiceValidationError):
-        await handlers[(DOMAIN, "set_tariff_rate")](SimpleNamespace(data={"rate": 1}))
+    with pytest.raises(ServiceValidationError) as err:
+        await handlers[(DOMAIN, "update_tariff")](
+            SimpleNamespace(
+                data={
+                    "export_rate_entity": first_entity.entity_id,
+                    "export_rate": 0.08,
+                }
+            )
+        )
+    assert err.value.translation_key == "exceptions.tariff_rate_entity_invalid"

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -22,8 +22,10 @@ from custom_components.enphase_ev.sensor import (
 )
 from custom_components.enphase_ev.tariff import (
     TARIFF_ENDPOINT_FAMILY,
+    TariffBillingUpdate,
     TariffRateLocator,
     TariffRateSnapshot,
+    TariffRateUpdate,
     TariffRuntime,
     _clean_text,
     _format_rate,
@@ -119,6 +121,35 @@ def test_next_billing_date_month_end_and_invalid_values() -> None:
     )
     assert invalid_interval is not None
     assert next_billing_date(invalid_interval, today=date(2026, 4, 26)) is None
+
+
+def test_tariff_update_parsers_cover_passthrough_and_invalid_inputs() -> None:
+    billing = TariffBillingUpdate(
+        start_date="2026-04-01",
+        billing_frequency="MONTH",
+        billing_interval_value=1,
+    )
+    assert TariffBillingUpdate.from_object(billing) is billing
+    assert TariffBillingUpdate.from_object("bad") is None
+    with pytest.raises(ServiceValidationError) as err:
+        TariffBillingUpdate.from_object(
+            {"billing_frequency": "MONTH", "billing_interval_value": 1}
+        )
+    assert err.value.translation_key == "exceptions.tariff_billing_start_date_invalid"
+
+    locator = TariffRateLocator(
+        branch="purchase",
+        kind="off_peak",
+        season_index=1,
+        season_id="default",
+    )
+    update = TariffRateUpdate(locator=locator, rate=0.1)
+    assert TariffRateUpdate.from_object(update) is update
+    assert TariffRateUpdate.from_object((locator, 0.2)) == TariffRateUpdate(
+        locator=locator,
+        rate=0.2,
+    )
+    assert TariffRateUpdate.from_object("bad") is None
 
 
 def test_parse_tariff_rate_flat_tou_and_tiered_shapes() -> None:
@@ -983,6 +1014,627 @@ async def test_tariff_runtime_updates_single_rate_and_preserves_payload(
 
 
 @pytest.mark.asyncio
+async def test_tariff_runtime_batches_rate_updates_with_one_tariff_put(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff = AsyncMock(
+        return_value={
+            "purchase": {
+                "typeId": "tou",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {"id": "off-peak", "rate": "0.18"},
+                                    {"id": "peak", "rate": "0.31"},
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+            "buyback": {
+                "typeId": "tou",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [{"id": "feed-in", "rate": "0.06"}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+    )
+    coord.client.site_tariff_update = AsyncMock(return_value={"message": "success"})
+    coord.client.notify_tariff_change = AsyncMock(return_value={"data": "ok"})
+    coord.tariff_runtime.async_refresh = AsyncMock()
+
+    out = await TariffRuntime(coord).async_update_tariff(
+        rate_updates=[
+            {
+                "locator": {
+                    "branch": "purchase",
+                    "kind": "period",
+                    "season_index": 1,
+                    "season_id": "default",
+                    "day_index": 1,
+                    "day_group_id": "week",
+                    "period_index": 2,
+                    "period_id": "peak",
+                },
+                "rate": 0.42,
+            },
+            {
+                "locator": {
+                    "branch": "buyback",
+                    "kind": "period",
+                    "season_index": 1,
+                    "season_id": "default",
+                    "day_index": 1,
+                    "day_group_id": "week",
+                    "period_index": 1,
+                    "period_id": "feed-in",
+                },
+                "rate": 0.08,
+            },
+        ]
+    )
+
+    assert out == {"tariff": {"message": "success"}, "billing": None}
+    coord.client.site_tariff.assert_awaited_once_with()
+    coord.client.site_tariff_update.assert_awaited_once()
+    update_payload = coord.client.site_tariff_update.await_args.args[0]
+    assert (
+        update_payload["purchase"]["seasons"][0]["days"][0]["periods"][1]["rate"]
+        == "0.42"
+    )
+    assert (
+        update_payload["buyback"]["seasons"][0]["days"][0]["periods"][0]["rate"]
+        == "0.08"
+    )
+    coord.client.notify_tariff_change.assert_awaited_once_with()
+    coord.tariff_runtime.async_refresh.assert_awaited_once_with(force=True)
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_updates_billing_only(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff_billing_update = AsyncMock(
+        return_value={"billingFrequency": "DAY"}
+    )
+    coord.client.notify_tariff_change = AsyncMock(return_value={"data": "ok"})
+    coord.tariff_runtime.async_refresh = AsyncMock()
+
+    out = await TariffRuntime(coord).async_update_tariff(
+        billing={
+            "billing_start_date": "2026-04-01",
+            "billing_frequency": "DAY",
+            "billing_interval_value": 30,
+        }
+    )
+
+    assert out == {"tariff": None, "billing": {"billingFrequency": "DAY"}}
+    coord.client.site_tariff_billing_update.assert_awaited_once_with(
+        {
+            "anyBillPeriodStartDate": "2026-04-01",
+            "billingFrequency": "DAY",
+            "billingIntervalValue": 30,
+        }
+    )
+    coord.client.notify_tariff_change.assert_awaited_once_with()
+    coord.tariff_runtime.async_refresh.assert_awaited_once_with(force=True)
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_updates_billing_and_rates(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff = AsyncMock(
+        return_value={
+            "purchase": {
+                "typeId": "tiered",
+                "seasons": [{"id": "default", "offPeak": "0.03", "tiers": []}],
+            }
+        }
+    )
+    coord.client.site_tariff_update = AsyncMock(return_value={"message": "success"})
+    coord.client.site_tariff_billing_update = AsyncMock(
+        return_value={"billingFrequency": "MONTH"}
+    )
+    coord.client.notify_tariff_change = AsyncMock(return_value={"data": "ok"})
+    coord.tariff_runtime.async_refresh = AsyncMock()
+
+    await TariffRuntime(coord).async_update_tariff(
+        billing={
+            "billing_start_date": "2026-04-01",
+            "billing_frequency": "MONTH",
+            "billing_interval_value": 2,
+        },
+        rate_updates=[
+            {
+                "locator": {
+                    "branch": "purchase",
+                    "kind": "off_peak",
+                    "season_index": 1,
+                    "season_id": "default",
+                },
+                "rate": 0.04,
+            }
+        ],
+    )
+
+    assert (
+        coord.client.site_tariff_update.await_args.args[0]["purchase"]["seasons"][0][
+            "offPeak"
+        ]
+        == "0.04"
+    )
+    coord.client.site_tariff_billing_update.assert_awaited_once()
+    coord.client.notify_tariff_change.assert_awaited_once_with()
+    coord.tariff_runtime.async_refresh.assert_awaited_once_with(force=True)
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_updates_structural_branches(coordinator_factory) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff = AsyncMock(
+        return_value={
+            "site_id": 123,
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "flat",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "id": "off-peak",
+                                        "rate": "0.20",
+                                        "startTime": "",
+                                        "endTime": "",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        }
+    )
+    coord.client.site_tariff_update = AsyncMock(return_value={"message": "success"})
+    coord.client.notify_tariff_change = AsyncMock(return_value={"data": "ok"})
+    coord.tariff_runtime.async_refresh = AsyncMock()
+    purchase = {
+        "typeKind": "seasonal-and-weekends",
+        "typeId": "tou",
+        "source": "manual",
+        "seasons": [
+            {
+                "id": "summer",
+                "startMonth": 1,
+                "endMonth": 3,
+                "days": [
+                    {
+                        "id": "week",
+                        "periods": [
+                            {
+                                "id": "peak",
+                                "type": "peak",
+                                "rate": "0.42",
+                                "startTime": 900,
+                                "endTime": 1260,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    buyback = {
+        "typeKind": "single",
+        "typeId": "flat",
+        "source": "manual",
+        "exportPlan": "netFit",
+        "seasons": [
+            {
+                "id": "default",
+                "days": [
+                    {
+                        "id": "week",
+                        "periods": [
+                            {
+                                "id": "off-peak",
+                                "type": "off-peak",
+                                "rate": "0.08",
+                                "startTime": "",
+                                "endTime": "",
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+    out = await TariffRuntime(coord).async_update_tariff(
+        purchase_tariff=purchase,
+        buyback_tariff=buyback,
+    )
+
+    assert out == {"tariff": {"message": "success"}, "billing": None}
+    coord.client.site_tariff.assert_awaited_once_with()
+    update_payload = coord.client.site_tariff_update.await_args.args[0]
+    assert update_payload["currency"] == "$"
+    assert update_payload["purchase"] == purchase
+    assert update_payload["buyback"] == buyback
+    coord.client.notify_tariff_change.assert_awaited_once_with()
+    coord.tariff_runtime.async_refresh.assert_awaited_once_with(force=True)
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_updates_full_structural_payload_and_rates(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff = AsyncMock()
+    coord.client.site_tariff_update = AsyncMock(return_value={"message": "success"})
+    coord.client.notify_tariff_change = AsyncMock(return_value={"data": "ok"})
+    coord.tariff_runtime.async_refresh = AsyncMock()
+    payload = {
+        "site_id": 123,
+        "currency": "$",
+        "purchase": {
+            "typeKind": "single",
+            "typeId": "tiered",
+            "source": "manual",
+            "seasons": [
+                {
+                    "id": "default",
+                    "offPeak": "0.03",
+                    "tiers": [
+                        {
+                            "id": "tier-1",
+                            "rate": "0.20",
+                            "startValue": "0",
+                            "endValue": -1,
+                        }
+                    ],
+                }
+            ],
+        },
+    }
+
+    await TariffRuntime(coord).async_update_tariff(
+        tariff_payload=payload,
+        rate_updates=[
+            {
+                "locator": {
+                    "branch": "purchase",
+                    "kind": "off_peak",
+                    "season_index": 1,
+                    "season_id": "default",
+                },
+                "rate": 0.05,
+            }
+        ],
+    )
+
+    coord.client.site_tariff.assert_not_awaited()
+    update_payload = coord.client.site_tariff_update.await_args.args[0]
+    assert update_payload["purchase"]["seasons"][0]["offPeak"] == "0.05"
+    assert payload["purchase"]["seasons"][0]["offPeak"] == "0.03"
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_rejects_invalid_structural_tariffs(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff = AsyncMock()
+    coord.client.site_tariff_update = AsyncMock()
+
+    invalid_inputs = (
+        ({"tariff_payload": []}, "exceptions.tariff_structure_invalid"),
+        ({"tariff_payload": {"currency": "$"}}, "exceptions.tariff_structure_invalid"),
+        ({"purchase_tariff": []}, "exceptions.tariff_structure_invalid"),
+        (
+            {
+                "purchase_tariff": {
+                    "typeKind": "bad",
+                    "typeId": "flat",
+                    "seasons": [],
+                }
+            },
+            "exceptions.tariff_structure_invalid",
+        ),
+        (
+            {
+                "purchase_tariff": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "seasons": [{"id": "default", "days": []}],
+                }
+            },
+            "exceptions.tariff_structure_invalid",
+        ),
+        (
+            {
+                "purchase_tariff": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "seasons": ["default"],
+                }
+            },
+            "exceptions.tariff_structure_invalid",
+        ),
+        (
+            {
+                "purchase_tariff": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "seasons": [{"id": "default", "days": ["week"]}],
+                }
+            },
+            "exceptions.tariff_structure_invalid",
+        ),
+        (
+            {
+                "purchase_tariff": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "seasons": [{"id": "default", "days": [{"id": "week"}]}],
+                }
+            },
+            "exceptions.tariff_structure_invalid",
+        ),
+        (
+            {
+                "purchase_tariff": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "seasons": [
+                        {
+                            "id": "default",
+                            "days": [{"id": "week", "periods": ["peak"]}],
+                        }
+                    ],
+                }
+            },
+            "exceptions.tariff_structure_invalid",
+        ),
+        (
+            {
+                "purchase_tariff": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "seasons": [
+                        {
+                            "id": "default",
+                            "days": [
+                                {
+                                    "id": "week",
+                                    "periods": [
+                                        {
+                                            "id": "peak",
+                                            "rate": "bad",
+                                            "startTime": 900,
+                                            "endTime": 1260,
+                                        }
+                                    ],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            },
+            "exceptions.tariff_rate_invalid",
+        ),
+        (
+            {
+                "purchase_tariff": {
+                    "typeKind": "single",
+                    "typeId": "tiered",
+                    "seasons": [{"id": "default"}],
+                }
+            },
+            "exceptions.tariff_structure_invalid",
+        ),
+        (
+            {
+                "purchase_tariff": {
+                    "typeKind": "single",
+                    "typeId": "tiered",
+                    "seasons": [{"id": "default", "tiers": ["tier-1"]}],
+                }
+            },
+            "exceptions.tariff_structure_invalid",
+        ),
+        (
+            {
+                "purchase_tariff": {
+                    "typeKind": "single",
+                    "typeId": "tiered",
+                    "seasons": [
+                        {
+                            "id": "default",
+                            "tiers": [{"rate": "0.1", "endValue": "bad"}],
+                        }
+                    ],
+                }
+            },
+            "exceptions.tariff_structure_invalid",
+        ),
+    )
+    for kwargs, translation_key in invalid_inputs:
+        with pytest.raises(ServiceValidationError) as err:
+            await TariffRuntime(coord).async_update_tariff(**kwargs)
+        assert err.value.translation_key == translation_key
+    coord.client.site_tariff.assert_not_awaited()
+    coord.client.site_tariff_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_rejects_structural_time_and_tier_bounds(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff = AsyncMock()
+    coord.client.site_tariff_update = AsyncMock()
+
+    invalid_inputs = (
+        {
+            "purchase_tariff": {
+                "typeKind": "seasonal",
+                "typeId": "tou",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "startMonth": 13,
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "id": "peak",
+                                        "rate": "0.2",
+                                        "startTime": 900,
+                                        "endTime": 1260,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        },
+        {
+            "purchase_tariff": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "id": "peak",
+                                        "rate": "0.2",
+                                        "startTime": 900,
+                                        "endTime": "",
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        },
+        {
+            "purchase_tariff": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "id": "peak",
+                                        "rate": "0.2",
+                                        "startTime": 900,
+                                        "endTime": 900,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        },
+        {
+            "purchase_tariff": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "id": "peak",
+                                        "rate": "0.2",
+                                        "startTime": 1500,
+                                        "endTime": 1560,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            }
+        },
+        {
+            "purchase_tariff": {
+                "typeKind": "single",
+                "typeId": "tiered",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "tiers": [{"rate": "0.1", "startValue": "-1", "endValue": -1}],
+                    }
+                ],
+            }
+        },
+    )
+    for kwargs in invalid_inputs:
+        with pytest.raises(ServiceValidationError) as err:
+            await TariffRuntime(coord).async_update_tariff(**kwargs)
+        assert err.value.translation_key == "exceptions.tariff_structure_invalid"
+    coord.client.site_tariff.assert_not_awaited()
+    coord.client.site_tariff_update.assert_not_awaited()
+
+    coord.client.site_tariff_update = None
+    with pytest.raises(ServiceValidationError) as err:
+        await TariffRuntime(coord).async_update_tariff(
+            tariff_payload={
+                "purchase": {
+                    "typeKind": "single",
+                    "typeId": "flat",
+                    "seasons": [
+                        {
+                            "id": "default",
+                            "days": [
+                                {
+                                    "id": "week",
+                                    "periods": [{"id": "off-peak", "rate": "0.1"}],
+                                }
+                            ],
+                        }
+                    ],
+                }
+            }
+        )
+    assert err.value.translation_key == "exceptions.tariff_rate_api_unavailable"
+
+
+@pytest.mark.asyncio
 async def test_tariff_runtime_updates_tiered_off_peak_and_ignores_notify_failure(
     coordinator_factory,
 ) -> None:
@@ -1100,6 +1752,80 @@ async def test_tariff_runtime_rejects_invalid_input_and_unavailable_api(
             },
             0.1,
         )
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_rejects_invalid_billing_and_duplicates(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff = AsyncMock(
+        return_value={
+            "purchase": {"seasons": [{"id": "default", "offPeak": "0.03", "tiers": []}]}
+        }
+    )
+    coord.client.site_tariff_update = AsyncMock()
+
+    with pytest.raises(ServiceValidationError) as err:
+        await TariffRuntime(coord).async_update_tariff()
+    assert err.value.translation_key == "exceptions.tariff_update_required"
+
+    coord.client.site_tariff_billing_update = None
+    with pytest.raises(ServiceValidationError) as err:
+        await TariffRuntime(coord).async_update_tariff(
+            billing={
+                "billing_start_date": "2026-04-01",
+                "billing_frequency": "DAY",
+                "billing_interval_value": 30,
+            }
+        )
+    assert err.value.translation_key == "exceptions.tariff_billing_api_unavailable"
+
+    with pytest.raises(ServiceValidationError) as err:
+        await TariffRuntime(coord).async_update_tariff(
+            billing={
+                "billing_start_date": "bad",
+                "billing_frequency": "MONTH",
+                "billing_interval_value": 1,
+            }
+        )
+    assert err.value.translation_key == "exceptions.tariff_billing_start_date_invalid"
+
+    with pytest.raises(ServiceValidationError) as err:
+        await TariffRuntime(coord).async_update_tariff(
+            billing={
+                "billing_start_date": "2026-04-01",
+                "billing_frequency": "WEEK",
+                "billing_interval_value": 1,
+            }
+        )
+    assert err.value.translation_key == "exceptions.tariff_billing_frequency_invalid"
+
+    with pytest.raises(ServiceValidationError) as err:
+        await TariffRuntime(coord).async_update_tariff(
+            billing={
+                "billing_start_date": "2026-04-01",
+                "billing_frequency": "MONTH",
+                "billing_interval_value": 25,
+            }
+        )
+    assert err.value.translation_key == "exceptions.tariff_billing_interval_invalid"
+
+    duplicate_update = {
+        "locator": {
+            "branch": "purchase",
+            "kind": "off_peak",
+            "season_index": 1,
+            "season_id": "default",
+        },
+        "rate": 0.04,
+    }
+    with pytest.raises(ServiceValidationError) as err:
+        await TariffRuntime(coord).async_update_tariff(
+            rate_updates=[duplicate_update, duplicate_update]
+        )
+    assert err.value.translation_key == "exceptions.tariff_rate_target_duplicate"
+    coord.client.site_tariff_update.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Adds a unified `enphase_ev.update_tariff` service for editing Enphase tariff settings in one action. The service supports billing-cycle updates, existing import/export tariff rate updates, advanced raw payload replacement, and guided structural tariff builders for common flat, time-of-use, and tiered import/export configurations.

The existing tariff rate number entities remain compatible by routing through the same shared runtime write path. The previous unreleased `set_tariff_rate` public action surface has been folded into `update_tariff`.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [x] New feature
- [x] Documentation
- [x] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev tests/components/enphase_ev && ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_tariff.py tests/components/enphase_ev/test_services.py tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/tariff.py,custom_components/enphase_ev/services.py,custom_components/enphase_ev/number.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
git diff --check
```

Manual verification:

- Started the local HA runtime container.
- Called `enphase_ev.update_tariff` through Home Assistant's REST service API for multiple live tariff structures.
- Verified each write by reading the Enphase tariff payload back after the action completed.
- Tested flat import/export, seasonal/weekend TOU import with TOU export, and tiered import with gross flat export.
- Restored the original raw Enphase tariff payload in a `finally` block and verified the original `purchase` and `buyback` branches matched after restore.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The guided structural fields are best-effort within Home Assistant's service-action UI constraints. The form cannot dynamically hide/show nested fields, so the action exposes explicit import/export builder toggles, selectors for valid enum choices, descriptions, and object-row examples for TOU periods and tier rows. Advanced raw object fields remain available for exact payload replacement.
