### PR TITLE
Refresh Storm Guard state during startup

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -2457,14 +2457,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._sync_site_energy_issue()
         phase_timings["site_energy_s"] = round(time.monotonic() - site_energy_start, 3)
         if context.first_refresh:
-            timing_key, duration = await self.refresh_runner.async_run_refresh_call(
-                "tariff_s",
-                "tariff",
-                lambda: self.tariff_runtime.async_refresh(force=True),
-                endpoint_family="tariff",
-            )
-            if duration is not None:
-                phase_timings[timing_key] = duration
+            await self._async_run_first_refresh_followups(phase_timings)
         else:
             followup_plan = build_site_only_followup_plan(
                 self,
@@ -2515,14 +2508,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         context: RefreshPipelineContext,
     ) -> None:
         if context.first_refresh:
-            timing_key, duration = await self.refresh_runner.async_run_refresh_call(
-                "tariff_s",
-                "tariff",
-                lambda: self.tariff_runtime.async_refresh(force=True),
-                endpoint_family="tariff",
-            )
-            if duration is not None:
-                context.phase_timings[timing_key] = duration
+            await self._async_run_first_refresh_followups(context.phase_timings)
         else:
             followup_plan = build_followup_plan(
                 self,
@@ -2534,6 +2520,50 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     plan=followup_plan,
                 )
         self._clear_auth_refresh_rejection_state_if_unchanged(context)
