### PR TITLE
[codex] Persist HEMS auth refresh suppression

### DIFF
--- a/custom_components/enphase_ev/api.py
+++ b/custom_components/enphase_ev/api.py
@@ -2017,6 +2017,8 @@ class EnphaseEVClient:
         self._eauth = eauth or None
         self._hems_site_supported: bool | None = None
         self._hems_auth_refresh_suppressed_until: float | None = None
+        self._hems_auth_refresh_suppressed_active_cb: Callable[[], bool] | None = None
+        self._hems_auth_refresh_suppressed_cb: Callable[[], None] | None = None
         self._reauth_cb: Callable[[], Awaitable[bool]] | None = reauth_callback
         self._last_unauthorized_request: str | None = None
         self._request_count = 0
@@ -2036,6 +2038,17 @@ class EnphaseEVClient:
 
         self._reauth_cb = callback
 
+    def set_hems_auth_refresh_suppression_callbacks(
+        self,
+        *,
+        active_callback: Callable[[], bool] | None,
+        suppress_callback: Callable[[], None] | None,
+    ) -> None:
+        """Register coordinator-backed HEMS auth-refresh suppression callbacks."""
+
+        self._hems_auth_refresh_suppressed_active_cb = active_callback
+        self._hems_auth_refresh_suppressed_cb = suppress_callback
+
     @staticmethod
     def _is_hems_api_endpoint(endpoint: str | None) -> bool:
         """Return True for HEMS JSON API endpoints that are optional/read-only."""
@@ -2045,6 +2058,15 @@ class EnphaseEVClient:
     def _hems_auth_refresh_suppressed_active(self) -> bool:
         """Return True while HEMS 401s should not trigger password refresh."""
 
+        active_cb = self._hems_auth_refresh_suppressed_active_cb
+        if active_cb is not None:
+            try:
+                if active_cb():
+                    return True
+            except Exception:  # noqa: BLE001 - suppression must not break requests
+                _LOGGER.debug(
+                    "HEMS auth refresh suppression callback failed", exc_info=True
+                )
         suppressed_until = self._hems_auth_refresh_suppressed_until
         if not isinstance(suppressed_until, (int, float)):
             return False
@@ -2059,6 +2081,14 @@ class EnphaseEVClient:
         self._hems_auth_refresh_suppressed_until = (
             time.monotonic() + HEMS_AUTH_REFRESH_SUPPRESS_AFTER_SUCCESS_S
         )
+        suppress_cb = self._hems_auth_refresh_suppressed_cb
+        if suppress_cb is not None:
+            try:
+                suppress_cb()
+            except Exception:  # noqa: BLE001 - local suppression is already active
+                _LOGGER.debug(
+                    "HEMS auth refresh suppression callback failed", exc_info=True
+                )
 
     @property
     def last_unauthorized_request(self) -> str | None:

--- a/custom_components/enphase_ev/auth_refresh_runtime.py
+++ b/custom_components/enphase_ev/auth_refresh_runtime.py
@@ -27,6 +27,7 @@ from .const import (
     AUTH_REFRESH_REJECTED_SUSPEND_THRESHOLD,
     AUTH_REFRESH_SUSPENDED_COOLDOWN_S,
     AUTH_REFRESH_SUCCESS_REUSE_WINDOW_S,
+    HEMS_AUTH_REFRESH_SUPPRESS_AFTER_SUCCESS_S,
 )
 from .log_redaction import redact_text
 
@@ -260,6 +261,25 @@ class AuthRefreshRuntime:
             return False
         return (time.monotonic() - float(last_success)) <= float(
             AUTH_REFRESH_SUCCESS_REUSE_WINDOW_S
+        )
+
+    def hems_auth_refresh_suppressed_active(self) -> bool:
+        """Return True while HEMS 401s should not trigger password refresh."""
+
+        coord = self.coordinator
+        suppressed_until = getattr(coord, "_hems_auth_refresh_suppressed_until", None)
+        if not isinstance(suppressed_until, (int, float)):
+            return False
+        if time.monotonic() < float(suppressed_until):
+            return True
+        coord._hems_auth_refresh_suppressed_until = None
+        return False
+
+    def suppress_hems_auth_refresh_after_success(self) -> None:
+        """Temporarily stop HEMS 401s from causing repeated password logins."""
+
+        self.coordinator._hems_auth_refresh_suppressed_until = (
+            time.monotonic() + HEMS_AUTH_REFRESH_SUPPRESS_AFTER_SUCCESS_S
         )
 
     def note_login_wall_block(self, *, reason: str) -> None:

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -619,6 +619,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                     )
                 except TypeError:
                     self.hass.async_create_task(result)
