### PR TITLE
Improve Enphase discovery and write efficiency

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+from builtins import ExceptionGroup
 import copy
 import hashlib
 import json
@@ -3261,7 +3262,7 @@ class EnphaseEVClient:
             and isinstance(json_body, dict)
             and "devices" in json_body
         ):
-            body_for_attempt = copy.deepcopy(json_body)
+            body_for_attempt = dict(json_body)
             body_for_attempt.pop("devices", None)
 
         if attempt.merged_payload:
@@ -3269,8 +3270,12 @@ class EnphaseEVClient:
                 endpoint_family,
                 body_for_attempt,
             )
+        elif isinstance(body_for_attempt, dict):
+            adjusted = dict(body_for_attempt)
+        elif isinstance(body_for_attempt, list):
+            adjusted = list(body_for_attempt)
         else:
-            adjusted = copy.deepcopy(body_for_attempt)
+            adjusted = body_for_attempt
         if not isinstance(adjusted, dict):
             return adjusted
         if attempt.strip_devices:
@@ -3445,12 +3450,13 @@ class EnphaseEVClient:
 
         base_payload = self._battery_config_write_bases.get(endpoint_family)
         if not isinstance(base_payload, dict):
-            return copy.deepcopy(json_body)
+            return dict(json_body)
 
-        merged = copy.deepcopy(base_payload)
+        merged = dict(base_payload)
         for key, value in json_body.items():
-            if isinstance(value, dict) and isinstance(merged.get(key), dict):
-                nested = dict(merged[key])
+            base_value = merged.get(key)
+            if isinstance(value, dict) and isinstance(base_value, dict):
+                nested = dict(base_value)
                 nested.update(copy.deepcopy(value))
                 merged[key] = nested
                 continue
@@ -5310,11 +5316,19 @@ class EnphaseEVClient:
     async def site_tariff_bundle(self) -> tuple[dict, dict]:
         """Return billing details and tariff configuration for the site."""
 
-        billing, tariff = await asyncio.gather(
-            self.site_tariff_billing_details(),
-            self.site_tariff(),
-        )
-        return billing, tariff
+        try:
+            async with asyncio.TaskGroup() as task_group:
+                billing_task = task_group.create_task(
+                    self.site_tariff_billing_details(),
+                    name="enphase_ev_site_tariff_billing",
+                )
+                tariff_task = task_group.create_task(
+                    self.site_tariff(),
+                    name="enphase_ev_site_tariff_config",
+                )
+        except ExceptionGroup as err:
+            raise err.exceptions[0] from err
+        return billing_task.result(), tariff_task.result()
 
     async def site_tariff_update(self, payload: dict[str, Any]) -> dict:
         """Update site import/export tariff configuration."""

--- a/custom_components/enphase_ev/config_flow.py
+++ b/custom_components/enphase_ev/config_flow.py
@@ -747,6 +747,12 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
     async def _ensure_chargers(self) -> None:
         if self._chargers_loaded:
             return
+        if self._inventory_iqevse_serials:
+            self._chargers = [
+                (serial, None) for serial in self._inventory_iqevse_serials
+            ]
+            self._chargers_loaded = True
+            return
         if not self._auth_tokens or not self._selected_site_id:
             self._chargers_loaded = True
             return
@@ -847,13 +853,10 @@ class EnphaseEVConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):  # type: ig
         ]
 
     async def _ensure_device_selection_data(self) -> None:
-        tasks = []
-        if not self._chargers_loaded:
-            tasks.append(self._ensure_chargers())
         if not self._type_keys_loaded:
-            tasks.append(self._ensure_available_type_keys())
-        if tasks:
-            await asyncio.gather(*tasks)
+            await self._ensure_available_type_keys()
+        if not self._chargers_loaded:
+            await self._ensure_chargers()
 
     def _reset_discovery_cache(self) -> None:
         self._chargers = []
@@ -1507,22 +1510,30 @@ class OptionsFlowHandler(config_entries.OptionsFlow):  # type: ignore[misc]
         )
         session = async_get_clientsession(self.hass)
 
-        chargers = await async_fetch_chargers(session, site_id, tokens)
         discovered: list[str] = []
