### PR TITLE
Fix regional Gateway firmware catalog selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 - Localized cloud diagnostic error states for rate limits, temporary authentication blocks, authentication failures, invalid payloads, service outages, DNS failures, and network errors; rate-limit repairs now include retry timing, de-duplicate repeated reports, and clear after a successful refresh.
 - Bounded the `Current Production Power` live-sample cache so stale values are not reused indefinitely when the latest-power endpoint stops returning valid samples.
 - Filtered advisory IQ Gateway firmware releases by country applicability so country-scoped Enphase release notes do not create invalid update prompts in unrelated regions.
+- Crawled IQ Gateway communication release notes without the removed product-media facet so current regional Gateway firmware versions remain discoverable.
+- Suppressed stale worldwide IQ Gateway firmware catalog fallbacks when newer country-scoped release notes show the public catalog no longer has a current global baseline.
 - Smoothed idle heat-pump power over existing low-load energy samples so whole-Wh cloud readings no longer flicker between `0 W` and standby load, while exposing the raw short-window value in diagnostics.
 - Reduced unnecessary EV charger post-status follow-up lookups, kept idle session-history catch-up off the main refresh path when cached data is still usable, and aligned HEMS preflight/device refresh cadence with fast polling to lower steady-state cloud overhead.
 - Hardened setup, polling, and EV charger service inputs by bounding scan/runtime intervals, restricting OCPP trigger messages to supported values, requiring confirmation for advanced trigger messages, and keeping raw Enphase error bodies out of raised exceptions.

--- a/custom_components/enphase_ev/firmware_catalog.py
+++ b/custom_components/enphase_ev/firmware_catalog.py
@@ -283,6 +283,7 @@ def select_catalog_entry(
     device_type: str,
     country: str | None,
     locale: str,
+    prefer_global: bool = False,
 ) -> CatalogSelection:
     normalized_locale = normalize_locale(locale)
     country_code = normalize_country(country)
