### PR TITLE
Fix regional firmware selection

### DIFF
--- a/custom_components/enphase_ev/firmware_catalog.py
+++ b/custom_components/enphase_ev/firmware_catalog.py
@@ -204,13 +204,6 @@ def normalize_country(value: Any) -> str | None:
     return None
 
 
-def country_from_locale(value: Any) -> str | None:
-    locale = normalize_locale(value)
-    if "-" not in locale:
-        return None
-    return normalize_country(locale.rsplit("-", 1)[-1])
-
-
 def resolve_country_and_locale(coord, hass) -> tuple[str | None, str]:
     raw_battery_locale = getattr(coord, "battery_locale", None)
     raw_hass_locale = getattr(getattr(hass, "config", None), "language", None)
@@ -226,8 +219,6 @@ def resolve_country_and_locale(coord, hass) -> tuple[str | None, str]:
     country_candidates = [
         normalize_country(getattr(coord, "battery_country_code", None)),
         normalize_country(getattr(getattr(hass, "config", None), "country", None)),
-        country_from_locale(battery_locale),
-        country_from_locale(hass_locale),
     ]
     resolved_country = next((item for item in country_candidates if item), None)
     return resolved_country, resolved_locale
@@ -301,47 +292,23 @@ def select_catalog_entry(
 
     entry = None
     source_scope = None
-    locale_scope_only = False
 
     by_locale = device_payload.get("latest_by_locale")
     if not prefer_global:
-        if isinstance(by_locale, dict) and by_locale:
-            candidate = by_locale.get(normalized_locale)
-            if isinstance(candidate, dict):
-                entry = candidate
-                source_scope = "locale"
-                locale_scope_only = True
-
-        if entry is None and country_code:
+        if country_code:
             by_country = device_payload.get("latest_by_country")
             if isinstance(by_country, dict):
                 candidate = by_country.get(country_code)
                 if isinstance(candidate, dict):
                     entry = candidate
                     source_scope = "country"
-
-        if entry is None and isinstance(by_locale, dict) and by_locale:
-            base_language = normalized_locale.split("-", 1)[0]
-            fallback = next(
-                (
-                    key
-                    for key, value in by_locale.items()
-                    if isinstance(value, dict)
-                    and str(key).split("-", 1)[0] == base_language
-                ),
-                None,
-            )
-            if fallback is not None:
-                maybe_entry = by_locale.get(fallback)
-                if isinstance(maybe_entry, dict):
-                    entry = maybe_entry
-                    source_scope = "locale"
-                    normalized_locale = str(fallback)
-                    locale_scope_only = True
+                    locale_candidate = _exact_locale_entry(by_locale, normalized_locale)
+                    if _same_catalog_release(entry, locale_candidate):
+                        entry = _with_merged_locale_urls(entry, locale_candidate)
 
     if entry is None:
         latest_global = device_payload.get("latest_global")
-        if isinstance(latest_global, dict):
+        if _is_worldwide_catalog_entry(latest_global):
             entry = latest_global
             source_scope = "global"
 
@@ -371,10 +338,73 @@ def select_catalog_entry(
                 locale_used = "en"
             else:
                 locale_used = str(next(iter(urls_by_locale.keys())))
-    elif locale_scope_only:
-        locale_used = normalize_locale(locale)
 
     return CatalogSelection(entry, locale_used, country_code, source_scope)
+
+
+def _exact_locale_entry(
+    by_locale: object, normalized_locale: str
+) -> dict[str, Any] | None:
+    if not isinstance(by_locale, dict):
+        return None
+    candidate = by_locale.get(normalized_locale)
+    return candidate if isinstance(candidate, dict) else None
+
+
+def _same_catalog_release(
+    entry: dict[str, Any] | None, candidate: dict[str, Any] | None
+) -> bool:
+    if not isinstance(entry, dict) or not isinstance(candidate, dict):
+        return False
+    entry_media_id = _text_or_none(entry.get("media_id"))
+    candidate_media_id = _text_or_none(candidate.get("media_id"))
+    if entry_media_id and candidate_media_id:
+        return entry_media_id == candidate_media_id
+    entry_version = normalize_version_token(entry.get("version"))
+    candidate_version = normalize_version_token(candidate.get("version"))
+    return entry_version is not None and entry_version == candidate_version
+
+
+def _with_merged_locale_urls(
+    entry: dict[str, Any], locale_entry: dict[str, Any] | None
+) -> dict[str, Any]:
+    if not isinstance(locale_entry, dict):
+        return entry
+    urls = entry.get("urls_by_locale")
+    locale_urls = locale_entry.get("urls_by_locale")
+    if not isinstance(locale_urls, dict) or not locale_urls:
+        return entry
+    merged = dict(urls) if isinstance(urls, dict) else {}
+    merged.update(locale_urls)
+    cloned = dict(entry)
+    cloned["urls_by_locale"] = merged
+    return cloned
+
+
+def _is_worldwide_catalog_entry(entry: object) -> bool:
+    if not isinstance(entry, dict):
+        return False
+    countries_text = _text_or_none(entry.get("countries_text"))
+    if countries_text is None:
+        return False
+    lowered = countries_text.lower()
+    if "except" in lowered:
+        return False
+    return (
+        "worldwide" in lowered
+        or "global" in lowered
+        or lowered.strip() == "all countries"
+    )
+
+
+def _text_or_none(value: Any) -> str | None:
+    if value is None:
+        return None
+    try:
+        text = str(value).strip()
+    except Exception:  # noqa: BLE001
+        return None
+    return text or None
 
 
 def _repair_legacy_release_urls(

--- a/custom_components/enphase_ev/update.py
+++ b/custom_components/enphase_ev/update.py
@@ -261,25 +261,6 @@ class FirmwareUpdateEntity(CoordinatorEntity[EnphaseCoordinator], UpdateEntity):
 
         raw_latest = _text(entry.get("version"))
         normalized_latest = normalize_version_token(raw_latest)
-        if (
-            selected.source_scope != "global"
-            and compare_versions(normalized_installed, normalized_latest) is True
-        ):
-            global_selected = select_catalog_entry(
-                catalog,
-                device_type=self._device_type,
-                country=country,
-                locale=normalized_locale,
-                prefer_global=True,
-            )
-            if isinstance(global_selected.entry, dict):
-                selected = global_selected
-                self._source_scope = selected.source_scope
-                self._locale_used = selected.locale_used or normalized_locale
-                entry = global_selected.entry
-                raw_latest = _text(entry.get("version"))
-                normalized_latest = normalize_version_token(raw_latest)
-
         self._raw_latest_version = raw_latest
         self._attr_latest_version = _latest_version_for_state(
             latest=normalized_latest,

--- a/tests/components/enphase_ev/test_firmware_catalog.py
+++ b/tests/components/enphase_ev/test_firmware_catalog.py
@@ -183,6 +183,15 @@ def test_resolve_country_and_locale_priority() -> None:
     assert country == "US"
     assert locale == "fr-fr"
 
+    coord = SimpleNamespace(
+        battery_country_code=None,
+        battery_locale="en-AU",
+    )
+    hass = SimpleNamespace(config=SimpleNamespace(country=None, language="fr-ca"))
+    country, locale = firmware_catalog.resolve_country_and_locale(coord, hass)
+    assert country is None
+    assert locale == "en-au"
+
 
 def test_version_normalization_and_comparison() -> None:
     assert firmware_catalog.normalize_version_token("v04.30.32") == "04.30.32"
@@ -218,6 +227,7 @@ def test_select_catalog_entry_country_and_locale_fallback() -> None:
                 },
                 "latest_global": {
                     "version": "8.2.4300",
+                    "countries_text": "Worldwide",
                     "urls_by_locale": {"en": "https://example.com/global"},
                 },
             }
@@ -230,9 +240,85 @@ def test_select_catalog_entry_country_and_locale_fallback() -> None:
         country="AU",
         locale="fr-fr",
     )
-    assert selected.source_scope == "locale"
+    assert selected.source_scope == "country"
     assert selected.locale_used == "fr-fr"
-    assert selected.entry and selected.entry["version"] == "8.2.4500"
+    assert selected.entry and selected.entry["version"] == "8.2.4401"
+
+    exact_locale_does_not_override_country = firmware_catalog.select_catalog_entry(
+        {
+            "schema_version": 1,
+            "generated_at": "2026-03-01T00:00:00Z",
+            "devices": {
+                "envoy": {
+                    "latest_by_locale": {
+                        "en-au": {
+                            "version": "8.3.5427",
+                            "urls_by_locale": {
+                                "en": "https://example.com/global-en",
+                                "en-au": "https://example.com/global-au",
+                            },
+                        }
+                    },
+                    "latest_by_country": {
+                        "AU": {
+                            "version": "8.3.5232",
+                            "urls_by_locale": {
+                                "en-au": "https://example.com/au-regional"
+                            },
+                        }
+                    },
+                    "latest_global": {
+                        "version": "8.3.5427",
+                        "urls_by_locale": {"en": "https://example.com/global"},
+                    },
+                }
+            },
+        },
+        device_type="envoy",
+        country="AU",
+        locale="en-au",
+    )
+    assert exact_locale_does_not_override_country.source_scope == "country"
+    assert exact_locale_does_not_override_country.locale_used == "en-au"
+    assert (
+        exact_locale_does_not_override_country.entry
+        and exact_locale_does_not_override_country.entry["version"] == "8.3.5232"
+    )
+
+    same_release_locale_urls = firmware_catalog.select_catalog_entry(
+        {
+            "schema_version": 1,
+            "generated_at": "2026-03-01T00:00:00Z",
+            "devices": {
+                "envoy": {
+                    "latest_by_locale": {
+                        "fr-be": {
+                            "version": "8.3.5286",
+                            "media_id": "regional-8-3",
+                            "urls_by_locale": {"fr-be": "https://example.com/be-fr"},
+                        }
+                    },
+                    "latest_by_country": {
+                        "BE": {
+                            "version": "8.3.5286",
+                            "media_id": "regional-8-3",
+                            "urls_by_locale": {"nl-be": "https://example.com/be-nl"},
+                        }
+                    },
+                }
+            },
+        },
+        device_type="envoy",
+        country="BE",
+        locale="fr-be",
+    )
+    assert same_release_locale_urls.source_scope == "country"
+    assert same_release_locale_urls.locale_used == "fr-be"
+    assert same_release_locale_urls.entry
+    assert same_release_locale_urls.entry["urls_by_locale"] == {
+        "nl-be": "https://example.com/be-nl",
+        "fr-be": "https://example.com/be-fr",
+    }
 
     locale_only_catalog = {
         "schema_version": 1,
@@ -259,12 +345,8 @@ def test_select_catalog_entry_country_and_locale_fallback() -> None:
         country="AU",
         locale="fr-ca",
     )
-    assert locale_base_fallback.source_scope == "locale"
-    assert locale_base_fallback.locale_used == "fr-fr"
-    assert (
-        locale_base_fallback.entry
-        and locale_base_fallback.entry["version"] == "8.2.4500"
-    )
+    assert locale_base_fallback.source_scope is None
+    assert locale_base_fallback.entry is None
 
     country_preferred_over_locale_base = firmware_catalog.select_catalog_entry(
         catalog,
@@ -291,10 +373,9 @@ def test_select_catalog_entry_country_and_locale_fallback() -> None:
         country="FR",
         locale="fr-fr",
     )
-    assert locale_scope_without_urls.source_scope == "locale"
+    assert locale_scope_without_urls.source_scope is None
     assert locale_scope_without_urls.locale_used == "fr-fr"
-    assert locale_scope_without_urls.entry
-    assert locale_scope_without_urls.entry["version"] == "1.2.3"
+    assert locale_scope_without_urls.entry is None
 
     fallback = firmware_catalog.select_catalog_entry(
         catalog,
@@ -338,6 +419,7 @@ def test_select_catalog_entry_country_and_locale_fallback() -> None:
                 },
                 "latest_global": {
                     "version": "8.2.4300",
+                    "countries_text": "Worldwide",
                     "urls_by_locale": {"en": "https://example.com/global"},
                 },
             }