+        try:
+            payload = await async_fetch_devices_inventory(session, site_id, tokens)
+        except Exception as err:  # noqa: BLE001
+            _LOGGER.debug(
+                "Failed to fetch device inventory during IQ EVSE serial discovery "
+                "for site %s: %s",
+                redact_site_id(site_id),
+                redact_text(err, site_ids=(site_id,)),
+            )
+        else:
+            discovered = self._normalize_serials(
+                active_type_serials_from_inventory(payload, type_key="iqevse")
+            )
+        if discovered:
+            return discovered
+
+        chargers = await async_fetch_chargers(session, site_id, tokens)
         for charger in chargers:
             if charger.serial:
                 serial = str(charger.serial).strip()
                 if serial and serial not in discovered:
                     discovered.append(serial)
-        if discovered:
-            return discovered
-
-        payload = await async_fetch_devices_inventory(session, site_id, tokens)
-        if payload is None:
-            return []
-        return self._normalize_serials(
-            active_type_serials_from_inventory(payload, type_key="iqevse")
-        )
+        return discovered
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import base64
 from contextlib import asynccontextmanager
 import datetime
@@ -4228,6 +4229,30 @@ async def test_site_tariff_bundle_fetches_billing_and_tariff() -> None:
 
 
 @pytest.mark.asyncio
+async def test_site_tariff_bundle_cancels_sibling_and_unwraps_single_failure() -> None:
+    client = _make_client()
+    err = RuntimeError("tariff billing failed")
+    tariff_cancelled = asyncio.Event()
+    client.site_tariff_billing_details = AsyncMock(side_effect=err)
+
+    async def _site_tariff() -> dict:
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            tariff_cancelled.set()
+            raise
+        return {"purchase": {"typeId": "flat"}}
+
+    client.site_tariff = AsyncMock(side_effect=_site_tariff)
+
+    with pytest.raises(RuntimeError) as exc:
+        await client.site_tariff_bundle()
+
+    assert exc.value is err
+    assert tariff_cancelled.is_set()
+
+
+@pytest.mark.asyncio
 async def test_site_tariff_update_passes_user_id_and_write_headers() -> None:
     token = _make_token({"user_id": "77"})
     client = _make_client()
@@ -5146,6 +5171,86 @@ def test_battery_config_write_payload_helpers_cover_merge_and_base_fallbacks() -
     ) == {
         "dtgControl": {"enabled": True, "startTime": "00:00"},
         "devices": {"iqEvse": {"enabled": True}},
+    }
+    assert (  # noqa: SLF001
+        client._battery_config_attempt_json_body(None, "battery_settings", attempt)
+        is None
+    )
+    lean_attempt = api._BatteryConfigWriteAttempt(  # noqa: SLF001
+        attempt_id="lean",
+        auth_mode=api._BATTERY_CONFIG_VARIANT_PRIMARY,
+    )
+    assert (  # noqa: SLF001
+        client._battery_config_attempt_json_body(None, "battery_settings", lean_attempt)
+        is None
+    )
+
+
+def test_battery_config_write_payload_helpers_preserve_inputs() -> None:
+    client = _make_client()
+    read_payload = {
+        "data": {
+            "dtgControl": {
+                "enabled": False,
+                "startTime": "00:00",
+                "schedule": {"weekday": True},
+            },
+            "devices": {"iqEvse": {"enabled": True}},
+        }
+    }
+    client._remember_battery_config_write_base(  # noqa: SLF001
+        "battery_settings", read_payload
+    )
+    write_payload = {
+        "dtgControl": {"schedule": {"weekday": False}},
+        "devices": {"iqEvse": {"enabled": False}},
+    }
+
+    merged = client._battery_config_merged_write_payload(  # noqa: SLF001
+        "battery_settings", write_payload
+    )
+
+    write_payload["dtgControl"]["schedule"]["weekday"] = "mutated"
+    assert merged == {
+        "dtgControl": {
+            "enabled": False,
+            "startTime": "00:00",
+            "schedule": {"weekday": False},
+        },
+        "devices": {"iqEvse": {"enabled": False}},
+    }
+    assert client._battery_config_write_bases["battery_settings"] == {  # noqa: SLF001
+        "dtgControl": {
+            "enabled": False,
+            "startTime": "00:00",
+            "schedule": {"weekday": True},
+        },
+        "devices": {"iqEvse": {"enabled": True}},
+    }
+
+    attempt = api._BatteryConfigWriteAttempt(  # noqa: SLF001
+        attempt_id="lean",
+        auth_mode=api._BATTERY_CONFIG_VARIANT_PRIMARY,
+        strip_devices=True,
+        disclaimer_bool_true=True,
+    )
+    request_payload = {
+        "acceptedItcDisclaimer": "true",
+        "devices": {"iqEvse": {"enabled": False}},
+        "dtgControl": {"enabled": True},
+    }
+    adjusted = client._battery_config_attempt_json_body(  # noqa: SLF001
+        request_payload, "battery_settings", attempt
+    )
+
+    assert adjusted == {
+        "acceptedItcDisclaimer": True,
+        "dtgControl": {"enabled": True},
+    }
+    assert request_payload == {
+        "acceptedItcDisclaimer": "true",
+        "devices": {"iqEvse": {"enabled": False}},
+        "dtgControl": {"enabled": True},
     }
 
 

