### PR TITLE
Fix final CFG schedule deletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
 - Reported the charger-specific minimum amp value during EV charger safe-limit charging instead of always showing `8 A`.
 - Redacted Enphase site IDs from logs and diagnostics, expanding the existing redaction coverage across API, summary, session history, EVSE timeseries, coordinator diagnostics, and service messages.
 - Made same-value IQ Battery reserve and shutdown-level number writes no-ops so unchanged settings do not trip the BatteryConfig write debounce or send unnecessary cloud writes.
+- Fixed last CFG schedule deletion so the integration sends the follow-up BatteryConfig disable write even when no replacement charge-from-grid schedule window remains.
 - Made same-value EV charger charge mode selections no-ops so the scheduler is not called when Home Assistant selects the already-active mode, avoiding Enphase `400` responses on unchanged selections.
 - Kept tariff refresh data stale-but-available when Enphase tariff endpoints are degraded, and made empty/unconfigured tariff responses explicit in diagnostics instead of failing normal polling.
 - Resolved current tariff price selection when Enphase time-of-use payloads include an all-day fallback period alongside timed peak periods.

--- a/custom_components/enphase_ev/battery_runtime.py
+++ b/custom_components/enphase_ev/battery_runtime.py
@@ -1749,9 +1749,10 @@ class BatteryRuntime:
         normalized_schedule_type = str(schedule_type).lower()
         coord = self.coordinator
         if normalized_schedule_type == "cfg":
-            if start_minutes is None or end_minutes is None:
+            include_window = start_minutes is not None and end_minutes is not None
+            if enabled and not include_window:
                 return None