+        set_hems_suppression_callbacks = getattr(
+            self.client, "set_hems_auth_refresh_suppression_callbacks", None
+        )
+        if callable(set_hems_suppression_callbacks):
+            set_hems_suppression_callbacks(
+                active_callback=self._hems_auth_refresh_suppressed_active,
+                suppress_callback=self._suppress_hems_auth_refresh_after_success,
+            )
         from .schedule_sync import ScheduleSync
 
         self.schedule_sync = ScheduleSync(hass, self, config_entry)
@@ -4558,7 +4566,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             merged[CONF_AUTH_BLOCK_REASON] = self._auth_block_reason
         else:
             merged.pop(CONF_AUTH_BLOCK_REASON, None)
-        self.hass.config_entries.async_update_entry(config_entry, data=merged)
+        changed = self.hass.config_entries.async_update_entry(config_entry, data=merged)
+        if changed:
+            self._mark_internal_config_entry_data_update()
 
     def _persist_auth_refresh_suspension_state(self) -> None:
         """Persist stored-credential auto-refresh suspension metadata."""
@@ -4573,7 +4583,17 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             merged[CONF_AUTH_REFRESH_SUSPENDED_UNTIL] = (
                 self._auth_refresh_suspended_until_utc.isoformat()
             )
-        self.hass.config_entries.async_update_entry(config_entry, data=merged)
+        changed = self.hass.config_entries.async_update_entry(config_entry, data=merged)
+        if changed:
+            self._mark_internal_config_entry_data_update()
+
+    def _mark_internal_config_entry_data_update(self) -> None:
+        """Avoid reloading this entry for coordinator-owned data persistence."""
+
+        config_entry = getattr(self, "config_entry", None)
+        runtime_data = getattr(config_entry, "runtime_data", None)
+        if hasattr(runtime_data, "skip_reload_once"):
+            runtime_data.skip_reload_once = True
 
     def _clear_auth_refresh_rejection_state(self) -> None:
         """Clear the short rejected-refresh streak and cooldown state."""
@@ -4745,6 +4765,16 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
         return self.auth_refresh_runtime.auth_refresh_recent_success_active()
 
+    def _hems_auth_refresh_suppressed_active(self) -> bool:
+        """Return True while HEMS 401s should not trigger password refresh."""
+
+        return self.auth_refresh_runtime.hems_auth_refresh_suppressed_active()
+
+    def _suppress_hems_auth_refresh_after_success(self) -> None:
+        """Temporarily stop HEMS 401s from causing repeated password logins."""
+
+        self.auth_refresh_runtime.suppress_hems_auth_refresh_after_success()
+
     async def _async_run_auto_refresh(self) -> bool:
         """Run one stored-credential refresh attempt for all concurrent waiters (delegates to ``AuthRefreshRuntime``)."""
 
@@ -4844,7 +4874,11 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         diagnostics = getattr(self, "diagnostics", None)
         if diagnostics is not None:
             diagnostics.clear_reauth_issue()
-        self.hass.config_entries.async_update_entry(self.config_entry, data=merged)
+        changed = self.hass.config_entries.async_update_entry(
+            self.config_entry, data=merged
+        )
+        if changed:
+            self._mark_internal_config_entry_data_update()
 
     def kick_fast(self, seconds: int = 60) -> None:
         self.evse_runtime.kick_fast(seconds)

--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -623,10 +623,18 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self.client, "set_hems_auth_refresh_suppression_callbacks", None
         )
         if callable(set_hems_suppression_callbacks):
