### PR TITLE
[codex] Optimize performance cache refreshes

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -1290,7 +1290,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def gateway_inventory_summary(self) -> dict[str, object]:
         source = self.inventory_runtime._gateway_inventory_summary_marker()
         summary = getattr(self, "_gateway_inventory_summary_cache", {}) or {}
-        if not summary or source != self._gateway_inventory_summary_source:
+        if source != self._gateway_inventory_summary_source:
             summary = self.inventory_runtime._build_gateway_inventory_summary()
             self._gateway_inventory_summary_cache = summary
             self._gateway_inventory_summary_source = source
@@ -1299,7 +1299,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def microinverter_inventory_summary(self) -> dict[str, object]:
         source = self.inventory_runtime._microinverter_inventory_summary_marker()
         summary = getattr(self, "_microinverter_inventory_summary_cache", {}) or {}
-        if not summary or source != self._microinverter_inventory_summary_source:
+        if source != self._microinverter_inventory_summary_source:
             summary = self.inventory_runtime._build_microinverter_inventory_summary()
             self._microinverter_inventory_summary_cache = summary
             self._microinverter_inventory_summary_source = source
@@ -1308,7 +1308,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def heatpump_inventory_summary(self) -> dict[str, object]:
         source = self.inventory_runtime._heatpump_inventory_summary_marker()
         summary = getattr(self, "_heatpump_inventory_summary_cache", {}) or {}
-        if not summary or source != self._heatpump_inventory_summary_source:
+        if source != self._heatpump_inventory_summary_source:
             summary = self.inventory_runtime._build_heatpump_inventory_summary()
             self._heatpump_inventory_summary_cache = summary
             self._heatpump_inventory_summary_source = source

--- a/custom_components/enphase_ev/inventory_runtime.py
+++ b/custom_components/enphase_ev/inventory_runtime.py
@@ -383,7 +383,7 @@ class InventoryRuntime:
     def gateway_inventory_summary(self) -> dict[str, object]:
         source = self._gateway_inventory_summary_marker()
         summary = getattr(self, "_gateway_inventory_summary_cache", {}) or {}
-        if not summary or source != self._gateway_inventory_summary_source:
+        if source != self._gateway_inventory_summary_source:
             summary = self._build_gateway_inventory_summary()
             self._gateway_inventory_summary_cache = summary
             self._gateway_inventory_summary_source = source
@@ -392,7 +392,7 @@ class InventoryRuntime:
     def microinverter_inventory_summary(self) -> dict[str, object]:
         source = self._microinverter_inventory_summary_marker()
         summary = getattr(self, "_microinverter_inventory_summary_cache", {}) or {}
-        if not summary or source != self._microinverter_inventory_summary_source:
+        if source != self._microinverter_inventory_summary_source:
             summary = self._build_microinverter_inventory_summary()
             self._microinverter_inventory_summary_cache = summary
             self._microinverter_inventory_summary_source = source
@@ -401,7 +401,7 @@ class InventoryRuntime:
     def heatpump_inventory_summary(self) -> dict[str, object]:
         source = self._heatpump_inventory_summary_marker()
         summary = getattr(self, "_heatpump_inventory_summary_cache", {}) or {}
-        if not summary or source != self._heatpump_inventory_summary_source:
+        if source != self._heatpump_inventory_summary_source:
             summary = self._build_heatpump_inventory_summary()
             self._heatpump_inventory_summary_cache = summary
             self._heatpump_inventory_summary_source = source
@@ -426,7 +426,7 @@ class InventoryRuntime:
     def gateway_iq_energy_router_summary_records(self) -> list[dict[str, object]]:
         source = self._gateway_iq_energy_router_records_marker()
         records = getattr(self, "_gateway_iq_energy_router_records_cache", [])
-        if not records or source != self._gateway_iq_energy_router_records_source:
+        if source != self._gateway_iq_energy_router_records_source:
             records = self._gateway_iq_energy_router_summary_records(
                 self.gateway_iq_energy_router_records()
             )
@@ -1701,31 +1701,46 @@ class InventoryRuntime:
         micro_source = self._microinverter_inventory_summary_marker()
         heatpump_source = self._heatpump_inventory_summary_marker()
         router_source = self._gateway_iq_energy_router_records_marker()
