### PR TITLE
Map EV charger status mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ All notable changes to this project will be documented in this file.
 - Hardened setup, polling, and EV charger service inputs by bounding scan/runtime intervals, restricting OCPP trigger messages to supported values, requiring confirmation for advanced trigger messages, and keeping raw Enphase error bodies out of raised exceptions.
 - Rejected unresolved EV charger and site service targets with clear validation errors instead of allowing ambiguous calls to fall through to the wrong coordinator.
 - Reported the charger-specific minimum amp value during EV charger safe-limit charging instead of always showing `8 A`.
+- Mapped IQ EV charger status `mode` values into the effective charge mode so manual override states no longer appear as green charging.
 - Redacted Enphase site IDs from logs and diagnostics, expanding the existing redaction coverage across API, summary, session history, EVSE timeseries, coordinator diagnostics, and service messages.
 - Made same-value IQ Battery reserve and shutdown-level number writes no-ops so unchanged settings do not trip the BatteryConfig write debounce or send unnecessary cloud writes.
 - Fixed last CFG schedule deletion so the integration sends the follow-up BatteryConfig disable write even when no replacement charge-from-grid schedule window remains.

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -3585,13 +3585,20 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     charge_mode_pref_source = "battery_profile_fallback"
 
             charge_mode_source = None
-            charge_mode = self._normalize_effective_charge_mode(
-                obj.get("chargeMode")
-                or obj.get("chargingMode")
-                or (obj.get("sch_d") or {}).get("mode")
-            )
-            if charge_mode is not None:
-                charge_mode_source = "explicit_status"
+            charge_mode = None
+            for charge_mode_candidate in (
+                obj.get("mode"),
+                obj.get("chargeMode"),
+                obj.get("chargingMode"),
+                obj.get("charge_mode"),
+                (obj.get("sch_d") or {}).get("mode"),
+            ):
+                charge_mode = self._normalize_effective_charge_mode(
+                    charge_mode_candidate
+                )
+                if charge_mode is not None:
+                    charge_mode_source = "explicit_status"
+                    break
             if charge_mode is None:
                 if charge_mode_pref:
                     charge_mode = charge_mode_pref
@@ -4334,7 +4341,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         """Check whether the status payload already exposes a charge mode."""
         if not isinstance(obj, dict):
             return False
-        for key in ("chargeMode", "chargingMode", "charge_mode"):
+        for key in ("mode", "chargeMode", "chargingMode", "charge_mode"):
             val = obj.get(key)
             if val is not None:
                 return True

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -57,6 +57,10 @@ CHARGE_MODE_PREFERENCE_MAP: dict[str, str] = {
     "SMART": "SMART_CHARGING",
     "SMART_CHARGING": "SMART_CHARGING",
 }
