### PR TITLE
Handle transient EV charge mode scheduler errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Mapped IQ EV charger status `mode` values into the effective charge mode so manual override states no longer appear as green charging.
 - Fixed last CFG schedule deletion so the integration sends the follow-up BatteryConfig disable write even when no replacement charge-from-grid schedule window remains.
 - Resolved current tariff price selection when Enphase time-of-use payloads include an all-day fallback period alongside timed peak periods.
+- Suppressed transient Enphase scheduler `400` errors for IQ EV charger mode changes when read-back confirms the requested mode was applied.
 
 ### 🔧 Improvements
 - Tracked dated tariff-rate availability separately so unsupported regional endpoints back off without degrading the main tariff refresh.

--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -363,6 +363,52 @@ def _safe_response_error_message(
     return f"HTTP error from Enphase endpoint ({', '.join(detail_parts)})"
 
 
+def _scheduler_error_context_from_text(
+    text: str | None,
+) -> tuple[str | None, str | None]:
+    """Return a scheduler error code/display tuple from a response body."""
+
+    if not text:
+        return None, None
+    try:
+        payload = json.loads(text)
+    except (TypeError, ValueError):
+        return None, None
+    if not isinstance(payload, dict):
+        return None, None
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return None, None
+    code = error.get("errorMessageCode")
+    display = error.get("displayMessage") or error.get("additionalInfo")
+    return (str(code) if code else None, str(display) if display else None)
+
+
+def _scheduler_error_context(
+    err: aiohttp.ClientResponseError,
+) -> tuple[str | None, str | None]:
+    """Return scheduler error context attached to a response error."""
+
+    context = getattr(err, "enphase_scheduler_error", None)
+    if isinstance(context, dict):
+        code = context.get("code")
+        display = context.get("display")
+        return (str(code) if code else None, str(display) if display else None)
+    return _scheduler_error_context_from_text(err.message)
+
+
+def _scheduler_error_code(err: aiohttp.ClientResponseError) -> str | None:
+    """Return a scheduler error code from a response error when available."""
+
+    return _scheduler_error_context(err)[0]
+
+
+def _is_scheduler_charging_mode_endpoint(endpoint: str | None) -> bool:
+    """Return True for IQ EV charger scheduler mode endpoints."""
+
+    return "/service/evse_scheduler/api/v1/iqevc/charging-mode/" in str(endpoint or "")
+
+
 def validate_ocpp_trigger_message(requested_message: object) -> str:
     """Return a supported OCPP trigger message name or raise ValueError."""
 
@@ -4276,13 +4322,23 @@ class EnphaseEVClient:
                                             max_length=256,
                                         ),
                                     )
