### PR TITLE
Prepare 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## Unreleased
+## v3.0.0 - 2026-05-01
 
 ### 🚧 Breaking changes
 - Raised the advertised minimum Home Assistant version from `2024.12.0` to `2026.3.0` and moved the development/test toolchain to Python `3.14`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,32 +5,52 @@ All notable changes to this project will be documented in this file.
 ## Unreleased
 
 ### 🚧 Breaking changes
-- None
+- Raised the advertised minimum Home Assistant version from `2024.12.0` to `2026.3.0` and moved the development/test toolchain to Python `3.14`.
 
 ### ✨ New features
-- Added site tariff sensors for next billing date and Energy-dashboard-ready current import/export prices, attached to the IQ Gateway device when available.
-- Added editable tariff rate number entities and an `update_tariff` service for updating billing-cycle details, guided tariff structures, and one or more Enphase import/export tariff rate values in one call.
-- Tariff sensors now refresh with normal sensor polling and keep their last known values while the Enphase tariff backend is degraded.
+- Added read-only site tariff support, including next billing date sensors and Energy-dashboard-ready current import/export price sensors attached to the IQ Gateway device when available.
+- Added editable tariff rate number entities for Enphase import and export tariff rates.
+- Added the unified `update_tariff` service for updating billing-cycle details, individual tariff rate values, guided flat/TOU/tiered tariff structures, and full advanced tariff payloads in one call.
+- Added localized service metadata, validation errors, icons, diagnostics, and README coverage for the tariff sensor and tariff editing surfaces.
+- Added a manual `try_reauth_now` service that uses stored credentials to make one immediate reauthentication attempt when an Enphase auth block or expired session is recoverable.
 
 ### 🐛 Bug fixes
 - Detected Enphase "too many active sessions" authentication failures explicitly, paused automatic login retries, and surfaced localized config-flow and repair messages that tell users to clear other Enphase sessions.
 - Localized cloud diagnostic error states for rate limits, temporary authentication blocks, authentication failures, invalid payloads, service outages, DNS failures, and network errors; rate-limit repairs now include retry timing, de-duplicate repeated reports, and clear after a successful refresh.
-- Bounded the `Current Production Power` live-sample cache so stale values are not reused indefinitely when the latest-power endpoint stops returning valid samples.
-- Filtered advisory IQ Gateway firmware releases by country applicability so country-scoped Enphase release notes do not create invalid update prompts in unrelated regions.
+- Treated Enphase active-session-limit failures consistently across login, automatic auth refresh, config flow, diagnostics, repairs, and services.
+- Preserved stored-credential authentication rejection streaks when optional follow-up refresh work records a new rejection, so successful unrelated endpoint refreshes no longer clear HEMS or heat-pump auth rejection state before retry suspension can activate.
+- Bounded the `Current Production Power` live-sample cache so stale values are not reused indefinitely when the latest-power endpoint stops returning valid samples after Home Assistant restarts or endpoint degradation.
+- Smoothed idle heat-pump power over existing low-load energy samples so whole-Wh cloud readings no longer flicker between `0 W` and standby load, while exposing the raw short-window value in diagnostics.
+- Filtered advisory IQ Gateway firmware catalog entries by country applicability so country-scoped Enphase release notes do not create invalid update prompts in unrelated regions.
 - Crawled IQ Gateway communication release notes without the removed product-media facet so current regional Gateway firmware versions remain discoverable.
 - Suppressed stale worldwide IQ Gateway firmware catalog fallbacks when newer country-scoped release notes show the public catalog no longer has a current global baseline.
-- Smoothed idle heat-pump power over existing low-load energy samples so whole-Wh cloud readings no longer flicker between `0 W` and standby load, while exposing the raw short-window value in diagnostics.
+- Improved firmware catalog routing and release metadata handling so advisory update entities keep the correct release URL, summary, latest-version state, skipped-version reconciliation, and previous-catalog fallback behavior.
 - Reduced unnecessary EV charger post-status follow-up lookups, kept idle session-history catch-up off the main refresh path when cached data is still usable, and aligned HEMS preflight/device refresh cadence with fast polling to lower steady-state cloud overhead.
 - Hardened setup, polling, and EV charger service inputs by bounding scan/runtime intervals, restricting OCPP trigger messages to supported values, requiring confirmation for advanced trigger messages, and keeping raw Enphase error bodies out of raised exceptions.
