### PR TITLE
Speed up startup warmup refresh

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -264,6 +264,7 @@ class RefreshPipelineContext:
     phase_timings: dict[str, float]
     fallback_data: dict[str, dict]
     first_refresh: bool
+    first_refresh_followups_task: asyncio.Task[None] | None = None
     auth_refresh_rejected_count_at_start: int = 0
     status_used_stale: bool = False
     fast_poll: bool = False
@@ -2460,13 +2461,19 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._last_error = None
         self.backoff_ends_utc = None
         self._has_successful_refresh = True
+        if context.first_refresh:
+            self._start_first_refresh_followups(context)
         site_energy_start = time.monotonic()
-        await self.energy._async_refresh_site_energy()
+        try:
+            await self.energy._async_refresh_site_energy()
+        except Exception:
+            await self._async_cancel_first_refresh_followups(context)
+            raise
         self.discovery_snapshot.sync_site_energy_discovery_state()
         self._sync_site_energy_issue()
         phase_timings["site_energy_s"] = round(time.monotonic() - site_energy_start, 3)
         if context.first_refresh:
-            await self._async_run_first_refresh_followups(phase_timings)
+            await self._async_await_first_refresh_followups(context)
         else:
             followup_plan = build_site_only_followup_plan(
                 self,
@@ -2517,7 +2524,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         context: RefreshPipelineContext,
     ) -> None:
         if context.first_refresh:
-            await self._async_run_first_refresh_followups(context.phase_timings)
+            await self._async_await_first_refresh_followups(context)
         else:
             followup_plan = build_followup_plan(
                 self,
@@ -2530,18 +2537,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 )
         self._clear_auth_refresh_rejection_state_if_unchanged(context)
 
-    async def _async_run_first_refresh_followups(
+    def _first_refresh_followup_calls(
         self,
-        phase_timings: dict[str, float],
-    ) -> None:
-        calls = [
-            (
-                "tariff_s",
-                "tariff",
-                lambda: self.tariff_runtime.async_refresh(force=True),
-                "tariff",
-            )
-        ]
+    ) -> tuple[tuple[str, str, Callable[[], object], str | None], ...]:
+        calls = []
         if self._first_refresh_storm_guard_followups_needed():
             calls.extend(
                 (
@@ -2559,10 +2558,55 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     ),
                 )
             )
+        return tuple(calls)
+
+    async def _async_run_first_refresh_followups(
+        self,
+        phase_timings: dict[str, float],
+    ) -> None:
+        calls = self._first_refresh_followup_calls()
+        if not calls:
+            return
         await self.refresh_runner.async_run_refresh_calls(
             phase_timings,
-            calls=tuple(calls),
+            calls=calls,
         )
+
+    def _start_first_refresh_followups(
+        self,
+        context: RefreshPipelineContext,
+    ) -> None:
+        if context.first_refresh_followups_task is not None:
+            return
+        context.first_refresh_followups_task = asyncio.create_task(
+            self._async_run_first_refresh_followups(context.phase_timings),
+            name=f"{DOMAIN}_first_refresh_followups",
+        )
+
+    async def _async_await_first_refresh_followups(
+        self,
+        context: RefreshPipelineContext,
+    ) -> None:
+        task = context.first_refresh_followups_task
+        if task is None:
+            await self._async_run_first_refresh_followups(context.phase_timings)
+            return
+        try:
+            await task
+        finally:
+            context.first_refresh_followups_task = None
+
+    async def _async_cancel_first_refresh_followups(
+        self,
+        context: RefreshPipelineContext,
+    ) -> None:
+        task = context.first_refresh_followups_task
+        if task is None:
+            return
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+        context.first_refresh_followups_task = None
 
     def _first_refresh_storm_guard_followups_needed(self) -> bool:
         if getattr(self, "_battery_has_encharge", None) is False:
@@ -2773,6 +2817,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self.diagnostics.create_auth_block_issue()
             raise ConfigEntryAuthFailed(self.last_failure_description)
 
