### PR TITLE
Improve Enphase refresh performance

### DIFF
--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -163,6 +163,8 @@ def _coerce_int_value(value: object) -> int | None:
         return int(value)
     if isinstance(value, int):
         return value
+    if isinstance(value, float):
+        return int(value) if value.is_integer() else None
     if isinstance(value, str):
         try:
             return int(value)
@@ -1326,9 +1328,16 @@ class OptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[misc]
                     default=self._entry.options.get(
                         OPT_API_TIMEOUT, DEFAULT_API_TIMEOUT
                     ),
-                ): vol.All(
-                    vol.Coerce(int),
-                    vol.Range(min=MIN_API_TIMEOUT, max=MAX_API_TIMEOUT),
+                ): selector(
+                    {
+                        "number": {
+                            "min": MIN_API_TIMEOUT,
+                            "max": MAX_API_TIMEOUT,
+                            "step": 1,
+                            "mode": "box",
+                            "unit_of_measurement": "s",
+                        }
+                    }
                 ),
                 vol.Optional(
                     OPT_NOMINAL_VOLTAGE,

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -229,6 +229,246 @@ COORDINATOR_RUNTIME_CLASSES: dict[str, type] = {
 }
 
 
+def _coerce_epoch_seconds(value: object) -> int | None:
+    try:
+        timestamp = int(value)
+    except Exception:
+        return None
+    if timestamp > 10**12:
+        timestamp = timestamp // 1000
+    return timestamp
+
+
+def _charger_sample_datetime(value: object) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        if value.tzinfo is None:
+            return value.replace(tzinfo=_tz.utc)
+        return value.astimezone(_tz.utc)
+    if isinstance(value, (int, float)):
+        try:
+            numeric = float(value)
+        except Exception:
+            return None
+        if numeric > 10**12:
+            numeric = numeric / 1000.0
+        if numeric <= 0:
+            return None
+        try:
+            return datetime.fromtimestamp(numeric, tz=_tz.utc)
+        except Exception:
+            return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        if text.isdigit():
+            return _charger_sample_datetime(int(text))
+        parsed = dt_util.parse_datetime(text)
+        if parsed is None:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=_tz.utc)
+        return parsed.astimezone(_tz.utc)
+    return None
+
+
+def _extract_error_description(raw: str | None) -> str | None:
+    """Best-effort extraction of a descriptive message from error payloads."""
+
+    if not raw:
+        return None
+    text = str(raw).strip()
+
+    def _search(obj):
+        if isinstance(obj, dict):
+            for key in (
+                "description",
+                "code_description",
+                "codeDescription",
+                "displayMessage",
+                "message",
+                "detail",
+                "error_description",
+                "errorDescription",
+                "errorMessage",
+            ):
+                val = obj.get(key)
+                if isinstance(val, str) and val.strip():
+                    return val.strip()
+            for key in ("error", "details", "data"):
+                nested = obj.get(key)
+                result = _search(nested)
+                if result:
+                    return result
+        elif isinstance(obj, list):
+            for item in obj:
+                result = _search(item)
+                if result:
+                    return result
+        elif isinstance(obj, str) and obj.strip():
+            return obj.strip()
+        return None
+
+    candidates = [text]
+    trimmed = text.strip("\"'")
+    if trimmed != text:
+        candidates.append(trimmed)
+    for candidate in candidates:
+        try:
+            parsed = json.loads(candidate)
+        except Exception:
+            continue
+        description = _search(parsed)
+        if description:
+            return description
+    return None
+
+
+def _coerce_boolish(value: object) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in ("true", "1", "yes", "y")
+    return False
+
+
+def _coerce_optional_boolish(value: object) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in ("true", "1", "yes", "y", "enabled", "enable", "on"):
+            return True
+        if normalized in (
+            "false",
+            "0",
+            "no",
+            "n",
+            "disabled",
+            "disable",
+            "off",
+        ):
+            return False
+    return None
+
+
+def _coerce_floatish(value: object, *, precision: int | None = None) -> float | None:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        parsed = float(value)
+    elif isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            parsed = float(text)
+        except Exception:
+            return None
+    else:
+        return None
+    if precision is not None:
+        try:
+            return round(parsed, precision)
+        except Exception:
+            return parsed
+    return parsed
+
+
+def _coerce_intish(value: object) -> int | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        try:
+            return int(value)
+        except Exception:
+            return None
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        try:
+            return int(float(text))
+        except Exception:
+            return None
+    return None
+
+
+def _coerce_textish(value: object) -> str | None:
+    if value is None:
+        return None
+    try:
+        text = str(value).strip()
+    except Exception:
+        return None
+    return text or None
+
+
+def _coerce_int_list(value: object) -> list[int] | None:
+    if not isinstance(value, list):
+        return None
+    parsed: list[int] = []
+    for item in value:
+        coerced = _coerce_intish(item)
+        if coerced is not None:
+            parsed.append(coerced)
+    return parsed or None
+
+
+def _power_parse_timestamp(raw: object) -> float | None:
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        try:
+            value = float(raw)
+        except Exception:
+            return None
+        if value > 10**12:
+            value = value / 1000.0
+        if value <= 0:
+            return None
+        try:
+            datetime.fromtimestamp(value, tz=_tz.utc)
+        except Exception:
+            return None
+        return value
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return None
+        normalized = stripped.replace("[UTC]", "").replace("Z", "+00:00")
+        try:
+            dt_obj = datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+        if dt_obj.tzinfo is None:
+            dt_obj = dt_obj.replace(tzinfo=_tz.utc)
+        return dt_obj.astimezone(_tz.utc).timestamp()
+    return None
+
+
+def _power_as_float(raw: object) -> float | None:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _power_as_int(raw: object) -> int | None:
+    try:
+        return int(float(raw))
+    except (TypeError, ValueError):
+        return None
+
+
 @dataclass(slots=True)
 class ChargerState:
     sn: str