-            if start_minutes == end_minutes:
+            if include_window and start_minutes == end_minutes:
                 self._raise_validation(
                     "charge_from_grid_schedule_times_different",
                     message=(
@@ -1769,10 +1770,11 @@ class BatteryRuntime:
             payload: dict[str, object] = {
                 "chargeFromGrid": (True if enabled else bool(charge_from_grid_enabled)),
                 "chargeFromGridScheduleEnabled": bool(enabled),
-                "chargeBeginTime": start_minutes,
-                "chargeEndTime": end_minutes,
                 "acceptedItcDisclaimer": self.battery_itc_disclaimer_value(),
             }
+            if include_window:
+                payload["chargeBeginTime"] = start_minutes
+                payload["chargeEndTime"] = end_minutes
             cfg_control = coord.battery_cfg_control
             if isinstance(cfg_control, dict):
                 cfg_payload: dict[str, object] = {}
@@ -1818,7 +1820,18 @@ class BatteryRuntime:
         coord = self.coordinator
         start_minutes = self._normalize_schedule_minutes(start_time)
         end_minutes = self._normalize_schedule_minutes(end_time)
-        if start_minutes is None or end_minutes is None:
+        effective_enabled = self._schedule_family_effective_enabled(
+            normalized_schedule_type, enabled
+        )
+        omit_missing_cfg_disable_window = (
+            normalized_schedule_type == "cfg"
+            and effective_enabled is False
+            and start_time is None
+            and end_time is None
+        )
+        if (
+            start_minutes is None or end_minutes is None
+        ) and not omit_missing_cfg_disable_window:
             current_start, current_end = self._current_battery_schedule_window_for_type(
                 normalized_schedule_type
             )
@@ -1831,9 +1844,7 @@ class BatteryRuntime:
             normalized_schedule_type,
             start_minutes=start_minutes,
             end_minutes=end_minutes,
-            enabled=self._schedule_family_effective_enabled(
-                normalized_schedule_type, enabled
-            ),
+            enabled=effective_enabled,
         )
         if payload is None:
             return

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -5307,6 +5307,7 @@ Notes:
 - Observed `chargeFromGrid` values so far: `true`, `false`.
 - The schedule checkbox ("Also up to 100% during this schedule") is represented by `chargeFromGridScheduleEnabled`; `chargeBeginTime`/`chargeEndTime` are minutes after midnight (local). Observed values so far: `chargeFromGridScheduleEnabled=true`, `chargeBeginTime=120`, `chargeEndTime=300`.
 - When the schedule is enabled, the status payload reports `chargeFromGridScheduleEnabled: true` and `cfgControl.forceScheduleOpted: true`.
+- Live local verification for issue `#634` on 2026-05-02 showed the final-CFG-delete path needs a follow-up `PUT /batterySettings/<site_id>` disable write even when no replacement CFG window remains. The backend accepted a payload with `chargeFromGridScheduleEnabled:false`, the current `chargeFromGrid` value, `acceptedItcDisclaimer`, and `cfgControl.forceScheduleOpted:false` while omitting `chargeBeginTime` and `chargeEndTime`; the follow-up read returned zero CFG schedules with `chargeFromGridScheduleEnabled:false`.
 - First-party browser captures documented for this repository used `acceptedItcDisclaimer: true`, while subsequent reads returned a timestamp string; the backend normalizes the acknowledgement state internally.
 - The current integration uses both shapes: direct charge-from-grid enablement sends boolean `true` after calling `acceptDisclaimer`, while CFG schedule/settings payloads send the stored timestamp or a current UTC timestamp.
 - `veryLowSoc` drives the "Battery shutdown level" slider, clamped between `veryLowSocMin` and `veryLowSocMax`. Observed values so far: `veryLowSoc=5` and `15`, `veryLowSocMin=5` and `10`, `veryLowSocMax=25`.
@@ -5593,6 +5594,7 @@ Observed behavior:
 - A `/delete` alias also exists. This path is useful as a compatibility note, but it was not present in the newer browser traces captured for this repository.
 - The current client implements the legacy `/delete` alias and sends it through the same compatibility write planner used by schedule create/update, including the raw-cookie browser request on affected sites.
 - The current integration treats the `/delete` alias response as opaque JSON and confirms the deletion via the follow-up `GET /schedules` refresh.
+- For CFG specifically, deleting the final saved schedule does not by itself prove the schedule-family toggle is off. Live local verification for issue `#634` confirmed clients should send the paired `PUT /batterySettings/<site_id>` disable write and should allow that settings payload to omit `chargeBeginTime` / `chargeEndTime` when no CFG schedule window remains.
 
 ### 5.9 Battery Schedule Validation
 ```
@@ -5748,6 +5750,7 @@ Observed behavior:
 - Ordinary time/limit edits on the affected site preserved `isEnabled: false` when updating the existing real disabled CFG/DTG/RBD schedules without sending `isEnabled`.
 - Temporary disabled schedules created with `isEnabled: false` were still echoed back from later update/readback calls as `isEnabled: true` even when the follow-up `PUT` omitted `isEnabled`.
 - Explicit CFG schedule-entry toggle writes that included `isEnabled: true` or `isEnabled: false` still read back as `false` for the existing real schedule on the affected site, indicating that effective CFG enablement is controlled by `batterySettings.chargeFromGridScheduleEnabled`, not reliably by the `/schedules` entry flag.
+- Live local verification for issue `#634` also reproduced a disabled CFG recreate quirk: creating a replacement CFG schedule with `isEnabled:false` could echo the new entry as `isEnabled:true` while `batterySettings.chargeFromGridScheduleEnabled` stayed `false`. An explicit schedule update with `isEnabled:false` plus the BatterySettings disable write restored both the entry flag and the effective settings flag.
 - Captured DTG/RBD enablement toggles were also observed as partial `PUT /batterySettings/<site_id>` payloads (`dtgControl.enabled` / `rbdControl.enabled`), so clients should not assume all schedule-family toggles go through `PUT /battery/sites/<site_id>/schedules/<schedule_id>`.
 - The current DTG runtime now follows that split explicitly:
   - toggle enable/disable uses `PUT /batterySettings/<site_id>`

--- a/tests/components/enphase_ev/test_battery_runtime_settings.py
+++ b/tests/components/enphase_ev/test_battery_runtime_settings.py
@@ -3472,15 +3472,27 @@ def test_schedule_family_settings_payload_cfg_guard_paths(
     )
     runtime = coord.battery_runtime
 
+    disabled_without_window = runtime._schedule_family_settings_payload(  # noqa: SLF001
+        "cfg",
+        start_minutes=None,
+        end_minutes=120,
+        enabled=False,
+    )
+    assert disabled_without_window["chargeFromGrid"] is True
+    assert disabled_without_window["chargeFromGridScheduleEnabled"] is False
+    assert "chargeBeginTime" not in disabled_without_window
+    assert "chargeEndTime" not in disabled_without_window
+    assert disabled_without_window["cfgControl"]["forceScheduleOpted"] is False
     assert (
         runtime._schedule_family_settings_payload(  # noqa: SLF001
             "cfg",
             start_minutes=None,
             end_minutes=120,
-            enabled=False,
+            enabled=True,
         )
         is None
     )
+
     with pytest.raises(ServiceValidationError, match="must be different"):
         runtime._schedule_family_settings_payload(  # noqa: SLF001
             "cfg",
@@ -3513,6 +3525,41 @@ def test_schedule_family_settings_payload_cfg_guard_paths(
             enabled=False,
         )
         is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_last_cfg_schedule_disables_schedule_without_window(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord._battery_charge_from_grid = False  # noqa: SLF001
+    coord._battery_charge_begin_time = None  # noqa: SLF001
+    coord._battery_charge_end_time = None  # noqa: SLF001
+    coord.battery_state._battery_charge_begin_time = None  # noqa: SLF001
+    coord.battery_state._battery_charge_end_time = None  # noqa: SLF001
+    coord._battery_accepted_itc_disclaimer = "accepted-at"  # noqa: SLF001
+    runtime = coord.battery_runtime
+    coord.client.delete_battery_schedule = AsyncMock(return_value={})
+    coord.client.set_battery_settings = AsyncMock(return_value={})
+
+    await runtime.async_delete_battery_schedule(
+        "sched-cfg",
+        schedule_type="cfg",
+        enabled=False,
+    )
+
+    coord.client.delete_battery_schedule.assert_awaited_once_with(
+        "sched-cfg",
+        schedule_type="cfg",
+    )
+    coord.client.set_battery_settings.assert_awaited_once_with(
+        {
+            "chargeFromGrid": False,
+            "chargeFromGridScheduleEnabled": False,
+            "acceptedItcDisclaimer": "accepted-at",
+        },
+        schedule_type="cfg",
     )
 
 

--- a/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
+++ b/tests/components/enphase_ev/test_battery_schedule_editor_parity.py
@@ -1607,8 +1607,8 @@ async def test_battery_schedule_services_support_crud_and_validation(
     assert isinstance(update_payload["acceptedItcDisclaimer"], str)
     delete_cfg_payload = coord.client.set_battery_settings.await_args_list[2].args[0]
     assert delete_cfg_payload["chargeFromGridScheduleEnabled"] is False
-    assert delete_cfg_payload["chargeBeginTime"] == 60
-    assert delete_cfg_payload["chargeEndTime"] == 210
+    assert "chargeBeginTime" not in delete_cfg_payload
+    assert "chargeEndTime" not in delete_cfg_payload
     delete_dtg_payload = coord.client.set_battery_settings.await_args_list[3].args[0]
     assert delete_dtg_payload == {
         "dtgControl": {

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -2722,7 +2722,9 @@ def test_rate_value_sensor_uses_home_assistant_currency_for_unit(
     assert sensor.extra_state_attributes["formatted_rate"] == "$0.31"
 
 
-def test_tariff_sensor_falls_back_to_cloud_device(coordinator_factory) -> None:
+def test_tariff_sensor_falls_back_to_cloud_device(
+    coordinator_factory, monkeypatch
+) -> None:
     coord = coordinator_factory()
     coord.inventory_view.type_device_info = MagicMock(return_value=None)
     coord.tariff_billing = parse_tariff_billing(
@@ -2731,6 +2733,10 @@ def test_tariff_sensor_falls_back_to_cloud_device(coordinator_factory) -> None:
             "billingFrequency": "DAY",
             "billingIntervalValue": 30,
         }
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.tariff.dt_util.now",
+        lambda: datetime(2026, 4, 26, tzinfo=timezone.utc),
     )
 
     sensor = EnphaseTariffBillingSensor(coord)


### PR DESCRIPTION
## Summary

Fixes #634.

Deleting the final charge-from-grid (CFG) battery schedule could skip the follow-up BatteryConfig disable write because no replacement schedule window remained. This leaves the backend schedule-family toggle at risk of staying enabled even after the schedule entry is removed.

This change allows disabled CFG settings writes to omit `chargeBeginTime` and `chargeEndTime`, while still requiring a valid window for enabled CFG writes. It also documents the live API behavior observed during validation and updates the regression coverage for the schedule editor/service path.

## Related Issues

- Fixes #634

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_runtime_settings.py::test_schedule_family_settings_payload_cfg_guard_paths tests/components/enphase_ev/test_battery_runtime_settings.py::test_delete_last_cfg_schedule_disables_schedule_without_window tests/components/enphase_ev/test_battery_runtime_settings.py::test_async_apply_schedule_family_settings_handles_noop_and_non_forbidden_error"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_battery_schedule_editor_parity.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_battery_schedule_editor_parity.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/battery_runtime.py tests/components/enphase_ev/test_battery_runtime_settings.py tests/components/enphase_ev/test_battery_schedule_editor_parity.py"
git diff --check
```

Manual validation:

- Tested against the local Home Assistant dev runtime using a live Enphase account.
- Deleted the only CFG schedule, sent the no-window BatteryConfig disable payload, and verified the follow-up API read returned `chargeFromGridScheduleEnabled: false` with zero CFG schedules.
- Restored the original CFG schedule disabled after validation and confirmed Home Assistant showed the schedule switch off.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- `docs/api/api_spec.md` records that the final-CFG-delete disable write is accepted without `chargeBeginTime` / `chargeEndTime`.
- No translation strings changed.