-        gateway_summary = self._build_gateway_inventory_summary()
-        micro_summary = self._build_microinverter_inventory_summary()
-        heatpump_summary = self._build_heatpump_inventory_summary()
-        heatpump_type_summaries = self._build_heatpump_type_summaries()
-        router_records = self._gateway_iq_energy_router_summary_records(
-            self.gateway_iq_energy_router_records()
-        )
-        router_by_key = {
-            record["key"]: record
-            for record in router_records
-            if isinstance(record, dict) and isinstance(record.get("key"), str)
-        }
-        self._update_shared_state(
-            _gateway_inventory_summary_cache=gateway_summary,
-            _gateway_inventory_summary_source=gateway_source,
-            _microinverter_inventory_summary_cache=micro_summary,
-            _microinverter_inventory_summary_source=micro_source,
-            _heatpump_inventory_summary_cache=heatpump_summary,
-            _heatpump_inventory_summary_source=heatpump_source,
-            _heatpump_type_summaries_cache=heatpump_type_summaries,
-            _heatpump_type_summaries_source=heatpump_source,
-            _gateway_iq_energy_router_records_cache=router_records,
-            _gateway_iq_energy_router_records_source=router_source,
-            _gateway_iq_energy_router_records_by_key_cache=router_by_key,
-        )
+        updates: dict[str, object] = {}
+
+        if gateway_source != self._gateway_inventory_summary_source:
+            updates["_gateway_inventory_summary_cache"] = (
+                self._build_gateway_inventory_summary()
+            )
+            updates["_gateway_inventory_summary_source"] = gateway_source
+
+        if micro_source != self._microinverter_inventory_summary_source:
+            updates["_microinverter_inventory_summary_cache"] = (
+                self._build_microinverter_inventory_summary()
+            )
+            updates["_microinverter_inventory_summary_source"] = micro_source
+
+        if heatpump_source != self._heatpump_inventory_summary_source:
+            updates["_heatpump_inventory_summary_cache"] = (
+                self._build_heatpump_inventory_summary()
+            )
+            updates["_heatpump_inventory_summary_source"] = heatpump_source
+
+        if heatpump_source != self._heatpump_type_summaries_source:
+            updates["_heatpump_type_summaries_cache"] = (
+                self._build_heatpump_type_summaries()
+            )
+            updates["_heatpump_type_summaries_source"] = heatpump_source
+
+        if router_source != self._gateway_iq_energy_router_records_source:
+            router_records = self._gateway_iq_energy_router_summary_records(
+                self.gateway_iq_energy_router_records()
+            )
+            updates["_gateway_iq_energy_router_records_cache"] = router_records
+            updates["_gateway_iq_energy_router_records_source"] = router_source
+            updates["_gateway_iq_energy_router_records_by_key_cache"] = {
+                record["key"]: record
+                for record in router_records
+                if isinstance(record, dict) and isinstance(record.get("key"), str)
+            }
+
+        if updates:
+            self._update_shared_state(**updates)
 
     async def _async_refresh_devices_inventory(self, *, force: bool = False) -> None:
         coord = self.coordinator

--- a/custom_components/enphase_ev/session_history.py
+++ b/custom_components/enphase_ev/session_history.py
@@ -482,14 +482,23 @@ class SessionHistoryManager:
         current = self._data_supplier()
         if not isinstance(current, dict):
             return
-        merged = dict(current)
+        merged: dict[str, dict] | None = None
         for sn, sessions in updates.items():
             existing = current.get(sn)
             entry = dict(existing) if isinstance(existing, dict) else {}
+            sessions_kwh = self._sum_session_energy(sessions)
+            if (
+                entry.get("energy_today_sessions") == sessions
+                and entry.get("energy_today_sessions_kwh") == sessions_kwh
+            ):
+                continue
+            if merged is None:
+                merged = dict(current)
             entry["energy_today_sessions"] = sessions
-            entry["energy_today_sessions_kwh"] = self._sum_session_energy(sessions)
+            entry["energy_today_sessions_kwh"] = sessions_kwh
             merged[sn] = entry