@@ -486,6 +726,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         super_kwargs = {
             "name": DOMAIN,
             "update_interval": timedelta(seconds=self._configured_slow_poll_interval),
+            "always_update": False,
         }
         if config_entry is not None:
             super_kwargs["config_entry"] = config_entry
@@ -2701,107 +2942,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         if self.site_only or not self.serials:
             return await self._async_run_site_only_refresh_pipeline(context)
 
-        # Helper to normalize epoch-like inputs to seconds
-        def _sec(v):
-            try:
-                iv = int(v)
-                # Convert ms -> s if too large
-                if iv > 10**12:
-                    iv = iv // 1000
-                return iv
-            except Exception:
-                return None
-
-        def _charger_sample_datetime(value: object) -> datetime | None:
-            if value is None:
-                return None
-            if isinstance(value, datetime):
-                if value.tzinfo is None:
-                    return value.replace(tzinfo=_tz.utc)
-                return value.astimezone(_tz.utc)
-            if isinstance(value, (int, float)):
-                try:
-                    numeric = float(value)
-                except Exception:
-                    return None
-                if numeric > 10**12:
-                    numeric = numeric / 1000.0
-                if numeric <= 0:
-                    return None
-                try:
-                    return datetime.fromtimestamp(numeric, tz=_tz.utc)
-                except Exception:
-                    return None
-            if isinstance(value, str):
-                text = value.strip()
-                if not text:
-                    return None
-                if text.isdigit():
-                    return _charger_sample_datetime(int(text))
-                parsed = dt_util.parse_datetime(text)
-                if parsed is None:
-                    return None
-                if parsed.tzinfo is None:
-                    parsed = parsed.replace(tzinfo=_tz.utc)
-                return parsed.astimezone(_tz.utc)
-            return None
-
-        def _extract_description(raw: str | None) -> str | None:
-            """Best-effort extraction of a descriptive message from error payloads."""
-
-            if not raw:
-                return None
-            text = str(raw).strip()
-
-            def _search(obj):
-                if isinstance(obj, dict):
-                    for key in (
-                        "description",
-                        "code_description",
-                        "codeDescription",
-                        "displayMessage",
-                        "message",
-                        "detail",
-                        "error_description",
-                        "errorDescription",
-                        "errorMessage",
-                    ):
-                        val = obj.get(key)
-                        if isinstance(val, str) and val.strip():
-                            return val.strip()
-                    # Dive into common nested containers
-                    for key in ("error", "details", "data"):
-                        nested = obj.get(key)
-                        result = _search(nested)
-                        if result:
-                            return result
-                elif isinstance(obj, list):
-                    for item in obj:
-                        result = _search(item)
-                        if result:
-                            return result
-                elif isinstance(obj, str):
-                    if obj.strip():
-                        return obj.strip()
-                return None
-
-            candidates = [text]
-            trimmed = text.strip("\"'")
-            if trimmed != text:
-                candidates.append(trimmed)
-            for candidate in candidates:
-                try:
-                    parsed = json.loads(candidate)
-                except Exception:
-                    continue
-                description = _search(parsed)
-                if description:
-                    return description
-            return None
-
         # Handle backoff window
         if self._backoff_until and time.monotonic() < self._backoff_until:
-            raise UpdateFailed("In backoff due to rate limiting or server errors")
+            retry_after = max(0.0, self._backoff_until - time.monotonic())
+            raise UpdateFailed(
+                "In backoff due to rate limiting or server errors",
+                retry_after=retry_after,
+            )
 
         if self._auth_block_active():
             self._last_error = "auth_blocked"
@@ -2939,7 +3086,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 self._schedule_backoff_timer(backoff)
                 if self._payload_errors >= 2:
                     self.diagnostics.report_cloud_issue()
-                raise UpdateFailed(f"Invalid API payload: {reason}")
+                raise UpdateFailed(
+                    f"Invalid API payload: {reason}",
+                    retry_after=backoff,
+                )
         except aiohttp.ClientResponseError as err:
             url = None
             try:
@@ -2977,7 +3127,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 else:
                     self.diagnostics.clear_cloud_issue()
             raw_payload = redact_text(err.message, site_ids=(self.site_id,))
