### PR TITLE
Prepare release 3.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to this project will be documented in this file.
 
+## v3.0.4 - 2026-05-07
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Hardened HEMS authentication-refresh suppression so follow-up HEMS `401` responses after a successful stored-credential refresh do not trigger repeated password login attempts. (#659)
+
+### 🔧 Improvements
+- Added recent HEMS authentication refresh and suppression state to site diagnostics to make degraded Enphase HEMS responses easier to troubleshoot. (#659)
+- Preferred coordinator-backed heat-pump topology data when available, with local topology fallback only when coordinator buckets are unavailable. (#659)
+- Kept config-flow imports lightweight by lazy-loading service registration and recorder statistics helpers until setup, unload, or Envoy history migration needs them. (#660)
+
+### 🔄 Other changes
+- Bumped `actions/upload-artifact` from `6` to `7` in GitHub Actions. (#658)
+
 ## v3.0.3 - 2026-05-03
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.0.3"
+  "version": "3.0.4"
 }


### PR DESCRIPTION
## Summary

Prepare release 3.0.4 by bumping the integration manifest version and adding changelog coverage for all PRs merged since v3.0.3.

Included merged PRs:
- #658 Bump actions/upload-artifact from 6 to 7
- #659 Harden HEMS auth diagnostics
- #660 Keep config flow imports lazy

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release preparation: manifest version bump and changelog update.

## Testing

```bash
git diff --check
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m json.tool custom_components/enphase_ev/manifest.json >/dev/null && python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_service_translations.py -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Targeted Python coverage was not applicable because this release PR touches only `CHANGELOG.md` and `custom_components/enphase_ev/manifest.json`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed. Not applicable; no supported behavior or setup changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid. Not applicable; no user-facing strings changed.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage. Not applicable; no Python modules changed.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Release-only change for 3.0.4.