+EFFECTIVE_CHARGE_MODE_INTEGER_MAP: dict[int, str] = {
+    0: "MANUAL_CHARGING",
+    1: "GREEN_CHARGING",
+}
 EFFECTIVE_CHARGE_MODE_VALUES: frozenset[str] = frozenset(
     {
         *CHARGE_MODE_PREFERENCE_MAP.values(),
@@ -1769,6 +1773,8 @@ class EvseRuntime:
         return CHARGE_MODE_PREFERENCE_MAP.get(normalized)
 
     def normalize_effective_charge_mode(self, value: object) -> str | None:
+        if isinstance(value, int) and not isinstance(value, bool):
+            return EFFECTIVE_CHARGE_MODE_INTEGER_MAP.get(value)
         preferred = self.normalize_charge_mode_preference(value)
         if preferred is not None:
             return preferred
@@ -1780,6 +1786,8 @@ class EvseRuntime:
             return None
         if not normalized:
             return None
+        if normalized.isdecimal():
+            return EFFECTIVE_CHARGE_MODE_INTEGER_MAP.get(int(normalized))
         if normalized in EFFECTIVE_CHARGE_MODE_VALUES:
             return normalized
         return None

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -6098,7 +6098,7 @@ There is no single universal header set; the implementation varies headers by en
 | `charging` | Active charging session |
 | `faulted` | Fault present |
 | `offGrid` | Charger grid-mode label from `/ev_chargers/status`; observed value so far: `ON_GRID` |
-| `mode` | Charger operating-mode integer from `/ev_chargers/status`; observed value so far: `1` |
+| `mode` | Charger operating-mode integer from `/ev_chargers/status`; observed values so far: `0` for manual charging and `1` for green charging |
 | `commissioned` | Status payload commissioning flag; observed value so far: `1` |
 | `smartEV.hasToken` | Smart-EV token availability flag; observed value so far: `false` |
 | `smartEV.hasEVDetails` | Smart-EV vehicle-details availability flag; observed value so far: `false` |

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -2052,6 +2052,90 @@ async def test_async_update_data_uses_cached_charge_preference_when_status_only_
 
 
 @pytest.mark.asyncio
+async def test_async_update_data_uses_status_mode_for_effective_charge_mode(
+    coordinator_factory,
+):
+    coord = coordinator_factory(
+        serials=["EV1"],
+        data={
+            "EV1": {
+                "sn": "EV1",
+                "name": "Garage EV",
+                "charge_mode_pref": "GREEN_CHARGING",
+                "charge_mode": "GREEN_CHARGING",
+            }
+        },
+    )
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._scheduler_available = False  # noqa: SLF001
+    coord._scheduler_backoff_active = lambda: False  # type: ignore[assignment]  # noqa: SLF001
+    coord._charge_mode_cache["EV1"] = (
+        "GREEN_CHARGING",
+        coord_mod.time.monotonic(),
+    )
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": "EV1",
+                    "name": "Garage EV",
+                    "mode": 0,
+                    "connectors": [
+                        {
+                            "connectorStatusType": coord_mod.SUSPENDED_EVSE_STATUS,
+                            "connectorStatusReason": "INSUFFICIENT_SOLAR",
+                        }
+                    ],
+                    "sch_d": {"status": 1, "info": [{"type": "greencharging"}]},
+                    "session_d": {},
+                    "charging": False,
+                    "pluggedIn": True,
+                }
+            ],
+            "ts": 1_700_000_000,
+        }
+    )
+    coord.summary = SimpleNamespace(
+        prepare_refresh=lambda **kwargs: False,
+        async_fetch=AsyncMock(return_value=[]),
+        invalidate=lambda: None,
+    )
+    coord.evse_timeseries.async_refresh = AsyncMock(return_value=None)  # noqa: SLF001
+    coord.evse_timeseries.merge_charger_payloads = MagicMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord.energy._async_refresh_site_energy = AsyncMock(
+        return_value=None
+    )  # noqa: SLF001
+    coord._async_refresh_battery_site_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_status = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_backup_history = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_battery_schedules = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_guard_profile = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_storm_alert = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_grid_control_check = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_devices_inventory = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_dry_contact_settings = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_hems_devices = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_inverters = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_current_power_consumption = AsyncMock()  # noqa: SLF001
+    coord._async_refresh_heatpump_power = AsyncMock()  # noqa: SLF001
+    coord._async_resolve_green_battery_settings = AsyncMock(
+        return_value={}
+    )  # noqa: SLF001
+    coord._async_resolve_auth_settings = AsyncMock(return_value={})  # noqa: SLF001
+    coord._get_charge_mode = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
+    coord._sync_battery_profile_pending_issue = MagicMock()  # noqa: SLF001
+
+    result = await coord._async_update_data()  # noqa: SLF001
+
+    assert result["EV1"]["charge_mode_pref"] == "GREEN_CHARGING"
+    assert result["EV1"]["charge_mode"] == "MANUAL_CHARGING"
+    assert result["EV1"]["charge_mode_source"] == "explicit_status"
+
+
+@pytest.mark.asyncio
 async def test_async_update_data_drops_expired_cached_charge_preference_when_status_only_has_custom_schedule(
     coordinator_factory,
 ):

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -69,6 +69,10 @@ def test_evse_runtime_helper_paths(coordinator_factory) -> None:
     assert runtime.pick_start_amps("EV1", requested=None, fallback=16) == 24
     assert runtime.normalize_charge_mode_preference("scheduled") == "SCHEDULED_CHARGING"
     assert runtime.normalize_charge_mode_preference("smart") == "SMART_CHARGING"
+    assert runtime.normalize_effective_charge_mode(0) == "MANUAL_CHARGING"
+    assert runtime.normalize_effective_charge_mode(1) == "GREEN_CHARGING"
+    assert runtime.normalize_effective_charge_mode("1") == "GREEN_CHARGING"
+    assert runtime.normalize_effective_charge_mode(False) is None
     assert runtime.normalize_effective_charge_mode("idle") == "IDLE"
     assert runtime.resolve_charge_mode_pref("EV1") == "SCHEDULED_CHARGING"
     prefs = runtime.charge_mode_start_preferences("EV1")


### PR DESCRIPTION
## Summary

Fixes #640.

Map the IQ EV charger status API `mode` integer into the effective charge mode before falling back to scheduler preference or schedule metadata. This lets `mode: 0` report `MANUAL_CHARGING` even when the scheduler preference and `sch_d.info[].type` still indicate green charging.

The root cause was that the coordinator preserved the top-level status `mode` field from `/ev_chargers/status`, but effective-mode derivation only checked `chargeMode`, `chargingMode`, and `sch_d.mode`. Numeric status modes were also not normalized.

## Related Issues

Fixes #640

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_coordinator_additional_coverage.py -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/evse_runtime.py,custom_components/enphase_ev/coordinator.py --fail-under=100"
```

Manual validation against a configured dev Home Assistant runtime confirmed the patched integration reports the live charger as `MANUAL_CHARGING` when cloud status reports `mode: 0`. I also attempted the reported plug-out / switch-to-green / replug sequence twice; this charger settled to `mode: 1` after the transition, so the exact split state did not reproduce live. The regression test covers the reported payload shape where `mode: 0` coexists with green scheduler data.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics payload is included in the PR. The reporter-provided issue payload shows the relevant status shape: top-level `mode: 0` with green scheduler metadata.
