### PR TITLE
Fix current tariff fallback selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ All notable changes to this project will be documented in this file.
 - Made same-value IQ Battery reserve and shutdown-level number writes no-ops so unchanged settings do not trip the BatteryConfig write debounce or send unnecessary cloud writes.
 - Made same-value EV charger charge mode selections no-ops so the scheduler is not called when Home Assistant selects the already-active mode, avoiding Enphase `400` responses on unchanged selections.
 - Kept tariff refresh data stale-but-available when Enphase tariff endpoints are degraded, and made empty/unconfigured tariff responses explicit in diagnostics instead of failing normal polling.
+- Resolved current tariff price selection when Enphase time-of-use payloads include an all-day fallback period alongside timed peak periods.
 
 ### 🔧 Improvements
 - Clarified Enphase authentication-block and active-session repair messages, including retry timing and guidance to clear other Enphase app/browser sessions.

--- a/custom_components/enphase_ev/tariff.py
+++ b/custom_components/enphase_ev/tariff.py
@@ -488,6 +488,26 @@ def _time_window_matches(
     return minute_of_day >= start or minute_of_day < end
 
 
+def _time_window_is_constrained(start_time: object, end_time: object) -> bool:
+    start = _time_to_minutes(start_time)
+    end = _time_to_minutes(end_time)
+    return start is not None and end is not None and start != end
+
+
+def _tariff_rate_scope_key(attrs: dict) -> tuple[object, ...]:
+    days = attrs.get("days")
+    days_key: tuple[object, ...] | None = None
+    if isinstance(days, list):
+        days_key = tuple(days)
+    return (
+        attrs.get("season_id"),
+        attrs.get("start_month"),
+        attrs.get("end_month"),
+        attrs.get("day_group_id"),
+        days_key,
+    )
+
+
 def current_tariff_rate_sensor_spec(
     snapshot: TariffRateSnapshot | None,
     when: datetime,
@@ -528,6 +548,23 @@ def current_tariff_rate_sensor_spec(
             continue
         matches.append(spec)
     if len(matches) != 1:
+        constrained_matches = [
+            spec
+            for spec in matches
+            if _time_window_is_constrained(
+                (spec.get("attributes") or {}).get("start_time"),
+                (spec.get("attributes") or {}).get("end_time"),
+            )
+        ]
+        if len(constrained_matches) == 1:
+            constrained_attrs = constrained_matches[0].get("attributes") or {}
+            constrained_scope = _tariff_rate_scope_key(constrained_attrs)
+            if all(
+                _tariff_rate_scope_key(spec.get("attributes") or {})
+                == constrained_scope
+                for spec in matches
+            ):
+                return constrained_matches[0]
         return None
     return matches[0]
 

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -563,6 +563,221 @@ def test_current_tariff_rate_sensor_spec_selects_active_period() -> None:
     assert winter["state"] == 0.30
 
 
+def test_current_tariff_rate_sensor_spec_prefers_timed_period_over_fallback() -> None:
+    snapshot = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "source": "manual",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "startMonth": "1",
+                        "endMonth": "12",
+                        "days": [
+                            {
+                                "id": "week",
+                                "days": [1, 2, 3, 4, 5, 6, 7],
+                                "periods": [
+                                    {
+                                        "id": "off-peak",
+                                        "type": "off-peak",
+                                        "rate": "0.18",
+                                        "startTime": "",
+                                        "endTime": "",
+                                    },
+                                    {
+                                        "id": "peak-1",
+                                        "type": "peak",
+                                        "rate": "0.31",
+                                        "startTime": "840",
+                                        "endTime": "1260",
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+
+    peak = current_tariff_rate_sensor_spec(
+        snapshot,
+        datetime(2026, 5, 1, 15, 12, tzinfo=timezone.utc),
+    )
+    off_peak = current_tariff_rate_sensor_spec(
+        snapshot,
+        datetime(2026, 5, 1, 21, 30, tzinfo=timezone.utc),
+    )
+
+    assert peak is not None
+    assert peak["name"] == "Peak"
+    assert peak["state"] == 0.31
+    assert off_peak is not None
+    assert off_peak["name"] == "Off-Peak"
+    assert off_peak["state"] == 0.18
+
+
+def test_current_tariff_rate_sensor_spec_rejects_overlapping_timed_periods() -> None:
+    snapshot = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "single",
+                "typeId": "tou",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "type": "peak",
+                                        "rate": "0.31",
+                                        "startTime": "840",
+                                        "endTime": "1260",
+                                    },
+                                    {
+                                        "type": "shoulder",
+                                        "rate": "0.25",
+                                        "startTime": "900",
+                                        "endTime": "1080",
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+
+    assert (
+        current_tariff_rate_sensor_spec(
+            snapshot,
+            datetime(2026, 5, 1, 15, 30, tzinfo=timezone.utc),
+        )
+        is None
+    )
+
+
+def test_current_tariff_rate_sensor_spec_rejects_cross_season_fallback() -> None:
+    snapshot = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "seasonal",
+                "typeId": "tou",
+                "seasons": [
+                    {
+                        "id": "first",
+                        "startMonth": "1",
+                        "endMonth": "12",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "type": "off-peak",
+                                        "rate": "0.18",
+                                        "startTime": "",
+                                        "endTime": "",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                    {
+                        "id": "second",
+                        "startMonth": "1",
+                        "endMonth": "12",
+                        "days": [
+                            {
+                                "id": "week",
+                                "periods": [
+                                    {
+                                        "type": "peak",
+                                        "rate": "0.31",
+                                        "startTime": "840",
+                                        "endTime": "1260",
+                                    }
+                                ],
+                            }
+                        ],
+                    },
+                ],
+            },
+        },
+        "purchase",
+    )
+
+    assert (
+        current_tariff_rate_sensor_spec(
+            snapshot,
+            datetime(2026, 5, 1, 15, 30, tzinfo=timezone.utc),
+        )
+        is None
+    )
+
+
+def test_current_tariff_rate_sensor_spec_rejects_cross_day_group_fallback() -> None:
+    snapshot = parse_tariff_rate(
+        {
+            "currency": "$",
+            "purchase": {
+                "typeKind": "weekends",
+                "typeId": "tou",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [
+                            {
+                                "id": "all",
+                                "days": [1, 2, 3, 4, 5, 6, 7],
+                                "periods": [
+                                    {
+                                        "type": "off-peak",
+                                        "rate": "0.18",
+                                        "startTime": "",
+                                        "endTime": "",
+                                    }
+                                ],
+                            },
+                            {
+                                "id": "week",
+                                "days": [1, 2, 3, 4, 5],
+                                "periods": [
+                                    {
+                                        "type": "peak",
+                                        "rate": "0.31",
+                                        "startTime": "840",
+                                        "endTime": "1260",
+                                    }
+                                ],
+                            },
+                        ],
+                    }
+                ],
+            },
+        },
+        "purchase",
+    )
+
+    assert (
+        current_tariff_rate_sensor_spec(
+            snapshot,
+            datetime(2026, 5, 1, 15, 30, tzinfo=timezone.utc),
+        )
+        is None
+    )
+
+
 def test_next_tariff_rate_change_finds_time_and_season_boundaries() -> None:
     snapshot = parse_tariff_rate(
         {


### PR DESCRIPTION
## Summary

Fixes current tariff price selection for Enphase time-of-use tariffs that include an all-day fallback period alongside timed peak periods. The current import/export price sensor now prefers a single timed match only when the fallback ambiguity is scoped to the same season and day group, while preserving unavailable behavior for genuinely ambiguous tariff structures.

Also adds regression coverage for the Enphase fallback shape, overlapping timed periods, cross-season ambiguity, and cross-day-group ambiguity.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_tariff.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/tariff.py tests/components/enphase_ev/test_tariff.py && ruff check custom_components/enphase_ev/tariff.py tests/components/enphase_ev/test_tariff.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/tariff.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/tariff.py tests/components/enphase_ev/test_tariff.py && ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "python3 -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/tariff.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Manual/dev diagnostic verification:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Downloads:/host-downloads:ro ha-dev bash -lc "python - <<'PY' ... PY"
```

Confirmed against the provided config-entry diagnostics that the account has healthy TOU tariff data, `Australia/Melbourne` site timezone, and the fixed selector returns the timed peak rate for the local 15:12 tariff refresh context.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The diagnostics export redacts live Enphase credentials, so verification used the account diagnostic facts plus the Enphase TOU fallback payload shape that caused the unavailable current-rate state. No translation keys changed.