--- a/tests/components/enphase_ev/test_config_flow_coverage.py
+++ b/tests/components/enphase_ev/test_config_flow_coverage.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -619,7 +618,7 @@ async def test_user_step_single_site_shortcuts_to_devices(hass) -> None:
         patch(
             "custom_components.enphase_ev.config_flow.async_fetch_chargers",
             AsyncMock(return_value=chargers),
-        ),
+        ) as mock_chargers,
         patch(
             "custom_components.enphase_ev.config_flow.async_fetch_devices_inventory",
             AsyncMock(
@@ -648,7 +647,8 @@ async def test_user_step_single_site_shortcuts_to_devices(hass) -> None:
     flow = hass.config_entries.flow._progress[result["flow_id"]]
     assert flow._selected_site_id == "12345"
     assert flow._chargers_loaded is True
-    assert flow._chargers == [("EV123", "Driveway")]
+    assert flow._chargers == [("EV123", None)]
+    mock_chargers.assert_not_awaited()
     hass.config_entries.flow.async_abort(result["flow_id"])
 
 
@@ -1543,33 +1543,27 @@ async def test_ensure_available_type_keys_skips_when_already_loaded(hass) -> Non
 
 
 @pytest.mark.asyncio
-async def test_ensure_device_selection_data_fetches_discovery_concurrently(
+async def test_ensure_device_selection_data_reuses_inventory_charger_serials(
     hass,
 ) -> None:
     flow = _make_flow(hass)
     flow._auth_tokens = TOKENS
     flow._selected_site_id = "12345"
-    chargers_started = asyncio.Event()
-    inventory_started = asyncio.Event()
-
-    async def _fetch_chargers(*_args, **_kwargs):
-        chargers_started.set()
-        await inventory_started.wait()
-        return []
-
-    async def _fetch_inventory(*_args, **_kwargs):
-        inventory_started.set()
-        await chargers_started.wait()
-        return {"result": []}
 
     with (
         patch(
             "custom_components.enphase_ev.config_flow.async_fetch_chargers",
-            _fetch_chargers,
-        ),
+            AsyncMock(side_effect=AssertionError("should not fetch chargers")),
+        ) as mock_chargers,
         patch(
             "custom_components.enphase_ev.config_flow.async_fetch_devices_inventory",
-            _fetch_inventory,
+            AsyncMock(
+                return_value={
+                    "result": [
+                        {"type": "iqevse", "devices": [{"serial_number": "EV1"}]}
+                    ]
+                }
+            ),
         ),
         patch(
             "custom_components.enphase_ev.config_flow.async_fetch_hems_devices",
@@ -1584,10 +1578,49 @@ async def test_ensure_device_selection_data_fetches_discovery_concurrently(
             AsyncMock(return_value=None),
         ),
     ):
-        await asyncio.wait_for(flow._ensure_device_selection_data(), timeout=1)
+        await flow._ensure_device_selection_data()
 
     assert flow._chargers_loaded is True
+    assert flow._chargers == [("EV1", None)]
     assert flow._type_keys_loaded is True
+    mock_chargers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ensure_device_selection_data_falls_back_to_charger_api(
+    hass,
+) -> None:
+    flow = _make_flow(hass)
+    flow._auth_tokens = TOKENS
+    flow._selected_site_id = "12345"
+
+    with (
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_chargers",
+            AsyncMock(return_value=[ChargerInfo(serial="EV2", name="Garage")]),
+        ) as mock_chargers,
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_devices_inventory",
+            AsyncMock(return_value={"result": []}),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_hems_devices",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_battery_site_settings",
+            AsyncMock(return_value=None),
+        ),
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_inverters_inventory",
+            AsyncMock(return_value=None),
+        ),
+    ):
+        await flow._ensure_device_selection_data()
+
+    assert flow._chargers_loaded is True
+    assert flow._chargers == [("EV2", "Garage")]
+    mock_chargers.assert_awaited_once()
 
 
 @pytest.mark.asyncio