-- Reported the charger-specific minimum amp value during EV charger safe-limit charging instead of always showing 8A.
+- Rejected unresolved EV charger and site service targets with clear validation errors instead of allowing ambiguous calls to fall through to the wrong coordinator.
+- Reported the charger-specific minimum amp value during EV charger safe-limit charging instead of always showing `8 A`.
+- Redacted Enphase site IDs from logs and diagnostics, expanding the existing redaction coverage across API, summary, session history, EVSE timeseries, coordinator diagnostics, and service messages.
+- Made same-value IQ Battery reserve and shutdown-level number writes no-ops so unchanged settings do not trip the BatteryConfig write debounce or send unnecessary cloud writes.
+- Made same-value EV charger charge mode selections no-ops so the scheduler is not called when Home Assistant selects the already-active mode, avoiding Enphase `400` responses on unchanged selections.
+- Kept tariff refresh data stale-but-available when Enphase tariff endpoints are degraded, and made empty/unconfigured tariff responses explicit in diagnostics instead of failing normal polling.
 
 ### 🔧 Improvements
-- Clarified the Enphase authentication-block repair message and added a manual stored-credential reauthentication service for trying one immediate unblock attempt.
+- Clarified Enphase authentication-block and active-session repair messages, including retry timing and guidance to clear other Enphase app/browser sessions.
 - Disabled less-common diagnostic and inventory entities by default to reduce recorder churn on larger sites while keeping them available for troubleshooting.
 - Parallelized setup discovery probes so slow optional inventory endpoints no longer block the device selection step serially.
+- Added refresh performance diagnostics and regression tests for cloud-call volume, refresh-stage timing, fast-poll behavior, and post-status endpoint fan-out.
+- Updated the refresh planner and runtime helpers to reduce redundant checks, run due EVSE enrichment work concurrently, and keep optional endpoint backoff/cooldown behavior visible in diagnostics.
+- Expanded the API reference for tariff payloads, EV charger live-stream MQTT findings, OCPP trigger messages, and the current runtime endpoint surface.
+- Added architecture and glossary documentation describing integration structure, runtime responsibilities, and Enphase terminology.
+- Removed redundant defensive code and duplicated helper branches after coverage was in place, reducing internal maintenance surface.
 
 ### 🔄 Other changes
-- Expanded Platinum quality-scale evidence and validation, including upstream brands validation, stricter runtime-data typing checks, and CI coverage enforcement.
+- Added Platinum quality-scale evidence validation, upstream brands validation, stricter runtime-data typing checks, import-time diagnostics, and CI coverage enforcement.
+- Added `.strict-typing`, `py.typed`, mypy coverage for runtime/config-flow typing contracts, and a minimum Home Assistant `2026.3.0` CI job.
+- Added the Docker `ha-dev` Python `3.14` environment and a pinned minimum-Home-Assistant dependency set for release validation.
+- Added `scripts/importtime_profile.py` and expanded quality-scale validator coverage.
+- Updated GitHub Actions to Python `3.14`, refreshed workflow trigger paths, and bumped `stefanbuck/github-issue-parser` from `3.2.3` to `3.2.5`.
+- Expanded test coverage across tariff parsing/writes, services, firmware catalog generation, diagnostics redaction, refresh performance, active-session handling, OCPP validation, Python `3.14` task naming, and minimum Home Assistant compatibility.
 
 ## v2.9.2 - 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Manual install steps: see the wiki Installation page.
 
 ## Compatibility
 
-- Minimum supported Home Assistant version is `2024.12.0` (Python `3.13`+).
+- Minimum supported Home Assistant version is `2026.3.0` (Python `3.14`+).
 - In v2.0.0, the integration display name changed to `Enphase Energy`.
 - The integration domain remains `enphase_ev`, so existing entity IDs, automations, and scripts do not require migration.
 - Users migrating from the core Enphase Envoy integration can optionally use the `Migrate Envoy history` assistant in the integration Options flow to take over compatible Energy-dashboard entity IDs. The assistant archives the migrated Envoy energy entities, swaps the entity IDs, and restores the remaining Envoy entities after the migration. Create a full Home Assistant backup first. Full steps: [Envoy History Migration](https://github.com/barneyonline/ha-enphase-energy/wiki/Envoy-History-Migration).

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "2.9.2"
+  "version": "3.0.0"
 }