-            description = _extract_description(raw_payload)
+            description = _extract_error_description(raw_payload)
             reason = redact_text(err.message, site_ids=(self.site_id,))
             if not reason:
                 reason = err.__class__.__name__
@@ -2997,7 +3147,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self.last_failure_endpoint = str(url) if url is not None else None
             self.payload_using_stale = False
             self.payload_failure_kind = None
-            raise UpdateFailed(f"Cloud error {err.status}: {reason}")
+            raise UpdateFailed(
+                f"Cloud error {err.status}: {reason}",
+                retry_after=backoff,
+            )
         except (aiohttp.ClientError, asyncio.TimeoutError) as err:
             msg = redact_text(err, site_ids=(self.site_id,))
             if not msg:
@@ -3039,7 +3192,10 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self.last_failure_endpoint = None
             self.payload_using_stale = False
             self.payload_failure_kind = None
-            raise UpdateFailed(f"Error communicating with API: {msg}")
+            raise UpdateFailed(
+                f"Error communicating with API: {msg}",
+                retry_after=backoff,
+            )
         finally:
             if not status_refresh_succeeded:
                 await self._async_cancel_first_refresh_followups(context)
@@ -3087,37 +3243,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             first_refresh=first_refresh,
         )
 
-        def _as_bool(v):
-            if isinstance(v, bool):
-                return v
-            if isinstance(v, (int, float)):
-                return v != 0
-            if isinstance(v, str):
-                return v.strip().lower() in ("true", "1", "yes", "y")
-            return False
-
-        def _as_optional_bool(v):
-            if v is None:
-                return None
-            if isinstance(v, bool):
-                return v
-            if isinstance(v, (int, float)):
-                return v != 0
-            if isinstance(v, str):
-                normalized = v.strip().lower()
-                if normalized in ("true", "1", "yes", "y", "enabled", "enable", "on"):
-                    return True
-                if normalized in (
-                    "false",
-                    "0",
-                    "no",
-                    "n",
-                    "disabled",
-                    "disable",
-                    "off",
-                ):
-                    return False
-            return None
+        _as_bool = _coerce_boolish
+        _as_optional_bool = _coerce_optional_boolish
+        _as_float = _coerce_floatish
+        _as_int = _coerce_intish
+        _as_text = _coerce_textish
+        _as_int_list = _coerce_int_list
+        _sec = _coerce_epoch_seconds
 
         def _support_value_and_source(
             runtime_value: bool | None,
@@ -3128,109 +3260,6 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             if feature_flag_value is not None:
                 return feature_flag_value, "feature_flag"
             return None, "unknown"
-
-        def _as_float(v, *, precision: int | None = None):
-            if v is None:
-                return None
-            if isinstance(v, (int, float)):
-                val = float(v)
-            elif isinstance(v, str):
-                s = v.strip()
-                if not s:
-                    return None
-                try:
-                    val = float(s)
-                except Exception:
-                    return None
-            else:
-                return None
-            if precision is not None:
-                try:
-                    return round(val, precision)
-                except Exception:
-                    return val
-            return val
-
-        def _as_int(v):
-            if isinstance(v, bool) or v is None:
-                return None
-            if isinstance(v, (int, float)):
-                try:
-                    return int(v)
-                except Exception:
-                    return None
-            if isinstance(v, str):
-                s = v.strip()
-                if not s:
-                    return None
-                try:
-                    return int(float(s))
-                except Exception:
-                    return None
-            return None
-
-        def _as_text(v):
-            if v is None:
-                return None
-            try:
-                text = str(v).strip()
-            except Exception:
-                return None
-            return text or None
-
-        def _as_int_list(v):
-            if not isinstance(v, list):
-                return None
-            out: list[int] = []
-            for item in v:
-                coerced = _as_int(item)
-                if coerced is None:
-                    continue
-                out.append(coerced)
-            return out or None
-
-        def _power_parse_timestamp(raw: object) -> float | None:
-            if raw is None:
-                return None
-            if isinstance(raw, (int, float)):
-                try:
-                    value = float(raw)
-                except Exception:
-                    return None
-                if value > 10**12:
-                    value = value / 1000.0
-                if value <= 0:
-                    return None
-                try:
-                    datetime.fromtimestamp(value, tz=_tz.utc)
-                except Exception:
-                    return None
-                return value
-            if isinstance(raw, str):
-                stripped = raw.strip()
-                if not stripped:
-                    return None
-                normalized = stripped.replace("[UTC]", "").replace("Z", "+00:00")
-                try:
-                    dt_obj = datetime.fromisoformat(normalized)
-                except ValueError:
-                    return None
-                if dt_obj.tzinfo is None:
-                    dt_obj = dt_obj.replace(tzinfo=_tz.utc)
-                return dt_obj.astimezone(_tz.utc).timestamp()
-            return None
-
-        def _power_as_float(raw: object) -> float | None:
-            try:
-                return float(raw)
-            except (TypeError, ValueError):
-                return None
-
-        def _power_as_int(raw: object) -> int | None:
-            try:
-                return int(float(raw))
-            except (TypeError, ValueError):
-                return None
 
         def _power_topology(entry: dict[str, object]) -> str:
             phase_mode = entry.get("phase_mode")
@@ -4367,20 +4396,48 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         # by current chargers are retained for normal TTL behavior.
         self._prune_runtime_caches(active_serials=out.keys(), keep_day_keys=day_locals)
 
-        for (day_key, max_cache_age), serials in immediate_by_day.items():
+        async def _async_fetch_immediate_session_updates(
+            day_key: str,
+            max_cache_age: float | None,
+            serials: list[str],
+        ) -> dict[str, list[dict]]:
             if max_cache_age is None:
-                updates = await self._async_enrich_sessions(
+                return await self._async_enrich_sessions(
                     serials,
                     day_locals.get(day_key, day_local_default),
                     in_background=False,
                 )
-            else:
-                updates = await self._async_enrich_sessions(
-                    serials,
-                    day_locals.get(day_key, day_local_default),
-                    in_background=False,
-                    max_cache_age=max_cache_age,
-                )
+            return await self._async_enrich_sessions(
+                serials,
+                day_locals.get(day_key, day_local_default),
+                in_background=False,
+                max_cache_age=max_cache_age,
+            )
+
+        immediate_items = tuple(immediate_by_day.items())
+        if len(immediate_items) == 1:
+            (day_key, max_cache_age), serials = immediate_items[0]
+            immediate_updates = (
+                await _async_fetch_immediate_session_updates(
+                    day_key, max_cache_age, serials
+                ),
+            )
+        elif immediate_items:
+            tasks: list[asyncio.Task[dict[str, list[dict]]]] = []
+            async with asyncio.TaskGroup() as task_group:
+                for (day_key, max_cache_age), serials in immediate_items:
+                    task = task_group.create_task(
+                        _async_fetch_immediate_session_updates(
+                            day_key, max_cache_age, serials
+                        ),
+                        name=f"{DOMAIN}_session_history_{day_key}",
+                    )
+                    tasks.append(task)
+            immediate_updates = tuple(task.result() for task in tasks)
+        else:
+            immediate_updates = ()
+
+        for updates in immediate_updates:
             for sn, sessions in updates.items():
                 cur = out.get(sn)
                 if cur is None:

--- a/custom_components/enphase_ev/discovery_snapshot.py
+++ b/custom_components/enphase_ev/discovery_snapshot.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import logging
 from datetime import datetime
 from typing import TYPE_CHECKING
@@ -70,6 +71,23 @@ class DiscoverySnapshotManager:
             DISCOVERY_SNAPSHOT_STORE_VERSION,
             f"{DOMAIN}.discovery_snapshot.{entry_id}",
         )
+        self._last_persisted_signature: str | None = None
+
+    def _snapshot_signature(self, snapshot: object) -> str:
+        compatible = _snapshot_compatible_value(snapshot)
+        return json.dumps(
+            compatible,
+            ensure_ascii=True,
+            separators=(",", ":"),
+            sort_keys=True,
+        )
+
+    def _capture_signature(self) -> tuple[dict[str, object], str]:
+        snapshot = self.capture()
+        return snapshot, self._snapshot_signature(snapshot)
+
+    def _mark_persisted(self, snapshot: object) -> None:
+        self._last_persisted_signature = self._snapshot_signature(snapshot)
 
     def live_site_energy_channels(self) -> set[str]:
         channels: set[str] = set()
@@ -308,6 +326,7 @@ class DiscoverySnapshotManager:
                 dict(item) for item in restored_router_records if isinstance(item, dict)
             ]
         self.coordinator._refresh_cached_topology()