+
+    async def _async_run_first_refresh_followups(
+        self,
+        phase_timings: dict[str, float],
+    ) -> None:
+        calls = [
+            (
+                "tariff_s",
+                "tariff",
+                lambda: self.tariff_runtime.async_refresh(force=True),
+                "tariff",
+            )
+        ]
+        if self._first_refresh_storm_guard_followups_needed():
+            calls.extend(
+                (
+                    (
+                        "battery_site_settings_s",
+                        "battery site settings",
+                        lambda: self._async_refresh_battery_site_settings(),
+                        "battery_site_settings",
+                    ),
+                    (
+                        "storm_guard_s",
+                        "storm guard",
+                        lambda: self._async_refresh_storm_guard_profile(),
+                        "storm_guard",
+                    ),
+                )
+            )
+        await self.refresh_runner.async_run_refresh_calls(
+            phase_timings,
+            calls=tuple(calls),
+        )
+
+    def _first_refresh_storm_guard_followups_needed(self) -> bool:
+        if getattr(self, "_battery_has_encharge", None) is False:
+            return False
+        selected = getattr(self, "_selected_type_keys", None)
+        if isinstance(selected, set) and selected:
+            if self.site_only or not self.serials:
+                return "envoy" in selected
+            return bool({"encharge", "envoy", "iqevse"} & selected)
+        return bool(self.site_id and (self.serials or self.site_only))
 
     async def _async_run_post_session_refresh_pipeline(
         self,

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -3338,7 +3338,7 @@ async def test_first_refresh_soft_fails_optional_evse_status_endpoint(
 
 
 @pytest.mark.asyncio
-async def test_first_refresh_defers_warmup_only_calls(
+async def test_first_refresh_runs_storm_guard_startup_calls_and_defers_warmup_only_calls(
     hass, monkeypatch, config_entry
 ) -> None:
     from custom_components.enphase_ev.coordinator import EnphaseCoordinator
@@ -3431,13 +3431,93 @@ async def test_first_refresh_defers_warmup_only_calls(
 
     await coord.async_refresh()
 
-    for mock in deferred_methods.values():
+    deferred_methods["_async_refresh_battery_site_settings"].assert_awaited_once()
+    deferred_methods["_async_refresh_storm_guard_profile"].assert_awaited_once()
+    for name, mock in deferred_methods.items():
+        if name in {
+            "_async_refresh_battery_site_settings",
+            "_async_refresh_storm_guard_profile",
+        }:
+            continue
         mock.assert_not_awaited()
     coord.energy._async_refresh_site_energy.assert_not_awaited()
     coord.evse_timeseries.async_refresh.assert_not_awaited()
     assert "status_s" in coord.bootstrap_phase_timings
     assert "summary_s" in coord.bootstrap_phase_timings
     assert "site_energy_s" not in coord.bootstrap_phase_timings
+
+
+@pytest.mark.asyncio
+async def test_first_refresh_populates_storm_guard_state_before_entities(
+    hass, monkeypatch, config_entry
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+    from custom_components.enphase_ev.switch import StormGuardSwitch
+
+    cfg = {
+        CONF_SITE_ID: RANDOM_SITE_ID,
+        CONF_SERIALS: [RANDOM_SERIAL],
+        CONF_EAUTH: "EAUTH",
+        CONF_COOKIE: "COOKIE",
+        CONF_SCAN_INTERVAL: 15,
+        CONF_SITE_ONLY: False,
+    }
+
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        coord_mod,
+        "async_call_later",
+        lambda *_args, **_kwargs: (lambda: None),
+    )
+
+    class DummyClient:
+        async def status(self):
+            return {
+                "evChargerData": [
+                    {
+                        "sn": RANDOM_SERIAL,
+                        "name": "Garage EV",
+                        "connectors": [{}],
+                        "session_d": {},
+                        "sch_d": {},
+                        "charging": False,
+                    }
+                ],
+                "ts": 1_700_000_000,
+            }
+
+        async def summary_v2(self):
+            return [{"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"}]
+
+        async def battery_site_settings(self):
+            return {
+                "data": {
+                    "showStormGuard": True,
+                    "hasEncharge": True,
+                    "userDetails": {"isOwner": True, "isInstaller": False},
+                }
+            }
+
+        async def storm_guard_profile(self, **_kwargs):
+            return {
+                "data": {
+                    "stormGuardState": "enabled",
+                    "evseStormEnabled": True,
+                }
+            }
+
+    coord = EnphaseCoordinator(hass, cfg, config_entry=config_entry)
+    coord.client = DummyClient()
+    coord.tariff_runtime.async_refresh = AsyncMock()
+
+    await coord.async_refresh()
+
+    assert coord.data[RANDOM_SERIAL]["storm_guard_state"] == "enabled"
+    assert coord.data[RANDOM_SERIAL]["storm_evse_enabled"] is True
+    assert StormGuardSwitch(coord).available is True
 
 
 def test_snapshot_helpers_and_discovery_capture_edge_paths(hass, monkeypatch) -> None:

--- a/tests/components/enphase_ev/test_coordinator_edge_cases.py
+++ b/tests/components/enphase_ev/test_coordinator_edge_cases.py
@@ -471,8 +471,18 @@ async def test_post_status_first_refresh_clears_auth_refresh_rejection(
     from custom_components.enphase_ev.coordinator import RefreshPipelineContext
 
     coord = coordinator_factory()
-    coord.refresh_runner.async_run_refresh_call = AsyncMock(
-        return_value=("tariff_s", 0.123)
+
+    async def _run_first_refresh_calls(phase_timings, *, calls, **_kwargs) -> None:
+        durations = {
+            "tariff_s": 0.123,
+            "battery_site_settings_s": 0.234,
+            "storm_guard_s": 0.345,
+        }
+        for timing_key, *_rest in calls:
+            phase_timings[timing_key] = durations[timing_key]
+
+    coord.refresh_runner.async_run_refresh_calls = AsyncMock(
+        side_effect=_run_first_refresh_calls
     )
     coord._auth_refresh_rejected_count = 2
     coord._auth_refresh_rejected_until = time.monotonic() + 60
@@ -490,8 +500,16 @@ async def test_post_status_first_refresh_clears_auth_refresh_rejection(
 
     await coord._async_run_post_status_refresh_pipeline(context)
 
-    coord.refresh_runner.async_run_refresh_call.assert_awaited_once()
+    coord.refresh_runner.async_run_refresh_calls.assert_awaited_once()
+    calls = coord.refresh_runner.async_run_refresh_calls.await_args.kwargs["calls"]
+    assert [call[0] for call in calls] == [
+        "tariff_s",
+        "battery_site_settings_s",
+        "storm_guard_s",
+    ]
     assert context.phase_timings["tariff_s"] == 0.123
+    assert context.phase_timings["battery_site_settings_s"] == 0.234
+    assert context.phase_timings["storm_guard_s"] == 0.345
     assert coord._auth_refresh_rejected_count == 0
     assert coord._auth_refresh_rejected_until is None
     assert coord._auth_refresh_rejected_ends_utc is None
@@ -505,15 +523,16 @@ async def test_post_status_preserves_new_auth_refresh_rejection(
 
     coord = coordinator_factory()
 
-    async def _reject_during_followup(*_args, **_kwargs) -> None:
+    async def _reject_during_followup(phase_timings, *, calls, **_kwargs) -> None:
         coord._auth_refresh_rejected_count = 1
         coord._auth_refresh_rejected_until = time.monotonic() + 60
         coord._auth_refresh_rejected_ends_utc = datetime.now(timezone.utc) + timedelta(
             seconds=60
         )
-        return ("tariff_s", 0.123)
+        for timing_key, *_rest in calls:
+            phase_timings[timing_key] = 0.123
 
-    coord.refresh_runner.async_run_refresh_call = AsyncMock(
+    coord.refresh_runner.async_run_refresh_calls = AsyncMock(
         side_effect=_reject_during_followup
     )
     coord._auth_refresh_rejected_count = 0
@@ -530,10 +549,39 @@ async def test_post_status_preserves_new_auth_refresh_rejection(
 
     await coord._async_run_post_status_refresh_pipeline(context)
 
-    coord.refresh_runner.async_run_refresh_call.assert_awaited_once()
+    coord.refresh_runner.async_run_refresh_calls.assert_awaited_once()
     assert coord._auth_refresh_rejected_count == 1
     assert coord._auth_refresh_rejected_until is not None
     assert coord._auth_refresh_rejected_ends_utc is not None
+
+
+@pytest.mark.parametrize(
+    ("selected", "site_only", "serials", "has_encharge", "expected"),
+    [
+        ({"iqevse"}, False, {"EV123"}, None, True),
+        ({"microinverter"}, False, {"EV123"}, None, False),
+        ({"envoy"}, True, set(), None, True),
+        ({"encharge"}, True, set(), None, False),
+        (None, False, {"EV123"}, False, False),
+    ],
+)
+def test_first_refresh_storm_guard_followups_are_gated(
+    coordinator_factory,
+    selected,
+    site_only,
+    serials,
+    has_encharge,
+    expected,
+) -> None:
+    coord = coordinator_factory()
+    coord._selected_type_keys = selected  # noqa: SLF001
+    coord.site_only = site_only
+    coord.serials = serials
+    coord._battery_has_encharge = has_encharge  # noqa: SLF001
+
+    assert (
+        coord._first_refresh_storm_guard_followups_needed() is expected
+    )  # noqa: SLF001
 
 
 def test_clear_auth_refresh_rejection_state_if_unchanged_preserves_suspension(


### PR DESCRIPTION
## Summary

Refresh Storm Guard BatteryConfig state during the blocking first refresh when the entry can expose Storm Guard entities. This prevents the Storm Guard state sensor and site switch from starting as unavailable until the startup warmup or next poll.

The first-refresh followups run in parallel and the Storm Guard-specific calls are gated so startup does not serialize extra cloud requests for unrelated configurations.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_edge_cases.py && ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python3 -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Targeted coverage confirmed 100% for `custom_components/enphase_ev/coordinator.py`.