--- a/custom_components/enphase_ev/number.py
+++ b/custom_components/enphase_ev/number.py
@@ -291,7 +291,10 @@ class BatteryReserveNumber(CoordinatorEntity, NumberEntity):
         return float(self._coord.battery_reserve_max)
 
     async def async_set_native_value(self, value: float) -> None:
-        await self._coord.async_set_battery_reserve(int(value))
+        reserve = int(value)
+        if self._coord.battery_selected_backup_percentage == reserve:
+            return
+        await self._coord.async_set_battery_reserve(reserve)
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -440,7 +443,10 @@ class BatteryShutdownLevelNumber(CoordinatorEntity, NumberEntity):
         return float(self._coord.battery_shutdown_level_max)
 
     async def async_set_native_value(self, value: float) -> None:
-        await self._coord.async_set_battery_shutdown_level(int(value))
+        level = int(value)
+        if self._coord.battery_shutdown_level == level:
+            return
+        await self._coord.async_set_battery_shutdown_level(level)
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -85,6 +85,22 @@ def _smart_charging_context(coord: EnphaseCoordinator, sn: str | None = None) ->
     return False
 
 
+def _explicit_charge_mode(coord: EnphaseCoordinator, sn: str) -> str | None:
+    try:
+        data = (coord.data or {}).get(sn, {})
+    except Exception:
+        data = {}
+    for key in ("charge_mode_pref", "charge_mode"):
+        normalizer = getattr(coord, "_normalize_charge_mode_preference", None)
+        raw = data.get(key) if isinstance(data, dict) else None
+        value = normalizer(raw) if callable(normalizer) else raw
+        if value is not None:
+            return str(value)
+    cached = getattr(coord, "_cached_charge_mode_preference", None)
+    value = cached(sn) if callable(cached) else None
+    return str(value) if value is not None else None
+
+
 def _solar_mode(coord: EnphaseCoordinator, sn: str | None = None) -> tuple[str, str]:
     if _smart_charging_context(coord, sn):
         # The Enphase UI can present the same solar option as Smart Charging
@@ -689,6 +705,8 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
                 translation_domain=DOMAIN,
                 translation_key="charge_mode_invalid_option",
             )
+        if _explicit_charge_mode(self._coord, self._sn) == mode:
+            return
         try:
             await self._coord.client.set_charge_mode(self._sn, mode)
             self._coord.mark_scheduler_available()

--- a/tests/components/enphase_ev/test_number_module.py
+++ b/tests/components/enphase_ev/test_number_module.py
@@ -415,6 +415,21 @@ async def test_battery_reserve_number_sets_value(hass, config_entry) -> None:
     coord.async_set_battery_reserve.assert_awaited_once_with(40)
 
 
+@pytest.mark.asyncio
+async def test_battery_reserve_number_ignores_current_value(hass, config_entry) -> None:
+    coord = _make_coordinator(hass, config_entry, {RANDOM_SERIAL: {}})
+    coord._battery_has_encharge = True  # noqa: SLF001
+    coord._battery_profile = "self-consumption"  # noqa: SLF001
+    coord.async_set_battery_reserve = AsyncMock()
+    coord._battery_show_charge_from_grid = True  # noqa: SLF001
+    coord._battery_show_battery_backup_percentage = True  # noqa: SLF001
+    coord._battery_backup_percentage = 25  # noqa: SLF001
+
+    await BatteryReserveNumber(coord).async_set_native_value(25)
+
+    coord.async_set_battery_reserve.assert_not_awaited()
+
+
 def test_battery_reserve_number_handles_none_and_super_unavailable(
     hass, config_entry
 ) -> None:
@@ -459,6 +474,20 @@ async def test_battery_shutdown_level_number_sets_value(hass, config_entry) -> N
     await BatteryShutdownLevelNumber(coord).async_set_native_value(12)
 
     coord.async_set_battery_shutdown_level.assert_awaited_once_with(12)