-            set_hems_suppression_callbacks(
+            result = set_hems_suppression_callbacks(
                 active_callback=self._hems_auth_refresh_suppressed_active,
                 suppress_callback=self._suppress_hems_auth_refresh_after_success,
             )
+            if inspect.isawaitable(result):
+                try:
+                    self.hass.async_create_task(
+                        result,
+                        name=f"{DOMAIN}_set_hems_auth_refresh_suppression_callbacks",
+                    )
+                except TypeError:
+                    self.hass.async_create_task(result)
         from .schedule_sync import ScheduleSync
 
         self.schedule_sync = ScheduleSync(hass, self, config_entry)

--- a/custom_components/enphase_ev/state_models.py
+++ b/custom_components/enphase_ev/state_models.py
@@ -128,6 +128,7 @@ class RefreshHealthState:
     _auth_refresh_rejected_ends_utc: datetime | None = None
     _auth_refresh_manual_retry_until: float | None = None
     _auth_refresh_last_success_mono: float | None = None
+    _hems_auth_refresh_suppressed_until: float | None = None
     _auth_refresh_suspended_until_utc: datetime | None = None
     _auth_blocked_until_utc: datetime | None = None
     _auth_block_reason: str | None = None

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -178,6 +178,46 @@ def test_hems_auth_refresh_suppression_uses_registered_callbacks() -> None:
     assert state["suppressed"] == 1
 
 
+def test_hems_auth_refresh_suppression_active_callback_failure_falls_back(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = _make_client()
+    client._hems_auth_refresh_suppressed_until = time.monotonic() + 30  # noqa: SLF001
+
+    def _active() -> bool:
+        raise RuntimeError("boom")
+
+    client.set_hems_auth_refresh_suppression_callbacks(
+        active_callback=_active,
+        suppress_callback=None,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=api._LOGGER.name):
+        assert client._hems_auth_refresh_suppressed_active() is True  # noqa: SLF001
+
+    assert "HEMS auth refresh suppression callback failed" in caplog.text
+
+
+def test_hems_auth_refresh_suppression_suppress_callback_failure_uses_local(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client = _make_client()
+
+    def _suppress() -> None:
+        raise RuntimeError("boom")
+
+    client.set_hems_auth_refresh_suppression_callbacks(
+        active_callback=None,
+        suppress_callback=_suppress,
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=api._LOGGER.name):
+        client._suppress_hems_auth_refresh_after_success()  # noqa: SLF001
+
+    assert client._hems_auth_refresh_suppressed_active() is True  # noqa: SLF001
+    assert "HEMS auth refresh suppression callback failed" in caplog.text
+
+
 def test_safe_response_error_message_handles_header_failures() -> None:
     class BadHeaders:
         def get(self, *_args, **_kwargs):

--- a/tests/components/enphase_ev/test_api_client_methods.py
+++ b/tests/components/enphase_ev/test_api_client_methods.py
@@ -155,6 +155,29 @@ def test_hems_auth_refresh_suppression_expires() -> None:
     assert client._hems_auth_refresh_suppressed_until is None  # noqa: SLF001
 
 
+def test_hems_auth_refresh_suppression_uses_registered_callbacks() -> None:
+    client = _make_client()
+    state = {"active": False, "suppressed": 0}
+
+    def _active() -> bool:
+        return state["active"]
+
+    def _suppress() -> None:
+        state["active"] = True
+        state["suppressed"] += 1
+
+    client.set_hems_auth_refresh_suppression_callbacks(
+        active_callback=_active,
+        suppress_callback=_suppress,
+    )
+
+    assert client._hems_auth_refresh_suppressed_active() is False  # noqa: SLF001
+    client._suppress_hems_auth_refresh_after_success()  # noqa: SLF001
+
+    assert client._hems_auth_refresh_suppressed_active() is True  # noqa: SLF001
+    assert state["suppressed"] == 1
+
+
 def test_safe_response_error_message_handles_header_failures() -> None:
     class BadHeaders:
         def get(self, *_args, **_kwargs):
@@ -1689,6 +1712,50 @@ async def test_json_hems_401_suppresses_repeated_password_refreshes() -> None:
         "GET",
         "https://hems-integration.enphaseenergy.com/api/v1/hems/SITE/hems-devices",
     )
+
+    assert payload == {"ok": True}
+    with pytest.raises(api.Unauthorized):
+        await client._json(
+            "GET",
+            "https://hems-integration.enphaseenergy.com/api/v1/hems/SITE/hems-devices",
+        )
+    reauth.assert_awaited_once_with()
+    assert len(session.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_json_hems_401_suppression_survives_client_state_reset() -> None:
+    session = _FakeSession(
+        [
+            _FakeResponse(status=401, json_body={}),
+            _FakeResponse(status=200, json_body={"ok": True}),
+            _FakeResponse(status=401, json_body={}),
+        ]
+    )
+    client = api.EnphaseEVClient(session, "SITE", None, None)
+    reauth = AsyncMock(return_value=True)
+    suppressed_until: float | None = None
+
+    def _active() -> bool:
+        return (
+            isinstance(suppressed_until, float) and time.monotonic() < suppressed_until
+        )
+
+    def _suppress() -> None:
+        nonlocal suppressed_until
+        suppressed_until = time.monotonic() + 300
+
+    client.set_reauth_callback(reauth)
+    client.set_hems_auth_refresh_suppression_callbacks(
+        active_callback=_active,
+        suppress_callback=_suppress,
+    )
+
+    payload = await client._json(
+        "GET",
+        "https://hems-integration.enphaseenergy.com/api/v1/hems/SITE/hems-devices",
+    )
+    client._hems_auth_refresh_suppressed_until = None  # noqa: SLF001
 
     assert payload == {"ok": True}
     with pytest.raises(api.Unauthorized):

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -3610,12 +3610,21 @@ async def test_handle_client_unauthorized_paths(
 def test_persist_tokens_updates_entry(coordinator_factory, config_entry):
     coord = coordinator_factory()
     coord.config_entry = config_entry
+    object.__setattr__(
+        config_entry,
+        "runtime_data",
+        SimpleNamespace(skip_reload_once=False),
+    )
 
     def _fake_update_entry(entry, *, data=None, options=None):
+        changed = False
         if data is not None:
+            changed = entry.data != data
             object.__setattr__(entry, "data", MappingProxyType(dict(data)))
         if options is not None:
+            changed = changed or entry.options != options
             object.__setattr__(entry, "options", MappingProxyType(dict(options)))
+        return changed
 
     coord.hass.config_entries.async_update_entry = _fake_update_entry  # type: ignore[assignment]
 
@@ -3625,6 +3634,40 @@ def test_persist_tokens_updates_entry(coordinator_factory, config_entry):
     coord._persist_tokens(tokens)
     assert config_entry.data[coord_mod.CONF_COOKIE] == "c"
     assert config_entry.data[coord_mod.CONF_ACCESS_TOKEN] == "t"
+    assert config_entry.runtime_data.skip_reload_once is True
+
+
+def test_persist_tokens_does_not_mark_reload_skip_for_noop_update(
+    coordinator_factory, config_entry
+):
+    coord = coordinator_factory()
+    coord.config_entry = config_entry
+    object.__setattr__(
+        config_entry,
+        "runtime_data",
+        SimpleNamespace(skip_reload_once=False),
+    )
+
+    coord.hass.config_entries.async_update_entry = MagicMock(return_value=False)
+
+    tokens = coord_mod.AuthTokens(
+        cookie="c", session_id="s", access_token="t", token_expires_at=123
+    )
+    coord._persist_tokens(tokens)
+
+    assert config_entry.runtime_data.skip_reload_once is False
+
+
+def test_hems_auth_refresh_suppression_is_coordinator_backed(coordinator_factory):
+    coord = coordinator_factory()
+
+    assert coord._hems_auth_refresh_suppressed_active() is False  # noqa: SLF001
+    coord._suppress_hems_auth_refresh_after_success()  # noqa: SLF001
+
+    assert coord._hems_auth_refresh_suppressed_active() is True  # noqa: SLF001
+    coord._hems_auth_refresh_suppressed_until = time.monotonic() - 1  # noqa: SLF001
+    assert coord._hems_auth_refresh_suppressed_active() is False  # noqa: SLF001
+    assert coord._hems_auth_refresh_suppressed_until is None  # noqa: SLF001
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_coordinator_edge_cases.py
+++ b/tests/components/enphase_ev/test_coordinator_edge_cases.py
@@ -186,6 +186,57 @@ async def test_coordinator_init_handles_bad_scalar_serial_and_legacy_super(
     assert "config_entry" in init_calls[0]
 
 
+@pytest.mark.parametrize("raise_type_error", [False, True])
+def test_coordinator_init_handles_async_hems_suppression_callback_registration(
+    hass, monkeypatch, raise_type_error
+):
+    from custom_components.enphase_ev import coordinator as coord_mod
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    entry = _make_entry(hass)
+    callback_kwargs: dict[str, object] = {}
+    task_calls: list[dict[str, str]] = []
+
+    class Client:
+        def __init__(self, *_args, **_kwargs) -> None:
+            pass
+
+        def set_reauth_callback(self, *_args) -> None:
+            return None
+
+        def set_hems_auth_refresh_suppression_callbacks(self, **kwargs):
+            callback_kwargs.update(kwargs)
+
+            async def _async_result() -> None:
+                return None
+
+            return _async_result()
+
+    def _create_task(coro, **kwargs):
+        task_calls.append(dict(kwargs))
+        if raise_type_error and kwargs:
+            raise TypeError("legacy signature")
+        coro.close()
+        return object()
+
+    monkeypatch.setattr(coord_mod, "EnphaseEVClient", Client)
+    monkeypatch.setattr(hass, "async_create_task", _create_task)
+
+    EnphaseCoordinator(hass, entry.data, config_entry=entry)
+
+    assert callable(callback_kwargs["active_callback"])
+    assert callable(callback_kwargs["suppress_callback"])
+    if raise_type_error:
+        assert task_calls == [
+            {"name": "enphase_ev_set_hems_auth_refresh_suppression_callbacks"},
+            {},
+        ]
+    else:
+        assert task_calls == [
+            {"name": "enphase_ev_set_hems_auth_refresh_suppression_callbacks"}
+        ]
+
+
 def test_collect_site_metrics_handles_unfriendly_datetime(hass):
     from custom_components.enphase_ev.coordinator import EnphaseCoordinator
 
@@ -444,6 +495,29 @@ def test_persist_auth_refresh_suspension_state_stores_field(hass, monkeypatch):
     assert (
         captured[-1][CONF_AUTH_REFRESH_SUSPENDED_UNTIL] == "2026-05-01T12:00:00+00:00"
     )
+
+
+def test_persist_auth_refresh_suspension_state_marks_internal_update(hass, monkeypatch):
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    entry = _make_entry(hass)
+    object.__setattr__(entry, "runtime_data", SimpleNamespace(skip_reload_once=False))
+    coord = _attach_evse_runtime(EnphaseCoordinator.__new__(EnphaseCoordinator))
+    coord.hass = hass
+    coord.config_entry = entry
+    coord._auth_refresh_suspended_until_utc = datetime(
+        2026, 5, 1, 12, 0, tzinfo=timezone.utc
+    )
+
+    def _update_entry(entry_obj, data=None, **kwargs):
+        assert entry_obj is entry
+        return True
+
+    monkeypatch.setattr(hass.config_entries, "async_update_entry", _update_entry)
+
+    coord._persist_auth_refresh_suspension_state()
+
+    assert entry.runtime_data.skip_reload_once is True
 
 
 def test_clear_auth_refresh_rejection_state_resets_counter_and_cooldown(hass):


### PR DESCRIPTION
## Summary
- keep the HEMS auth-refresh suppression window on the coordinator as well as the API client
- wire the API client to coordinator-backed suppression callbacks so the cooldown survives client state resets
- prevent internal token/auth-state persistence from reloading the config entry and clearing runtime cooldown state

## Root Cause
The latest #528 logs still showed repeated HEMS `401` responses causing stored-credential refresh attempts every few seconds. The previous suppression was held on the API client instance, but token persistence/config-entry updates could reload or recreate runtime state and lose that client-local cooldown.

## Validation
- `uvx --with pytest --with pytest-homeassistant-custom-component --with aiohttp --with yarl --with multidict --with freezegun --with respx --with pytest-asyncio pytest -q tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_behavior.py::test_handle_client_unauthorized_refresh tests/components/enphase_ev/test_coordinator_behavior.py::test_handle_client_unauthorized_failure`
- `uvx pre-commit run --files custom_components/enphase_ev/api.py custom_components/enphase_ev/auth_refresh_runtime.py custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/state_models.py tests/components/enphase_ev/test_api_client_methods.py tests/components/enphase_ev/test_coordinator_additional_coverage.py`

Fixes #528.
