### PR TITLE
Add degraded service diagnostics

### DIFF
--- a/.github/workflows/service-status.yml
+++ b/.github/workflows/service-status.yml
@@ -100,6 +100,12 @@ jobs:
             git -C "${PUBLISH_DIR}" -c user.name="github-actions" -c user.email="github-actions@github.com" \
               commit -m "Update service status"
             git -C "${PUBLISH_DIR}" push origin "${BRANCH}"
+            for path in status_badge.json status.svg; do
+              purge_url="https://purge.jsdelivr.net/gh/${GITHUB_REPOSITORY}@${BRANCH}/${path}"
+              if ! curl -fsS "${purge_url}" >/dev/null; then
+                echo "Warning: failed to purge jsDelivr cache for ${path}"
+              fi
+            done
           fi
 
       - name: Publish wiki page

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,28 @@
 
 All notable changes to this project will be documented in this file.
 
+## v3.0.5 - 2026-05-08
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Added a site-level diagnostic service-status sensor on the Enphase Site device that reports `OK`, `Degraded`, or `Unknown`, lists degraded Enphase service families, and exposes whether the service metrics snapshot is available.
+
+### 🐛 Bug fixes
+- Updated the GitHub service-status badge path to use a low-cache Shields endpoint backed by a purgeable jsDelivr URL so badge updates are not blocked by the raw GitHub SVG cache.
+- Classified broad multi-service Enphase outages as `Down` while keeping explicitly non-impacting checks from forcing outage status unless they are part of a broad-outage endpoint family.
+- Kept the site service-status sensor from reporting `OK` when metrics cannot be collected; it now reports `Unknown`.
+- Attached the site service-status sensor to the Enphase Site device instead of the Enphase Cloud service device.
+
+### 🔧 Improvements
+- Made Home Assistant diagnostics downloads snapshot-only so optional Enphase endpoint prefetches no longer make diagnostics collection wait on degraded services.
+- Included degraded endpoint families in site metrics and system health output.
+- Cached one site service-status metrics snapshot per coordinator update so the sensor state and attributes are derived from the same data.
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `3.0.5`.
+
 ## v3.0.4 - 2026-05-07
 
 ### 🚧 Breaking changes

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 [![Open Issues](https://img.shields.io/github/issues/barneyonline/ha-enphase-energy)](https://github.com/barneyonline/ha-enphase-energy/issues)
 ![Development Status](https://img.shields.io/badge/development-active-success?style=flat-square)
 
-[![Enphase Service Status](https://raw.githubusercontent.com/barneyonline/ha-enphase-energy/service-status/status.svg)](https://github.com/barneyonline/ha-enphase-energy/wiki/Service-Status-History)
+[![Enphase Service Status](https://img.shields.io/endpoint?url=https%3A%2F%2Fcdn.jsdelivr.net%2Fgh%2Fbarneyonline%2Fha-enphase-energy%40service-status%2Fstatus_badge.json&cacheSeconds=60)](https://github.com/barneyonline/ha-enphase-energy/wiki/Service-Status-History)
 
 Cloud-based Home Assistant integration for Enphase Energy systems.
 

--- a/custom_components/enphase_ev/coordinator_diagnostics.py
+++ b/custom_components/enphase_ev/coordinator_diagnostics.py
@@ -875,6 +875,26 @@ class CoordinatorDiagnostics:
         if evse_timeseries is not None:
             metrics["evse_timeseries"] = evse_timeseries.diagnostics()
 
+        def _endpoint_family_degraded(state: object) -> bool:
+            if not isinstance(state, dict):
+                return False
+            try:
+                failures = int(state.get("consecutive_failures") or 0)
+            except (TypeError, ValueError):
+                failures = 0
+            return (
+                bool(state.get("cooldown_active"))
+                or failures > 0
+                or bool(state.get("suppressed"))
+            )
+
+        degraded_endpoint_families = [
+            family
+            for family, state in endpoint_family_health.items()
+            if _endpoint_family_degraded(state)
+        ]
+        metrics["degraded_endpoint_families"] = degraded_endpoint_families
+
         degraded_services = [
             service
             for service, available_key in (
@@ -888,6 +908,11 @@ class CoordinatorDiagnostics:
         ]
         if tariff_service_status == "degraded":
             degraded_services.append(TARIFF_ENDPOINT_FAMILY)
+        degraded_services.extend(
+            family
+            for family in degraded_endpoint_families
+            if family not in degraded_services
+        )
         metrics["degraded_services"] = degraded_services
 
         firmware_catalog_manager = getattr(coord, "firmware_catalog_manager", None)

--- a/custom_components/enphase_ev/device_info_helpers.py
+++ b/custom_components/enphase_ev/device_info_helpers.py
@@ -145,3 +145,24 @@ def _cloud_device_info(site_id: object):
     except Exception:
         return payload
     return DeviceInfo(**payload)
+
+
+def _site_device_info(site_id: object):
+    """Return DeviceInfo for site-level diagnostic entities."""
+    try:
+        site_text = str(site_id).strip()
+    except Exception:
+        site_text = ""
+    if not site_text:
+        site_text = "unknown"
+    payload = {
+        "identifiers": {(DOMAIN, f"site:{site_text}")},
+        "manufacturer": "Enphase",
+        "name": f"Enphase Site {site_text}",
+        "model": "Site",
+    }
+    try:
+        from homeassistant.helpers.entity import DeviceInfo
+    except Exception:
+        return payload
+    return DeviceInfo(**payload)

--- a/custom_components/enphase_ev/diagnostics.py
+++ b/custom_components/enphase_ev/diagnostics.py
@@ -516,33 +516,6 @@ async def async_get_config_entry_diagnostics(
         payload_health = {}
 
     try:
-        ensure_system_dashboard = getattr(
-            coord, "async_ensure_system_dashboard_diagnostics", None
-        )
-        if callable(ensure_system_dashboard):
-            # Device diagnostics may need optional dashboard payloads that are
-            # not fetched during every normal coordinator refresh.
-            await ensure_system_dashboard()
-    except DIAGNOSTIC_CAPTURE_ERRORS:
-        pass
-
-    try:
-        ensure_heatpump_runtime = getattr(
-            coord, "async_ensure_heatpump_runtime_diagnostics", None
-        )
-        if callable(ensure_heatpump_runtime):
-            await ensure_heatpump_runtime()
-    except DIAGNOSTIC_CAPTURE_ERRORS:
-        pass
-
-    try:
-        ensure_ac_battery = getattr(coord, "async_ensure_ac_battery_diagnostics", None)
-        if callable(ensure_ac_battery):
-            await ensure_ac_battery()
-    except DIAGNOSTIC_CAPTURE_ERRORS:
-        pass
-
-    try:
         system_dashboard = coord.system_dashboard_diagnostics()
     except DIAGNOSTIC_CAPTURE_ERRORS:
         system_dashboard = {}
@@ -674,11 +647,14 @@ async def async_get_device_diagnostics(hass, entry, device):
     sn = None
     type_key = None
     type_site_id = None
+    site_device_id = None
     for domain, ident in dev.identifiers:
         if domain != DOMAIN:
             continue
         ident_text = str(ident)
         if ident_text.startswith("site:"):
+            site_device_id = ident_text.removeprefix("site:").strip() or None
+            site_ids = _normalize_site_ids([*site_ids, site_device_id])
             continue
         if ident_text.startswith("type:"):
             parsed = parse_type_identifier(ident_text)
@@ -739,14 +715,6 @@ async def async_get_device_diagnostics(hass, entry, device):
             payload["microinverter_summary"] = _microinverter_summary(payload)
         if type_key in ("envoy", "encharge") and coord is not None:
             system_dashboard_payload = {}
-            ensure_system_dashboard = getattr(
-                coord, "async_ensure_system_dashboard_diagnostics", None
-            )
-            if callable(ensure_system_dashboard):
-                try:
-                    await ensure_system_dashboard()
-                except DIAGNOSTIC_CAPTURE_ERRORS:
-                    pass
             helper = getattr(coord, "system_dashboard_diagnostics", None)
             if callable(helper):
                 try:
@@ -783,14 +751,6 @@ async def async_get_device_diagnostics(hass, entry, device):
             if system_dashboard_payload:
                 payload["system_dashboard_details"] = system_dashboard_payload
         if type_key == "encharge" and coord is not None:
-            ensure_battery_status = getattr(
-                coord, "async_ensure_battery_status_diagnostics", None
-            )
-            if callable(ensure_battery_status):
-                try:
-                    await ensure_battery_status()
-                except DIAGNOSTIC_CAPTURE_ERRORS:
-                    pass
             battery_status_payload = getattr(coord, "battery_status_payload", None)
             if not isinstance(battery_status_payload, dict):
                 battery_status_payload = getattr(coord, "_battery_status_payload", None)
@@ -803,14 +763,6 @@ async def async_get_device_diagnostics(hass, entry, device):
             if battery_status_summary:
                 payload["battery_status_summary"] = battery_status_summary
         if type_key == "ac_battery" and coord is not None:
-            ensure_ac_battery = getattr(
-                coord, "async_ensure_ac_battery_diagnostics", None
-            )
-            if callable(ensure_ac_battery):
-                try:
-                    await ensure_ac_battery()
-                except DIAGNOSTIC_CAPTURE_ERRORS:
-                    pass
             ac_battery_devices_payload = getattr(
                 coord, "_ac_battery_devices_payload", None
             )
@@ -841,14 +793,6 @@ async def async_get_device_diagnostics(hass, entry, device):
             if ac_battery_status_summary:
                 payload["ac_battery_status_summary"] = ac_battery_status_summary
         if type_key == "heatpump" and coord is not None:
-            ensure_heatpump_runtime = getattr(
-                coord, "async_ensure_heatpump_runtime_diagnostics", None
-            )
-            if callable(ensure_heatpump_runtime):
-                try:
-                    await ensure_heatpump_runtime()
-                except DIAGNOSTIC_CAPTURE_ERRORS:
-                    pass
             helper = getattr(coord, "heatpump_runtime_diagnostics", None)
             if callable(helper):
                 try:
@@ -859,6 +803,49 @@ async def async_get_device_diagnostics(hass, entry, device):
                     payload["heatpump_runtime"] = runtime_payload
         return _redact_diagnostics_payload(payload, site_ids=site_ids)
     if not sn:
+        if site_device_id:
+            coord = None
+            try:
+                coord = get_runtime_data(entry).coordinator
+            except RuntimeError:
+                pass
+            metrics: dict[str, Any] = {}
+            metrics_available = False
+            if coord is not None:
+                raw_metrics: object = None
+                try:
+                    raw_metrics = coord.collect_site_metrics()
+                except DIAGNOSTIC_CAPTURE_ERRORS:
+                    pass
+                if isinstance(raw_metrics, dict):
+                    metrics = raw_metrics
+                    metrics_available = True
+                site_ids = _normalize_site_ids(
+                    [
+                        *site_ids,
+                        getattr(coord, "site_id", None),
+                        metrics.get("site_id") if metrics else None,
+                    ]
+                )
+            return _redact_diagnostics_payload(
+                {
+                    "device_kind": "site",
+                    "site_id": site_device_id,
+                    "metrics_available": metrics_available,
+                    "site_metrics": metrics or None,
+                    "serials_count": (
+                        len(getattr(coord, "serials", []) or [])
+                        if coord is not None
+                        else None
+                    ),
+                    "phase_timings": (
+                        getattr(coord, "phase_timings", None)
+                        if coord is not None
+                        else None
+                    ),
+                },
+                site_ids=site_ids,
+            )
         return {"error": "serial_not_resolved"}
     coord = None
     try:

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.0.4"
+  "version": "3.0.5"
 }

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -53,6 +53,7 @@ from .const import (
 from .coordinator import EnphaseCoordinator
 from .device_types import is_dry_contact_type_key, member_is_retired
 from .device_info_helpers import _cloud_device_info
+from .device_info_helpers import _site_device_info
 from .energy import SiteEnergyFlow
 from .entity import (
     EnphaseBaseEntity,
@@ -90,6 +91,7 @@ CLOUD_ERROR_CODE_STATES: tuple[str, ...] = (
     "dns_error",
     "network_error",
 )
+SITE_SERVICE_STATUS_STATES: tuple[str, ...] = ("ok", "degraded", "unknown")
 BATTERY_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = (
     "_charge_level",
     "_status",
@@ -761,6 +763,10 @@ async def async_setup_entry(
         _async_remove_site_sensor_entity("grid_import_power")
         _async_remove_site_sensor_entity("grid_export_power")
         _add_site_entity("site_last_error_code", EnphaseSiteLastErrorCodeSensor(coord))
+        _add_site_entity(
+            "site_service_status",
+            EnphaseSiteServiceStatusSensor(coord),
+        )
         _add_site_entity("site_backoff_ends", EnphaseSiteBackoffEndsSensor(coord))
 
         if gateway_available:
@@ -6711,6 +6717,88 @@ class EnphaseSiteLastErrorCodeSensor(_SiteBaseEntity):
         if info is not None:
             return info
         return _cloud_device_info(self._coord.site_id)
+
+
+class EnphaseSiteServiceStatusSensor(_SiteBaseEntity):
+    _attr_translation_key = "site_service_status"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = list(SITE_SERVICE_STATUS_STATES)
+    _unrecorded_attributes = _SiteBaseEntity._unrecorded_attributes | frozenset(
+        {
+            "degraded_services",
+            "degraded_endpoint_families",
+        }
+    )
+
+    def __init__(self, coord: EnphaseCoordinator):
+        super().__init__(
+            coord,
+            "service_status",
+            "Service Status",
+            type_key=None,
+        )
+        self._metrics_snapshot: dict[str, object] | None = self._read_metrics()
+
+    def _read_metrics(self) -> dict[str, object] | None:
+        collect_site_metrics = getattr(self._coord, "collect_site_metrics", None)
+        if not callable(collect_site_metrics):
+            return None
+        try:
+            metrics = collect_site_metrics()
+        except Exception:  # noqa: BLE001
+            return None
+        return metrics if isinstance(metrics, dict) else None
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        self._metrics_snapshot = self._read_metrics()
+        super()._handle_coordinator_update()
+
+    @staticmethod
+    def _string_list(value: object) -> list[str]:
+        if not isinstance(value, (list, tuple, set)):
+            return []
+        return sorted(
+            text for item in value if (text := _gateway_clean_text(item)) is not None
+        )
+
+    @property
+    def native_value(self):
+        metrics = self._metrics_snapshot
+        if metrics is None:
+            return "unknown"
+        degraded_services = self._string_list(metrics.get("degraded_services"))
+        degraded_endpoint_families = self._string_list(
+            metrics.get("degraded_endpoint_families")
+        )
+        if degraded_services or degraded_endpoint_families:
+            return "degraded"
+        return "ok"
+
+    @property
+    def extra_state_attributes(self):
+        metrics = self._metrics_snapshot
+        metrics_available = metrics is not None
+        if metrics is None:
+            metrics = {}
+        degraded_services = self._string_list(metrics.get("degraded_services"))
+        degraded_endpoint_families = self._string_list(
+            metrics.get("degraded_endpoint_families")
+        )
+        attrs: dict[str, object] = {
+            "degraded_services": degraded_services,
+            "degraded_endpoint_families": degraded_endpoint_families,
+            "degraded_service_count": len(degraded_services),
+            "degraded_endpoint_family_count": len(degraded_endpoint_families),
+            "metrics_available": metrics_available,
+        }
+        attrs.update(self._cloud_diag_attrs())
+        return attrs
+
+    @property
+    def device_info(self):
+        return _site_device_info(self._coord.site_id)
 
 
 class EnphaseSiteBackoffEndsSensor(_SiteBaseEntity):

--- a/custom_components/enphase_ev/strings.json
+++ b/custom_components/enphase_ev/strings.json
@@ -863,6 +863,31 @@
           "network_error": "Network error"
         }
       },
+      "site_service_status": {
+        "name": "Service Status",
+        "state": {
+          "ok": "OK",
+          "degraded": "Degraded",
+          "unknown": "Unknown"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Degraded Services"
+          },
+          "degraded_endpoint_families": {
+            "name": "Degraded Endpoint Families"
+          },
+          "degraded_service_count": {
+            "name": "Degraded Service Count"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Degraded Endpoint Family Count"
+          },
+          "metrics_available": {
+            "name": "Metrics Available"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
         "state": {

--- a/custom_components/enphase_ev/system_health.py
+++ b/custom_components/enphase_ev/system_health.py
@@ -80,6 +80,7 @@ async def system_health_info(hass: HomeAssistant):
         "tariff_failures": primary.get("tariff_failures"),
         "tariff_backoff_active": primary.get("tariff_backoff_active"),
         "tariff_backoff_ends_utc": primary.get("tariff_backoff_ends_utc"),
+        "degraded_endpoint_families": primary.get("degraded_endpoint_families", []),
         "degraded_services": primary.get("degraded_services", []),
         "firmware_catalog_last_fetch_utc": primary.get(
             "firmware_catalog_last_fetch_utc"

--- a/custom_components/enphase_ev/translations/bg.json
+++ b/custom_components/enphase_ev/translations/bg.json
@@ -860,6 +860,31 @@
           "network_error": "Мрежова грешка"
         }
       },
+      "site_service_status": {
+        "name": "Състояние на услугата",
+        "state": {
+          "ok": "В изправност",
+          "unknown": "Неизвестно",
+          "degraded": "Влошено"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Влошени услуги"
+          },
+          "degraded_endpoint_families": {
+            "name": "Влошени групи крайни точки"
+          },
+          "degraded_service_count": {
+            "name": "Брой влошени услуги"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Брой влошени групи крайни точки"
+          },
+          "metrics_available": {
+            "name": "Налични показатели"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud backoff приключва",
         "state": {

--- a/custom_components/enphase_ev/translations/cs.json
+++ b/custom_components/enphase_ev/translations/cs.json
@@ -860,6 +860,31 @@
           "network_error": "Chyba sítě"
         }
       },
+      "site_service_status": {
+        "name": "Stav služby",
+        "state": {
+          "ok": "V pořádku",
+          "unknown": "Neznámý",
+          "degraded": "Snížený výkon"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Služby se sníženým výkonem"
+          },
+          "degraded_endpoint_families": {
+            "name": "Skupiny koncových bodů se sníženým výkonem"
+          },
+          "degraded_service_count": {
+            "name": "Počet služeb se sníženým výkonem"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Počet skupin koncových bodů se sníženým výkonem"
+          },
+          "metrics_available": {
+            "name": "Metriky dostupné"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud backoff končí",
         "state": {

--- a/custom_components/enphase_ev/translations/da.json
+++ b/custom_components/enphase_ev/translations/da.json
@@ -860,6 +860,31 @@
           "network_error": "Netværksfejl"
         }
       },
+      "site_service_status": {
+        "name": "Tjenestestatus",
+        "state": {
+          "ok": "I orden",
+          "unknown": "Ukendt",
+          "degraded": "Forringet"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Forringede tjenester"
+          },
+          "degraded_endpoint_families": {
+            "name": "Forringede endpointfamilier"
+          },
+          "degraded_service_count": {
+            "name": "Antal forringede tjenester"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Antal forringede endpointfamilier"
+          },
+          "metrics_available": {
+            "name": "Metrikker tilgængelige"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud-backoff slutter",
         "state": {

--- a/custom_components/enphase_ev/translations/de.json
+++ b/custom_components/enphase_ev/translations/de.json
@@ -860,6 +860,31 @@
           "network_error": "Netzwerkfehler"
         }
       },
+      "site_service_status": {
+        "name": "Dienststatus",
+        "state": {
+          "ok": "In Ordnung",
+          "unknown": "Unbekannt",
+          "degraded": "Beeinträchtigt"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Beeinträchtigte Dienste"
+          },
+          "degraded_endpoint_families": {
+            "name": "Beeinträchtigte Endpunktfamilien"
+          },
+          "degraded_service_count": {
+            "name": "Anzahl beeinträchtigter Dienste"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Anzahl beeinträchtigter Endpunktfamilien"
+          },
+          "metrics_available": {
+            "name": "Metriken verfügbar"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Ende des Cloud-Backoffs",
         "state": {

--- a/custom_components/enphase_ev/translations/el.json
+++ b/custom_components/enphase_ev/translations/el.json
@@ -860,6 +860,31 @@
           "network_error": "Σφάλμα δικτύου"
         }
       },
+      "site_service_status": {
+        "name": "Κατάσταση υπηρεσίας",
+        "state": {
+          "ok": "Εντάξει",
+          "unknown": "Άγνωστη",
+          "degraded": "Υποβαθμισμένη"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Υποβαθμισμένες υπηρεσίες"
+          },
+          "degraded_endpoint_families": {
+            "name": "Υποβαθμισμένες οικογένειες τελικών σημείων"
+          },
+          "degraded_service_count": {
+            "name": "Πλήθος υποβαθμισμένων υπηρεσιών"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Πλήθος υποβαθμισμένων οικογενειών τελικών σημείων"
+          },
+          "metrics_available": {
+            "name": "Διαθέσιμες μετρήσεις"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Λήξη backoff cloud",
         "state": {

--- a/custom_components/enphase_ev/translations/en-AU.json
+++ b/custom_components/enphase_ev/translations/en-AU.json
@@ -863,6 +863,31 @@
           "network_error": "Network error"
         }
       },
+      "site_service_status": {
+        "name": "Service Status",
+        "state": {
+          "ok": "OK",
+          "unknown": "Unknown",
+          "degraded": "Degraded"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Degraded Services"
+          },
+          "degraded_endpoint_families": {
+            "name": "Degraded Endpoint Families"
+          },
+          "degraded_service_count": {
+            "name": "Degraded Service Count"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Degraded Endpoint Family Count"
+          },
+          "metrics_available": {
+            "name": "Metrics Available"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
         "state": {

--- a/custom_components/enphase_ev/translations/en-CA.json
+++ b/custom_components/enphase_ev/translations/en-CA.json
@@ -863,6 +863,31 @@
           "network_error": "Network error"
         }
       },
+      "site_service_status": {
+        "name": "Service Status",
+        "state": {
+          "ok": "OK",
+          "unknown": "Unknown",
+          "degraded": "Degraded"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Degraded Services"
+          },
+          "degraded_endpoint_families": {
+            "name": "Degraded Endpoint Families"
+          },
+          "degraded_service_count": {
+            "name": "Degraded Service Count"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Degraded Endpoint Family Count"
+          },
+          "metrics_available": {
+            "name": "Metrics Available"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
         "state": {

--- a/custom_components/enphase_ev/translations/en-IE.json
+++ b/custom_components/enphase_ev/translations/en-IE.json
@@ -863,6 +863,31 @@
           "network_error": "Network error"
         }
       },
+      "site_service_status": {
+        "name": "Service Status",
+        "state": {
+          "ok": "OK",
+          "unknown": "Unknown",
+          "degraded": "Degraded"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Degraded Services"
+          },
+          "degraded_endpoint_families": {
+            "name": "Degraded Endpoint Families"
+          },
+          "degraded_service_count": {
+            "name": "Degraded Service Count"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Degraded Endpoint Family Count"
+          },
+          "metrics_available": {
+            "name": "Metrics Available"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
         "state": {

--- a/custom_components/enphase_ev/translations/en-NZ.json
+++ b/custom_components/enphase_ev/translations/en-NZ.json
@@ -863,6 +863,31 @@
           "network_error": "Network error"
         }
       },
+      "site_service_status": {
+        "name": "Service Status",
+        "state": {
+          "ok": "OK",
+          "unknown": "Unknown",
+          "degraded": "Degraded"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Degraded Services"
+          },
+          "degraded_endpoint_families": {
+            "name": "Degraded Endpoint Families"
+          },
+          "degraded_service_count": {
+            "name": "Degraded Service Count"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Degraded Endpoint Family Count"
+          },
+          "metrics_available": {
+            "name": "Metrics Available"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
         "state": {

--- a/custom_components/enphase_ev/translations/en-US.json
+++ b/custom_components/enphase_ev/translations/en-US.json
@@ -863,6 +863,31 @@
           "network_error": "Network error"
         }
       },
+      "site_service_status": {
+        "name": "Service Status",
+        "state": {
+          "ok": "OK",
+          "unknown": "Unknown",
+          "degraded": "Degraded"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Degraded Services"
+          },
+          "degraded_endpoint_families": {
+            "name": "Degraded Endpoint Families"
+          },
+          "degraded_service_count": {
+            "name": "Degraded Service Count"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Degraded Endpoint Family Count"
+          },
+          "metrics_available": {
+            "name": "Metrics Available"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
         "state": {

--- a/custom_components/enphase_ev/translations/en.json
+++ b/custom_components/enphase_ev/translations/en.json
@@ -863,6 +863,31 @@
           "network_error": "Network error"
         }
       },
+      "site_service_status": {
+        "name": "Service Status",
+        "state": {
+          "ok": "OK",
+          "unknown": "Unknown",
+          "degraded": "Degraded"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Degraded Services"
+          },
+          "degraded_endpoint_families": {
+            "name": "Degraded Endpoint Families"
+          },
+          "degraded_service_count": {
+            "name": "Degraded Service Count"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Degraded Endpoint Family Count"
+          },
+          "metrics_available": {
+            "name": "Metrics Available"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff Ends",
         "state": {

--- a/custom_components/enphase_ev/translations/es.json
+++ b/custom_components/enphase_ev/translations/es.json
@@ -860,6 +860,31 @@
           "network_error": "Error de red"
         }
       },
+      "site_service_status": {
+        "name": "Estado del servicio",
+        "state": {
+          "ok": "Correcto",
+          "unknown": "Desconocido",
+          "degraded": "Degradado"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Servicios degradados"
+          },
+          "degraded_endpoint_families": {
+            "name": "Familias de endpoints degradadas"
+          },
+          "degraded_service_count": {
+            "name": "Recuento de servicios degradados"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Recuento de familias de endpoints degradadas"
+          },
+          "metrics_available": {
+            "name": "Métricas disponibles"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Fin del tiempo de espera en la nube",
         "state": {

--- a/custom_components/enphase_ev/translations/et.json
+++ b/custom_components/enphase_ev/translations/et.json
@@ -860,6 +860,31 @@
           "network_error": "Võrgu viga"
         }
       },
+      "site_service_status": {
+        "name": "Teenuse olek",
+        "state": {
+          "ok": "Korras",
+          "unknown": "Teadmata",
+          "degraded": "Halvenenud"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Halvenenud teenused"
+          },
+          "degraded_endpoint_families": {
+            "name": "Halvenenud lõpp-punktide rühmad"
+          },
+          "degraded_service_count": {
+            "name": "Halvenenud teenuste arv"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Halvenenud lõpp-punktide rühmade arv"
+          },
+          "metrics_available": {
+            "name": "Mõõdikud saadaval"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Pilve backoff lõpeb",
         "state": {

--- a/custom_components/enphase_ev/translations/fi.json
+++ b/custom_components/enphase_ev/translations/fi.json
@@ -860,6 +860,31 @@
           "network_error": "Verkkovirhe"
         }
       },
+      "site_service_status": {
+        "name": "Palvelun tila",
+        "state": {
+          "ok": "Kunnossa",
+          "unknown": "Tuntematon",
+          "degraded": "Heikentynyt"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Heikentyneet palvelut"
+          },
+          "degraded_endpoint_families": {
+            "name": "Heikentyneet päätepisteryhmät"
+          },
+          "degraded_service_count": {
+            "name": "Heikentyneiden palvelujen määrä"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Heikentyneiden päätepisteryhmien määrä"
+          },
+          "metrics_available": {
+            "name": "Mittarit saatavilla"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud Backoff päättyy",
         "state": {

--- a/custom_components/enphase_ev/translations/fr.json
+++ b/custom_components/enphase_ev/translations/fr.json
@@ -860,6 +860,31 @@
           "network_error": "Erreur réseau"
         }
       },
+      "site_service_status": {
+        "name": "État du service",
+        "state": {
+          "ok": "Opérationnel",
+          "unknown": "Inconnu",
+          "degraded": "Dégradé"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Services dégradés"
+          },
+          "degraded_endpoint_families": {
+            "name": "Familles de points de terminaison dégradées"
+          },
+          "degraded_service_count": {
+            "name": "Nombre de services dégradés"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Nombre de familles de points de terminaison dégradées"
+          },
+          "metrics_available": {
+            "name": "Métriques disponibles"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Fin du backoff cloud",
         "state": {

--- a/custom_components/enphase_ev/translations/hu.json
+++ b/custom_components/enphase_ev/translations/hu.json
@@ -860,6 +860,31 @@
           "network_error": "Hálózati hiba"
         }
       },
+      "site_service_status": {
+        "name": "Szolgáltatás állapota",
+        "state": {
+          "ok": "Rendben",
+          "unknown": "Ismeretlen",
+          "degraded": "Korlátozott"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Korlátozott szolgáltatások"
+          },
+          "degraded_endpoint_families": {
+            "name": "Korlátozott végpontcsaládok"
+          },
+          "degraded_service_count": {
+            "name": "Korlátozott szolgáltatások száma"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Korlátozott végpontcsaládok száma"
+          },
+          "metrics_available": {
+            "name": "Mérőszámok elérhetők"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud backoff vége",
         "state": {

--- a/custom_components/enphase_ev/translations/it.json
+++ b/custom_components/enphase_ev/translations/it.json
@@ -860,6 +860,31 @@
           "network_error": "Errore di rete"
         }
       },
+      "site_service_status": {
+        "name": "Stato del servizio",
+        "state": {
+          "ok": "Operativo",
+          "unknown": "Sconosciuto",
+          "degraded": "Degradato"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Servizi degradati"
+          },
+          "degraded_endpoint_families": {
+            "name": "Famiglie di endpoint degradate"
+          },
+          "degraded_service_count": {
+            "name": "Conteggio servizi degradati"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Conteggio famiglie di endpoint degradate"
+          },
+          "metrics_available": {
+            "name": "Metriche disponibili"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Fine backoff cloud",
         "state": {

--- a/custom_components/enphase_ev/translations/lt.json
+++ b/custom_components/enphase_ev/translations/lt.json
@@ -860,6 +860,31 @@
           "network_error": "Tinklo klaida"
         }
       },
+      "site_service_status": {
+        "name": "Paslaugos būsena",
+        "state": {
+          "ok": "Gerai",
+          "unknown": "Nežinoma",
+          "degraded": "Suprastėjusi"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Suprastėjusios paslaugos"
+          },
+          "degraded_endpoint_families": {
+            "name": "Suprastėjusios galinių taškų grupės"
+          },
+          "degraded_service_count": {
+            "name": "Suprastėjusių paslaugų skaičius"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Suprastėjusių galinių taškų grupių skaičius"
+          },
+          "metrics_available": {
+            "name": "Metrikos pasiekiamos"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Debesies backoff pabaiga",
         "state": {

--- a/custom_components/enphase_ev/translations/lv.json
+++ b/custom_components/enphase_ev/translations/lv.json
@@ -860,6 +860,31 @@
           "network_error": "Tīkla kļūda"
         }
       },
+      "site_service_status": {
+        "name": "Pakalpojuma statuss",
+        "state": {
+          "ok": "Labi",
+          "unknown": "Nezināms",
+          "degraded": "Pasliktināts"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Pasliktināti pakalpojumi"
+          },
+          "degraded_endpoint_families": {
+            "name": "Pasliktinātas galapunktu grupas"
+          },
+          "degraded_service_count": {
+            "name": "Pasliktināto pakalpojumu skaits"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Pasliktināto galapunktu grupu skaits"
+          },
+          "metrics_available": {
+            "name": "Metrikas pieejamas"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Mākoņa backoff beidzas",
         "state": {

--- a/custom_components/enphase_ev/translations/nb-NO.json
+++ b/custom_components/enphase_ev/translations/nb-NO.json
@@ -860,6 +860,31 @@
           "network_error": "Nettverksfeil"
         }
       },
+      "site_service_status": {
+        "name": "Tjenestestatus",
+        "state": {
+          "ok": "I orden",
+          "unknown": "Ukjent",
+          "degraded": "Degradert"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Degraderte tjenester"
+          },
+          "degraded_endpoint_families": {
+            "name": "Degraderte endepunktfamilier"
+          },
+          "degraded_service_count": {
+            "name": "Antall degraderte tjenester"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Antall degraderte endepunktfamilier"
+          },
+          "metrics_available": {
+            "name": "Målinger tilgjengelige"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Sky-backoff slutter",
         "state": {

--- a/custom_components/enphase_ev/translations/nl.json
+++ b/custom_components/enphase_ev/translations/nl.json
@@ -860,6 +860,31 @@
           "network_error": "Netwerkfout"
         }
       },
+      "site_service_status": {
+        "name": "Servicestatus",
+        "state": {
+          "ok": "In orde",
+          "unknown": "Onbekend",
+          "degraded": "Verminderd"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Verminderde services"
+          },
+          "degraded_endpoint_families": {
+            "name": "Verminderde endpointfamilies"
+          },
+          "degraded_service_count": {
+            "name": "Aantal verminderde services"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Aantal verminderde endpointfamilies"
+          },
+          "metrics_available": {
+            "name": "Metrieken beschikbaar"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud-backoff eindigt",
         "state": {

--- a/custom_components/enphase_ev/translations/pl.json
+++ b/custom_components/enphase_ev/translations/pl.json
@@ -860,6 +860,31 @@
           "network_error": "Błąd sieci"
         }
       },
+      "site_service_status": {
+        "name": "Stan usługi",
+        "state": {
+          "ok": "Działa",
+          "unknown": "Nieznany",
+          "degraded": "Zdegradowany"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Zdegradowane usługi"
+          },
+          "degraded_endpoint_families": {
+            "name": "Zdegradowane rodziny punktów końcowych"
+          },
+          "degraded_service_count": {
+            "name": "Liczba zdegradowanych usług"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Liczba zdegradowanych rodzin punktów końcowych"
+          },
+          "metrics_available": {
+            "name": "Metryki dostępne"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Koniec backoff chmury",
         "state": {

--- a/custom_components/enphase_ev/translations/pt-BR.json
+++ b/custom_components/enphase_ev/translations/pt-BR.json
@@ -860,6 +860,31 @@
           "network_error": "Erro de rede"
         }
       },
+      "site_service_status": {
+        "name": "Status do serviço",
+        "state": {
+          "ok": "Operacional",
+          "unknown": "Desconhecido",
+          "degraded": "Degradado"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Serviços degradados"
+          },
+          "degraded_endpoint_families": {
+            "name": "Famílias de endpoints degradadas"
+          },
+          "degraded_service_count": {
+            "name": "Contagem de serviços degradados"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Contagem de famílias de endpoints degradadas"
+          },
+          "metrics_available": {
+            "name": "Métricas disponíveis"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Fim do tempo de espera da nuvem",
         "state": {

--- a/custom_components/enphase_ev/translations/ro.json
+++ b/custom_components/enphase_ev/translations/ro.json
@@ -860,6 +860,31 @@
           "network_error": "Eroare de rețea"
         }
       },
+      "site_service_status": {
+        "name": "Starea serviciului",
+        "state": {
+          "ok": "Funcțional",
+          "unknown": "Necunoscut",
+          "degraded": "Degradat"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Servicii degradate"
+          },
+          "degraded_endpoint_families": {
+            "name": "Familii de endpointuri degradate"
+          },
+          "degraded_service_count": {
+            "name": "Număr servicii degradate"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Număr familii de endpointuri degradate"
+          },
+          "metrics_available": {
+            "name": "Metrici disponibile"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Backoff cloud se încheie",
         "state": {

--- a/custom_components/enphase_ev/translations/sv-SE.json
+++ b/custom_components/enphase_ev/translations/sv-SE.json
@@ -860,6 +860,31 @@
           "network_error": "Nätverksfel"
         }
       },
+      "site_service_status": {
+        "name": "Tjänstestatus",
+        "state": {
+          "ok": "Fungerar",
+          "unknown": "Okänd",
+          "degraded": "Försämrad"
+        },
+        "state_attributes": {
+          "degraded_services": {
+            "name": "Försämrade tjänster"
+          },
+          "degraded_endpoint_families": {
+            "name": "Försämrade slutpunktsfamiljer"
+          },
+          "degraded_service_count": {
+            "name": "Antal försämrade tjänster"
+          },
+          "degraded_endpoint_family_count": {
+            "name": "Antal försämrade slutpunktsfamiljer"
+          },
+          "metrics_available": {
+            "name": "Mätvärden tillgängliga"
+          }
+        }
+      },
       "cloud_backoff_ends": {
         "name": "Cloud-backoff slutar",
         "state": {

--- a/scripts/service_status.py
+++ b/scripts/service_status.py
@@ -28,6 +28,21 @@ DEFAULT_WIKI_PAGE = "Service-Status-History.md"
 MIN_VISIBLE_INCIDENT_MINUTES = 60
 MAX_INCIDENT_SAMPLE_GAP_MINUTES = 90
 DEFAULT_REPOSITORY = "barneyonline/ha-enphase-energy"
+DOWN_FAILED_AFFECTING_CHECK_THRESHOLD = 2
+BROAD_OUTAGE_FAILED_CHECK_THRESHOLD = 3
+BROAD_OUTAGE_ENDPOINT_CATEGORIES = frozenset(
+    {
+        "battery_config",
+        "battery_runtime",
+        "evse_management",
+        "evse_timeseries",
+        "hems",
+        "inventory",
+        "microinverters",
+        "site_live",
+        "system_dashboard",
+    }
+)
 
 
 @dataclass(frozen=True)
@@ -41,6 +56,7 @@ class EndpointSpec:
     form: dict[str, Any] | None = None
     json_body: Any | None = None
     affects_status: bool = True
+    affects_broad_outage: bool | None = None
     check_group: str | None = None
     check_mode: str = "all"  # "all" or "any"
     ok_statuses: tuple[int, ...] = (200,)
@@ -150,6 +166,15 @@ def _badge_svg(label: str, value: str, color: str) -> str:
         f'<text x="{value_x}" y="14">{value}</text>'
         f"</g></svg>"
     )
+
+
+def _shields_badge_payload(label: str, value: str, color: str) -> dict[str, Any]:
+    return {
+        "schemaVersion": 1,
+        "label": label,
+        "message": value,
+        "color": color,
+    }
 
 
 def _decode_jwt_payload(token: str) -> dict[str, Any] | None:
@@ -368,8 +393,6 @@ def _first_device_uid(payload: Any, *, type_tokens: tuple[str, ...]) -> str | No
 
     tokens = tuple(token.lower() for token in type_tokens)
     for item in _walk_payload(payload):
-        if not isinstance(item, dict):
-            continue
         type_candidates = [
             item.get("type"),
             item.get("device_type"),
@@ -455,6 +478,11 @@ def _endpoint_result(
     ok = status in ok_statuses if status is not None else False
     if ok:
         error = None
+    affects_broad_outage = (
+        spec.affects_broad_outage
+        if spec.affects_broad_outage is not None
+        else spec.affects_status or spec.category in BROAD_OUTAGE_ENDPOINT_CATEGORIES
+    )
 
     return {
         "name": spec.name,
@@ -468,6 +496,7 @@ def _endpoint_result(
         "check_group": spec.check_group or spec.category,
         "check_mode": spec.check_mode,
         "affects_status": spec.affects_status,
+        "affects_broad_outage": affects_broad_outage,
     }
 
 
@@ -483,6 +512,9 @@ def _evaluate_status(results: list[dict[str, Any]]) -> tuple[str, dict[str, Any]
                 "group": item.get("group"),
                 "category": item.get("category") or key,
                 "affects": bool(item.get("affects_status", True)),
+                "affects_broad_outage": bool(
+                    item.get("affects_broad_outage", item.get("affects_status", True))
+                ),
                 "endpoints": [],
             }
             groups[key] = entry
@@ -490,6 +522,11 @@ def _evaluate_status(results: list[dict[str, Any]]) -> tuple[str, dict[str, Any]
             entry["group"] = _merge_status_group(entry.get("group"), item.get("group"))
             entry["affects"] = bool(entry.get("affects")) or bool(
                 item.get("affects_status", True)
+            )
+            entry["affects_broad_outage"] = bool(
+                entry.get("affects_broad_outage")
+            ) or bool(
+                item.get("affects_broad_outage", item.get("affects_status", True))
             )
         entry["endpoints"].append(item)
 
@@ -507,18 +544,28 @@ def _evaluate_status(results: list[dict[str, Any]]) -> tuple[str, dict[str, Any]
                 "category": entry["category"],
                 "ok": ok,
                 "affects": entry["affects"],
+                "affects_broad_outage": entry["affects_broad_outage"],
                 "endpoints": [ep["name"] for ep in entry["endpoints"]],
             }
         )
 
+    failed_checks = [c for c in checks if not c["ok"]]
     affecting = [c for c in checks if c["affects"]]
+    failed_affecting = [c for c in affecting if not c["ok"]]
     all_down = bool(affecting) and all(not c["ok"] for c in affecting)
-    main_down = any(c["group"] == "main" and not c["ok"] for c in affecting)
-    degraded_down = any(
-        c["group"] in ("degraded", "other") and not c["ok"] for c in affecting
+    main_down = any(c["group"] == "main" for c in failed_affecting)
+    degraded_down = any(c["group"] in ("degraded", "other") for c in failed_affecting)
+    multiple_affecting_down = (
+        len(failed_affecting) >= DOWN_FAILED_AFFECTING_CHECK_THRESHOLD
+    )
+    failed_broad_outage_checks = [
+        c for c in failed_checks if c.get("affects_broad_outage")
+    ]
+    broad_outage = (
+        len(failed_broad_outage_checks) >= BROAD_OUTAGE_FAILED_CHECK_THRESHOLD
     )
 
-    if main_down or all_down:
+    if main_down or all_down or multiple_affecting_down or broad_outage:
         status = "Down"
     elif degraded_down:
         status = "Degraded"
@@ -532,6 +579,9 @@ def _evaluate_status(results: list[dict[str, Any]]) -> tuple[str, dict[str, Any]
         "endpoints_total": len(results),
         "endpoints_ok": sum(1 for r in results if r["ok"]),
         "endpoints_failed": sum(1 for r in results if not r["ok"]),
+        "checks_failed_affecting": len(failed_affecting),
+        "checks_failed_non_affecting": len(failed_checks) - len(failed_affecting),
+        "checks_failed_broad_outage": len(failed_broad_outage_checks),
     }
     return status, {"checks": checks, "summary": summary}
 
@@ -964,6 +1014,14 @@ def _write_outputs(
     }
     svg = _badge_svg("Enphase Service Status", status, color_map.get(status, "#9f9f9f"))
     (output_path / "status.svg").write_text(f"{svg}\n", encoding="utf-8")
+    _write_json_file(
+        output_path / "status_badge.json",
+        _shields_badge_payload(
+            "Enphase Service Status",
+            status,
+            color_map.get(status, "#9f9f9f"),
+        ),
+    )
 
     history_samples = _build_history_samples(
         _load_history_samples(previous_history_file),
@@ -1794,9 +1852,6 @@ def main() -> int:
                 )
             ):
                 hems_supported = True
-        elif spec.name == "hems_devices":
-            hems_devices_body = body
-
     if hems_supported:
         hems_devices_spec = EndpointSpec(
             name="hems_devices",

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -273,7 +273,48 @@ def test_tariff_endpoint_family_failure_reports_degraded_service(
     assert metrics["tariff_last_error"] == "Tariff payload did not include data"
     assert metrics["tariff_backoff_active"] is True
     assert metrics["tariff_backoff_ends_utc"] == tariff_health["next_retry_utc"]
+    assert metrics["degraded_endpoint_families"] == ["tariff"]
     assert "tariff" in metrics["degraded_services"]
+
+
+def test_battery_endpoint_family_failure_reports_degraded_service(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    monkeypatch.setattr(coord_mod.random, "uniform", lambda _a, _b: 1.0)
+
+    err = OptionalEndpointUnavailable("battery status temporarily unavailable")
+
+    assert (
+        coord._note_endpoint_family_failure("battery_status", err) is True
+    )  # noqa: SLF001
+
+    metrics = coord.collect_site_metrics()
+    assert metrics["degraded_endpoint_families"] == ["battery_status"]
+    assert "battery_status" in metrics["degraded_services"]
+
+
+def test_degraded_endpoint_family_rollup_tolerates_unexpected_health(
+    coordinator_factory, monkeypatch
+) -> None:
+    coord = coordinator_factory()
+    monkeypatch.setattr(
+        coord.diagnostics,
+        "endpoint_family_health_diagnostics",
+        lambda: {
+            "invalid": object(),
+            "suppressed": {
+                "consecutive_failures": "bad",
+                "cooldown_active": False,
+                "suppressed": True,
+            },
+        },
+    )
+
+    metrics = coord.collect_site_metrics()
+
+    assert metrics["degraded_endpoint_families"] == ["suppressed"]
+    assert "suppressed" in metrics["degraded_services"]
 
 
 def test_endpoint_family_misc_branches_and_diagnostics(

--- a/tests/components/enphase_ev/test_device_info.py
+++ b/tests/components/enphase_ev/test_device_info.py
@@ -154,6 +154,28 @@ def test_cloud_device_info_handles_bad_site_id_str():
     assert info["identifiers"] == {("enphase_ev", "type:unknown:cloud")}
 
 
+def test_site_device_info_uses_site_identifier():
+    from custom_components.enphase_ev.device_info_helpers import _site_device_info
+
+    info = _site_device_info("12345")
+    assert info["identifiers"] == {("enphase_ev", "site:12345")}
+    assert info["name"] == "Enphase Site 12345"
+    assert info["model"] == "Site"
+
+
+def test_site_device_info_handles_blank_and_bad_site_id():
+    from custom_components.enphase_ev.device_info_helpers import _site_device_info
+
+    class BadStr:
+        def __str__(self) -> str:
+            raise ValueError("boom")
+
+    assert _site_device_info("   ")["identifiers"] == {("enphase_ev", "site:unknown")}
+    assert _site_device_info(BadStr())["identifiers"] == {
+        ("enphase_ev", "site:unknown")
+    }
+
+
 def test_device_info_helpers_imports_without_home_assistant(monkeypatch):
     import builtins
     import importlib
@@ -173,6 +195,8 @@ def test_device_info_helpers_imports_without_home_assistant(monkeypatch):
     info = helpers._cloud_device_info("12345")
     assert info["identifiers"] == {("enphase_ev", "type:12345:cloud")}
     assert info["name"] == "Enphase Cloud"
+    site_info = helpers._site_device_info("12345")
+    assert site_info["identifiers"] == {("enphase_ev", "site:12345")}
 
 
 def test_evse_display_name_normalization_and_model_deduping() -> None:

--- a/tests/components/enphase_ev/test_diagnostics.py
+++ b/tests/components/enphase_ev/test_diagnostics.py
@@ -1183,7 +1183,7 @@ async def test_config_entry_diagnostics_handles_system_dashboard_capture_error(
 
 
 @pytest.mark.asyncio
-async def test_config_entry_diagnostics_fetches_system_dashboard_lazily(
+async def test_config_entry_diagnostics_uses_cached_system_dashboard_only(
     hass, config_entry
 ) -> None:
     coord = DummyCoordinator()
@@ -1192,12 +1192,12 @@ async def test_config_entry_diagnostics_fetches_system_dashboard_lazily(
 
     diag = await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
 
-    coord.async_ensure_system_dashboard_diagnostics.assert_awaited_once()
+    coord.async_ensure_system_dashboard_diagnostics.assert_not_awaited()
     assert "system_dashboard" in diag["coordinator"]
 
 
 @pytest.mark.asyncio
-async def test_config_entry_diagnostics_ignores_dashboard_prefetch_failure(
+async def test_config_entry_diagnostics_does_not_prefetch_dashboard(
     hass, config_entry
 ) -> None:
     coord = DummyCoordinator()
@@ -1208,7 +1208,7 @@ async def test_config_entry_diagnostics_ignores_dashboard_prefetch_failure(
 
     diag = await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
 
-    coord.async_ensure_system_dashboard_diagnostics.assert_awaited_once()
+    coord.async_ensure_system_dashboard_diagnostics.assert_not_awaited()
     assert "system_dashboard" in diag["coordinator"]
 
 
@@ -1321,14 +1321,92 @@ async def test_device_diagnostics_returns_snapshot(hass, config_entry) -> None:
 
 
 @pytest.mark.asyncio
-async def test_device_diagnostics_handles_missing_serial(hass, config_entry) -> None:
-    """If a device has no serial identifier, report the error."""
+async def test_device_diagnostics_returns_site_snapshot(hass, config_entry) -> None:
+    """Site devices should return redacted site diagnostics instead of a serial error."""
     coord = DummyCoordinator()
     config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
     dev_reg = dr.async_get(hass)
     device = dev_reg.async_get_or_create(
         config_entry_id=config_entry.entry_id,
         identifiers={(DOMAIN, f"site:{RANDOM_SITE_ID}")},
+        manufacturer="Enphase",
+    )
+
+    result = await diagnostics.async_get_device_diagnostics(hass, config_entry, device)
+    assert result["device_kind"] == "site"
+    assert result["site_id"] == "**REDACTED**"
+    assert result["metrics_available"] is True
+    assert result["site_metrics"]["site_id"] == "**REDACTED**"
+    assert result["site_metrics"]["last_failure_endpoint"] == (
+        "/service/evse_controller/[site]/ev_chargers/status"
+    )
+    assert result["serials_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_device_diagnostics_returns_site_snapshot_without_runtime_data(
+    hass, config_entry, monkeypatch
+) -> None:
+    """Site device diagnostics should still be useful before runtime data is attached."""
+    monkeypatch.setattr(
+        diagnostics,
+        "get_runtime_data",
+        lambda _entry: (_ for _ in ()).throw(RuntimeError("missing runtime")),
+    )
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"site:{RANDOM_SITE_ID}")},
+        manufacturer="Enphase",
+    )
+
+    result = await diagnostics.async_get_device_diagnostics(hass, config_entry, device)
+    assert result["device_kind"] == "site"
+    assert result["site_id"] == "**REDACTED**"
+    assert result["metrics_available"] is False
+    assert result["site_metrics"] is None
+    assert result["serials_count"] is None
+
+
+@pytest.mark.asyncio
+async def test_device_diagnostics_returns_site_snapshot_when_metrics_fail(
+    hass, config_entry, monkeypatch
+) -> None:
+    """Site device diagnostics should not fail when metrics capture fails."""
+
+    class RaisingCoordinator(DummyCoordinator):
+        def collect_site_metrics(self):
+            raise RuntimeError("boom")
+
+    coord = RaisingCoordinator()
+    monkeypatch.setattr(
+        diagnostics,
+        "get_runtime_data",
+        lambda _entry: SimpleNamespace(coordinator=coord),
+    )
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={(DOMAIN, f"site:{RANDOM_SITE_ID}")},
+        manufacturer="Enphase",
+    )
+
+    result = await diagnostics.async_get_device_diagnostics(hass, config_entry, device)
+    assert result["device_kind"] == "site"
+    assert result["metrics_available"] is False
+    assert result["site_metrics"] is None
+    assert result["serials_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_device_diagnostics_handles_missing_serial(hass, config_entry) -> None:
+    """If a non-site device has no serial identifier, report the error."""
+    coord = DummyCoordinator()
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+    dev_reg = dr.async_get(hass)
+    device = dev_reg.async_get_or_create(
+        config_entry_id=config_entry.entry_id,
+        identifiers={("other_domain", "site-without-enphase-identifier")},
         manufacturer="Enphase",
     )
 
@@ -1565,6 +1643,35 @@ async def test_config_entry_diagnostics_ac_battery_capture_errors_are_swallowed(
 
 
 @pytest.mark.asyncio
+async def test_config_entry_diagnostics_skips_optional_type_prefetch(
+    hass, config_entry
+) -> None:
+    coord = DummyCoordinator()
+    coord._selected_type_keys = {"envoy", "encharge"}  # noqa: SLF001
+    coord.inventory_view = SimpleNamespace(
+        has_type_for_entities=lambda type_key: False,
+        iter_type_keys=lambda: ["envoy", "encharge"],
+        type_bucket=lambda type_key: None,
+    )
+    coord._ac_battery_devices_payload = None  # noqa: SLF001
+    coord._ac_battery_telemetry_payloads = None  # noqa: SLF001
+    coord._ac_battery_events_payloads = None  # noqa: SLF001
+    coord._heatpump_runtime_state = None  # noqa: SLF001
+    coord._heatpump_daily_consumption = None  # noqa: SLF001
+    coord._show_livestream_payload = None  # noqa: SLF001
+    coord._heatpump_events_payloads = []  # noqa: SLF001
+    coord._heatpump_power_snapshot = None  # noqa: SLF001
+    coord.async_ensure_ac_battery_diagnostics = AsyncMock()
+    coord.async_ensure_heatpump_runtime_diagnostics = AsyncMock()
+    config_entry.runtime_data = EnphaseRuntimeData(coordinator=coord)
+
+    await diagnostics.async_get_config_entry_diagnostics(hass, config_entry)
+
+    coord.async_ensure_ac_battery_diagnostics.assert_not_awaited()
+    coord.async_ensure_heatpump_runtime_diagnostics.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_device_diagnostics_heatpump_runtime_errors_are_swallowed(
     hass, config_entry
 ) -> None:
@@ -1596,6 +1703,7 @@ async def test_device_diagnostics_heatpump_runtime_errors_are_swallowed(
 
     result = await diagnostics.async_get_device_diagnostics(hass, config_entry, device)
 
+    coord.async_ensure_heatpump_runtime_diagnostics.assert_not_awaited()
     assert "heatpump_runtime" not in result
 
 
@@ -1628,6 +1736,7 @@ async def test_device_diagnostics_ac_battery_capture_errors_are_swallowed(
 
     result = await diagnostics.async_get_device_diagnostics(hass, config_entry, device)
 
+    coord.async_ensure_ac_battery_diagnostics.assert_not_awaited()
     assert result["type_key"] == "ac_battery"
     assert result["ac_battery_status_summary"]["aggregate_status"] == "warning"
 
@@ -1828,8 +1937,8 @@ async def test_device_diagnostics_encharge_includes_system_dashboard_details(
     )
 
     result = await diagnostics.async_get_device_diagnostics(hass, config_entry, device)
-    coord.async_ensure_system_dashboard_diagnostics.assert_awaited_once()
-    coord.async_ensure_battery_status_diagnostics.assert_awaited_once()
+    coord.async_ensure_system_dashboard_diagnostics.assert_not_awaited()
+    coord.async_ensure_battery_status_diagnostics.assert_not_awaited()
     assert result["system_dashboard_details"]["connectivity"]["rssi"] == -61
     assert result["system_dashboard_details"]["software"]["app_version"] == "1.2.3"
     assert result["system_dashboard_details"]["operation_mode"]["mode"] == "backup"
@@ -1850,7 +1959,7 @@ async def test_device_diagnostics_encharge_includes_system_dashboard_details(
 
 
 @pytest.mark.asyncio
-async def test_device_diagnostics_encharge_ignores_battery_status_prefetch_failure(
+async def test_device_diagnostics_encharge_does_not_prefetch_battery_status(
     hass, config_entry
 ) -> None:
     coord = DummyCoordinator()
@@ -1881,13 +1990,14 @@ async def test_device_diagnostics_encharge_ignores_battery_status_prefetch_failu
 
     result = await diagnostics.async_get_device_diagnostics(hass, config_entry, device)
 
-    coord.async_ensure_battery_status_diagnostics.assert_awaited_once()
+    coord.async_ensure_system_dashboard_diagnostics.assert_not_awaited()
+    coord.async_ensure_battery_status_diagnostics.assert_not_awaited()
     assert "battery_status_payload" not in result
     assert "battery_status_summary" not in result
 
 
 @pytest.mark.asyncio
-async def test_device_diagnostics_ignores_dashboard_prefetch_failure(
+async def test_device_diagnostics_does_not_prefetch_dashboard(
     hass, config_entry
 ) -> None:
     coord = DummyCoordinator()
@@ -1915,7 +2025,7 @@ async def test_device_diagnostics_ignores_dashboard_prefetch_failure(
 
     result = await diagnostics.async_get_device_diagnostics(hass, config_entry, device)
 
-    coord.async_ensure_system_dashboard_diagnostics.assert_awaited_once()
+    coord.async_ensure_system_dashboard_diagnostics.assert_not_awaited()
     assert result["type_key"] == "envoy"
 
 

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.const import UnitOfEnergy
+from homeassistant.helpers.entity import EntityCategory
 
 from custom_components.enphase_ev import sensor as sensor_mod
 from custom_components.enphase_ev.runtime_data import EnphaseRuntimeData
@@ -5267,6 +5268,7 @@ def test_cloud_sensor_device_info_falls_back_to_default_cloud_device(
         EnphaseSiteBackoffEndsSensor,
         EnphaseSiteEnergySensor,
         EnphaseSiteLastErrorCodeSensor,
+        EnphaseSiteServiceStatusSensor,
     )
 
     coord = coordinator_factory(serials=[])
@@ -5291,13 +5293,16 @@ def test_cloud_sensor_device_info_falls_back_to_default_cloud_device(
     current_power = EnphaseCurrentPowerConsumptionSensor(coord)
     latency = EnphaseCloudLatencySensor(coord)
     last_error = EnphaseSiteLastErrorCodeSensor(coord)
+    service_status = EnphaseSiteServiceStatusSensor(coord)
     backoff = EnphaseSiteBackoffEndsSensor(coord)
 
     expected_identifiers = {("enphase_ev", f"type:{coord.site_id}:cloud")}
+    expected_site_identifiers = {("enphase_ev", f"site:{coord.site_id}")}
     assert site_energy.device_info["identifiers"] == expected_identifiers
     assert current_power.device_info["identifiers"] == expected_identifiers
     assert latency.device_info["identifiers"] == expected_identifiers
     assert last_error.device_info["identifiers"] == expected_identifiers
+    assert service_status.device_info["identifiers"] == expected_site_identifiers
     assert backoff.device_info["identifiers"] == expected_identifiers
 
 
@@ -5370,6 +5375,7 @@ async def test_async_setup_entry_adds_cloud_site_entities_without_envoy_type(
         EnphaseCurrentPowerConsumptionSensor,
         EnphaseSiteBackoffEndsSensor,
         EnphaseSiteLastErrorCodeSensor,
+        EnphaseSiteServiceStatusSensor,
         EnphaseSiteLastUpdateSensor,
         async_setup_entry,
     )
@@ -5399,7 +5405,132 @@ async def test_async_setup_entry_adds_cloud_site_entities_without_envoy_type(
     assert any(isinstance(ent, EnphaseCloudLatencySensor) for ent in added)
     assert any(isinstance(ent, EnphaseCurrentPowerConsumptionSensor) for ent in added)
     assert any(isinstance(ent, EnphaseSiteLastErrorCodeSensor) for ent in added)
+    assert any(isinstance(ent, EnphaseSiteServiceStatusSensor) for ent in added)
     assert any(isinstance(ent, EnphaseSiteBackoffEndsSensor) for ent in added)
+
+
+def test_site_service_status_sensor_reports_degraded_services(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseSiteServiceStatusSensor
+
+    coord = coordinator_factory(serials=[])
+    coord.collect_site_metrics = lambda: {
+        "degraded_services": ["site_energy", "battery_status"],
+        "degraded_endpoint_families": ["battery_status"],
+    }
+    sensor = EnphaseSiteServiceStatusSensor(coord)
+
+    assert sensor.native_value == "degraded"
+    assert sensor.entity_category is EntityCategory.DIAGNOSTIC
+    attrs = sensor.extra_state_attributes
+    assert attrs["degraded_services"] == ["battery_status", "site_energy"]
+    assert attrs["degraded_endpoint_families"] == ["battery_status"]
+    assert attrs["degraded_service_count"] == 2
+    assert attrs["degraded_endpoint_family_count"] == 1
+    assert attrs["metrics_available"] is True
+
+
+def test_site_service_status_sensor_reports_unknown_for_invalid_metrics(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseSiteServiceStatusSensor
+
+    coord = coordinator_factory(serials=[])
+    coord.collect_site_metrics = lambda: "bad"
+    sensor = EnphaseSiteServiceStatusSensor(coord)
+
+    assert sensor.native_value == "unknown"
+    assert sensor.extra_state_attributes["degraded_services"] == []
+    assert sensor.extra_state_attributes["metrics_available"] is False
+
+
+def test_site_service_status_sensor_reports_ok_without_degraded_services(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseSiteServiceStatusSensor
+
+    coord = coordinator_factory(serials=[])
+    coord.collect_site_metrics = lambda: {
+        "degraded_services": [],
+        "degraded_endpoint_families": None,
+    }
+    sensor = EnphaseSiteServiceStatusSensor(coord)
+
+    assert sensor.native_value == "ok"
+    assert sensor.extra_state_attributes["degraded_services"] == []
+
+
+def test_site_service_status_sensor_handles_metrics_errors(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseSiteServiceStatusSensor
+
+    coord = coordinator_factory(serials=[])
+
+    def _raise_metrics():
+        raise RuntimeError("boom")
+
+    coord.collect_site_metrics = _raise_metrics
+    sensor = EnphaseSiteServiceStatusSensor(coord)
+
+    assert sensor.native_value == "unknown"
+    assert sensor.extra_state_attributes["degraded_endpoint_families"] == []
+    assert sensor.extra_state_attributes["metrics_available"] is False
+
+
+def test_site_service_status_sensor_handles_missing_metrics_callback(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseSiteServiceStatusSensor
+
+    coord = coordinator_factory(serials=[])
+    coord.collect_site_metrics = None
+    sensor = EnphaseSiteServiceStatusSensor(coord)
+
+    assert sensor.native_value == "unknown"
+
+
+def test_site_service_status_sensor_reuses_cached_metrics_snapshot(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseSiteServiceStatusSensor
+
+    coord = coordinator_factory(serials=[])
+    calls = 0
+
+    def _metrics():
+        nonlocal calls
+        calls += 1
+        return {"degraded_services": ["site_energy"]}
+
+    coord.collect_site_metrics = _metrics
+    sensor = EnphaseSiteServiceStatusSensor(coord)
+
+    assert sensor.native_value == "degraded"
+    assert sensor.extra_state_attributes["degraded_services"] == ["site_energy"]
+    assert calls == 1
+
+
+def test_site_service_status_sensor_refreshes_snapshot_on_coordinator_update(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseSiteServiceStatusSensor
+
+    coord = coordinator_factory(serials=[])
+    degraded = False
+
+    def _metrics():
+        return {"degraded_services": ["site_energy"] if degraded else []}
+
+    coord.collect_site_metrics = _metrics
+    sensor = EnphaseSiteServiceStatusSensor(coord)
+    sensor.async_write_ha_state = lambda: None
+
+    assert sensor.native_value == "ok"
+    degraded = True
+    sensor._handle_coordinator_update()
+    assert sensor.native_value == "degraded"
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_service_translations.py
+++ b/tests/components/enphase_ev/test_service_translations.py
@@ -142,6 +142,49 @@ def test_cloud_error_code_states_exist_for_all_locales() -> None:
             ), f"{name} should localize issues.rate_limited.title"
 
 
+def test_site_service_status_states_exist_for_all_locales() -> None:
+    """Ensure the site service-status diagnostic sensor can be translated."""
+
+    from custom_components.enphase_ev.sensor import SITE_SERVICE_STATUS_STATES
+
+    root = (
+        pathlib.Path(__file__).resolve().parents[3] / "custom_components" / "enphase_ev"
+    )
+    translations_dir = root / "translations"
+    paths = [
+        "entity.sensor.site_service_status.name",
+        "entity.sensor.site_service_status.state.ok",
+        "entity.sensor.site_service_status.state.degraded",
+        "entity.sensor.site_service_status.state.unknown",
+        "entity.sensor.site_service_status.state_attributes.degraded_services.name",
+        "entity.sensor.site_service_status.state_attributes.degraded_endpoint_families.name",
+        "entity.sensor.site_service_status.state_attributes.degraded_service_count.name",
+        "entity.sensor.site_service_status.state_attributes.degraded_endpoint_family_count.name",
+        "entity.sensor.site_service_status.state_attributes.metrics_available.name",
+    ]
+    strings_data = json.loads((root / "strings.json").read_text(encoding="utf-8"))
+    en_data = json.loads((translations_dir / "en.json").read_text(encoding="utf-8"))
+    assert set(strings_data["entity"]["sensor"]["site_service_status"]["state"]) == set(
+        SITE_SERVICE_STATUS_STATES
+    )
+    for path in paths:
+        value = _at_path(strings_data, path)
+        assert value.strip(), f"strings.json missing value for {path}"
+    for locale in translations_dir.glob("*.json"):
+        name = locale.name
+        data = json.loads(locale.read_text(encoding="utf-8"))
+        assert set(data["entity"]["sensor"]["site_service_status"]["state"]) == set(
+            SITE_SERVICE_STATUS_STATES
+        ), f"{name} site service-status states differ from sensor options"
+        for path in paths:
+            value = _at_path(data, path)
+            assert value.strip(), f"{name} missing value for {path}"
+            if name != "en.json" and not name.startswith("en-"):
+                assert value != _at_path(
+                    en_data, path
+                ), f"{name} should localize {path} (still matches English)"
+
+
 def _at_path(data: dict, path: str) -> str:
     cur = data
     for part in path.split("."):

--- a/tests/components/enphase_ev/test_system_health.py
+++ b/tests/components/enphase_ev/test_system_health.py
@@ -69,6 +69,7 @@ async def test_system_health_info_reports_state(
         "tariff_failures": 1,
         "tariff_backoff_active": True,
         "tariff_backoff_ends_utc": "2026-04-26T01:00:00+00:00",
+        "degraded_endpoint_families": ["tariff"],
         "degraded_services": ["tariff"],
     }
 
@@ -104,6 +105,7 @@ async def test_system_health_info_reports_state(
     assert info["tariff_failures"] == 1
     assert info["tariff_backoff_active"] is True
     assert info["tariff_backoff_ends_utc"] == "2026-04-26T01:00:00+00:00"
+    assert info["degraded_endpoint_families"] == ["tariff"]
     assert info["degraded_services"] == ["tariff"]
 
 

--- a/tests/scripts/test_service_status.py
+++ b/tests/scripts/test_service_status.py
@@ -256,6 +256,38 @@ def test_render_mermaid_timeline_anchors_to_30_day_window(
     assert "section Window" not in content
 
 
+def test_nested_payload_and_timeline_helpers(
+    service_status_module, monkeypatch
+) -> None:
+    payload = {
+        "devices": [
+            "bad",
+            {"type": "heat_pump", "device_uid": "HP-1"},
+            {"device_type": "iq_er", "uid": "ER-1"},
+        ]
+    }
+
+    assert (
+        service_status_module._first_device_uid(
+            payload, type_tokens=("heat_pump", "heatpump")
+        )
+        == "HP-1"
+    )
+    assert service_status_module._first_device_uid({}, type_tokens=("missing",)) is None
+    assert service_status_module._extract_summary_hems_flag("bad") is None
+    assert service_status_module._extract_summary_hems_flag({"is_hems": True}) is True
+
+    window_start, window_end = service_status_module._timeline_window(checked_at="bad")
+    assert window_start < window_end
+
+    monkeypatch.setattr(service_status_module, "DEFAULT_HISTORY_DAYS", -1)
+    window_start, window_end = service_status_module._timeline_window(
+        checked_at="2026-03-18T23:23:31Z"
+    )
+    assert window_start == "2026-03-18T22:23:31"
+    assert window_end == "2026-03-18T23:23:31"
+
+
 def test_write_outputs_generates_status_history_and_wiki(
     service_status_module, tmp_path: Path
 ) -> None:
@@ -296,6 +328,13 @@ def test_write_outputs_generates_status_history_and_wiki(
     wiki_text = (tmp_path / "out" / "wiki" / "Service-Status-History.md").read_text()
 
     assert (tmp_path / "out" / "status.svg").exists()
+    badge_payload = json.loads((tmp_path / "out" / "status_badge.json").read_text())
+    assert badge_payload == {
+        "schemaVersion": 1,
+        "label": "Enphase Service Status",
+        "message": "Fully Operational",
+        "color": "#4c1",
+    }
     assert history_payload["samples"][-1]["checked_at"] == "2026-03-07T08:00:00Z"
     assert incidents_payload["incidents"][0]["status"] == "Degraded"
     assert "Current status.json" in wiki_text
@@ -593,6 +632,23 @@ def test_endpoint_result_and_status_evaluation(service_status_module) -> None:
     assert (
         endpoint["url"] == "/service/{site_id}/{serial}?site={site_id}&serial={serial}"
     )
+    optional_spec = service_status_module.EndpointSpec(
+        name="battery_status",
+        method="GET",
+        url="https://example.invalid/app-api/SITE/battery_status.json",
+        group="degraded",
+        category="battery_runtime",
+        affects_status=False,
+    )
+    optional_endpoint = service_status_module._endpoint_result(
+        optional_spec,
+        500,
+        "HTTP 500",
+        site_id="SITE",
+        serial="SERIAL",
+    )
+    assert optional_endpoint["affects_status"] is False
+    assert optional_endpoint["affects_broad_outage"] is True
 
     status, details = service_status_module._evaluate_status(
         [
@@ -616,6 +672,179 @@ def test_endpoint_result_and_status_evaluation(service_status_module) -> None:
     )
     assert status == "Down"
     assert details["summary"]["checks_failed"] == 1
+    assert details["summary"]["checks_failed_affecting"] == 1
+
+
+def test_evaluate_status_escalates_multiple_degraded_failures(
+    service_status_module,
+) -> None:
+    status, details = service_status_module._evaluate_status(
+        [
+            {
+                "name": "site_energy",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "auth_settings",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "charger_status",
+                "group": "main",
+                "ok": True,
+                "affects_status": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+        ]
+    )
+
+    assert status == "Down"
+    assert details["summary"]["checks_failed"] == 2
+    assert details["summary"]["checks_failed_affecting"] == 2
+
+
+def test_evaluate_status_escalates_broad_non_affecting_outage(
+    service_status_module,
+) -> None:
+    status, details = service_status_module._evaluate_status(
+        [
+            {
+                "name": "charger_status",
+                "group": "main",
+                "ok": True,
+                "affects_status": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "battery_config",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": False,
+                "affects_broad_outage": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "battery_runtime",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": False,
+                "affects_broad_outage": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "microinverters",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": False,
+                "affects_broad_outage": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+        ]
+    )
+
+    assert status == "Down"
+    assert details["summary"]["checks_failed"] == 3
+    assert details["summary"]["checks_failed_affecting"] == 0
+    assert details["summary"]["checks_failed_non_affecting"] == 3
+    assert details["summary"]["checks_failed_broad_outage"] == 3
+
+
+def test_evaluate_status_ignores_non_affecting_non_broad_outage_failures(
+    service_status_module,
+) -> None:
+    status, details = service_status_module._evaluate_status(
+        [
+            {
+                "name": "charger_status",
+                "group": "main",
+                "ok": True,
+                "affects_status": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "optional_a",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": False,
+                "affects_broad_outage": False,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "optional_b",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": False,
+                "affects_broad_outage": False,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "optional_c",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": False,
+                "affects_broad_outage": False,
+                "check_group": None,
+                "check_mode": "all",
+            },
+        ]
+    )
+
+    assert status == "Fully Operational"
+    assert details["summary"]["checks_failed"] == 3
+    assert details["summary"]["checks_failed_broad_outage"] == 0
+
+
+def test_evaluate_status_keeps_single_degraded_failure_degraded(
+    service_status_module,
+) -> None:
+    status, details = service_status_module._evaluate_status(
+        [
+            {
+                "name": "site_energy",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "battery_config",
+                "group": "degraded",
+                "ok": False,
+                "affects_status": False,
+                "check_group": None,
+                "check_mode": "all",
+            },
+            {
+                "name": "charger_status",
+                "group": "main",
+                "ok": True,
+                "affects_status": True,
+                "check_group": None,
+                "check_mode": "all",
+            },
+        ]
+    )
+
+    assert status == "Degraded"
+    assert details["summary"]["checks_failed"] == 2
+    assert details["summary"]["checks_failed_affecting"] == 1
 
 
 def test_render_table_unknown_gap_and_incident_duration_default(
@@ -1030,3 +1259,79 @@ def test_main_success_generates_history_and_wiki(
         not in wiki_text
     )
     assert "raw.example.invalid/service-status/history.json" in wiki_text
+
+
+def test_main_checks_hems_endpoints_when_inventory_reports_hems(
+    service_status_module, tmp_path: Path, monkeypatch
+) -> None:
+    token = _jwt({"user_id": "user-1", "session_id": "session-1"})
+    seen_urls: list[str] = []
+
+    monkeypatch.setenv("ENPHASE_EMAIL", "user@example.com")
+    monkeypatch.setenv("ENPHASE_PASSWORD", "secret")
+    monkeypatch.setenv("ENPHASE_SITE_ID", "SITE")
+    monkeypatch.setenv("ENPHASE_SERIAL", "SERIAL")
+    monkeypatch.setattr(
+        service_status_module,
+        "_cookie_header_for",
+        lambda url, jar: (
+            f"XSRF-TOKEN=xsrf-token; enlighten_manager_token_production={token}"
+            if "enlighten" in url
+            else ""
+        ),
+    )
+
+    def fake_request(opener, method, url, **kwargs):  # noqa: ARG001
+        seen_urls.append(url)
+        if url == service_status_module.LOGIN_URL:
+            return 200, {}, b'{"session_id":"session-1","success":true}', None
+        if url == f"{service_status_module.ENTREZ_URL}/tokens":
+            return 200, {}, json.dumps({"token": token}).encode("utf-8"), None
+        if url.endswith("/ev_chargers/status"):
+            return 200, {}, b'{"evChargerData":[{"serial":"SERIAL"}]}', None
+        if url.endswith("/devices.json"):
+            return 200, {}, b'{"devices":[{"kind":"hems"}]}', None
+        if "/system_dashboard/api_internal/cs/sites/" in url:
+            return 500, {}, b"{}", "HTTP 500"
+        if "hems-devices" in url:
+            return (
+                200,
+                {},
+                json.dumps(
+                    {
+                        "devices": [
+                            {"type": "heat_pump", "device_uid": "HP-1"},
+                            {"device_type": "iq_er", "uid": "ER-1"},
+                        ]
+                    }
+                ).encode("utf-8"),
+                None,
+            )
+        return 200, {}, b"{}", None
+
+    monkeypatch.setattr(service_status_module, "_request", fake_request)
+
+    argv = [
+        "service_status.py",
+        "--output-dir",
+        str(tmp_path / "out"),
+    ]
+    old_argv = sys.argv
+    sys.argv = argv
+    try:
+        result = service_status_module.main()
+    finally:
+        sys.argv = old_argv
+
+    status_payload = json.loads((tmp_path / "out" / "status.json").read_text())
+    endpoint_names = {endpoint["name"] for endpoint in status_payload["endpoints"]}
+
+    assert result == 0
+    assert status_payload["status"] == "Fully Operational"
+    assert "hems_devices" in endpoint_names
+    assert "hems_heatpump_state" in endpoint_names
+    assert "hems_power_timeseries" in endpoint_names
+    assert "heat_pump_events" in endpoint_names
+    assert "iq_er_events" in endpoint_names
+    assert any("hems_consumption_lifetime" in url for url in seen_urls)
+    assert any("energy-consumption" in url for url in seen_urls)


### PR DESCRIPTION
## Summary

Adds a site-level diagnostic service-status sensor for Enphase sites and expands degraded-service reporting so Home Assistant diagnostics, system health, and the GitHub service-status badge better reflect partial Enphase outages.

The change also makes Home Assistant diagnostics snapshot-only, avoiding slow optional endpoint prefetches while Enphase services are degraded, and moves the README badge to a low-cache Shields endpoint backed by a purgeable jsDelivr URL.

## Related Issues

Related to degraded Enphase service availability and slow diagnostics downloads discussed in local diagnostics review.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [x] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [x] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check . && black custom_components/enphase_ev tests/components/enphase_ev scripts/service_status.py tests/scripts/test_service_status.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator_diagnostics.py,custom_components/enphase_ev/diagnostics.py,custom_components/enphase_ev/system_health.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/device_info_helpers.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/service_status.coverage python -m coverage erase && COVERAGE_FILE=/tmp/service_status.coverage python -m coverage run -m pytest tests/scripts/test_service_status.py -q && COVERAGE_FILE=/tmp/service_status.coverage python -m coverage report -m --include=scripts/service_status.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py --validate-remote-brands"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/importtime_profile.py --strict-integration-warnings --output importtime-enphase-ev.log"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pip install mypy && mypy --strict --ignore-missing-imports --follow-imports=skip custom_components/enphase_ev/runtime_data.py custom_components/enphase_ev/config_flow.py"
```

Results: full test suite passed with 3301 tests. Targeted coverage remained 100% for the touched integration modules and `scripts/service_status.py`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- The new site service-status diagnostic sensor reports `ok`, `degraded`, or `unknown` and exposes degraded service families in attributes.
- Site-device diagnostics now return a redacted site metrics snapshot instead of `serial_not_resolved`.
- Diagnostics collection no longer waits on optional Enphase endpoint prefetches.
- The service-status badge now reads `status_badge.json` through Shields/jsDelivr and the workflow purges jsDelivr after status branch updates.