-                                raise aiohttp.ClientResponseError(
+                                response_error = aiohttp.ClientResponseError(
                                     r.request_info,
                                     r.history,
                                     status=r.status,
                                     message=message,
                                     headers=r.headers,
                                 )
+                                if _is_scheduler_charging_mode_endpoint(endpoint):
+                                    code, display = _scheduler_error_context_from_text(
+                                        body_text
+                                    )
+                                    if code or display:
+                                        response_error.enphase_scheduler_error = {
+                                            "code": code,
+                                            "display": display,
+                                        }
+                                raise response_error
                             try:
                                 payload = await r.json()
                             except (aiohttp.ContentTypeError, ValueError) as err:
@@ -4975,7 +5031,9 @@ class EnphaseEVClient:
             return None
         return None
 
-    async def set_charge_mode(self, sn: str, mode: str) -> dict:
+    async def set_charge_mode(
+        self, sn: str, mode: str, *, previous_mode: str | None = None
+    ) -> dict:
         """Set the charging mode via scheduler API.
 
         PUT /service/evse_scheduler/api/v1/iqevc/charging-mode/<site>/<sn>/preference
@@ -4985,13 +5043,53 @@ class EnphaseEVClient:
         url = f"{BASE_URL}/service/evse_scheduler/api/v1/iqevc/charging-mode/{self._site}/{sn}/preference"
         headers = self._today_json_headers()
         headers.update(self._control_headers())
-        payload = {"mode": str(mode)}
+        normalized_mode = str(mode)
+        observed_previous_mode = str(previous_mode) if previous_mode else None
+        if observed_previous_mode is None:
+            try:
+                observed_previous_mode = await self.charge_mode(sn)
+            except SchedulerUnavailable:
+                raise
+            except (aiohttp.ClientError, asyncio.TimeoutError):
+                observed_previous_mode = None
+        if observed_previous_mode == normalized_mode:
+            return {
+                "status": "already_set",
+                "mode": normalized_mode,
+            }
+        payload = {"mode": normalized_mode}
         try:
             return await self._json("PUT", url, json=payload, headers=headers)
         except aiohttp.ClientResponseError as err:
             if is_scheduler_unavailable_error(err.message, err.status, url):
                 raise SchedulerUnavailable(str(err)) from err
+            if (
+                err.status == 400
+                and observed_previous_mode is not None
+                and observed_previous_mode != normalized_mode
+                and _scheduler_error_code(err) != "iqevc_sch_10031"
+                and await self._charge_mode_write_landed(sn, normalized_mode)
+            ):
+                return {
+                    "status": "accepted",
+                    "mode": normalized_mode,
+                    "verified_after_error": True,
+                }
             raise
+
+    async def _charge_mode_write_landed(self, sn: str, mode: str) -> bool:
+        """Return True if a failed preference write is visible on read-back."""
+
+        for attempt in range(6):
+            if attempt:
+                await asyncio.sleep(2)
+            try:
+                current_mode = await self.charge_mode(sn)
+            except (aiohttp.ClientError, asyncio.TimeoutError):
+                return False
+            if current_mode == mode:
+                return True
+        return False
 
     async def green_charging_settings(self, sn: str) -> list[dict[str, Any]]:
         """Return green charging settings for the charger.

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -194,6 +194,17 @@ def _parse_scheduler_error(message: str) -> tuple[str | None, str | None]:
     return (str(code) if code else None, str(display) if display else None)
 
 
+def _scheduler_error_context(
+    err: aiohttp.ClientResponseError,
+) -> tuple[str | None, str | None]:
+    context = getattr(err, "enphase_scheduler_error", None)
+    if isinstance(context, dict):
+        code = context.get("code")
+        display = context.get("display")
+        return (str(code) if code else None, str(display) if display else None)
+    return _parse_scheduler_error(err.message)
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: EnphaseConfigEntry,
@@ -705,10 +716,13 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
                 translation_domain=DOMAIN,
                 translation_key="charge_mode_invalid_option",
             )
-        if _explicit_charge_mode(self._coord, self._sn) == mode:
+        previous_mode = _explicit_charge_mode(self._coord, self._sn)
+        if previous_mode == mode:
             return
         try:
-            await self._coord.client.set_charge_mode(self._sn, mode)
+            await self._coord.client.set_charge_mode(
+                self._sn, mode, previous_mode=previous_mode
+            )
             self._coord.mark_scheduler_available()
         except SchedulerUnavailable as err:
             self._coord.note_scheduler_unavailable(err)
@@ -721,7 +735,7 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
                 ),
             )
         except aiohttp.ClientResponseError as err:
-            code, display = _parse_scheduler_error(err.message)
+            code, display = _scheduler_error_context(err)
             if err.status == 400 and (
                 code == "iqevc_sch_10031"
                 or (display and "No Schedules enabled" in display)

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -162,6 +162,25 @@ def test_safe_response_error_message_handles_header_failures() -> None:
     assert "content_type" not in message
 
 
+def test_scheduler_error_code_ignores_unexpected_payload_shapes() -> None:
+    assert api._scheduler_error_context_from_text(None) == (None, None)  # noqa: SLF001
+    assert api._scheduler_error_context_from_text(
+        json.dumps(["bad"])
+    ) == (  # noqa: SLF001
+        None,
+        None,
+    )
+    assert api._scheduler_error_context_from_text(
+        json.dumps({"error": "bad"})
+    ) == (  # noqa: SLF001
+        None,
+        None,
+    )
+
+    err = _make_cre(400, json.dumps({"error": "bad"}))
+    assert api._scheduler_error_code(err) is None  # noqa: SLF001
+
+
 def _make_optional_payload_error(endpoint: str) -> api.InvalidPayloadError:
     return api.InvalidPayloadError(
         "Invalid JSON response",
@@ -1817,6 +1836,34 @@ async def test_json_raises_response_error_with_structured_body_summary() -> None
     assert "body_sha256=" not in err.value.message
     assert "secret cloud failure" not in err.value.message
     assert "SITE" not in err.value.message
+    assert not hasattr(err.value, "enphase_response_body")
+
+
+@pytest.mark.asyncio
+async def test_json_attaches_scheduler_error_context_without_raw_body() -> None:
+    body = json.dumps(
+        {
+            "error": {
+                "displayMessage": "No Schedules enabled for Scheduled Charging",
+                "errorMessageCode": "iqevc_sch_10031",
+            }
+        }
+    )
+    session = _FakeSession([_FakeResponse(status=400, json_body={}, text_body=body)])
+    client = api.EnphaseEVClient(session, "SITE", None, None)
+
+    with pytest.raises(aiohttp.ClientResponseError) as err:
+        await client._json(
+            "PUT",
+            "https://example.test/service/evse_scheduler/api/v1/iqevc/"
+            "charging-mode/SITE/SN/preference",
+        )
+
+    assert err.value.enphase_scheduler_error == {
+        "code": "iqevc_sch_10031",
+        "display": "No Schedules enabled for Scheduled Charging",
+    }
+    assert not hasattr(err.value, "enphase_response_body")
 
 
 @pytest.mark.asyncio
@@ -3628,10 +3675,210 @@ async def test_charge_mode_returns_none_when_no_enabled() -> None:
 async def test_set_charge_mode_passes_payload() -> None:
     client = _make_client()
     client._json = AsyncMock(return_value={"status": "ok"})
-    out = await client.set_charge_mode("SN", "GREEN_CHARGING")
+    out = await client.set_charge_mode(
+        "SN", "GREEN_CHARGING", previous_mode="MANUAL_CHARGING"
+    )
     assert out == {"status": "ok"}
     args, kwargs = client._json.await_args
     assert kwargs["json"] == {"mode": "GREEN_CHARGING"}
+
+
+@pytest.mark.asyncio
+async def test_set_charge_mode_skips_write_when_already_active() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        return_value={
+            "data": {
+                "modes": {
+                    "manualCharging": {
+                        "enabled": True,
+                        "chargingMode": "MANUAL_CHARGING",
+                    }
+                }
+            }
+        }
+    )
+
+    out = await client.set_charge_mode("SN", "MANUAL_CHARGING")
+
+    assert out == {"status": "already_set", "mode": "MANUAL_CHARGING"}
+    assert client._json.await_args.args[0] == "GET"
+    assert client._json.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_set_charge_mode_accepts_verified_preference_after_400() -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=[
+            {
+                "data": {
+                    "modes": {
+                        "greenCharging": {
+                            "enabled": True,
+                            "chargingMode": "GREEN_CHARGING",
+                        }
+                    }
+                }
+            },
+            _make_cre(400, "HTTP error from Enphase endpoint (status=400)"),
+            {
+                "data": {
+                    "modes": {
+                        "manualCharging": {
+                            "enabled": True,
+                            "chargingMode": "MANUAL_CHARGING",
+                        }
+                    }
+                }
+            },
+        ]
+    )
+
+    out = await client.set_charge_mode("SN", "MANUAL_CHARGING")
+
+    assert out == {
+        "status": "accepted",
+        "mode": "MANUAL_CHARGING",
+        "verified_after_error": True,
+    }
+    assert client._json.await_args_list[0].args[0] == "GET"
+    assert client._json.await_args_list[1].args[0] == "PUT"
+    assert client._json.await_args_list[2].args[0] == "GET"
+
+
+@pytest.mark.asyncio
+async def test_set_charge_mode_retries_verified_preference_after_400(
+    monkeypatch,
+) -> None:
+    client = _make_client()
+    client._json = AsyncMock(
+        side_effect=[
+            {
+                "data": {
+                    "modes": {
+                        "greenCharging": {
+                            "enabled": True,
+                            "chargingMode": "GREEN_CHARGING",
+                        }
+                    }
+                }
+            },
+            _make_cre(400, "HTTP error from Enphase endpoint (status=400)"),
+            {
+                "data": {
+                    "modes": {
+                        "greenCharging": {
+                            "enabled": True,
+                            "chargingMode": "GREEN_CHARGING",
+                        }
+                    }
+                }
+            },
+            {
+                "data": {
+                    "modes": {
+                        "manualCharging": {
+                            "enabled": True,
+                            "chargingMode": "MANUAL_CHARGING",
+                        }
+                    }
+                }
+            },
+        ]
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr(api.asyncio, "sleep", sleep)
+
+    out = await client.set_charge_mode("SN", "MANUAL_CHARGING")
+
+    assert out["verified_after_error"] is True
+    sleep.assert_awaited_once_with(2)
+    assert client._json.await_count == 4
+
+
+@pytest.mark.asyncio
+async def test_set_charge_mode_does_not_verify_schedule_required_error() -> None:
+    client = _make_client()
+    err = _make_cre(400, "HTTP error from Enphase endpoint (status=400)")
+    err.enphase_scheduler_error = {
+        "code": "iqevc_sch_10031",
+        "display": "No Schedules enabled for Scheduled Charging",
+    }
+    client._json = AsyncMock(
+        side_effect=[
+            {
+                "data": {
+                    "modes": {
+                        "manualCharging": {
+                            "enabled": True,
+                            "chargingMode": "MANUAL_CHARGING",
+                        }
+                    }
+                }
+            },
+            err,
+        ]
+    )
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.set_charge_mode("SN", "SCHEDULED_CHARGING")
+
+    assert client._json.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_set_charge_mode_preserves_scheduler_unavailable_error() -> None:
+    client = _make_client()
+    client._json = AsyncMock(side_effect=_make_cre(503, "Scheduler MS unavailable"))
+
+    with pytest.raises(api.SchedulerUnavailable):
+        await client.set_charge_mode(
+            "SN", "MANUAL_CHARGING", previous_mode="GREEN_CHARGING"
+        )
+
+    assert client._json.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_set_charge_mode_reraises_when_400_readback_never_matches(
+    monkeypatch,
+) -> None:
+    client = _make_client()
+    err = _make_cre(400, "HTTP error from Enphase endpoint (status=400)")
+    green_payload = {
+        "data": {
+            "modes": {
+                "greenCharging": {
+                    "enabled": True,
+                    "chargingMode": "GREEN_CHARGING",
+                }
+            }
+        }
+    }
+    client._json = AsyncMock(side_effect=[green_payload, err, *([green_payload] * 6)])
+    sleep = AsyncMock()
+    monkeypatch.setattr(api.asyncio, "sleep", sleep)
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.set_charge_mode("SN", "MANUAL_CHARGING")
+
+    assert client._json.await_count == 8
+    assert sleep.await_count == 5
+
+
+@pytest.mark.asyncio
+async def test_set_charge_mode_reraises_when_400_readback_fails() -> None:
+    client = _make_client()
+    err = _make_cre(400, "HTTP error from Enphase endpoint (status=400)")
+    client._json = AsyncMock(side_effect=[err, aiohttp.ClientError("down")])
+
+    with pytest.raises(aiohttp.ClientResponseError):
+        await client.set_charge_mode(
+            "SN", "MANUAL_CHARGING", previous_mode="GREEN_CHARGING"
+        )
+
+    assert client._json.await_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -41,7 +41,9 @@ async def test_charge_mode_select(hass, monkeypatch):
     coord.data = {RANDOM_SERIAL: {"charge_mode": "SCHEDULED_CHARGING"}}
 
     class StubClient:
-        async def set_charge_mode(self, sn: str, mode: str):
+        async def set_charge_mode(
+            self, sn: str, mode: str, *, previous_mode: str | None = None
+        ):
             return {"status": "accepted", "mode": mode}
 
     coord.client = StubClient()
@@ -153,23 +155,21 @@ async def test_charge_mode_select_scheduled_requires_enabled_schedule(
     coord = EnphaseCoordinator(hass, cfg)
     coord.data = {RANDOM_SERIAL: {"charge_mode": "MANUAL_CHARGING"}}
 
-    error_message = json.dumps(
-        {
-            "error": {
-                "displayMessage": "No Schedules enabled for Scheduled Charging",
-                "errorMessageCode": "iqevc_sch_10031",
-            }
-        }
-    )
-
     class StubClient:
-        async def set_charge_mode(self, sn: str, mode: str):
-            raise aiohttp.ClientResponseError(
+        async def set_charge_mode(
+            self, sn: str, mode: str, *, previous_mode: str | None = None
+        ):
+            err = aiohttp.ClientResponseError(
                 request_info=SimpleNamespace(real_url="https://example.test"),
                 history=(),
                 status=400,
-                message=error_message,
+                message="HTTP error from Enphase endpoint (status=400)",
             )
+            err.enphase_scheduler_error = {
+                "code": "iqevc_sch_10031",
+                "display": "No Schedules enabled for Scheduled Charging",
+            }
+            raise err
 
     coord.client = StubClient()
 
@@ -225,7 +225,9 @@ async def test_charge_mode_select_reraises_unknown_scheduler_error(
     )
 
     class StubClient:
-        async def set_charge_mode(self, sn: str, mode: str):
+        async def set_charge_mode(
+            self, sn: str, mode: str, *, previous_mode: str | None = None
+        ):
             raise aiohttp.ClientResponseError(
                 request_info=SimpleNamespace(real_url="https://example.test"),
                 history=(),
@@ -469,7 +471,7 @@ async def test_charge_mode_select_sets_smart_mode_for_single_evse_profile_contex
     await sel.async_select_option("Smart")
 
     coord.client.set_charge_mode.assert_awaited_once_with(
-        RANDOM_SERIAL, "SMART_CHARGING"
+        RANDOM_SERIAL, "SMART_CHARGING", previous_mode=None
     )
 
 
@@ -492,7 +494,7 @@ async def test_charge_mode_select_maps_legacy_green_alias_to_smart_mode(
     await sel.async_select_option("Green")
 
     coord.client.set_charge_mode.assert_awaited_once_with(
-        RANDOM_SERIAL, "SMART_CHARGING"
+        RANDOM_SERIAL, "SMART_CHARGING", previous_mode=None
     )
 
 
@@ -518,7 +520,7 @@ async def test_charge_mode_select_maps_localized_green_alias_to_smart_mode(
     await sel.async_select_option("Grün")
 
     coord.client.set_charge_mode.assert_awaited_once_with(
-        RANDOM_SERIAL, "SMART_CHARGING"
+        RANDOM_SERIAL, "SMART_CHARGING", previous_mode=None
     )
 
 
@@ -542,7 +544,7 @@ async def test_charge_mode_select_keeps_green_for_other_evse_on_ai_site(
     await sel.async_select_option("Green")
 
     coord.client.set_charge_mode.assert_awaited_once_with(
-        other_serial, "GREEN_CHARGING"
+        other_serial, "GREEN_CHARGING", previous_mode=None
     )
 
 
@@ -596,6 +598,24 @@ def test_charge_mode_select_helper_branches(coordinator_factory):
 
     coord._resolve_charge_mode_pref = lambda _sn: "EXPERIMENTAL"  # noqa: SLF001
     assert sel.current_option is None
+
+
+@pytest.mark.asyncio
+async def test_charge_mode_select_passes_previous_mode_to_client(
+    coordinator_factory,
+):
+    from custom_components.enphase_ev.select import ChargeModeSelect
+
+    coord = coordinator_factory()
+    coord.data[RANDOM_SERIAL]["charge_mode_pref"] = "GREEN_CHARGING"
+    coord.client.set_charge_mode = AsyncMock(return_value={"status": "accepted"})
+    coord.async_request_refresh = AsyncMock()
+
+    await ChargeModeSelect(coord, RANDOM_SERIAL).async_select_option("Manual")
+
+    coord.client.set_charge_mode.assert_awaited_once_with(
+        RANDOM_SERIAL, "MANUAL_CHARGING", previous_mode="GREEN_CHARGING"
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes IQ EV charger mode changes that can return a transient Enphase scheduler `400` even when the cloud later applies the requested mode.

The API client now verifies generic scheduler `400` responses by reading the charge mode back, but only when the pre-write mode was known and different from the requested target. Scheduler validation errors, including selecting Scheduled mode without an enabled schedule, still surface normally. Scheduler error parsing now keeps only minimal parsed context instead of retaining raw response bodies.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/select.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_select_charge_mode.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_select_charge_mode.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/select.py --fail-under=100"
```

Full component coverage result: `3120 passed`; `api.py` and `select.py` both reported 100% targeted coverage.

Live verification used a stored dev Enphase account/config and changed one charger through `GREEN_CHARGING -> MANUAL_CHARGING -> GREEN_CHARGING -> MANUAL_CHARGING`; each transition read back correctly and the charger ended on its original `MANUAL_CHARGING` mode.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This is an Enphase cloud scheduler consistency fix. It does not add or change user-facing strings.