@@ -303,39 +304,40 @@ def select_catalog_entry(
     locale_scope_only = False
 
     by_locale = device_payload.get("latest_by_locale")
-    if isinstance(by_locale, dict) and by_locale:
-        candidate = by_locale.get(normalized_locale)
-        if isinstance(candidate, dict):
-            entry = candidate
-            source_scope = "locale"
-            locale_scope_only = True
-
-    if entry is None and country_code:
-        by_country = device_payload.get("latest_by_country")
-        if isinstance(by_country, dict):
-            candidate = by_country.get(country_code)
+    if not prefer_global:
+        if isinstance(by_locale, dict) and by_locale:
+            candidate = by_locale.get(normalized_locale)
             if isinstance(candidate, dict):
                 entry = candidate
-                source_scope = "country"
-
-    if entry is None and isinstance(by_locale, dict) and by_locale:
-        base_language = normalized_locale.split("-", 1)[0]
-        fallback = next(
-            (
-                key
-                for key, value in by_locale.items()
-                if isinstance(value, dict)
-                and str(key).split("-", 1)[0] == base_language
-            ),
-            None,
-        )
-        if fallback is not None:
-            maybe_entry = by_locale.get(fallback)
-            if isinstance(maybe_entry, dict):
-                entry = maybe_entry
                 source_scope = "locale"
-                normalized_locale = str(fallback)
                 locale_scope_only = True
+
+        if entry is None and country_code:
+            by_country = device_payload.get("latest_by_country")
+            if isinstance(by_country, dict):
+                candidate = by_country.get(country_code)
+                if isinstance(candidate, dict):
+                    entry = candidate
+                    source_scope = "country"
+
+        if entry is None and isinstance(by_locale, dict) and by_locale:
+            base_language = normalized_locale.split("-", 1)[0]
+            fallback = next(
+                (
+                    key
+                    for key, value in by_locale.items()
+                    if isinstance(value, dict)
+                    and str(key).split("-", 1)[0] == base_language
+                ),
+                None,
+            )
+            if fallback is not None:
+                maybe_entry = by_locale.get(fallback)
+                if isinstance(maybe_entry, dict):
+                    entry = maybe_entry
+                    source_scope = "locale"
+                    normalized_locale = str(fallback)
+                    locale_scope_only = True
 
     if entry is None:
         latest_global = device_payload.get("latest_global")

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -261,6 +261,24 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
 
         raw_latest = _text(entry.get("version"))
         normalized_latest = normalize_version_token(raw_latest)
+        if (
+            selected.source_scope != "global"
+            and compare_versions(normalized_installed, normalized_latest) is True
+        ):
+            global_selected = select_catalog_entry(
+                catalog,
+                device_type=self._device_type,
+                country=country,
+                locale=normalized_locale,
+                prefer_global=True,
+            )
+            if isinstance(global_selected.entry, dict):
+                selected = global_selected
+                self._source_scope = selected.source_scope
+                self._locale_used = selected.locale_used or normalized_locale
+                entry = global_selected.entry
+                raw_latest = _text(entry.get("version"))
+                normalized_latest = normalize_version_token(raw_latest)
 
         self._raw_latest_version = raw_latest
         self._attr_latest_version = _latest_version_for_state(

--- a/scripts/firmware_catalog.py
+++ b/scripts/firmware_catalog.py
@@ -34,11 +34,13 @@ TARGET_PRODUCTS: dict[str, dict[str, Any]] = {
     "envoy": {
         "label": "IQ Gateway software",
         "docs_path": COMMUNICATION_CATEGORY_PATH,
+        "product_media_name_required": False,
         "required": True,
     },
     "iqevse": {
         "label": "IQ EV Charger software",
         "docs_path": TARGET_CATEGORY_PATH,
+        "product_media_name_required": True,
         "required": False,
     },
 }
@@ -1397,6 +1399,16 @@ def _is_same_release_card(left: ReleaseCard, right: ReleaseCard) -> bool:
     )
 
 
+def _version_family(value: str | None) -> tuple[int, ...] | None:
+    family: list[int] = []
+    for part in _version_sort_key(value):
+        if isinstance(part, int):
+            family.append(part)
+            if len(family) == 2:
+                return tuple(family)
+    return tuple(family) if family else None
+
+
 def pick_latest_release(releases: list[ReleaseCard]) -> ReleaseCard | None:
     if not releases:
         return None
@@ -1411,24 +1423,63 @@ def pick_latest_release(releases: list[ReleaseCard]) -> ReleaseCard | None:
     return max(releases, key=_sort_key)
 
 
+def _release_is_newer(candidate: ReleaseCard, baseline: ReleaseCard) -> bool:
+    if _is_same_release_card(candidate, baseline):
+        return False
+    return pick_latest_release([baseline, candidate]) is candidate
+
+
+def _is_stale_global_fallback(
+    card: ReleaseCard,
+    latest_known: ReleaseCard | None,
+    *,
+    alias_map: dict[str, str],
+) -> bool:
+    if latest_known is None or not _release_is_newer(latest_known, card):
+        return False
+
+    applicability = parse_country_applicability(
+        card.countries_text, alias_map=alias_map
+    )
+    if not country_applicability_is_global_fallback(applicability):
+        return False
+
+    card_family = _version_family(card.version)
+    latest_family = _version_family(latest_known.version)
+    return bool(card_family and latest_family and card_family != latest_family)
+
+
+def _is_global_fallback_card(card: ReleaseCard, *, alias_map: dict[str, str]) -> bool:
+    return country_applicability_is_global_fallback(
+        parse_country_applicability(card.countries_text, alias_map=alias_map)
+    )
+
+
 def pick_latest_release_for_country(
     releases: list[ReleaseCard],
     country_code: str,
     *,
     alias_map: dict[str, str],
+    latest_known: ReleaseCard | None = None,
 ) -> ReleaseCard | None:
     applicable = [
         card
         for card in releases
         if release_applies_to_country(card, country_code, alias_map=alias_map)
     ]
-    return pick_latest_release(applicable)
+    latest = pick_latest_release(applicable)
+    if latest is not None and _is_stale_global_fallback(
+        latest, latest_known, alias_map=alias_map
+    ):
+        return None
+    return latest
 
 
 def pick_latest_global_release(
     releases: list[ReleaseCard],
     *,
     alias_map: dict[str, str],
+    latest_known: ReleaseCard | None = None,
 ) -> ReleaseCard | None:
     applicable = []
     for card in releases:
@@ -1437,7 +1488,12 @@ def pick_latest_global_release(
         )
         if country_applicability_is_global_fallback(country_applicability):
             applicable.append(card)
-    return pick_latest_release(applicable)
+    latest = pick_latest_release(applicable)
+    if latest is not None and _is_stale_global_fallback(
+        latest, latest_known, alias_map=alias_map
+    ):
+        return None
+    return latest
 
 
 def build_release_urls_by_locale(
@@ -1446,20 +1502,22 @@ def build_release_urls_by_locale(
     apps_url: str,
     product_type: str,
     topic_id: int,
-    product_media_name_id: int,
+    product_media_name_id: int | None,
 ) -> dict[str, str]:
     urls: dict[str, str] = {}
     for locale in locales:
         normalized = _normalize_locale(locale)
+        query = {
+            "product_type": product_type,
+            "f[0]": f"document:{topic_id}",
+            "search_api_language": normalized,
+            "field_alternative_language": normalized,
+        }
+        if product_media_name_id is not None:
+            query["f[1]"] = f"product_media_name:{product_media_name_id}"
         urls[normalized] = _with_query(
             apps_url,
-            {
-                "product_type": product_type,
-                "f[0]": f"document:{topic_id}",
-                "f[1]": f"product_media_name:{product_media_name_id}",
-                "search_api_language": normalized,
-                "field_alternative_language": normalized,
-            },
+            query,
         )
     return urls
 
@@ -1469,7 +1527,7 @@ def card_to_runtime_entry(
     card: ReleaseCard,
     product_type: str,
     topic_id: int,
-    product_media_name_id: int,
+    product_media_name_id: int | None,
     locales: list[str],
     apps_url: str,
 ) -> dict[str, Any]:
@@ -1504,21 +1562,23 @@ def crawl_release_cards(
     apps_url: str,
     product_type: str,
     topic_id: int,
-    product_media_name_id: int,
+    product_media_name_id: int | None,
     search_locale: str,
     timeout: int,
     max_pages: int,
 ) -> tuple[list[ReleaseCard], list[str]]:
+    query = {
+        "product_type": product_type,
+        "f[0]": f"document:{topic_id}",
+        "search_api_language": _normalize_locale(search_locale),
+        "field_alternative_language": _normalize_locale(search_locale),
+        "page": "0",
+    }
+    if product_media_name_id is not None:
+        query["f[1]"] = f"product_media_name:{product_media_name_id}"
     page_url = _with_query(
         apps_url,
-        {
-            "product_type": product_type,
-            "f[0]": f"document:{topic_id}",
-            "f[1]": f"product_media_name:{product_media_name_id}",
-            "search_api_language": _normalize_locale(search_locale),
-            "field_alternative_language": _normalize_locale(search_locale),
-            "page": "0",
-        },
+        query,
     )
 
     cards: list[ReleaseCard] = []
@@ -1727,8 +1787,11 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
         )
         global_target["bootstrap_error"] = None
 
+        product_media_name_required = bool(
+            product_meta.get("product_media_name_required", True)
+        )
         global_product_id_raw = global_target["product_ids"].get(device_key)
-        if global_product_id_raw is None:
+        if global_product_id_raw is None and product_media_name_required:
             missing_message = (
                 f"Could not discover product id for '{product_meta['label']}'"
             )
@@ -1762,7 +1825,9 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
                 missing_message,
             )
             continue
