### PR TITLE
[codex] Keep config flow imports lazy

### DIFF
--- a/custom_components/enphase_ev/__init__.py
+++ b/custom_components/enphase_ev/__init__.py
@@ -38,11 +38,29 @@ from .entity_cleanup import (
 from .log_redaction import redact_identifier, redact_site_id, redact_text
 from .runtime_data import EnphaseConfigEntry, EnphaseRuntimeData, get_runtime_data
 from .runtime_helpers import coerce_optional_text as _clean_optional_text
-from .services import async_setup_services, async_unload_services
 
 _LOGGER = logging.getLogger(__name__)
 
 CONFIG_SCHEMA = cv.config_entry_only_config_schema(DOMAIN)
+
+
+def async_setup_services(
+    hass: HomeAssistant, *, supports_response: object = SupportsResponse
+) -> None:
+    """Register integration services without importing service schemas at module load."""
+
+    from .services import async_setup_services as setup_services
+
+    setup_services(hass, supports_response=supports_response)
+
+
+def async_unload_services(hass: HomeAssistant) -> None:
+    """Unload integration services without importing service schemas at module load."""
+
+    from .services import async_unload_services as unload_services
+
+    unload_services(hass)
+
 
 PLATFORMS: list[str] = [
     "sensor",

--- a/custom_components/enphase_ev/envoy_history.py
+++ b/custom_components/enphase_ev/envoy_history.py
@@ -4,7 +4,6 @@ from dataclasses import dataclass, field
 import re
 from typing import Any
 
-from homeassistant.components.recorder import statistics as recorder_statistics
 from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import UnitOfEnergy
 from homeassistant.core import HomeAssistant, State
@@ -14,6 +13,25 @@ from homeassistant.helpers import entity_registry as er
 from .const import CONF_SITE_ID, DOMAIN
 from .runtime_data import EnphaseConfigEntry
 
+_recorder_statistics_module: Any | None = None
+
+
+def _load_recorder_statistics() -> Any:
+    global _recorder_statistics_module
+
+    if _recorder_statistics_module is None:
+        from homeassistant.components.recorder import statistics
+
+        _recorder_statistics_module = statistics
+    return _recorder_statistics_module
+
+
+class _RecorderStatisticsProxy:
+    def __getattr__(self, name: str) -> Any:
+        return getattr(_load_recorder_statistics(), name)
+
+
+recorder_statistics: Any = _RecorderStatisticsProxy()
 ENVOY_DOMAIN = "enphase_envoy"
 MIGRATION_FLOWS: tuple[str, ...] = (
     "solar_production",
@@ -214,11 +232,16 @@ def _statistics_unit(metadata: dict[str, Any]) -> object:
     )
 
 
+def _recorder_statistics() -> Any:
+    return recorder_statistics
+
+
 async def _statistics_metadata_by_id(
     hass: HomeAssistant, statistic_ids: set[str]
 ) -> dict[str, dict[str, Any]]:
     if not statistic_ids:
         return {}
+    recorder_statistics = _recorder_statistics()
     try:
         rows = await recorder_statistics.async_list_statistic_ids(
             hass,
@@ -240,6 +263,7 @@ async def _last_statistic_value_kwh(
     factor = _unit_to_kwh_factor(unit)
     if factor is None:
         return None
+    recorder_statistics = _recorder_statistics()
     try:
         result = await hass.async_add_executor_job(
             recorder_statistics.get_last_statistics,

--- a/tests/components/enphase_ev/test_performance_audit_regressions.py
+++ b/tests/components/enphase_ev/test_performance_audit_regressions.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import subprocess
+import sys
 import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
@@ -17,6 +20,38 @@ from custom_components.enphase_ev.const import (
 from custom_components.enphase_ev.session_history import SessionCacheView
 
 from tests.components.enphase_ev.random_ids import RANDOM_SERIAL
+
+
+def test_config_flow_import_keeps_heavy_modules_lazy() -> None:
+    script = """
+import importlib
+import json
+import sys
+
+importlib.import_module("custom_components.enphase_ev.config_flow")
+print(json.dumps({
+    name: name in sys.modules
+    for name in (
+        "custom_components.enphase_ev.config_flow",
+        "custom_components.enphase_ev.services",
+        "homeassistant.components.recorder",
+        "homeassistant.components.recorder.statistics",
+    )
+}))
+"""
+
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+    modules = json.loads(result.stdout)
+
+    assert modules["custom_components.enphase_ev.config_flow"] is True
+    assert modules["custom_components.enphase_ev.services"] is False
+    assert modules["homeassistant.components.recorder"] is False
+    assert modules["homeassistant.components.recorder.statistics"] is False
 
 
 def _prepare_refresh_target(


### PR DESCRIPTION
## Summary
- Keep Enphase service registration helpers available at package scope while lazy-loading the heavy `services` module only when setup/unload actually runs.
- Lazy-load Home Assistant recorder statistics in Envoy history migration helpers through a proxy that preserves the existing monkeypatch surface.
- Add a subprocess regression test that verifies importing `custom_components.enphase_ev.config_flow` does not eagerly import service or recorder modules.

## Testing
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/__init__.py custom_components/enphase_ev/envoy_history.py tests/components/enphase_ev/test_performance_audit_regressions.py"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/__init__.py,custom_components/enphase_ev/envoy_history.py --fail-under=100"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "git config --global --add safe.directory /workspace && python -m pre_commit run --all-files"`
- `docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"`
- `git diff --check`