@@ -2544,6 +2577,73 @@ async def test_options_flow_discover_iqevse_serials_returns_empty_when_inventory
 
 
 @pytest.mark.asyncio
+async def test_options_flow_discover_iqevse_serials_prefers_inventory(
+    hass,
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SITE_ID: "12345",
+            CONF_EAUTH: "token-abc",
+            CONF_COOKIE: "jar=1",
+        },
+    )
+    handler = OptionsFlowHandler(entry)
+    handler.hass = hass
+
+    with (
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_chargers",
+            AsyncMock(side_effect=AssertionError("should not fetch chargers")),
+        ) as mock_chargers,
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_devices_inventory",
+            AsyncMock(
+                return_value={
+                    "result": [
+                        {"type": "iqevse", "devices": [{"serial_number": "EV-INV"}]}
+                    ]
+                }
+            ),
+        ),
+    ):
+        assert await handler._discover_iqevse_serials() == ["EV-INV"]
+
+    mock_chargers.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_options_flow_discover_iqevse_serials_falls_back_when_inventory_fails(
+    hass,
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_SITE_ID: "12345",
+            CONF_EAUTH: "token-abc",
+            CONF_COOKIE: "jar=1",
+        },
+    )
+    handler = OptionsFlowHandler(entry)
+    handler.hass = hass
+
+    with (
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_chargers",
+            AsyncMock(return_value=[ChargerInfo(serial="EV-FALLBACK", name="Garage")]),
+        ) as mock_chargers,
+        patch(
+            "custom_components.enphase_ev.config_flow.async_fetch_devices_inventory",
+            AsyncMock(side_effect=RuntimeError("inventory failed")),
+        ) as mock_inventory,
+    ):
+        assert await handler._discover_iqevse_serials() == ["EV-FALLBACK"]
+
+    mock_inventory.assert_awaited_once()
+    mock_chargers.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_options_flow_forget_password(hass) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
@@ -2929,7 +3029,7 @@ async def test_options_flow_enabling_iqevse_discovers_serials(hass) -> None:
     assert entry.data[CONF_SERIALS] == ["EV-DISCOVERED"]
     assert entry.data[CONF_SITE_ONLY] is False
     assert entry.data[CONF_SELECTED_TYPE_KEYS] == ["envoy", "encharge", "iqevse"]
-    mock_inventory.assert_not_awaited()
+    mock_inventory.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_entities_and_flow.py
+++ b/tests/components/enphase_ev/test_entities_and_flow.py
@@ -119,7 +119,7 @@ async def test_config_flow_happy_path(hass: HomeAssistant) -> None:
     assert data[CONF_TOKEN_EXPIRES_AT] == 1_700_000_000
     assert result["title"] == "Site: 12345"
     mock_auth.assert_awaited_once()
-    mock_chargers.assert_awaited_once()
+    mock_chargers.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Improve a few remaining integration performance paths after the refresh-runner work:

- Prefer IQ EV charger serials from devices inventory during onboarding/options discovery, avoiding the separate charger-summary call when inventory already contains the serials.
- Preserve charger-summary fallback behavior when inventory omits charger serials or inventory lookup fails.
- Use `asyncio.TaskGroup` for the paired tariff billing/config fetch, cancelling sibling work on failure while preserving the prior caller-facing exception shape.
- Reduce recursive copy churn in BatteryConfig write preparation by shallow-copying top-level payloads and only deep-copying replaced nested branches.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [x] Other (performance)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/api.py custom_components/enphase_ev/config_flow.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_config_flow_coverage.py tests/components/enphase_ev/test_entities_and_flow.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/api.py,custom_components/enphase_ev/config_flow.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Results:

- `ruff check .`: passed
- `black ...`: 5 files left unchanged
- `python -m pre_commit run --all-files`: passed
- targeted coverage: 3150 passed; `api.py` and `config_flow.py` at 100%
- `pytest -q tests/components/enphase_ev`: 3150 passed
- `pytest`: 3263 passed

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No user-facing strings or translations changed. The discovery fallback tests cover both inventory fast-path and charger-summary fallback behavior.
