### PR TITLE
Add dated export tariff rate fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### ✨ New features
+- Added read-only current export rate support for Enphase sites whose NEM/export buyback rates are only exposed by the dated tariff-rates endpoint.
+
+### 🔧 Improvements
+- Tracked dated tariff-rate availability separately so unsupported regional endpoints back off without degrading the main tariff refresh.
+
 ## v3.0.0 - 2026-05-01
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -5141,6 +5141,34 @@ class EnphaseEVClient:
             headers=self._tariff_headers(),
         )
 
+    async def site_tariff_rates(
+        self,
+        *,
+        rate_type: str,
+        request_date: date | datetime | str | None = None,
+    ) -> dict:
+        """Return dated tariff rates for a site tariff branch."""
+
+        if request_date is None:
+            request_date_text = date.today().isoformat()
+        elif isinstance(request_date, datetime):
+            request_date_text = request_date.date().isoformat()
+        elif isinstance(request_date, date):
+            request_date_text = request_date.isoformat()
+        else:
+            request_date_text = str(request_date)
+        url = f"{BASE_URL}/service/tariff/tariff-ms/systems/{self._site}/tariffs"
+        return await self._json(
+            "GET",
+            url,
+            params={
+                "rateType": str(rate_type).upper(),
+                "date": request_date_text,
+                "includeUtility": "",
+            },
+            headers=self._tariff_headers(),
+        )
+
     async def site_tariff_bundle(self) -> tuple[dict, dict]:
         """Return billing details and tariff configuration for the site."""
 

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -682,6 +682,15 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 suppress_after_failures=3,
                 support_state_on_success=True,
             ),