+        self._mark_persisted(self.capture())
 
     async def async_restore_state(self) -> None:
         if self.coordinator._discovery_snapshot_loaded:
@@ -329,7 +348,9 @@ class DiscoverySnapshotManager:
 
     async def async_save(self) -> None:
         self.coordinator._discovery_snapshot_pending = False
-        snapshot = self.capture()
+        snapshot, signature = self._capture_signature()
+        if signature == self._last_persisted_signature:
+            return
         try:
             await self._store.async_save(snapshot)
         except Exception:  # noqa: BLE001
@@ -338,8 +359,14 @@ class DiscoverySnapshotManager:
                 redact_site_id(self.coordinator.site_id),
                 exc_info=True,
             )
+            return
+        self._last_persisted_signature = signature
 
     def schedule_save(self) -> None:
+        _, signature = self._capture_signature()
+        if signature == self._last_persisted_signature:
+            self.coordinator._discovery_snapshot_pending = False
+            return
         self.coordinator._discovery_snapshot_pending = True
         if self.coordinator._discovery_snapshot_save_cancel is not None:
             return

--- a/custom_components/enphase_ev/refresh_runner.py
+++ b/custom_components/enphase_ev/refresh_runner.py
@@ -38,6 +38,10 @@ _SKIPPABLE_REFRESH_ERRORS = (
 )
 
 