@@ -491,11 +573,41 @@ def test_helper_edge_branches() -> None:
         firmware_catalog._parse_iso_datetime("2026-03-01T00:00:00").tzinfo is not None
     )
 
+    assert firmware_catalog.normalize_locale(None) == "en"
     assert firmware_catalog.normalize_locale(_BadStr()) == "en"
     assert firmware_catalog.normalize_country("AUS") is None
     assert firmware_catalog.normalize_country(_BadStr()) is None
     assert firmware_catalog.normalize_version_token(None) is None
     assert firmware_catalog.normalize_version_token(_BadStr()) is None
+    assert firmware_catalog._text_or_none(None) is None
+    assert firmware_catalog._text_or_none(_BadStr()) is None
+    assert firmware_catalog._exact_locale_entry([], "en") is None
+    assert firmware_catalog._exact_locale_entry({"en": "bad"}, "en") is None
+    assert not firmware_catalog._same_catalog_release(None, {})
+    assert firmware_catalog._same_catalog_release(
+        {"version": "1.0", "media_id": "same"},
+        {"version": "2.0", "media_id": "same"},
+    )
+    assert not firmware_catalog._same_catalog_release(
+        {"version": "unknown"},
+        {"version": None},
+    )
+    assert firmware_catalog._with_merged_locale_urls({"version": "1.0"}, None) == {
+        "version": "1.0"
+    }
+    assert firmware_catalog._with_merged_locale_urls(
+        {"version": "1.0"}, {"urls_by_locale": []}
+    ) == {"version": "1.0"}
+    assert not firmware_catalog._is_worldwide_catalog_entry(None)
+    assert not firmware_catalog._is_worldwide_catalog_entry({"countries_text": None})
+    assert not firmware_catalog._is_worldwide_catalog_entry(
+        {"countries_text": "All countries except Ireland"}
+    )
+    assert firmware_catalog._is_worldwide_catalog_entry({"countries_text": "Worldwide"})
+    assert firmware_catalog._is_worldwide_catalog_entry(
+        {"countries_text": "All countries"}
+    )
+    assert firmware_catalog._repair_legacy_release_urls({}, {}) == {}
     assert firmware_catalog._parse_version_parts("") is None
     assert firmware_catalog._parse_version_parts("1.a") is None
 