+        if first_refresh:
+            self._start_first_refresh_followups(context)
+        status_refresh_succeeded = False
         try:
             status_start = time.monotonic()
             data = await self.client.status()
@@ -2789,6 +2836,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self.payload_failure_kind = None
             self._unauth_errors = 0
             self._clear_auth_repair_issues_on_success()
+            status_refresh_succeeded = True
         except ConfigEntryAuthFailed:
             raise
         except Unauthorized as err:
@@ -2837,6 +2885,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._network_errors = 0
             self._http_errors = 0
             self._clear_auth_repair_issues_on_success()
+            status_refresh_succeeded = True
         except InvalidPayloadError as err:
             reason = (err.summary or str(err) or "Invalid JSON response").strip()
             signature = err.signature_dict()
@@ -2872,6 +2921,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 self._backoff_until = None
                 self._clear_backoff_timer()
                 self.diagnostics.clear_cloud_issue()
+                status_refresh_succeeded = True
             else:
                 self.payload_using_stale = False
                 self._note_payload_endpoint_failure(
@@ -2991,6 +3041,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self.payload_failure_kind = None
             raise UpdateFailed(f"Error communicating with API: {msg}")
         finally:
+            if not status_refresh_succeeded:
+                await self._async_cancel_first_refresh_followups(context)
             self.latency_ms = int((time.monotonic() - t0) * 1000)
 
         self._record_status_refresh_success(context)

--- a/custom_components/enphase_ev/refresh_plan.py
+++ b/custom_components/enphase_ev/refresh_plan.py
@@ -218,6 +218,13 @@ WARMUP_STATE_STAGE = RefreshStage(
         ),
         method_task("storm_alert_s", "storm alert", "_async_refresh_storm_alert"),
         object_method_task(
+            "tariff_s",
+            "tariff",
+            "tariff_runtime",
+            "async_refresh",
+            force=True,
+        ),
+        object_method_task(
             "grid_control_check_s",
             "grid control",
             "battery_runtime",

--- a/custom_components/enphase_ev/refresh_runner.py
+++ b/custom_components/enphase_ev/refresh_runner.py
@@ -44,6 +44,27 @@ class RefreshRunner:
     def __init__(self, coordinator: EnphaseCoordinator) -> None:
         self._coordinator = coordinator
 
+    def _warmup_site_state_available(self) -> bool:
+        coordinator = self._coordinator
+        energy = getattr(coordinator, "energy", None)
+        site_energy = (
+            getattr(energy, "site_energy", None)
+            if energy is not None
+            else getattr(coordinator, "site_energy", None)
+        )
+        if isinstance(site_energy, dict) and site_energy:
+            return True
+        return any(
+            getattr(coordinator, attr, None) is not None
+            for attr in (
+                "tariff_billing",
+                "tariff_import_rate",
+                "tariff_export_rate",
+                "tariff_last_refresh_utc",
+                "tariff_rates_last_refresh_utc",
+            )
+        )
+
     async def async_run_refresh_call(
         self,
         timing_key: str,
@@ -229,7 +250,7 @@ class RefreshRunner:
                 warmup_timings,
                 plan=warmup_plan(warmup_data),
             )
-            if warmup_data:
+            if warmup_data or self._warmup_site_state_available():
                 coordinator.async_set_updated_data(warmup_data)
         except asyncio.CancelledError:
             raise

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1602,6 +1602,64 @@ async def test_site_only_clears_issues_and_counters(
 
 
 @pytest.mark.asyncio
+async def test_site_only_first_refresh_cancels_startup_followups_when_energy_fails(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.site_only = True
+    coord.serials = set()
+    coord._serial_order = []  # noqa: SLF001
+    coord._has_successful_refresh = False  # noqa: SLF001
+    followup_cancelled = asyncio.Event()
+
+    async def _fail_site_energy() -> None:
+        await asyncio.sleep(0)
+        raise RuntimeError("site energy failed")
+
+    async def _run_first_refresh_followups(_phase_timings) -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            followup_cancelled.set()
+            raise
+
+    coord._async_run_first_refresh_followups = _run_first_refresh_followups  # type: ignore[method-assign]  # noqa: SLF001
+    coord.energy._async_refresh_site_energy = AsyncMock(  # noqa: SLF001
+        side_effect=_fail_site_energy
+    )
+
+    with pytest.raises(RuntimeError, match="site energy failed"):
+        await coord._async_update_data()  # noqa: SLF001
+
+    assert followup_cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_start_first_refresh_followups_keeps_existing_task(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.coordinator import RefreshPipelineContext
+
+    coord = coordinator_factory()
+    existing_task = asyncio.create_task(asyncio.sleep(0))
+    context = RefreshPipelineContext(
+        started_mono=time.monotonic(),
+        refresh_started_utc=datetime.now(timezone.utc),
+        phase_timings={},
+        fallback_data={},
+        first_refresh=True,
+        first_refresh_followups_task=existing_task,
+    )
+    coord._async_run_first_refresh_followups = AsyncMock()  # type: ignore[method-assign]  # noqa: SLF001
+
+    coord._start_first_refresh_followups(context)  # noqa: SLF001
+
+    assert context.first_refresh_followups_task is existing_task
+    coord._async_run_first_refresh_followups.assert_not_called()
+    await existing_task
+
+
+@pytest.mark.asyncio
 async def test_backoff_on_429(hass, monkeypatch):
     from homeassistant.helpers.update_coordinator import UpdateFailed
 
@@ -3448,6 +3506,54 @@ async def test_first_refresh_runs_storm_guard_startup_calls_and_defers_warmup_on
 
 
 @pytest.mark.asyncio
+async def test_first_refresh_overlaps_startup_followups_with_status(
+    hass, monkeypatch
+) -> None:
+    coord = _make_coordinator(hass, monkeypatch)
+    status_started = asyncio.Event()
+    followup_started = asyncio.Event()
+
+    async def _status():
+        status_started.set()
+        await followup_started.wait()
+        return {
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                    "charging": False,
+                }
+            ],
+            "ts": 1_700_000_000,
+        }
+
+    async def _run_first_refresh_calls(phase_timings, *, calls, **_kwargs) -> None:
+        followup_started.set()
+        await status_started.wait()
+        for timing_key, *_rest in calls:
+            phase_timings[timing_key] = 0.001
+
+    coord.client.status = AsyncMock(side_effect=_status)
+    coord.client.summary_v2 = AsyncMock(
+        return_value=[{"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"}]
+    )
+    coord.refresh_runner.async_run_refresh_calls = AsyncMock(
+        side_effect=_run_first_refresh_calls
+    )
+
+    await asyncio.wait_for(coord.async_refresh(), timeout=1)
+
+    assert followup_started.is_set()
+    assert coord.refresh_runner.async_run_refresh_calls.await_count == 1
+    assert "status_s" in coord.bootstrap_phase_timings
+    assert "battery_site_settings_s" in coord.bootstrap_phase_timings
+    assert "tariff_s" not in coord.bootstrap_phase_timings
+
+
+@pytest.mark.asyncio
 async def test_first_refresh_populates_storm_guard_state_before_entities(
     hass, monkeypatch, config_entry
 ) -> None:
@@ -3845,6 +3951,23 @@ async def test_startup_warmup_runner_and_task_edge_paths(
     assert "heatpump_runtime_s" in coord._warmup_phase_timings  # noqa: SLF001
     assert "heatpump_daily_s" in coord._warmup_phase_timings  # noqa: SLF001
     coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
+
+    coord = coordinator_factory(data={})
+    coord.data = {}
+    coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]
+    coord.async_set_updated_data = Mock()  # type: ignore[assignment]
+    coord.tariff_runtime.async_refresh = AsyncMock()  # type: ignore[method-assign]
+    coord.tariff_last_refresh_utc = datetime.now(timezone.utc)
+
+    await coord.refresh_runner.async_startup_warmup_runner()
+
+    coord.async_set_updated_data.assert_called_once_with({})  # type: ignore[attr-defined]
+    coord.discovery_snapshot.schedule_save.assert_called_once()  # type: ignore[attr-defined]
+
+    coord = coordinator_factory(data={})
+    coord.data = {}
+    coord.energy.site_energy = {"production": []}
+    assert coord.refresh_runner._warmup_site_state_available() is True  # noqa: SLF001
 
     coord = coordinator_factory()
     coord.discovery_snapshot.schedule_save = Mock()  # type: ignore[assignment]

--- a/tests/components/enphase_ev/test_coordinator_edge_cases.py
+++ b/tests/components/enphase_ev/test_coordinator_edge_cases.py
@@ -474,7 +474,6 @@ async def test_post_status_first_refresh_clears_auth_refresh_rejection(
 
     async def _run_first_refresh_calls(phase_timings, *, calls, **_kwargs) -> None:
         durations = {
-            "tariff_s": 0.123,
             "battery_site_settings_s": 0.234,
             "storm_guard_s": 0.345,
         }
@@ -503,11 +502,9 @@ async def test_post_status_first_refresh_clears_auth_refresh_rejection(
     coord.refresh_runner.async_run_refresh_calls.assert_awaited_once()
     calls = coord.refresh_runner.async_run_refresh_calls.await_args.kwargs["calls"]
     assert [call[0] for call in calls] == [
-        "tariff_s",
         "battery_site_settings_s",
         "storm_guard_s",
     ]
-    assert context.phase_timings["tariff_s"] == 0.123
     assert context.phase_timings["battery_site_settings_s"] == 0.234
     assert context.phase_timings["storm_guard_s"] == 0.345
     assert coord._auth_refresh_rejected_count == 0

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -316,7 +316,7 @@ class _RefreshOwner:
             refresh_due=lambda: True,
         )
         self.tariff_runtime = SimpleNamespace(
-            async_refresh=lambda: self._record("tariff"),
+            async_refresh=lambda **_kwargs: self._record("tariff"),
             refresh_due=lambda: True,
         )
         self.heatpump_runtime = SimpleNamespace(
@@ -477,6 +477,7 @@ def test_refresh_plans_bind_dynamic_followup_and_warmup_calls() -> None:
         None,
         "energy",
     ]
+    assert "tariff_s" in [call[0] for call in bound_warmup.stages[1].parallel_calls]
     assert bound_warmup.stages[2].ordered_calls[0][2]() == "heatpump-runtime"
     assert bound_warmup.stages[3].parallel_calls[0][2]() == "warmup-site-energy"
     assert bound_warmup.stages[3].parallel_calls[1][2]() == "warmup-evse-timeseries"


### PR DESCRIPTION
## Summary

Move slower optional startup work out of the blocking first refresh path and into startup warmup so Home Assistant can finish setting up the integration faster.

The first refresh now overlaps storm-guard startup follow-up calls with the mandatory EVSE status/site-energy fetches, while tariff refresh runs during warmup. Warmup also publishes when site-level tariff or site-energy state changes even if the coordinator has no charger serial data, so site-only tariff entities are notified after warmup.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/refresh_plan.py custom_components/enphase_ev/refresh_runner.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_edge_cases.py tests/components/enphase_ev/test_coordinator_redesign.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/refresh_plan.py,custom_components/enphase_ev/refresh_runner.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Live profile with the local Home Assistant account showed blocking bootstrap around 1.3s after moving tariff to warmup, with tariff completing during warmup instead of first refresh.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Targeted coverage report:

```text
custom_components/enphase_ev/coordinator.py       3921      0   100%
custom_components/enphase_ev/refresh_plan.py       155      0   100%
custom_components/enphase_ev/refresh_runner.py     223      0   100%
```