+
+
+@pytest.mark.asyncio
+async def test_battery_shutdown_level_number_ignores_current_value(
+    hass, config_entry
+) -> None:
+    coord = _make_coordinator(hass, config_entry, {RANDOM_SERIAL: {}})
+    coord._battery_envoy_supports_vls = True  # noqa: SLF001
+    coord._battery_very_low_soc = 15  # noqa: SLF001
+    coord.async_set_battery_shutdown_level = AsyncMock()
+
+    await BatteryShutdownLevelNumber(coord).async_set_native_value(15)
+
+    coord.async_set_battery_shutdown_level.assert_not_awaited()
 
 
 def test_battery_shutdown_level_number_handles_none_and_super_unavailable(

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -62,6 +62,45 @@ async def test_charge_mode_select(hass, monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_charge_mode_select_ignores_current_option(hass, monkeypatch) -> None:
+    from custom_components.enphase_ev.const import (
+        CONF_COOKIE,
+        CONF_EAUTH,
+        CONF_SCAN_INTERVAL,
+        CONF_SERIALS,
+        CONF_SITE_ID,
+    )
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from custom_components.enphase_ev.select import ChargeModeSelect
+
+    cfg = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 30,
+    }
+    from custom_components.enphase_ev import coordinator as coord_mod
+
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    coord = EnphaseCoordinator(hass, cfg)
+    coord.data = {RANDOM_SERIAL: {"charge_mode": "MANUAL_CHARGING"}}
+    coord.async_request_refresh = AsyncMock()
+
+    class StubClient:
+        set_charge_mode = AsyncMock()
+
+    coord.client = StubClient()
+
+    await ChargeModeSelect(coord, RANDOM_SERIAL).async_select_option("Manual")
+
+    coord.client.set_charge_mode.assert_not_awaited()
+    coord.async_request_refresh.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_async_setup_entry_falls_back_to_generic_listener_for_selects(
     hass, config_entry, coordinator_factory, monkeypatch
 ) -> None:
@@ -249,6 +288,20 @@ def test_select_helper_fallbacks() -> None:
     coord.inventory_view.has_type_for_entities = lambda _type_key: False
     coord.battery_user_is_owner = True
     assert select_mod._retain_system_profile(coord) is False
+
+
+def test_explicit_charge_mode_handles_bad_data() -> None:
+    from custom_components.enphase_ev.select import _explicit_charge_mode
+
+    class BadDataCoordinator:
+        @property
+        def data(self):
+            raise RuntimeError
+
+        def _cached_charge_mode_preference(self, _sn):
+            return None
+
+    assert _explicit_charge_mode(BadDataCoordinator(), RANDOM_SERIAL) is None
 
 
 def test_ac_battery_target_state_of_charge_select_state_and_options(


### PR DESCRIPTION
## Summary

Prepare the integration for the 3.0.0 release by:

- Bumping the integration manifest version to `3.0.0`.
- Updating the README compatibility note for Home Assistant `2026.3.0` and Python `3.14+`.
- Expanding the Unreleased changelog with all notable changes since `v2.9.2`.
- Making unchanged IQ Battery reserve/shutdown-level writes and unchanged EV charger charge-mode selections no-ops so idempotent Home Assistant actions do not send unnecessary Enphase writes.
- Adding regression tests for those same-value write paths.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release preparation for `3.0.0`.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_manifest.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --files README.md"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --files CHANGELOG.md"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/*.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pre-commit run --all-files"
```

Additional live validation against the local `ha-runtime` dev environment:

- Verified read-only endpoint status probe returned overall `Fully Operational`; optional battery schedule validation preflight returned Enphase `403`, which the integration already handles as non-fatal.
- Verified reversible/idempotent service paths including refresh, schedule sync, live stream start/stop, schedule refresh/save, same-value number/select/time/switch writes.
- Verified the two previously failing same-value calls now return successfully through Home Assistant services.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The local Home Assistant recorder database in `.ha-config/home-assistant_v2.db` reports SQLite integrity errors. That appears to be local runtime state and is separate from the integration validation above.