-        self._publish_callback(merged)
+        if merged is not None:
+            self._publish_callback(merged)
 
     async def _async_refresh_filter_criteria(
         self,

--- a/tests/components/enphase_ev/test_performance_audit_regressions.py
+++ b/tests/components/enphase_ev/test_performance_audit_regressions.py
@@ -86,6 +86,116 @@ def _prepare_refresh_target(
     coord._sync_battery_profile_pending_issue = MagicMock()  # noqa: SLF001
 
 
+def test_topology_refresh_reuses_summary_caches_for_unchanged_sources(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1"])
+    runtime = coord.inventory_runtime
+    runtime._build_gateway_inventory_summary = MagicMock(  # type: ignore[method-assign]
+        return_value={"gateway": "summary"}
+    )
+    runtime._build_microinverter_inventory_summary = MagicMock(  # type: ignore[method-assign]
+        return_value={"micro": "summary"}
+    )
+    runtime._build_heatpump_inventory_summary = MagicMock(  # type: ignore[method-assign]
+        return_value={"heatpump": "summary"}
+    )
+    runtime._build_heatpump_type_summaries = MagicMock(  # type: ignore[method-assign]
+        return_value={"HPWH": {"member_count": 1}}
+    )
+    runtime.gateway_iq_energy_router_records = MagicMock(  # type: ignore[method-assign]
+        return_value=[]
+    )
+    runtime._gateway_iq_energy_router_summary_records = MagicMock(  # type: ignore[method-assign]
+        return_value=[]
+    )
+
+    assert runtime._refresh_cached_topology() is True  # noqa: SLF001
+    assert runtime._refresh_cached_topology() is False  # noqa: SLF001
+
+    runtime._build_gateway_inventory_summary.assert_called_once()
+    runtime._build_microinverter_inventory_summary.assert_called_once()
+    runtime._build_heatpump_inventory_summary.assert_called_once()
+    runtime._build_heatpump_type_summaries.assert_called_once()
+    runtime._gateway_iq_energy_router_summary_records.assert_called_once()
+
+    coord._hems_devices_payload = {"changed": True}  # noqa: SLF001
+
+    assert runtime._refresh_cached_topology() is False  # noqa: SLF001
+
+    runtime._build_gateway_inventory_summary.assert_called_once()
+    runtime._build_microinverter_inventory_summary.assert_called_once()
+    assert runtime._build_heatpump_inventory_summary.call_count == 2
+    assert runtime._build_heatpump_type_summaries.call_count == 2
+    assert runtime._gateway_iq_energy_router_summary_records.call_count == 2
+
+
+def test_session_history_apply_updates_skips_unchanged_publish(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=["EV1", "EV2"])
+    sessions = [{"session_id": "cached", "energy_kwh": 1.25}]
+    coord.data = {
+        "EV1": {
+            "display_name": "Garage EV",
+            "energy_today_sessions": sessions,
+            "energy_today_sessions_kwh": 1.25,
+        },
+        "EV2": {"display_name": "Driveway EV"},
+    }
+    publish = MagicMock()
+    coord.session_history._publish_callback = publish  # noqa: SLF001
+
+    coord.session_history._apply_updates({"EV1": list(sessions)})  # noqa: SLF001
+
+    publish.assert_not_called()
+
+    fresh_sessions = [{"session_id": "fresh", "energy_kwh": 2.0}]
+
+    coord.session_history._apply_updates({"EV1": fresh_sessions})  # noqa: SLF001
+
+    publish.assert_called_once()
+    merged = publish.call_args.args[0]
+    assert merged["EV1"]["energy_today_sessions"] == fresh_sessions
+    assert merged["EV1"]["energy_today_sessions_kwh"] == 2.0
+    assert merged["EV2"] is coord.data["EV2"]
+
+
+def test_coordinator_summary_wrappers_cache_empty_summaries(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.inventory_runtime._gateway_inventory_summary_marker = MagicMock(  # type: ignore[method-assign]
+        return_value=("gateway",)
+    )
+    coord.inventory_runtime._microinverter_inventory_summary_marker = MagicMock(  # type: ignore[method-assign]
+        return_value=("micro",)
+    )
+    coord.inventory_runtime._heatpump_inventory_summary_marker = MagicMock(  # type: ignore[method-assign]
+        return_value=("heatpump",)
+    )
+    coord.inventory_runtime._build_gateway_inventory_summary = MagicMock(  # type: ignore[method-assign]
+        return_value={}
+    )
+    coord.inventory_runtime._build_microinverter_inventory_summary = MagicMock(  # type: ignore[method-assign]
+        return_value={}
+    )
+    coord.inventory_runtime._build_heatpump_inventory_summary = MagicMock(  # type: ignore[method-assign]
+        return_value={}
+    )
+
+    assert coord.gateway_inventory_summary() == {}
+    assert coord.gateway_inventory_summary() == {}
+    assert coord.microinverter_inventory_summary() == {}
+    assert coord.microinverter_inventory_summary() == {}
+    assert coord.heatpump_inventory_summary() == {}
+    assert coord.heatpump_inventory_summary() == {}
+
+    coord.inventory_runtime._build_gateway_inventory_summary.assert_called_once()
+    coord.inventory_runtime._build_microinverter_inventory_summary.assert_called_once()
+    coord.inventory_runtime._build_heatpump_inventory_summary.assert_called_once()
+
+
 @pytest.mark.asyncio
 async def test_post_status_evse_enrichment_uses_hot_caches_without_followup_io(
     coordinator_factory,


### PR DESCRIPTION
## Summary
- Cache inventory summaries and gateway router records by source marker so unchanged topology refreshes avoid repeated summary rebuilds, including valid empty results.
- Suppress background session-history publishes when the refreshed session list and computed kWh are unchanged.
- Add performance regression coverage for no-op topology rebuilds, no-op session publishes, and empty coordinator summary caches.

## Testing
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/inventory_runtime.py custom_components/enphase_ev/session_history.py tests/components/enphase_ev/test_performance_audit_regressions.py"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_performance_audit_regressions.py"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python3 -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/inventory_runtime.py,custom_components/enphase_ev/session_history.py --fail-under=100"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"`

## Notes
- Docker `python3 -m pre_commit run --all-files` could not run because the container sees `.git` as a worktree pointer to an unmounted host path: `/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git/worktrees/ha-enphase-ev-charger15`.