--- a/tests/components/enphase_ev/test_update_module.py
+++ b/tests/components/enphase_ev/test_update_module.py
@@ -424,9 +424,37 @@ async def test_gateway_update_entity_states_and_release_url_selection(hass) -> N
 
     coord._gateway_version = "8.3.5300"
     entity._refresh_from_catalog(regional_payload)
-    assert entity.latest_version == "8.3.5427"
-    assert entity.release_url == "https://example.test/envoy/global-newer"
-    assert entity.release_summary == "Gateway global"
+    assert entity.latest_version == "8.3.5300"
+    assert entity.release_url is None
+    assert entity.release_summary is None
+
+    coord.battery_locale = "en-AU"
+    coord._gateway_version = "8.3.5232"
+    regional_payload["devices"]["envoy"]["latest_by_locale"]["en-au"] = {
+        "version": "8.3.5427",
+        "summary": "Gateway non-regional",
+        "urls_by_locale": {
+            "en": "https://example.test/envoy/global-newer",
+            "en-au": "https://example.test/envoy/global-au",
+        },
+    }
+    entity._refresh_from_catalog(regional_payload)
+    assert entity.latest_version == "8.3.5232"
+    assert entity.release_url == "https://example.test/envoy/au-regional"
+    assert entity.release_summary == "Gateway regional"
+    assert entity.extra_state_attributes["catalog_source_scope"] == "country"
+    assert entity.extra_state_attributes["locale_used"] == "en-au"
+
+    coord.battery_country_code = None
+    hass.config.country = None
+    entity._refresh_from_catalog(regional_payload)
+    assert entity.latest_version is None
+    assert entity.release_url is None
+    assert entity.extra_state_attributes["country_used"] is None
+    assert entity.extra_state_attributes["catalog_source_scope"] is None
+
+    coord.battery_country_code = "AU"
+    coord.battery_locale = "fr-fr"
 
     coord._gateway_version = "8.2.4300"
     entity._refresh_from_catalog(manager.cached_catalog)