+class _RefreshCallCancelled(Exception):
+    """Signal a child refresh cancellation that should cancel sibling tasks."""
+
+
 class RefreshRunner:
     """Execute refresh plans and startup warmup on behalf of the coordinator."""
 
@@ -110,6 +114,27 @@ class RefreshRunner:
             raise
         return timing_key, round(time.monotonic() - started, 3)
 
+    async def _async_run_refresh_call_for_group(
+        self,
+        timing_key: str,
+        log_label: str,
+        callback_factory: Callable[[], object],
+        *,
+        endpoint_family: str | None = None,
+    ) -> tuple[str, float | None]:
+        try:
+            return await self.async_run_refresh_call(
+                timing_key,
+                log_label,
+                callback_factory,
+                endpoint_family=endpoint_family,
+            )
+        except asyncio.CancelledError as err:
+            task = asyncio.current_task()
+            if task is not None and task.cancelling():
+                raise
+            raise _RefreshCallCancelled from err
+
     async def async_run_refresh_calls(
         self,
         phase_timings: dict[str, float],
@@ -122,32 +147,43 @@ class RefreshRunner:
             self._coordinator._begin_topology_refresh_batch()
 
         group_started = time.monotonic()
-        tasks: list[asyncio.Task[tuple[str, float | None]]] = []
         try:
-            tasks = [
-                asyncio.create_task(
-                    self.async_run_refresh_call(
+            async with asyncio.TaskGroup() as task_group:
+                tasks = [
+                    task_group.create_task(
+                        self._async_run_refresh_call_for_group(
+                            timing_key,
+                            log_label,
+                            callback_factory,
+                            endpoint_family=endpoint_family,
+                        ),
+                        name=f"{DOMAIN}_refresh_{timing_key}",
+                    )
+                    for (
                         timing_key,
                         log_label,
                         callback_factory,
-                        endpoint_family=endpoint_family,
-                    ),
-                    name=f"{DOMAIN}_refresh_{timing_key}",
-                )
-                for timing_key, log_label, callback_factory, endpoint_family in calls
-            ]
-            results = await asyncio.gather(*tasks)
-        except (asyncio.CancelledError, Exception):
-            for task in tasks:
-                if not task.done():
-                    task.cancel()
-            if tasks:
-                await asyncio.gather(*tasks, return_exceptions=True)
+                        endpoint_family,
+                    ) in calls
+                ]
+        except* Exception as err_group:
+            exceptions = tuple(
+                err
+                for err in err_group.exceptions
+                if not isinstance(err, _RefreshCallCancelled)
+            )
+            if len(exceptions) == 1:
+                raise exceptions[0] from None
+            if not exceptions:
+                raise asyncio.CancelledError from None
+            if len(exceptions) != len(err_group.exceptions):
+                raise err_group.derive(exceptions) from None
             raise
         finally:
             if defer_topology:
                 self._coordinator._end_topology_refresh_batch()
 
+        results = [task.result() for task in tasks]
         for timing_key, duration in results:
             if duration is not None:
                 phase_timings[timing_key] = duration

--- a/tests/components/enphase_ev/test_config_flow_coverage.py
+++ b/tests/components/enphase_ev/test_config_flow_coverage.py
@@ -2298,6 +2298,14 @@ def test_options_flow_schema_bounds_runtime_options(hass) -> None:
     handler.hass = hass
 
     schema = handler._build_schema()
+    api_timeout_selector = next(
+        value
+        for marker, value in schema.schema.items()
+        if isinstance(marker, VolOptional) and marker.schema == OPT_API_TIMEOUT
+    )
+
+    assert api_timeout_selector.selector_type == "number"
+    assert api_timeout_selector.config["mode"] == "box"
 
     assert (
         schema(
@@ -2787,7 +2795,7 @@ async def test_options_flow_normalizes_poll_intervals_on_save(hass) -> None:
             OPT_FAST_POLL_INTERVAL: 45,
             OPT_SLOW_POLL_INTERVAL: MIN_SLOW_POLL_INTERVAL,
             OPT_FAST_WHILE_STREAMING: True,
-            OPT_API_TIMEOUT: 15,
+            OPT_API_TIMEOUT: 15.0,
             OPT_NOMINAL_VOLTAGE: 230,
             OPT_SESSION_HISTORY_INTERVAL: 10,
             OPT_SCHEDULE_SYNC_ENABLED: False,
@@ -2798,8 +2806,46 @@ async def test_options_flow_normalizes_poll_intervals_on_save(hass) -> None:
     )
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["data"][OPT_API_TIMEOUT] == 15
     assert result["data"][OPT_FAST_POLL_INTERVAL] == 45
     assert result["data"][OPT_SLOW_POLL_INTERVAL] == 45
+
+
+@pytest.mark.asyncio
+async def test_options_flow_rejects_non_integral_api_timeout_float(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SITE_ID: "12345",
+            CONF_SELECTED_TYPE_KEYS: ["envoy", "microinverter"],
+        },
+        options={},
+    )
+    entry.add_to_hass(hass)
+    handler = OptionsFlowHandler(entry)
+    handler.hass = hass
+
+    result = await handler.async_step_settings(
+        {
+            CONF_TYPE_ENVOY: True,
+            CONF_TYPE_ENCHARGE: False,
+            CONF_TYPE_AC_BATTERY: False,
+            CONF_TYPE_IQEVSE: False,
+            CONF_TYPE_HEATPUMP: False,
+            CONF_TYPE_MICROINVERTER: True,
+            OPT_FAST_POLL_INTERVAL: 45,
+            OPT_SLOW_POLL_INTERVAL: MIN_SLOW_POLL_INTERVAL,
+            OPT_FAST_WHILE_STREAMING: True,
+            OPT_API_TIMEOUT: 15.5,
+            OPT_NOMINAL_VOLTAGE: 230,
+            OPT_SESSION_HISTORY_INTERVAL: 10,
+            OPT_SCHEDULE_SYNC_ENABLED: False,
+            OPT_BATTERY_SCHEDULES_ENABLED: False,
+        }
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["errors"] == {OPT_API_TIMEOUT: "unknown"}
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -3837,6 +3837,19 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
         async_save=AsyncMock(side_effect=RuntimeError("boom"))
     )
     await coord.discovery_snapshot.async_save()
+    coord.discovery_snapshot._store.async_save.assert_awaited_once_with(  # type: ignore[attr-defined]
+        {"serial_order": []}
+    )
+
+    coord.discovery_snapshot._store = SimpleNamespace(  # type: ignore[assignment]  # noqa: SLF001
+        async_save=AsyncMock()
+    )
+    await coord.discovery_snapshot.async_save()
+    coord.discovery_snapshot._store.async_save.assert_awaited_once_with(  # type: ignore[attr-defined]
+        {"serial_order": []}
+    )
+    await coord.discovery_snapshot.async_save()
+    coord.discovery_snapshot._store.async_save.assert_awaited_once()
 
     create_calls: list[object] = []
 
@@ -3856,8 +3869,15 @@ async def test_discovery_snapshot_restore_save_and_metrics_edge_paths(
 
     monkeypatch.setattr(snapshot_mod, "async_call_later", _capture_call_later)
     coord._discovery_snapshot_save_cancel = lambda: None  # type: ignore[assignment]  # noqa: SLF001
+    coord.discovery_snapshot.capture = Mock(return_value={"serial_order": []})  # type: ignore[assignment]
     coord.discovery_snapshot.schedule_save()
     assert scheduled == []
+    assert coord._discovery_snapshot_pending is False  # noqa: SLF001
+
+    coord.discovery_snapshot.capture = Mock(return_value={"serial_order": ["NEW"]})  # type: ignore[assignment]
+    coord.discovery_snapshot.schedule_save()
+    assert scheduled == []
+    assert coord._discovery_snapshot_pending is True  # noqa: SLF001
 
     coord._discovery_snapshot_save_cancel = None  # noqa: SLF001
     coord.discovery_snapshot.schedule_save()
@@ -4249,6 +4269,12 @@ async def test_restore_discovery_state_applies_snapshot_topology(
     assert coord.discovery_snapshot.site_energy_channel_known("water_heater") is True
     router_records = coord.inventory_view.gateway_iq_energy_router_records()
     assert router_records[0]["device-uid"] == "ROUTER-1"
+
+    coord.discovery_snapshot._store = SimpleNamespace(  # type: ignore[assignment]  # noqa: SLF001
+        async_save=AsyncMock()
+    )
+    await coord.discovery_snapshot.async_save()
+    coord.discovery_snapshot._store.async_save.assert_not_awaited()  # type: ignore[attr-defined]
 
 
 def test_restored_site_energy_and_router_hints_expire_after_authoritative_refresh(

--- a/tests/components/enphase_ev/test_coordinator_edge_cases.py
+++ b/tests/components/enphase_ev/test_coordinator_edge_cases.py
@@ -896,13 +896,14 @@ async def test_http_error_retry_after_date_triggers_rate_limit_issue(hass, monke
     coord.client = StubClient()
     coord._rate_limit_hits = 1  # ensure branch triggers issue creation
 
-    with pytest.raises(UpdateFailed):
+    with pytest.raises(UpdateFailed) as exc_info:
         await coord._async_update_data()
 
     assert coord.last_failure_status == 429
     assert coord.last_failure_source == "http"
     assert issue_calls, "Expected rate limit issue creation"
     assert scheduled["delay"] > 0
+    assert exc_info.value.retry_after == pytest.approx(scheduled["delay"])
     assert coord._backoff_until == pytest.approx(time_keeper.value + scheduled["delay"])
 
 

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from builtins import ExceptionGroup
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -820,6 +821,156 @@ async def test_coordinator_run_refresh_calls_drains_siblings_before_batch_end(
     coord._end_topology_refresh_batch.assert_called_once_with()  # noqa: SLF001
     assert drained is True
     assert end_saw_drained is True
+
+
+@pytest.mark.asyncio
+async def test_coordinator_run_refresh_calls_cancelled_child_drains_siblings(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    started = asyncio.Event()
+    drained = False
+    end_saw_drained = False
+
+    async def _slow() -> None:
+        nonlocal drained
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            drained = True
+            raise
+
+    async def _cancel() -> None:
+        await started.wait()
+        raise asyncio.CancelledError
+
+    def _end_topology_batch() -> None:
+        nonlocal end_saw_drained
+        end_saw_drained = drained
+
+    coord._begin_topology_refresh_batch = MagicMock()  # type: ignore[method-assign]  # noqa: SLF001
+    coord._end_topology_refresh_batch = MagicMock(  # type: ignore[method-assign]  # noqa: SLF001
+        side_effect=_end_topology_batch
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await coord.refresh_runner.async_run_refresh_calls(
+            {},
+            calls=(
+                ("slow_s", "slow", _slow, None),
+                ("cancel_s", "cancel", _cancel, None),
+            ),
+            defer_topology=True,
+        )
+
+    coord._begin_topology_refresh_batch.assert_called_once_with()  # noqa: SLF001
+    coord._end_topology_refresh_batch.assert_called_once_with()  # noqa: SLF001
+    assert drained is True
+    assert end_saw_drained is True
+
+
+@pytest.mark.asyncio
+async def test_coordinator_run_refresh_calls_prefers_failure_over_child_cancel(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    started = 0
+    ready = asyncio.Event()
+
+    async def _wait_until_ready() -> None:
+        nonlocal started
+        started += 1
+        if started == 2:
+            ready.set()
+        await ready.wait()
+
+    async def _cancel() -> None:
+        await _wait_until_ready()
+        raise asyncio.CancelledError
+
+    async def _fail() -> None:
+        await _wait_until_ready()
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await coord.refresh_runner.async_run_refresh_calls(
+            {},
+            calls=(
+                ("cancel_s", "cancel", _cancel, None),
+                ("fail_s", "fail", _fail, None),
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_coordinator_run_refresh_calls_filters_child_cancel_from_failures(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    started = 0
+    ready = asyncio.Event()
+
+    async def _wait_until_ready() -> None:
+        nonlocal started
+        started += 1
+        if started == 3:
+            ready.set()
+        await ready.wait()
+
+    async def _cancel() -> None:
+        await _wait_until_ready()
+        raise asyncio.CancelledError
+
+    async def _fail_runtime() -> None:
+        await _wait_until_ready()
+        raise RuntimeError("boom")
+
+    async def _fail_value() -> None:
+        await _wait_until_ready()
+        raise ValueError("bad")
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        await coord.refresh_runner.async_run_refresh_calls(
+            {},
+            calls=(
+                ("cancel_s", "cancel", _cancel, None),
+                ("runtime_s", "runtime", _fail_runtime, None),
+                ("value_s", "value", _fail_value, None),
+            ),
+        )
+
+    assert {type(err) for err in exc_info.value.exceptions} == {
+        RuntimeError,
+        ValueError,
+    }
+
+
+@pytest.mark.asyncio
+async def test_coordinator_run_refresh_calls_preserves_multiple_failures(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+
+    async def _fail_runtime() -> None:
+        raise RuntimeError("boom")
+
+    async def _fail_value() -> None:
+        raise ValueError("bad")
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        await coord.refresh_runner.async_run_refresh_calls(
+            {},
+            calls=(
+                ("runtime_s", "runtime", _fail_runtime, None),
+                ("value_s", "value", _fail_value, None),
+            ),
+        )
+
+    assert {type(err) for err in exc_info.value.exceptions} == {
+        RuntimeError,
+        ValueError,
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_performance_audit_regressions.py
+++ b/tests/components/enphase_ev/test_performance_audit_regressions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -365,3 +366,111 @@ async def test_session_history_refresh_classifies_inline_vs_background_paths(
             coord._schedule_session_enrichment.call_args.kwargs["max_cache_age"]  # type: ignore[attr-defined]  # noqa: SLF001
             == 120.0
         )
+
+
+@pytest.mark.asyncio
+async def test_immediate_session_history_buckets_refresh_concurrently(
+    coordinator_factory,
+    monkeypatch,
+) -> None:
+    coord = coordinator_factory(serials=[RANDOM_SERIAL, "EV2"])
+    await coord.hass.config.async_set_time_zone("UTC")
+    now_local = datetime(2026, 4, 27, 12, 0, 0, tzinfo=timezone.utc)
+    previous_day_epoch = int(
+        datetime(2026, 4, 26, 12, 0, tzinfo=timezone.utc).timestamp()
+    )
+    monkeypatch.setattr(dt_util, "now", lambda: now_local)
+    coord._has_successful_refresh = True  # noqa: SLF001
+    coord._scheduler_available = True  # noqa: SLF001
+    coord.client.status = AsyncMock(
+        return_value={
+            "evChargerData": [
+                {
+                    "sn": RANDOM_SERIAL,
+                    "name": "Garage EV",
+                    "charging": True,
+                    "pluggedIn": True,
+                    "charge_mode": "IMMEDIATE",
+                    "connectors": [{}],
+                    "session_d": {},
+                    "sch_d": {},
+                },
+                {
+                    "sn": "EV2",
+                    "name": "Driveway EV",
+                    "charging": False,
+                    "pluggedIn": False,
+                    "charge_mode": "IMMEDIATE",
+                    "connectors": [{}],
+                    "session_d": {"plg_out_at": previous_day_epoch},
+                    "sch_d": {},
+                },
+            ],
+            "ts": int(now_local.timestamp()),
+        }
+    )
+    coord.summary = SimpleNamespace(
+        prepare_refresh=lambda **_kwargs: False,
+        async_fetch=AsyncMock(
+            return_value=[
+                {"serialNumber": RANDOM_SERIAL, "displayName": "Garage EV"},
+                {"serialNumber": "EV2", "displayName": "Driveway EV"},
+            ]
+        ),
+        invalidate=lambda: None,
+    )
+    coord.evse_timeseries = SimpleNamespace(
+        refresh_due=MagicMock(return_value=False),
+        async_refresh=AsyncMock(),
+        merge_charger_payloads=MagicMock(),
+        diagnostics=lambda: {},
+    )
+    coord._async_run_post_status_refresh_pipeline = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value=None
+    )
+    coord._async_run_post_session_refresh_pipeline = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value=None
+    )
+    coord._async_resolve_green_battery_settings = AsyncMock(  # type: ignore[assignment]  # noqa: SLF001
+        return_value={}
+    )
+    coord._async_resolve_auth_settings = AsyncMock(return_value={})  # noqa: SLF001
+    coord._async_resolve_charger_config = AsyncMock(return_value={})  # noqa: SLF001
+    coord._schedule_session_enrichment = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+    coord._prune_runtime_caches = MagicMock()  # type: ignore[assignment]  # noqa: SLF001
+
+    def _cache_view(sn: str, _day_key: str, _now_mono: float) -> SessionCacheView:
+        return SessionCacheView(
+            sessions=[{"session_id": f"cached-{sn}", "energy_kwh": 1.0}],
+            cache_age=1300.0 if sn == "EV2" else 950.0,
+            needs_refresh=True,
+            blocked=False,
+            state="valid",
+            has_valid_cache=True,
+            last_error=None,
+        )
+
+    coord.session_history.get_cache_view = MagicMock(side_effect=_cache_view)  # type: ignore[assignment]
+    started: list[str] = []
+    both_started = asyncio.Event()
+
+    async def _enrich(serials, _day_local, **_kwargs):  # noqa: ANN001
+        serial = serials[0]
+        started.append(serial)
+        if len(started) == 2:
+            both_started.set()
+        await asyncio.wait_for(both_started.wait(), timeout=1)
+        return {serial: [{"session_id": f"fresh-{serial}", "energy_kwh": 2.0}]}
+
+    coord._async_enrich_sessions = AsyncMock(side_effect=_enrich)  # type: ignore[assignment]  # noqa: SLF001
+
+    data = await coord._async_update_data()  # noqa: SLF001
+
+    assert set(started) == {RANDOM_SERIAL, "EV2"}
+    assert data[RANDOM_SERIAL]["energy_today_sessions"] == [
+        {"session_id": f"fresh-{RANDOM_SERIAL}", "energy_kwh": 2.0}
+    ]
+    assert data["EV2"]["energy_today_sessions"] == [
+        {"session_id": "fresh-EV2", "energy_kwh": 2.0}
+    ]
+    coord._schedule_session_enrichment.assert_not_called()  # type: ignore[attr-defined]  # noqa: SLF001


### PR DESCRIPTION
## Summary

Improve refresh-path performance and resilience for the Enphase integration:

- Use coordinator `always_update=False`, preserve retry timing with `UpdateFailed.retry_after`, and reduce repeated helper work during refreshes.
- Use `asyncio.TaskGroup` for coordinated refresh/session-history concurrency while preserving operational exception behavior over child self-cancellation.
- Avoid unchanged discovery snapshot writes by comparing serialized snapshot signatures.
- Change the options-flow API timeout control from a slider to a boxed number selector for consistency with poll interval fields.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [x] Other (performance)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/config_flow.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/discovery_snapshot.py custom_components/enphase_ev/refresh_runner.py tests/components/enphase_ev/test_config_flow_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_edge_cases.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_performance_audit_regressions.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/config_flow.py,custom_components/enphase_ev/refresh_runner.py,custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/discovery_snapshot.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Results:

- `ruff check .`: passed
- `black ...`: 9 files left unchanged
- `python -m pre_commit run --all-files`: passed
- targeted coverage: 3145 passed; touched modules at 100%
- `pytest -q tests/components/enphase_ev`: 3145 passed
- `pytest`: 3258 passed

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No translations were changed. The API timeout options-flow control reuses the existing string key and changes only the selector layout.