+            "tariff_dated_rates": EndpointFamilyPolicy(
+                success_ttl_s=300.0,
+                stale_after_s=86400.0,
+                failure_backoff_schedule_s=(3600.0, 21600.0, 86400.0),
+                max_backoff_s=86400.0,
+                optional=True,
+                suppress_after_failures=3,
+                support_state_on_success=True,
+            ),
             "inventory_topology": EndpointFamilyPolicy(
                 success_ttl_s=21600.0,
                 failure_backoff_schedule_s=(1800.0, 3600.0, 7200.0, 21600.0),

--- a/custom_components/enphase_ev/tariff.py
+++ b/custom_components/enphase_ev/tariff.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from .coordinator import EnphaseCoordinator
 
 TARIFF_ENDPOINT_FAMILY = "tariff"
+TARIFF_DATED_RATES_ENDPOINT_FAMILY = "tariff_dated_rates"
 TARIFF_BRANCH_KEYS = frozenset({"purchase", "buyback"})
 TARIFF_TYPE_IDS = frozenset({"flat", "tou", "tiered"})
 TARIFF_TYPE_KINDS = frozenset(
@@ -898,6 +899,79 @@ def parse_tariff_rate(
     )
 
 
+def parse_dated_tariff_rate(
+    payload: object,
+    branch_key: str,
+) -> TariffRateSnapshot | None:
+    """Return a read-only tariff snapshot from the dated rates endpoint."""
+
+    if branch_key not in TARIFF_BRANCH_KEYS or not isinstance(payload, dict):
+        return None
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        return None
+    rate_rows = data.get(branch_key)
+    if not isinstance(rate_rows, list):
+        return None
+
+    periods: list[dict[str, object]] = []
+    for index, row in enumerate(rate_rows, start=1):
+        if not isinstance(row, dict) or _rate_value(row.get("rate")) is None:
+            continue
+        period: dict[str, object] = {
+            "id": f"rate-{index}",
+            "type": branch_key,
+            "rate": _clean_text(row.get("rate")),
+        }
+        start = _int_or_none(row.get("start"))
+        end = _int_or_none(row.get("end"))
+        if (
+            start is not None
+            and end is not None
+            and 0 <= start < 24 * 60
+            and 0 <= end < 24 * 60
+        ):
+            period["start_time"] = _minutes_to_hhmm(start)
+            period["end_time"] = _minutes_to_hhmm(end + 1)
+        periods.append(period)
+
+    if not periods:
+        return None
+
+    site_details = data.get("siteDetails")
+    if not isinstance(site_details, dict):
+        site_details = {}
+    currency = _clean_text(data.get("currency")) or _clean_text(
+        site_details.get("currency")
+    )
+    rate_structure = "Flat" if len(periods) == 1 else "Time of use"
+    export_plan = None
+    if branch_key == "buyback":
+        export_plan = _clean_text(site_details.get("exportPlanType"))
+
+    return TariffRateSnapshot(
+        state=rate_structure,
+        rate_structure=rate_structure,
+        variation_type="Single",
+        source=_clean_text(data.get("tariff-type")) or _clean_text(payload.get("type")),
+        currency=currency,
+        export_plan=export_plan,
+        seasons=(
+            {
+                "id": _clean_text(data.get("tariff-version-id")) or "current",
+                "days": [
+                    {
+                        "id": "all",
+                        "days": [1, 2, 3, 4, 5, 6, 7],
+                        "periods": periods,
+                    }
+                ],
+            },
+        ),
+        branch_key=None,
+    )
+
+
 def _format_write_rate(value: float) -> str:
     if not math.isfinite(value) or value < 0:
         _raise_tariff_validation(
@@ -1168,6 +1242,41 @@ def _locate_tariff_rate(
     )
 
 
+def _site_local_today(coord: EnphaseCoordinator) -> date:
+    tz_name = None
+    site_tz = getattr(coord, "_site_timezone_name", None)
+    if callable(site_tz):
+        tz_name = site_tz()
+    tzinfo = dt_util.get_time_zone(tz_name) if isinstance(tz_name, str) else None
+    return dt_util.now(tzinfo or dt_util.DEFAULT_TIME_ZONE).date()
+
+
+def _endpoint_family_diagnostics(coord: EnphaseCoordinator, family: str) -> dict:
+    health = coord._endpoint_family_state(family)
+    return {
+        "support_state": health.support_state,
+        "cooldown_active": health.cooldown_active,
+        "consecutive_failures": health.consecutive_failures,
+        "last_success_utc": (
+            health.last_success_utc.isoformat()
+            if health.last_success_utc is not None
+            else None
+        ),
+        "last_failure_utc": (
+            health.last_failure_utc.isoformat()
+            if health.last_failure_utc is not None
+            else None
+        ),
+        "last_status": health.last_status,
+        "last_error": health.last_error,
+        "next_retry_utc": (
+            health.next_retry_utc.isoformat()
+            if health.next_retry_utc is not None
+            else None
+        ),
+    }
+
+
 class TariffRuntime:
     """Fetch, normalize, and update site tariff data."""
 
@@ -1193,6 +1302,7 @@ class TariffRuntime:
             billing = parse_tariff_billing(billing_payload)
             import_rate = parse_tariff_rate(tariff_payload, "purchase")
             export_rate = parse_tariff_rate(tariff_payload, "buyback")
+            export_rate = await self._async_export_rate_with_dated_fallback(export_rate)
         except (
             aiohttp.ClientError,
             AttributeError,
@@ -1218,6 +1328,59 @@ class TariffRuntime:
         if isinstance(tariff_payload, dict) and tariff_payload:
             coord.tariff_rates_last_refresh_utc = refresh_time
         coord._note_endpoint_family_success(TARIFF_ENDPOINT_FAMILY)
+
+    async def _async_export_rate_with_dated_fallback(
+        self,
+        export_rate: TariffRateSnapshot | None,
+    ) -> TariffRateSnapshot | None:
+        """Fetch dated export rates when the main tariff payload has no rates."""
+
+        if export_rate is None:
+            return None
+        if tariff_rate_sensor_specs(export_rate):
+            return export_rate
+        coord = self.coordinator
+        site_tariff_rates = getattr(coord.client, "site_tariff_rates", None)
+        if not callable(site_tariff_rates):
+            return export_rate
+        if not coord._endpoint_family_should_run(TARIFF_DATED_RATES_ENDPOINT_FAMILY):
+            previous = getattr(coord, "tariff_export_rate", None)
+            if tariff_rate_sensor_specs(previous):
+                return previous
+            return export_rate
+        try:
+            payload = await site_tariff_rates(
+                rate_type="BUYBACK",
+                request_date=_site_local_today(coord),
+            )
+            fallback = parse_dated_tariff_rate(payload, "buyback")
+        except (
+            aiohttp.ClientError,
+            AttributeError,
+            InvalidPayloadError,
+            OptionalEndpointUnavailable,
+            TimeoutError,
+        ) as err:
+            coord._note_endpoint_family_failure(TARIFF_DATED_RATES_ENDPOINT_FAMILY, err)
+            _LOGGER.debug(
+                "Dated export tariff rates are unavailable for site %s: %s",
+                getattr(coord, "site_id", None),
+                err,
+            )
+            previous = getattr(coord, "tariff_export_rate", None)
+            if tariff_rate_sensor_specs(previous):
+                return previous
+            return export_rate
+        if fallback is None:
+            coord._note_endpoint_family_failure(
+                TARIFF_DATED_RATES_ENDPOINT_FAMILY,
+                OptionalEndpointUnavailable(
+                    "Dated export tariff rates did not include data"
+                ),
+            )
+            return export_rate
+        coord._note_endpoint_family_success(TARIFF_DATED_RATES_ENDPOINT_FAMILY)
+        return fallback
 
     async def async_set_tariff_rate(
         self,
@@ -1376,7 +1539,6 @@ class TariffRuntime:
         """Return tariff refresh diagnostics without raw tariff payloads."""
 
         coord = self.coordinator
-        health = coord._endpoint_family_state(TARIFF_ENDPOINT_FAMILY)
         last_refresh_utc = getattr(coord, "tariff_last_refresh_utc", None)
         rates_last_refresh_utc = getattr(coord, "tariff_rates_last_refresh_utc", None)
         return {
@@ -1397,26 +1559,10 @@ class TariffRuntime:
                 if hasattr(rates_last_refresh_utc, "isoformat")
                 else None
             ),
-            "endpoint_family": {
-                "support_state": health.support_state,
-                "cooldown_active": health.cooldown_active,
-                "consecutive_failures": health.consecutive_failures,
-                "last_success_utc": (
-                    health.last_success_utc.isoformat()
-                    if health.last_success_utc is not None
-                    else None
-                ),
-                "last_failure_utc": (
-                    health.last_failure_utc.isoformat()
-                    if health.last_failure_utc is not None
-                    else None
-                ),
-                "next_retry_utc": (
-                    health.next_retry_utc.isoformat()
-                    if health.next_retry_utc is not None
-                    else None
-                ),
-                "last_status": health.last_status,
-                "last_error": health.last_error,
-            },
+            "endpoint_family": _endpoint_family_diagnostics(
+                coord, TARIFF_ENDPOINT_FAMILY
+            ),
+            "dated_rates_endpoint_family": _endpoint_family_diagnostics(
+                coord, TARIFF_DATED_RATES_ENDPOINT_FAMILY
+            ),
         }

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -118,6 +118,7 @@ Status labels:
 | Legacy site tariff flags | `GET` | `/app-api/<site_id>/tariff.json?country=<country>` | authenticated session cookies + `e-auth-token` | Browser capture only |
 | Site billing-cycle details | `GET/POST` | `/service/tariff/tariff-ms/systems/<site_id>/billing-details[?date=<YYYY-MM-DD>]` | tariff web headers: authenticated cookies, `e-auth-token`, `Username`, `Requestid`; writes add `Origin`, `Content-Type`, and `x-xsrf-token` | Runtime |
 | Site tariff configuration | `GET/PUT` | `/service/tariff/tariff-ms/systems/<site_id>/tariff?include-site-details=true` and `/service/tariff/tariff-ms/systems/<site_id>/tariff?user-id=<user_id>` | tariff web headers: authenticated cookies, `e-auth-token`, `Username`, `Requestid`, `X-Requested-With`; writes add `Origin`, `Content-Type`, and `x-xsrf-token` | Runtime |
+| Dated site tariff rates | `GET` | `/service/tariff/tariff-ms/systems/<site_id>/tariffs?rateType=<BUYBACK>&date=<YYYY-MM-DD>&includeUtility=` | tariff web headers: authenticated cookies, `e-auth-token`, `Username`, `Requestid`, `X-Requested-With` | Runtime |
 | Tariff settings MQTT authorizer | `GET` | `/pv/aws_sigv4/tariff_settings_response_stream?serial_number=<gateway_sn>` | authenticated Enlighten session cookies + `e-auth-token` + `x-xsrf-token` | Browser capture only |
 | EVSE tariff-change notification | `PUT` | `/service/evse_scheduler/api/v1/siteConfig/<site_id>/tariff_change` | tariff web write headers + JSON `null` body | Runtime (best-effort) |
 | System dashboard summary | `GET` | `/service/system_dashboard/api_internal/cs/sites/<site_id>/summary` | session cookies + optional `Authorization: Bearer <token>` (current implementation adds bearer when available) | Runtime |
@@ -2619,6 +2620,67 @@ Example response (anonymized; representative values only):
   "dtCustomChargeEnabled": true
 }
 ```
+
+#### Dated Tariff Rates Read
+```
+GET /service/tariff/tariff-ms/systems/<site_id>/tariffs?rateType=BUYBACK&date=<YYYY-MM-DD>&includeUtility=
+```
+
+Returns date-specific tariff rate windows for sites where the main tariff configuration can include an empty `buyback.seasons[]` branch.
+The active runtime uses this endpoint as a read-only fallback for current export price sensors; these rates are not exposed as editable tariff number entities.
+
+Observed query parameters:
+- `rateType`: observed as `BUYBACK` for export compensation rates.
+- `date`: local date whose rates should be returned, formatted as `YYYY-MM-DD`.
+- `includeUtility`: observed with an empty value.
+
+Observed response shape:
+```json
+{
+  "type": "tariff-rates",
+  "timestamp": "2026-05-01T16:25:02.851080797Z",
+  "data": {
+    "tariff-version-id": "0123456789abcdef01234567",
+    "tariff-type": "static",
+    "currency": "$",
+    "timezone": "US/Pacific",
+    "siteDetails": {
+      "currency": "$",
+      "timezone": "US/Pacific",
+      "importPlanType": "NEM3",
+      "exportPlanType": "NEM3",
+      "exportApplicabilityYear": 2026,
+      "interconnectionApplicationDate": "2024-01-15T00:00:00Z",
+      "installDate": "2024-01-15",
+      "lastExportDate": "2033-09-11T07:00:00Z"
+    },
+    "buyback": [
+      {
+        "start": 0,
+        "end": 59,
+        "rate": 0.0789
+      },
+      {
+        "start": 60,
+        "end": 119,
+        "rate": 0.0733
+      },
+      {
+        "start": 1380,
+        "end": 1439,
+        "rate": 0.0764
+      }
+    ]
+  }
+}
+```
+
+Observed notes:
+- `data.buyback[]` contains rate windows for the requested date. `start` and `end` are minute offsets from local midnight; observed rows used inclusive end minutes, for example `0..59` for 00:00-01:00 and `1380..1439` for 23:00-00:00.
+- `data.timezone` and `data.siteDetails.timezone` identify the site timezone for interpreting those minute offsets.
+- The endpoint can provide export rates even when `GET /tariff?include-site-details=true` returns `buyback.seasons: []`.
+- The runtime currently uses this endpoint only for read-only `Current Export Rate` selection when the main tariff payload has no usable export rate specs.
+- This endpoint is not expected to be available for every account or region. The runtime tracks it as its own optional endpoint family (`tariff_dated_rates`) so unsupported or degraded responses back off independently from the main tariff configuration endpoint.
 
 #### Tariff Update
 ```

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -3863,6 +3863,45 @@ async def test_site_tariff_passes_include_site_details() -> None:
 
 
 @pytest.mark.asyncio
+async def test_site_tariff_rates_passes_rate_type_and_date() -> None:
+    client = _make_client()
+    client._json = AsyncMock(return_value={"data": {"buyback": []}})
+
+    out = await client.site_tariff_rates(
+        rate_type="buyback",
+        request_date=datetime.date(2026, 5, 1),
+    )
+
+    assert out == {"data": {"buyback": []}}
+    args, kwargs = client._json.await_args
+    assert args[0] == "GET"
+    assert "/service/tariff/tariff-ms/systems/SITE/tariffs" in args[1]
+    assert kwargs["params"] == {
+        "rateType": "BUYBACK",
+        "date": "2026-05-01",
+        "includeUtility": "",
+    }
+    assert (
+        kwargs["headers"]["Accept"] == "application/json, text/javascript, */*; q=0.01"
+    )
+
+    await client.site_tariff_rates(
+        rate_type="purchase",
+        request_date=datetime.datetime(2026, 5, 2, 12, 0),
+    )
+    _args, kwargs = client._json.await_args
+    assert kwargs["params"]["date"] == "2026-05-02"
+
+    await client.site_tariff_rates(rate_type="buyback", request_date="2026-05-03")
+    _args, kwargs = client._json.await_args
+    assert kwargs["params"]["date"] == "2026-05-03"
+
+    await client.site_tariff_rates(rate_type="buyback")
+    _args, kwargs = client._json.await_args
+    assert kwargs["params"]["date"] == datetime.date.today().isoformat()
+
+
+@pytest.mark.asyncio
 async def test_site_tariff_bundle_fetches_billing_and_tariff() -> None:
     client = _make_client()
     client.site_tariff_billing_details = AsyncMock(

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -21,6 +21,7 @@ from custom_components.enphase_ev.sensor import (
     async_setup_entry,
 )
 from custom_components.enphase_ev.tariff import (
+    TARIFF_DATED_RATES_ENDPOINT_FAMILY,
     TARIFF_ENDPOINT_FAMILY,
     TariffBillingUpdate,
     TariffRateLocator,
@@ -35,6 +36,7 @@ from custom_components.enphase_ev.tariff import (
     next_billing_date,
     next_tariff_rate_change,
     parse_tariff_billing,
+    parse_dated_tariff_rate,
     parse_tariff_rate,
     tariff_rate_sensor_specs,
 )
@@ -226,6 +228,73 @@ def test_parse_tariff_rate_flat_tou_and_tiered_shapes() -> None:
     assert buyback.attributes["export_plan"] == "netFit"
     assert buyback.seasons[0]["off_peak"] == "0.04"
     assert buyback.seasons[0]["tiers"][1]["unbounded"] is True
+
+
+def test_parse_dated_tariff_rate_builds_read_only_buyback_snapshot() -> None:
+    snapshot = parse_dated_tariff_rate(
+        {
+            "type": "tariff-rates",
+            "data": {
+                "tariff-version-id": "abc123",
+                "tariff-type": "static",
+                "currency": "$",
+                "siteDetails": {"exportPlanType": "NEM3"},
+                "buyback": [
+                    {"start": 0, "end": 59, "rate": 0.0789},
+                    {"start": 60, "end": 119, "rate": "0.0733"},
+                    {"start": 1380, "end": 1439, "rate": 0.0764},
+                ],
+            },
+        },
+        "buyback",
+    )
+
+    assert snapshot is not None
+    assert snapshot.state == "Time of use"
+    assert snapshot.source == "static"
+    assert snapshot.export_plan == "NEM3"
+    assert snapshot.branch_key is None
+    specs = tariff_rate_sensor_specs(snapshot)
+    assert len(specs) == 3
+    assert specs[0]["state"] == 0.0789
+    assert specs[0]["attributes"]["start_time"] == "00:00"
+    assert specs[0]["attributes"]["end_time"] == "01:00"
+    assert specs[2]["attributes"]["start_time"] == "23:00"
+    assert specs[2]["attributes"]["end_time"] == "00:00"
+    assert "tariff_locator" not in specs[0]["attributes"]
+    current = current_tariff_rate_sensor_spec(
+        snapshot,
+        datetime(2026, 5, 1, 1, 30, tzinfo=timezone.utc),
+    )
+    assert current is not None
+    assert current["state"] == 0.0733
+
+
+def test_parse_dated_tariff_rate_rejects_bad_payloads() -> None:
+    assert parse_dated_tariff_rate({}, "buyback") is None
+    assert parse_dated_tariff_rate({"data": {"buyback": {}}}, "buyback") is None
+    assert parse_dated_tariff_rate({"data": {"buyback": []}}, "buyback") is None
+    assert (
+        parse_dated_tariff_rate({"data": {"buyback": [{"rate": "bad"}]}}, "buyback")
+        is None
+    )
+    flat = parse_dated_tariff_rate(
+        {
+            "data": {
+                "siteDetails": "bad",
+                "currency": "USD",
+                "buyback": [{"rate": "0.01"}],
+            }
+        },
+        "buyback",
+    )
+    assert flat is not None
+    assert flat.state == "Flat"
+    assert flat.currency == "USD"
+    assert (
+        parse_dated_tariff_rate({"data": {"buyback": [{"rate": "0.01"}]}}, "bad")
+        is None
+    )
 
 
 def test_tariff_rate_sensor_specs_for_tou_and_tiered_rates() -> None:
@@ -1153,6 +1222,336 @@ async def test_tariff_runtime_refreshes_snapshots(coordinator_factory) -> None:
     assert coord.tariff_last_refresh_utc is not None
     assert coord.tariff_rates_last_refresh_utc is coord.tariff_last_refresh_utc
     assert coord._endpoint_family_state("tariff").support_state == "supported"
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_uses_dated_buyback_when_export_seasons_empty(
+    coordinator_factory,
+    monkeypatch,
+) -> None:
+    fixed_now = datetime(2026, 5, 1, 16, 25, tzinfo=timezone.utc)
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.tariff.dt_util.now",
+        lambda tz=None: fixed_now.astimezone(tz) if tz is not None else fixed_now,
+    )
+    coord = coordinator_factory()
+    coord._site_timezone_name = lambda: "UTC"  # noqa: SLF001
+    coord.client.site_tariff_bundle = AsyncMock(
+        return_value=(
+            {
+                "anyBillPeriodStartDate": "2025-08-18",
+                "billingFrequency": "MONTH",
+                "billingIntervalValue": 1,
+            },
+            {
+                "currency": "$",
+                "purchase": {
+                    "typeKind": "single",
+                    "typeId": "flat",
+                    "source": "manual",
+                    "seasons": [
+                        {
+                            "id": "default",
+                            "days": [{"id": "all", "periods": [{"rate": "0.30"}]}],
+                        }
+                    ],
+                },
+                "buyback": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "source": "autofill",
+                    "exportPlan": "nem",
+                    "seasons": [],
+                },
+            },
+        )
+    )
+    coord.client.site_tariff_rates = AsyncMock(
+        return_value={
+            "type": "tariff-rates",
+            "data": {
+                "tariff-version-id": "abc123",
+                "tariff-type": "static",
+                "currency": "$",
+                "siteDetails": {"exportPlanType": "NEM3"},
+                "buyback": [
+                    {"start": 0, "end": 959, "rate": 0.0402},
+                    {"start": 960, "end": 1019, "rate": 0.0426},
+                    {"start": 1020, "end": 1439, "rate": 0.0567},
+                ],
+            },
+        }
+    )
+
+    await TariffRuntime(coord).async_refresh()
+
+    coord.client.site_tariff_rates.assert_awaited_once_with(
+        rate_type="BUYBACK",
+        request_date=date(2026, 5, 1),
+    )
+    assert coord.tariff_export_rate is not None
+    assert coord.tariff_export_rate.state == "Time of use"
+    assert coord.tariff_export_rate.export_plan == "NEM3"
+    assert (
+        coord._endpoint_family_state(TARIFF_DATED_RATES_ENDPOINT_FAMILY).support_state
+        == "supported"
+    )
+    current = current_tariff_rate_sensor_spec(
+        coord.tariff_export_rate,
+        fixed_now,
+    )
+    assert current is not None
+    assert current["state"] == 0.0426
+    assert "tariff_locator" not in current["attributes"]
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_skips_dated_buyback_when_export_has_specs(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff_bundle = AsyncMock(
+        return_value=(
+            {},
+            {
+                "currency": "$",
+                "buyback": {
+                    "typeKind": "single",
+                    "typeId": "flat",
+                    "seasons": [
+                        {
+                            "id": "default",
+                            "days": [{"id": "all", "periods": [{"rate": "0.01"}]}],
+                        }
+                    ],
+                },
+            },
+        )
+    )
+    coord.client.site_tariff_rates = AsyncMock()
+
+    await TariffRuntime(coord).async_refresh()
+
+    coord.client.site_tariff_rates.assert_not_awaited()
+    assert coord.tariff_export_rate is not None
+    assert tariff_rate_sensor_specs(coord.tariff_export_rate)[0]["state"] == 0.01
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_keeps_empty_export_when_dated_api_missing(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff_bundle = AsyncMock(
+        return_value=(
+            {},
+            {
+                "currency": "$",
+                "buyback": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "seasons": [],
+                },
+            },
+        )
+    )
+    coord.client.site_tariff_rates = None
+
+    await TariffRuntime(coord).async_refresh()
+
+    assert coord.tariff_export_rate is not None
+    assert coord.tariff_export_rate.state == "Time of use"
+    assert tariff_rate_sensor_specs(coord.tariff_export_rate) == ()
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_preserves_previous_export_on_dated_api_failure(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    previous = parse_tariff_rate(
+        {
+            "currency": "$",
+            "buyback": {
+                "typeKind": "single",
+                "typeId": "flat",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [{"id": "all", "periods": [{"rate": "0.01"}]}],
+                    }
+                ],
+            },
+        },
+        "buyback",
+    )
+    coord.tariff_export_rate = previous
+    coord.client.site_tariff_bundle = AsyncMock(
+        return_value=(
+            {},
+            {
+                "currency": "$",
+                "buyback": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "seasons": [],
+                },
+            },
+        )
+    )
+    coord.client.site_tariff_rates = AsyncMock(side_effect=aiohttp.ClientError("boom"))
+
+    await TariffRuntime(coord).async_refresh()
+
+    assert coord.tariff_export_rate is previous
+    health = coord._endpoint_family_state(TARIFF_DATED_RATES_ENDPOINT_FAMILY)
+    assert health.consecutive_failures == 1
+    assert health.cooldown_active is True
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_keeps_empty_export_on_dated_api_failure(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff_bundle = AsyncMock(
+        return_value=(
+            {},
+            {
+                "currency": "$",
+                "buyback": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "seasons": [],
+                },
+            },
+        )
+    )
+    coord.client.site_tariff_rates = AsyncMock(side_effect=aiohttp.ClientError("boom"))
+
+    await TariffRuntime(coord).async_refresh()
+
+    assert coord.tariff_export_rate is not None
+    assert coord.tariff_export_rate.state == "Time of use"
+    assert tariff_rate_sensor_specs(coord.tariff_export_rate) == ()
+    assert (
+        coord._endpoint_family_state(TARIFF_DATED_RATES_ENDPOINT_FAMILY).last_error
+        == "boom"
+    )
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_skips_dated_buyback_during_cooldown(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    previous = parse_tariff_rate(
+        {
+            "currency": "$",
+            "buyback": {
+                "typeKind": "single",
+                "typeId": "flat",
+                "seasons": [
+                    {
+                        "id": "default",
+                        "days": [{"id": "all", "periods": [{"rate": "0.01"}]}],
+                    }
+                ],
+            },
+        },
+        "buyback",
+    )
+    coord.tariff_export_rate = previous
+    coord.client.site_tariff_bundle = AsyncMock(
+        return_value=(
+            {},
+            {
+                "currency": "$",
+                "buyback": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "seasons": [],
+                },
+            },
+        )
+    )
+    coord.client.site_tariff_rates = AsyncMock()
+    coord._note_endpoint_family_failure(
+        TARIFF_DATED_RATES_ENDPOINT_FAMILY,
+        aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=404,
+        ),
+    )
+
+    await TariffRuntime(coord).async_refresh()
+
+    coord.client.site_tariff_rates.assert_not_awaited()
+    assert coord.tariff_export_rate is previous
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_keeps_empty_export_during_dated_cooldown(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff_bundle = AsyncMock(
+        return_value=(
+            {},
+            {
+                "currency": "$",
+                "buyback": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "seasons": [],
+                },
+            },
+        )
+    )
+    coord.client.site_tariff_rates = AsyncMock()
+    coord._note_endpoint_family_failure(
+        TARIFF_DATED_RATES_ENDPOINT_FAMILY,
+        aiohttp.ClientResponseError(
+            request_info=None,
+            history=(),
+            status=404,
+        ),
+    )
+
+    await TariffRuntime(coord).async_refresh()
+
+    coord.client.site_tariff_rates.assert_not_awaited()
+    assert coord.tariff_export_rate is not None
+    assert tariff_rate_sensor_specs(coord.tariff_export_rate) == ()
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_marks_empty_dated_buyback_response_unavailable(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.site_tariff_bundle = AsyncMock(
+        return_value=(
+            {},
+            {
+                "currency": "$",
+                "buyback": {
+                    "typeKind": "single",
+                    "typeId": "tou",
+                    "seasons": [],
+                },
+            },
+        )
+    )
+    coord.client.site_tariff_rates = AsyncMock(return_value={"data": {"buyback": []}})
+
+    await TariffRuntime(coord).async_refresh()
+
+    health = coord._endpoint_family_state(TARIFF_DATED_RATES_ENDPOINT_FAMILY)
+    assert health.consecutive_failures == 1
+    assert health.cooldown_active is True
+    assert health.last_error == "Dated export tariff rates did not include data"
 
 
 @pytest.mark.asyncio
@@ -2199,6 +2598,10 @@ def test_tariff_runtime_diagnostics(coordinator_factory) -> None:
     health.consecutive_failures = 1
     health.last_failure_utc = datetime(2026, 4, 25, tzinfo=timezone.utc)
     health.last_error = "Tariff payload did not include data"
+    dated_health = coord._endpoint_family_state(TARIFF_DATED_RATES_ENDPOINT_FAMILY)
+    dated_health.support_state = "suppressed"
+    dated_health.last_status = 404
+    dated_health.last_error = "404"
 
     diag = TariffRuntime(coord).diagnostics()
 
@@ -2213,6 +2616,8 @@ def test_tariff_runtime_diagnostics(coordinator_factory) -> None:
     assert (
         diag["endpoint_family"]["last_error"] == "Tariff payload did not include data"
     )
+    assert diag["dated_rates_endpoint_family"]["support_state"] == "suppressed"
+    assert diag["dated_rates_endpoint_family"]["last_status"] == 404
 
 
 def test_tariff_sensors_expose_state_attributes_and_gateway_device(


### PR DESCRIPTION
## Summary

Add read-only current export rate support for Enphase sites whose main tariff configuration returns an empty `buyback.seasons[]` branch but exposes dated BUYBACK rates from `/service/tariff/tariff-ms/systems/<site_id>/tariffs`.

The runtime now falls back to the dated tariff-rates endpoint only when the main export tariff has no usable rate specs, keeps the resulting rates read-only, and tracks dated-rate availability as a separate optional endpoint family so unsupported regional endpoints back off without degrading the main tariff refresh.

Fixes #638.

## Related Issues

Fixes #638.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/api.py custom_components/enphase_ev/tariff.py tests/components/enphase_ev/test_tariff.py tests/components/enphase_ev/test_api_client_methods.py && ruff check . && pytest -q tests/components/enphase_ev/test_tariff.py tests/components/enphase_ev/test_api_client_methods.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/tariff.py,custom_components/enphase_ev/coordinator.py --fail-under=100"
```

Manual/dev verification:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/.codex/worktrees/4e0c/ha-enphase-ev-charger/.ha-config:/host-config:ro ha-dev bash -lc "python - <<'PY' ... PY"
```

Post-conflict validation results:

- Focused tariff/API tests: `541 passed`.
- Targeted component coverage: `3109 passed`.
- `custom_components/enphase_ev/api.py`, `custom_components/enphase_ev/tariff.py`, and `custom_components/enphase_ev/coordinator.py`: `100%` coverage.
- Live saved-account verification confirmed the main `/tariff` endpoint returns two export specs, the dated `BUYBACK` endpoint returns three rows in the `Australia/Melbourne` timezone, and a forced empty `buyback.seasons[]` runtime fallback produces three read-only export specs with `tariff_dated_rates` marked supported and zero failures.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid; no translation keys changed.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The dated tariff-rates endpoint is intentionally read-only and omits tariff locators, so editable tariff number entities are not created for rates sourced only from this endpoint.
