### PR TITLE
Fix skipped Envoy history confirmation mappings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable changes to this project will be documented in this file.
 - Suppressed transient Enphase scheduler `400` errors for IQ EV charger mode changes when read-back confirms the requested mode was applied.
 - Fixed regional firmware selection so country-scoped firmware catalog entries are matched without stale global fallback prompts.
 - Guarded HEMS authentication refresh loops so repeated recoverable failures do not trigger unnecessary retry churn or stale rejection handling.
+- Kept cleared Envoy history migration mappings skipped on the final confirmation step instead of restoring suggested entities.
 
 ### 🔧 Improvements
 - Optimized performance cache refreshes by caching unchanged inventory summaries and suppressing no-op session-history publishes.

--- a/custom_components/enphase_ev/envoy_history.py
+++ b/custom_components/enphase_ev/envoy_history.py
@@ -33,7 +33,7 @@ FLOW_LABELS: dict[str, str] = {
 }
 ALLOWED_STATE_CLASSES = {"total", "total_increasing"}
 LOW_VALUE_TOLERANCE_KWH = 0.01
-_OPTION_SKIP = ""
+_OPTION_SKIP = "__skip__"
 _EXCLUDED_OBJECT_ID_TERMS = ("daily", "today", "current", "power")
 _PHASE_OBJECT_ID_PATTERN = re.compile(r"(^|_)(l[123]|phase_[a-z0-9]+)$")
 _UNIT_TO_KWH: dict[str, float] = {

--- a/tests/components/enphase_ev/test_config_flow_coverage.py
+++ b/tests/components/enphase_ev/test_config_flow_coverage.py
@@ -3577,7 +3577,7 @@ async def test_options_flow_migrate_mapping_includes_external_compatible_sensors
     selector_config = next(iter(schema.schema.values())).config
     options = selector_config["options"]
     assert [option["value"] for option in options] == [
-        "",
+        skip_option_value(),
         envoy_entity,
         template_entity,
     ]
@@ -3631,6 +3631,76 @@ async def test_options_flow_migrate_mapping_handles_user_input_paths(
     )
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "migrate_envoy_confirm"
+
+
+@pytest.mark.asyncio
+async def test_options_flow_migrate_confirm_preview_excludes_skipped_suggestions(
+    hass, monkeypatch
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN, entry_id="enphase-entry", data={CONF_SITE_ID: "12345"}
+    )
+    entry.add_to_hass(hass)
+    envoy = MockConfigEntry(domain="enphase_envoy", entry_id="envoy-a", title="Envoy A")
+    _patch_entry_lookup(monkeypatch, hass, envoy)
+    attrs = {
+        "device_class": "energy",
+        "state_class": "total_increasing",
+        "unit_of_measurement": UnitOfEnergy.KILO_WATT_HOUR,
+    }
+    prod_entity = _add_registry_sensor(
+        hass,
+        entry=envoy,
+        platform="enphase_envoy",
+        unique_id="envoy-a-prod",
+        object_id="envoy_lifetime_production",
+        state="5.0",
+        attrs=attrs,
+    )
+    cons_entity = _add_registry_sensor(
+        hass,
+        entry=envoy,
+        platform="enphase_envoy",
+        unique_id="envoy-a-cons",
+        object_id="envoy_lifetime_consumption",
+        state="4.0",
+        attrs=attrs,
+    )
+    _add_registry_sensor(
+        hass,
+        entry=entry,
+        platform=DOMAIN,
+        unique_id=migration_target_unique_id("12345", "solar_production"),
+        object_id="site_solar_production",
+        state="5.1",
+        attrs=attrs,
+    )
+    _add_registry_sensor(
+        hass,
+        entry=entry,
+        platform=DOMAIN,
+        unique_id=migration_target_unique_id("12345", "consumption"),
+        object_id="site_consumption",
+        state="4.2",
+        attrs=attrs,
+    )
+    handler = OptionsFlowHandler(entry)
+    handler.hass = hass
+    handler._selected_migration_source_id = "envoy-a"
+
+    result = await handler.async_step_migrate_envoy_mapping(
+        {
+            "solar_production": prod_entity,
+            "consumption": skip_option_value(),
+        }
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "migrate_envoy_confirm"
+    assert handler._migration_selection == {"solar_production": prod_entity}
+    mapping_preview = result["description_placeholders"]["mapping_preview"]
+    assert prod_entity in mapping_preview
+    assert cons_entity not in mapping_preview
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_envoy_history.py
+++ b/tests/components/enphase_ev/test_envoy_history.py
@@ -777,6 +777,7 @@ def test_score_candidate_hits_additional_flow_branches() -> None:
 
 
 def test_selected_mappings_skips_empty_values() -> None:
+    assert skip_option_value()
     assert selected_mappings(
         {
             "solar_production": "sensor.a",
@@ -814,7 +815,7 @@ def test_source_helpers_render_options() -> None:
     assert candidate_options(source)[0]["value"] == skip_option_value()
     assert candidate_options(source)[0]["label"] == ""
     assert [option["value"] for option in candidate_options(source, extra)] == [
-        "",
+        skip_option_value(),
         "sensor.envoy_lifetime_production",
         "sensor.template_energy_total",
     ]


### PR DESCRIPTION
## Summary

Fixes the Envoy history migration mapping flow so a mapping that the user clears or skips stays skipped on the final confirmation step. The skip selector value now uses a non-empty sentinel, preventing form defaults from restoring suggested entities before confirmation.

Also adds regression coverage for a two-suggestion flow where one entity is skipped and must not appear in the confirmation preview, plus a changelog entry for the user-facing bug fix.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/envoy_history.py tests/components/enphase_ev/test_envoy_history.py tests/components/enphase_ev/test_config_flow_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger:/Users/james/Documents/GitHub/ha-enphase-ev-charger ha-dev bash -lc "git config --global --add safe.directory /workspace && python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/envoy_history.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Targeted coverage confirmed `custom_components/enphase_ev/envoy_history.py` at 100%.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The first pre-commit attempt failed before hooks ran because the Docker container could not resolve this Git worktree's external `.git` path. The successful pre-commit command mounts the parent Git directory into the container.
