### PR TITLE
Preserve auth refresh rejection streaks

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -264,6 +264,7 @@ class RefreshPipelineContext:
     phase_timings: dict[str, float]
     fallback_data: dict[str, dict]
     first_refresh: bool
+    auth_refresh_rejected_count_at_start: int = 0
     status_used_stale: bool = False
     fast_poll: bool = False
 
@@ -2416,6 +2417,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             phase_timings={},
             fallback_data=fallback_data,
             first_refresh=not self._has_successful_refresh,
+            auth_refresh_rejected_count_at_start=int(
+                getattr(self, "_auth_refresh_rejected_count", 0)
+            ),
         )
 
     async def _async_run_site_only_refresh_pipeline(
@@ -2462,8 +2466,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     phase_timings,
                     plan=followup_plan,
                 )
-        if not self._auth_refresh_suspended_active():
-            self._clear_auth_refresh_rejection_state()
+        self._clear_auth_refresh_rejection_state_if_unchanged(context)
         self._prune_runtime_caches(active_serials=(), keep_day_keys=())
         self._sync_battery_profile_pending_issue()
         self.last_success_utc = dt_util.utcnow()
@@ -2521,8 +2524,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     context.phase_timings,
                     plan=followup_plan,
                 )
-        if not self._auth_refresh_suspended_active():
-            self._clear_auth_refresh_rejection_state()
+        self._clear_auth_refresh_rejection_state_if_unchanged(context)
 
     async def _async_run_post_session_refresh_pipeline(
         self,
@@ -4415,6 +4417,20 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._auth_refresh_rejected_count = 0
         self._auth_refresh_rejected_until = None
         self._auth_refresh_rejected_ends_utc = None
+
+    def _clear_auth_refresh_rejection_state_if_unchanged(
+        self, context: RefreshPipelineContext
+    ) -> None:
+        """Clear stale refresh rejections only when this refresh added none."""
+
+        if self._auth_refresh_suspended_active():
+            return
+        if (
+            int(getattr(self, "_auth_refresh_rejected_count", 0))
+            != context.auth_refresh_rejected_count_at_start
+        ):
+            return
+        self._clear_auth_refresh_rejection_state()
 
     def _clear_auth_refresh_suspension(self, *, persist: bool = True) -> None:
         """Clear stored-credential auto-refresh suspension state."""

--- a/tests/components/enphase_ev/test_coordinator_edge_cases.py
+++ b/tests/components/enphase_ev/test_coordinator_edge_cases.py
@@ -485,6 +485,7 @@ async def test_post_status_first_refresh_clears_auth_refresh_rejection(
         phase_timings={},
         fallback_data={},
         first_refresh=True,
+        auth_refresh_rejected_count_at_start=2,
     )
 
     await coord._async_run_post_status_refresh_pipeline(context)
@@ -494,6 +495,72 @@ async def test_post_status_first_refresh_clears_auth_refresh_rejection(
     assert coord._auth_refresh_rejected_count == 0
     assert coord._auth_refresh_rejected_until is None
     assert coord._auth_refresh_rejected_ends_utc is None
+
+
+@pytest.mark.asyncio
+async def test_post_status_preserves_new_auth_refresh_rejection(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import RefreshPipelineContext
+
+    coord = coordinator_factory()
+
+    async def _reject_during_followup(*_args, **_kwargs) -> None:
+        coord._auth_refresh_rejected_count = 1
+        coord._auth_refresh_rejected_until = time.monotonic() + 60
+        coord._auth_refresh_rejected_ends_utc = datetime.now(timezone.utc) + timedelta(
+            seconds=60
+        )
+        return ("tariff_s", 0.123)
+
+    coord.refresh_runner.async_run_refresh_call = AsyncMock(
+        side_effect=_reject_during_followup
+    )
+    coord._auth_refresh_rejected_count = 0
+    coord._auth_refresh_rejected_until = None
+    coord._auth_refresh_rejected_ends_utc = None
+    context = RefreshPipelineContext(
+        started_mono=time.monotonic(),
+        refresh_started_utc=datetime.now(timezone.utc),
+        phase_timings={},
+        fallback_data={},
+        first_refresh=True,
+        auth_refresh_rejected_count_at_start=0,
+    )
+
+    await coord._async_run_post_status_refresh_pipeline(context)
+
+    coord.refresh_runner.async_run_refresh_call.assert_awaited_once()
+    assert coord._auth_refresh_rejected_count == 1
+    assert coord._auth_refresh_rejected_until is not None
+    assert coord._auth_refresh_rejected_ends_utc is not None
+
+
+def test_clear_auth_refresh_rejection_state_if_unchanged_preserves_suspension(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import RefreshPipelineContext
+
+    coord = coordinator_factory()
+    coord._auth_refresh_rejected_count = 3
+    coord._auth_refresh_rejected_until = None
+    coord._auth_refresh_rejected_ends_utc = None
+    coord._auth_refresh_suspended_until_utc = datetime.now(timezone.utc) + timedelta(
+        seconds=60
+    )
+    context = RefreshPipelineContext(
+        started_mono=time.monotonic(),
+        refresh_started_utc=datetime.now(timezone.utc),
+        phase_timings={},
+        fallback_data={},
+        first_refresh=False,
+        auth_refresh_rejected_count_at_start=3,
+    )
+
+    coord._clear_auth_refresh_rejection_state_if_unchanged(context)
+
+    assert coord._auth_refresh_rejected_count == 3
+    assert coord._auth_refresh_suspended_until_utc is not None
 
 
 def test_coordinator_init_restores_auth_refresh_state(hass, monkeypatch):


### PR DESCRIPTION
## Summary

Preserves stored-credential auth rejection state when a coordinator refresh records a new rejection during optional follow-up work. This prevents successful unrelated endpoint refreshes from clearing HEMS/heat-pump auth rejections too early, allowing the existing retry-suspension safeguards to activate as intended.

## Related Issues

Related to #528.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_edge_cases.py && ruff check custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_coordinator_edge_cases.py && black --check custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_coordinator_edge_cases.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"
uvx pre-commit run --all-files
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The reporter logs showed HEMS/heat-pump `401` responses repeatedly rejecting stored-credential refresh while other endpoint families still refreshed successfully. This change makes the rejection counter survive that successful outer refresh when the rejection was added during the same refresh pipeline.