-        global_product_id = int(global_product_id_raw)
+        global_product_id = (
+            int(global_product_id_raw) if global_product_id_raw is not None else None
+        )
 
         for target in device_targets:
             if str(target["key"]) == global_target_key:
@@ -1811,8 +1876,7 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
             )
 
         target_cards: dict[str, list[ReleaseCard]] = {}
-        target_product_ids: dict[str, int] = {}
-        target_entries: dict[str, dict[str, Any] | None] = {}
+        target_product_ids: dict[str, int | None] = {}
         target_crawl: dict[str, Any] = {}
         total_count = 0
         missing_product_ids: list[str] = []
@@ -1823,8 +1887,10 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
 
         for target in device_targets:
             target_product_id = target["product_ids"].get(device_key)
-            used_global_product_id = target_product_id is None
-            if used_global_product_id:
+            used_global_product_id = (
+                target_product_id is None and global_product_id is not None
+            )
+            if target_product_id is None:
                 missing_product_ids.append(str(target["key"]))
             product_id = (
                 int(target_product_id)
@@ -1875,55 +1941,64 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
             target_key = str(target["key"])
             target_cards[target_key] = cards
             target_product_ids[target_key] = product_id
-            latest_card = pick_latest_global_release(cards, alias_map=country_alias_map)
-            target_entries[target_key] = (
-                card_to_runtime_entry(
-                    card=latest_card,
-                    product_type=str(target["product_type"]),
-                    topic_id=int(target["topic_id"]),
-                    product_media_name_id=product_id,
-                    locales=list(target["locales"]),
-                    apps_url=str(target["apps_url"]),
-                )
-                if latest_card
-                else None
-            )
+
+        latest_known_card = pick_latest_release(
+            [card for cards in target_cards.values() for card in cards]
+        )
 
         def _latest_applicable_card_for_route(
             route: dict[str, Any],
         ) -> tuple[ReleaseCard, str] | None:
             target_key = str(route["target_key"])
             route_country = route.get("country_code")
-            source_target_keys = [target_key]
-            if target_key != global_target_key:
-                source_target_keys.append(global_target_key)
 
-            candidates: list[tuple[ReleaseCard, str]] = []
-            for source_target_key in source_target_keys:
+            def _latest_for_target(source_target_key: str) -> ReleaseCard | None:
                 cards = target_cards.get(source_target_key, [])
                 if isinstance(route_country, str):
-                    latest_card = pick_latest_release_for_country(
-                        cards, route_country, alias_map=country_alias_map
+                    return pick_latest_release_for_country(
+                        cards,
+                        route_country,
+                        alias_map=country_alias_map,
+                        latest_known=latest_known_card,
                     )
-                else:
-                    latest_card = pick_latest_global_release(
-                        cards, alias_map=country_alias_map
-                    )
-                if latest_card is not None:
-                    candidates.append((latest_card, source_target_key))
+                return pick_latest_global_release(
+                    cards,
+                    alias_map=country_alias_map,
+                    latest_known=latest_known_card,
+                )
 
-            if not candidates:
-                return None
+            route_card = _latest_for_target(target_key)
+            if target_key == global_target_key:
+                return (route_card, target_key) if route_card is not None else None
 
-            selected_card, selected_target_key = candidates[0]
-            for candidate_card, candidate_target_key in candidates[1:]:
-                if _is_same_release_card(selected_card, candidate_card):
-                    continue
-                latest_card = pick_latest_release([selected_card, candidate_card])
-                if latest_card is candidate_card:
-                    selected_card = candidate_card
-                    selected_target_key = candidate_target_key
-            return selected_card, selected_target_key
+            global_card = _latest_for_target(global_target_key)
+            if route_card is None:
+                return (
+                    (global_card, global_target_key)
+                    if global_card is not None
+                    else None
+                )
+            if global_card is None or _is_same_release_card(route_card, global_card):
+                return route_card, target_key
+
+            route_is_fallback = _is_global_fallback_card(
+                route_card, alias_map=country_alias_map
+            )
+            global_is_fallback = _is_global_fallback_card(
+                global_card, alias_map=country_alias_map
+            )
+            if route_is_fallback and not global_is_fallback:
+                return global_card, global_target_key
+
+            route_family = _version_family(route_card.version)
+            global_family = _version_family(global_card.version)
+            if route_family and route_family == global_family:
+                return route_card, target_key
+
+            latest_card = pick_latest_release([route_card, global_card])
+            if latest_card is global_card:
+                return global_card, global_target_key
+            return route_card, target_key
 
         def _entry_for_route(route: dict[str, Any]) -> dict[str, Any] | None:
             selected_card = _latest_applicable_card_for_route(route)
@@ -1941,7 +2016,23 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
                 apps_url=str(target["apps_url"]),
             )
 
-        latest_global_entry = target_entries.get(global_target_key)
+        latest_global_card = pick_latest_global_release(
+            target_cards.get(global_target_key, []),
+            alias_map=country_alias_map,
+            latest_known=latest_known_card,
+        )
+        latest_global_entry = (
+            card_to_runtime_entry(
+                card=latest_global_card,
+                product_type=str(global_target["product_type"]),
+                topic_id=int(global_target["topic_id"]),
+                product_media_name_id=target_product_ids[global_target_key],
+                locales=list(global_target["locales"]),
+                apps_url=global_apps_url,
+            )
+            if latest_global_card
+            else None
+        )
         latest_global = (
             _entry_with_locale_url(latest_global_entry, "en")
             if isinstance(latest_global_entry, dict)
@@ -2083,9 +2174,9 @@ def build_catalog(output_dir: Path, *, timeout: int, max_pages: int) -> None:
             "targets": {
                 key: {
                     "label": TARGET_PRODUCTS[key]["label"],
-                    "product_media_name_id": int(
-                        devices_catalog[key]["product_media_name_id"]
-                    ),
+                    "product_media_name_id": devices_catalog[key][
+                        "product_media_name_id"
+                    ],
                 }
                 for key in TARGET_PRODUCTS
                 if key in devices_catalog

--- a/tests/components/enphase_ev/test_firmware_catalog.py
+++ b/tests/components/enphase_ev/test_firmware_catalog.py
@@ -314,6 +314,17 @@ def test_select_catalog_entry_country_and_locale_fallback() -> None:
     assert global_fallback.source_scope == "global"
     assert global_fallback.entry and global_fallback.entry["version"] == "8.2.4300"
 
+    preferred_global = firmware_catalog.select_catalog_entry(
+        catalog,
+        device_type="envoy",
+        country="AU",
+        locale="fr-fr",
+        prefer_global=True,
+    )
+    assert preferred_global.source_scope == "global"
+    assert preferred_global.locale_used == "en"
+    assert preferred_global.entry and preferred_global.entry["version"] == "8.2.4300"
+
     legacy_catalog = {
         "schema_version": 1,
         "generated_at": "2026-03-01T00:00:00Z",

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -397,6 +397,37 @@ async def test_gateway_update_entity_states_and_release_url_selection(hass) -> N
     assert entity.release_url is None
     assert entity.release_summary is None
 
+    regional_payload = _catalog_payload()
+    regional_payload["devices"]["envoy"]["latest_by_locale"]["fr-fr"] = {
+        "version": "8.3.5232",
+        "summary": "Gateway regional",
+        "urls_by_locale": {"fr-fr": "https://example.test/envoy/fr-regional"},
+    }
+    regional_payload["devices"]["envoy"]["latest_by_country"]["AU"] = {
+        "version": "8.3.5232",
+        "summary": "Gateway regional",
+        "urls_by_locale": {
+            "fr-fr": "https://example.test/envoy/fr-regional",
+            "en-au": "https://example.test/envoy/au-regional",
+        },
+    }
+    regional_payload["devices"]["envoy"]["latest_global"] = {
+        "version": "8.3.5427",
+        "summary": "Gateway global",
+        "urls_by_locale": {"en": "https://example.test/envoy/global-newer"},
+    }
+    coord._gateway_version = "8.3.5000"
+    entity._refresh_from_catalog(regional_payload)
+    assert entity.latest_version == "8.3.5232"
+    assert entity.release_url == "https://example.test/envoy/fr-regional"
+    assert entity.release_summary == "Gateway regional"
+
+    coord._gateway_version = "8.3.5300"
+    entity._refresh_from_catalog(regional_payload)
+    assert entity.latest_version == "8.3.5427"
+    assert entity.release_url == "https://example.test/envoy/global-newer"
+    assert entity.release_summary == "Gateway global"
+
     coord._gateway_version = "8.2.4300"
     entity._refresh_from_catalog(manager.cached_catalog)
     await entity.async_skip()

--- a/tests/scripts/test_firmware_catalog.py
+++ b/tests/scripts/test_firmware_catalog.py
@@ -186,9 +186,31 @@ def test_pick_latest_release_and_urls(firmware_catalog_module) -> None:
         summary="New",
         countries_text="USA",
     )
+    card_recent_global = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (8.2.4398)",
+        version="8.2.4398",
+        release_date="2025-10-20",
+        media_id="global-8-2",
+        langcode="und",
+        summary="Countries: Worldwide",
+        countries_text="Worldwide",
+    )
+    card_stale_global = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (7.0.86)",
+        version="7.0.86",
+        release_date="2021-12-21",
+        media_id="global-7-0",
+        langcode="und",
+        summary="Countries: Worldwide",
+        countries_text="Worldwide",
+    )
 
     latest = firmware_catalog_module.pick_latest_release([card_old, card_new])
     assert latest == card_new
+    assert firmware_catalog_module._version_family("8.2.4401") == (8, 2)
+    assert firmware_catalog_module._version_family("7") == (7,)
+    assert firmware_catalog_module._version_family("release") is None
+    assert firmware_catalog_module._version_family(None) is None
     assert (
         firmware_catalog_module.pick_latest_release_for_country(
             [card_old, card_new], "US", alias_map={"usa": "US"}
@@ -210,6 +232,43 @@ def test_pick_latest_release_and_urls(firmware_catalog_module) -> None:
     assert firmware_catalog_module.release_applies_to_country(
         card_new, "US", alias_map={"usa": "US"}
     )
+    assert (
+        firmware_catalog_module.pick_latest_release_for_country(
+            [card_stale_global, card_new],
+            "AU",
+            alias_map={"usa": "US"},
+            latest_known=card_new,
+        )
+        is None
+    )
+    assert (
+        firmware_catalog_module.pick_latest_release_for_country(
+            [card_recent_global, card_new],
+            "AU",
+            alias_map={"usa": "US"},
+            latest_known=card_new,
+        )
+        == card_recent_global
+    )
+    assert (
+        firmware_catalog_module.pick_latest_global_release(
+            [card_stale_global, card_new],
+            alias_map={"usa": "US"},
+            latest_known=card_new,
+        )
+        is None
+    )
+    assert (
+        firmware_catalog_module.pick_latest_global_release(
+            [card_recent_global, card_new],
+            alias_map={"usa": "US"},
+            latest_known=card_new,
+        )
+        == card_recent_global
+    )
+    assert not firmware_catalog_module._is_stale_global_fallback(
+        card_old, card_new, alias_map={"usa": "US"}
+    )
 
     urls = firmware_catalog_module.build_release_urls_by_locale(
         locales=["en", "fr-fr", "en-au"],
@@ -229,6 +288,18 @@ def test_pick_latest_release_and_urls(firmware_catalog_module) -> None:
     assert "f%5B1%5D=product_media_name%3A5002" in urls["en-au"]
     assert "search_api_language=en-au" in urls["en-au"]
     assert "field_alternative_language=en-au" in urls["en-au"]
+    urls_without_product_filter = firmware_catalog_module.build_release_urls_by_locale(
+        locales=["en-au"],
+        apps_url=(
+            "https://enphase.com/en-au/installers/resources/documentation/"
+            "communication"
+        ),
+        product_type="216",
+        topic_id=217,
+        product_media_name_id=None,
+    )
+    assert "f%5B0%5D=document%3A217" in urls_without_product_filter["en-au"]
+    assert "f%5B1%5D" not in urls_without_product_filter["en-au"]
 
 
 def test_catalogs_equal_ignoring_generated_at(firmware_catalog_module) -> None:
@@ -787,8 +858,9 @@ def test_build_catalog_success_and_error_paths(
             {"Release notes": 217} if alias == "document" else {}
         ),
     )
-    with pytest.raises(RuntimeError, match="IQ Gateway software"):
-        firmware_catalog_module.build_catalog(tmp_path, timeout=5, max_pages=1)
+    firmware_catalog_module.build_catalog(tmp_path, timeout=5, max_pages=1)
+    runtime_payload = json.loads(runtime_path.read_text(encoding="utf-8"))
+    assert runtime_payload["devices"]["envoy"]["product_media_name_id"] is None
 
 
 def test_build_catalog_skips_later_missing_product_id(
@@ -912,6 +984,246 @@ def test_build_catalog_skips_later_missing_product_id(
     }
 
 
+def test_build_catalog_crawls_gateway_without_product_media_filter(
+    firmware_catalog_module,
+    fixture_dir: Path,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    root_html = (fixture_dir / "enphase_root.html").read_text(encoding="utf-8")
+    apps_html = (fixture_dir / "enphase_apps_facets.html").read_text(encoding="utf-8")
+    gateway_card = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (8.3.5232)",
+        version="8.3.5232",
+        release_date="2026-04-28",
+        media_id="24523",
+        langcode="und",
+        summary="Countries: Australia",
+        countries_text="Australia",
+    )
+    global_gateway_card = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (8.3.5427)",
+        version="8.3.5427",
+        release_date="2026-04-30",
+        media_id="24527",
+        langcode="und",
+        summary="Global Gateway release",
+        countries_text=None,
+    )
+
+    monkeypatch.setattr(
+        firmware_catalog_module, "_now_utc_iso", lambda: "2026-05-01T00:00:00Z"
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "REGION_SITE_ROUTE_ROWS",
+        [
+            {
+                "label": "United States",
+                "country_code": "US",
+                "locale": "en",
+                "site_url": "https://enphase.com/",
+            },
+            {
+                "label": "Australia",
+                "country_code": "AU",
+                "locale": "en-au",
+                "site_url": "https://enphase.com/en-au/",
+                "query_locale": "en-au",
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "fetch_text",
+        lambda url, timeout=30: (
+            root_html
+            if url.endswith("/installers/resources/documentation")
+            else apps_html
+        ),
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "parse_facet_values",
+        lambda _html, alias: {"Release notes": 217} if alias == "document" else {},
+    )
+    crawl_calls: list[dict[str, object]] = []
+
+    def _fake_crawl_release_cards(**kwargs):
+        crawl_calls.append(dict(kwargs))
+        if kwargs["search_locale"] == "en":
+            return [global_gateway_card], [
+                (
+                    "https://enphase.com/installers/resources/documentation/"
+                    "communication?search_api_language=en&f%5B0%5D=document%3A217"
+                )
+            ]
+        if kwargs["search_locale"] == "en-au":
+            return [gateway_card], [
+                (
+                    "https://enphase.com/en-au/installers/resources/documentation/"
+                    "communication?search_api_language=en-au&f%5B0%5D=document%3A217"
+                )
+            ]
+        return [], [f"https://example.test/empty/{kwargs['search_locale']}"]
+
+    monkeypatch.setattr(
+        firmware_catalog_module, "crawl_release_cards", _fake_crawl_release_cards
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "fetch_previous_runtime_catalog",
+        lambda timeout=30: None,
+    )
+
+    firmware_catalog_module.build_catalog(tmp_path, timeout=5, max_pages=1)
+    runtime = json.loads(
+        (tmp_path / "catalog" / "v1" / "runtime_catalog.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    product_sources = json.loads(
+        (
+            tmp_path / "sources" / "enphase_doc_center" / "product_media_name_ids.json"
+        ).read_text(encoding="utf-8")
+    )
+    envoy = runtime["devices"]["envoy"]
+
+    assert {call["product_media_name_id"] for call in crawl_calls} == {None}
+    assert envoy["product_media_name_id"] is None
+    assert envoy["latest_global"]["version"] == "8.3.5427"
+    assert envoy["latest_by_country"]["AU"]["version"] == "8.3.5232"
+    au_url = envoy["latest_by_locale"]["en-au"]["urls_by_locale"]["en-au"]
+    assert envoy["latest_by_locale"]["en-au"]["version"] == "8.3.5232"
+    assert "f%5B0%5D=document%3A217" in au_url
+    assert "f%5B1%5D" not in au_url
+    assert "en-au/installers" in au_url
+    assert product_sources["targets"]["envoy"] == {
+        "label": "IQ Gateway software",
+        "product_media_name_id": None,
+    }
+
+
+def test_build_catalog_uses_newest_release_when_families_differ(
+    firmware_catalog_module,
+    fixture_dir: Path,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    root_html = (fixture_dir / "enphase_root.html").read_text(encoding="utf-8")
+    apps_html = (fixture_dir / "enphase_apps_facets.html").read_text(encoding="utf-8")
+    global_card = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (9.0.100)",
+        version="9.0.100",
+        release_date="2026-04-30",
+        media_id="global-9",
+        langcode="und",
+        summary="Countries: Australia",
+        countries_text="Australia",
+    )
+    global_nz_card = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (9.0.200)",
+        version="9.0.200",
+        release_date="2026-04-30",
+        media_id="global-nz-9",
+        langcode="und",
+        summary="Countries: New Zealand",
+        countries_text="New Zealand",
+    )
+    older_regional_card = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (8.3.5232)",
+        version="8.3.5232",
+        release_date="2026-04-28",
+        media_id="au-8",
+        langcode="und",
+        summary="Countries: Australia",
+        countries_text="Australia",
+    )
+    newer_regional_card = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (10.0.1)",
+        version="10.0.1",
+        release_date="2026-05-01",
+        media_id="nz-10",
+        langcode="und",
+        summary="Countries: New Zealand",
+        countries_text="New Zealand",
+    )
+
+    monkeypatch.setattr(
+        firmware_catalog_module, "_now_utc_iso", lambda: "2026-05-01T00:00:00Z"
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "REGION_SITE_ROUTE_ROWS",
+        [
+            {
+                "label": "United States",
+                "country_code": "US",
+                "locale": "en",
+                "site_url": "https://enphase.com/",
+            },
+            {
+                "label": "Australia",
+                "country_code": "AU",
+                "locale": "en-au",
+                "site_url": "https://enphase.com/en-au/",
+                "query_locale": "en-au",
+            },
+            {
+                "label": "New Zealand",
+                "country_code": "NZ",
+                "locale": "en-nz",
+                "site_url": "https://enphase.com/en-nz/",
+                "query_locale": "en-nz",
+            },
+        ],
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "fetch_text",
+        lambda url, timeout=30: (
+            root_html
+            if url.endswith("/installers/resources/documentation")
+            else apps_html
+        ),
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "parse_facet_values",
+        lambda _html, alias: {"Release notes": 217} if alias == "document" else {},
+    )
+
+    def _fake_crawl_release_cards(**kwargs):
+        cards_by_locale = {
+            "en": [global_card, global_nz_card],
+            "en-au": [older_regional_card],
+            "en-nz": [newer_regional_card],
+        }
+        return cards_by_locale.get(kwargs["search_locale"], []), [
+            f"https://example.test/{kwargs['search_locale']}"
+        ]
+
+    monkeypatch.setattr(
+        firmware_catalog_module, "crawl_release_cards", _fake_crawl_release_cards
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "fetch_previous_runtime_catalog",
+        lambda timeout=30: None,
+    )
+
+    firmware_catalog_module.build_catalog(tmp_path, timeout=5, max_pages=1)
+    runtime = json.loads(
+        (tmp_path / "catalog" / "v1" / "runtime_catalog.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    envoy = runtime["devices"]["envoy"]
+
+    assert envoy["latest_by_country"]["AU"]["version"] == "9.0.100"
+    assert envoy["latest_by_country"]["NZ"]["version"] == "10.0.1"
+
+
 def test_build_catalog_required_product_is_explicit(
     firmware_catalog_module,
     fixture_dir: Path,
@@ -933,6 +1245,7 @@ def test_build_catalog_required_product_is_explicit(
             "envoy": {
                 "label": "IQ Gateway software",
                 "docs_path": firmware_catalog_module.COMMUNICATION_CATEGORY_PATH,
+                "product_media_name_required": True,
                 "required": True,
             },
         },
@@ -1403,6 +1716,106 @@ def test_build_catalog_filters_country_scoped_releases(
     assert envoy["latest_by_country"]["PH"]["version"] == "8.2.4401"
     assert envoy["latest_by_locale"]["en-ph"]["version"] == "8.2.4401"
     assert envoy["latest_by_locale"]["en-ph"]["media_id"] == "zz-us-scoped-envoy"
+
+
+def test_build_catalog_suppresses_stale_worldwide_fallback(
+    firmware_catalog_module,
+    fixture_dir: Path,
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    root_html = (fixture_dir / "enphase_root.html").read_text(encoding="utf-8")
+    apps_html = (fixture_dir / "enphase_apps_facets.html").read_text(encoding="utf-8")
+
+    def _fake_fetch_text(url: str, *, timeout: int = 30) -> str:  # noqa: ARG001
+        if url.endswith("/installers/resources/documentation"):
+            return root_html
+        return apps_html
+
+    scoped_envoy = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (8.2.4401)",
+        version="8.2.4401",
+        release_date="2025-11-20",
+        media_id="us-scoped-envoy",
+        langcode="und",
+        summary="Countries: United States",
+        countries_text="United States",
+    )
+    stale_worldwide_envoy = firmware_catalog_module.ReleaseCard(
+        title="IQ Gateway software release notes (7.0.86)",
+        version="7.0.86",
+        release_date="2021-12-21",
+        media_id="stale-worldwide-envoy",
+        langcode="und",
+        summary="Countries: Worldwide",
+        countries_text="Worldwide",
+    )
+
+    def _fake_crawl_release_cards(**kwargs):
+        if kwargs["product_media_name_id"] == 5002:
+            return [scoped_envoy, stale_worldwide_envoy], [
+                f"https://example.test/envoy/{kwargs['search_locale']}"
+            ]
+        return [], [f"https://example.test/empty/{kwargs['search_locale']}"]
+
+    monkeypatch.setattr(
+        firmware_catalog_module, "_now_utc_iso", lambda: "2026-03-01T00:00:00Z"
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "REGION_SITE_ROUTE_ROWS",
+        [
+            {
+                "label": "United States",
+                "country_code": "US",
+                "locale": "en",
+                "site_url": "https://enphase.com/",
+            },
+            {
+                "label": "Australia",
+                "country_code": "AU",
+                "locale": "en-au",
+                "site_url": "https://enphase.com/en-au/",
+                "query_locale": "en-au",
+            },
+        ],
+    )
+    monkeypatch.setattr(firmware_catalog_module, "fetch_text", _fake_fetch_text)
+    original_parse_facet_values = firmware_catalog_module.parse_facet_values
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "parse_facet_values",
+        lambda html, alias: (
+            {
+                **original_parse_facet_values(html, alias),
+                "IQ EV Charger software": 6001,
+            }
+            if alias == "product_media_name"
+            else original_parse_facet_values(html, alias)
+        ),
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module, "crawl_release_cards", _fake_crawl_release_cards
+    )
+    monkeypatch.setattr(
+        firmware_catalog_module,
+        "fetch_previous_runtime_catalog",
+        lambda timeout=30: None,
+    )
+
+    firmware_catalog_module.build_catalog(tmp_path, timeout=5, max_pages=1)
+    runtime_payload = json.loads(
+        (tmp_path / "catalog" / "v1" / "runtime_catalog.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    envoy = runtime_payload["devices"]["envoy"]
+
+    assert envoy["latest_global"] is None
+    assert envoy["latest_by_country"]["US"]["version"] == "8.2.4401"
+    assert envoy["latest_by_locale"]["en"]["version"] == "8.2.4401"
+    assert "AU" not in envoy["latest_by_country"]
+    assert "en-au" not in envoy["latest_by_locale"]
 
 
 def test_route_helper_edge_branches(firmware_catalog_module) -> None:


### PR DESCRIPTION
## Summary

Fixes the Gateway firmware catalog routing for regional release notes related to #626.

The catalog now crawls IQ Gateway communication release notes without the removed `product_media_name` facet, which allows the AU documentation route to expose the current regional Gateway release notes. It also keeps region-specific Gateway entries and release-note URLs preferred for regional users, while allowing the update entity to fall back to the newer global entry when the installed firmware has already passed the regional catalog version.

## Related Issues

- #626

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black scripts/firmware_catalog.py tests/scripts/test_firmware_catalog.py && ruff check scripts/firmware_catalog.py tests/scripts/test_firmware_catalog.py && pytest -q tests/scripts/test_firmware_catalog.py && COVERAGE_FILE=/tmp/firmware_catalog.coverage python -m coverage erase && COVERAGE_FILE=/tmp/firmware_catalog.coverage python -m coverage run -m pytest tests/scripts/test_firmware_catalog.py -q && COVERAGE_FILE=/tmp/firmware_catalog.coverage python -m coverage report -m --include=scripts/firmware_catalog.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/firmware_catalog.py custom_components/enphase_ev/update.py scripts/firmware_catalog.py tests/components/enphase_ev/test_firmware_catalog.py tests/components/enphase_ev/test_update_module.py tests/scripts/test_firmware_catalog.py && ruff check custom_components/enphase_ev/firmware_catalog.py custom_components/enphase_ev/update.py scripts/firmware_catalog.py tests/components/enphase_ev/test_firmware_catalog.py tests/components/enphase_ev/test_update_module.py tests/scripts/test_firmware_catalog.py && pytest -q tests/scripts/test_firmware_catalog.py tests/components/enphase_ev/test_firmware_catalog.py tests/components/enphase_ev/test_update_module.py && COVERAGE_FILE=/tmp/firmware_followup.coverage python -m coverage erase && COVERAGE_FILE=/tmp/firmware_followup.coverage python -m coverage run -m pytest tests/scripts/test_firmware_catalog.py tests/components/enphase_ev/test_firmware_catalog.py tests/components/enphase_ev/test_update_module.py -q && COVERAGE_FILE=/tmp/firmware_followup.coverage python -m coverage report -m --include=scripts/firmware_catalog.py,custom_components/enphase_ev/firmware_catalog.py,custom_components/enphase_ev/update.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/hostgit ha-dev bash -lc "GIT_DIR=/hostgit/worktrees/ha-enphase-ev-charger10 GIT_COMMON_DIR=/hostgit GIT_WORK_TREE=/workspace python3 -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Live validation:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python - <<'PY'
import importlib.util, json, sys
from pathlib import Path
spec = importlib.util.spec_from_file_location('firmware_catalog_live', 'scripts/firmware_catalog.py')
module = importlib.util.module_from_spec(spec)
sys.modules['firmware_catalog_live'] = module
spec.loader.exec_module(module)
module.TARGET_PRODUCTS = {'envoy': module.TARGET_PRODUCTS['envoy']}
module.REGION_SITE_ROUTE_ROWS = [
    {'label': 'United States', 'country_code': 'US', 'locale': 'en', 'site_url': 'https://enphase.com/'},
    {'label': 'Australia', 'country_code': 'AU', 'locale': 'en-au', 'site_url': 'https://enphase.com/en-au/', 'query_locale': 'en-au'},
]
module.fetch_previous_runtime_catalog = lambda timeout=30: None
out = Path('/tmp/firmware-catalog-au-check')
module.build_catalog(out, timeout=20, max_pages=3)
payload = json.loads((out / 'catalog' / 'v1' / 'runtime_catalog.json').read_text())
print(payload['devices']['envoy']['latest_by_country']['AU']['version'])
PY"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Narrow live AU/US Gateway crawl selected regional AU `8.3.5232` and global `8.3.5427`.
- AU release URL uses `https://enphase.com/en-au/installers/resources/documentation/communication?...document%3A217...` without `product_media_name`.
- GitHub Actions results are pending for this PR.