@@ -521,7 +549,7 @@ async def test_charger_update_entity_uses_fw_details_payload(hass) -> None:
     assert attrs["is_auto_ota"] is False
     assert attrs["firmware_rollout_enabled"] is True
     assert attrs["details_last_error"] is None
-    assert attrs["catalog_source_scope"] == "locale"
+    assert attrs["catalog_source_scope"] == "country"
     assert attrs["catalog_generated_at"] == "2026-03-01T00:00:00Z"
 
     entity.async_write_ha_state = lambda: None
@@ -801,6 +829,7 @@ async def test_refresh_from_catalog_none_and_locale_fallback_paths(hass) -> None
     payload["devices"]["envoy"]["latest_by_country"] = {}
     payload["devices"]["envoy"]["latest_global"] = {
         "version": "8.2.4401",
+        "countries_text": "Worldwide",
         "summary": "Global only",
         "urls_by_locale": {
             "de-de": "https://example.test/envoy/de",


### PR DESCRIPTION
## Summary

Fixes firmware update selection so regional Enphase gateway releases are chosen by site country rather than Home Assistant or Enphase locale. This prevents Australian sites on `8.3.5232` from being shown the US/Canada-region `8.3.5427` gateway firmware as an available update.

The firmware catalog selector now:
- uses Enphase site `countryCode` first, then Home Assistant country as a fallback
- stops inferring firmware applicability from locale values such as `en-AU`
- treats country catalog entries as authoritative
- only uses global firmware entries when the catalog marks them as worldwide/global applicable
- keeps locale only for release-note URL selection, including same-release localized URL merging

## Related Issues

None linked.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/firmware_catalog.py custom_components/enphase_ev/update.py tests/components/enphase_ev/test_firmware_catalog.py tests/components/enphase_ev/test_update_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev/test_firmware_catalog.py tests/components/enphase_ev/test_update_module.py -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/firmware_catalog.py,custom_components/enphase_ev/update.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "git status --short && python3 -m pre_commit run --all-files"
```

The first Docker pre-commit attempt without the Git metadata bind mount failed before hooks because this Codex worktree's `.git` file points at a host worktree path not mounted inside `/workspace`. The rerun above mounted that Git metadata path and passed all hooks.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Live catalog sanity check after the change:

```text
AU   -> country 8.3.5232 en-au
None -> no entry
ZZ   -> no entry
```
