### PR TITLE
Attach service status to cloud device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## v3.0.6 - 2026-05-08
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Attached the site service-status diagnostic sensor to the Enphase Cloud device instead of creating a separate Enphase Site device.
+
+### 🔧 Improvements
+- Added state-aware icons for the site service-status diagnostic sensor.
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `3.0.6`.
+
 ## v3.0.5 - 2026-05-08
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/device_info_helpers.py
+++ b/custom_components/enphase_ev/device_info_helpers.py
@@ -145,24 +145,3 @@ def _cloud_device_info(site_id: object):
     except Exception:
         return payload
     return DeviceInfo(**payload)
-
-
-def _site_device_info(site_id: object):
-    """Return DeviceInfo for site-level diagnostic entities."""
-    try:
-        site_text = str(site_id).strip()
-    except Exception:
-        site_text = ""
-    if not site_text:
-        site_text = "unknown"
-    payload = {
-        "identifiers": {(DOMAIN, f"site:{site_text}")},
-        "manufacturer": "Enphase",
-        "name": f"Enphase Site {site_text}",
-        "model": "Site",
-    }
-    try:
-        from homeassistant.helpers.entity import DeviceInfo
-    except Exception:
-        return payload
-    return DeviceInfo(**payload)

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.0.5"
+  "version": "3.0.6"
 }

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -53,7 +53,6 @@ from .const import (
 from .coordinator import EnphaseCoordinator
 from .device_types import is_dry_contact_type_key, member_is_retired
 from .device_info_helpers import _cloud_device_info
-from .device_info_helpers import _site_device_info
 from .energy import SiteEnergyFlow
 from .entity import (
     EnphaseBaseEntity,
@@ -6777,6 +6776,14 @@ class EnphaseSiteServiceStatusSensor(_SiteBaseEntity):
         return "ok"
 
     @property
+    def icon(self):
+        if self.native_value == "degraded":
+            return "mdi:cloud-alert"
+        if self.native_value == "unknown":
+            return "mdi:cloud-question"
+        return "mdi:cloud-check"
+
+    @property
     def extra_state_attributes(self):
         metrics = self._metrics_snapshot
         metrics_available = metrics is not None
@@ -6798,7 +6805,10 @@ class EnphaseSiteServiceStatusSensor(_SiteBaseEntity):
 
     @property
     def device_info(self):
-        return _site_device_info(self._coord.site_id)
+        info = _type_device_info(self._coord, "cloud")
+        if info is not None:
+            return info
+        return _cloud_device_info(self._coord.site_id)
 
 
 class EnphaseSiteBackoffEndsSensor(_SiteBaseEntity):

--- a/tests/components/enphase_ev/test_device_info.py
+++ b/tests/components/enphase_ev/test_device_info.py
@@ -154,28 +154,6 @@ def test_cloud_device_info_handles_bad_site_id_str():
     assert info["identifiers"] == {("enphase_ev", "type:unknown:cloud")}
 
 
-def test_site_device_info_uses_site_identifier():
-    from custom_components.enphase_ev.device_info_helpers import _site_device_info
-
-    info = _site_device_info("12345")
-    assert info["identifiers"] == {("enphase_ev", "site:12345")}
-    assert info["name"] == "Enphase Site 12345"
-    assert info["model"] == "Site"
-
-
-def test_site_device_info_handles_blank_and_bad_site_id():
-    from custom_components.enphase_ev.device_info_helpers import _site_device_info
-
-    class BadStr:
-        def __str__(self) -> str:
-            raise ValueError("boom")
-
-    assert _site_device_info("   ")["identifiers"] == {("enphase_ev", "site:unknown")}
-    assert _site_device_info(BadStr())["identifiers"] == {
-        ("enphase_ev", "site:unknown")
-    }
-
-
 def test_device_info_helpers_imports_without_home_assistant(monkeypatch):
     import builtins
     import importlib
@@ -195,8 +173,6 @@ def test_device_info_helpers_imports_without_home_assistant(monkeypatch):
     info = helpers._cloud_device_info("12345")
     assert info["identifiers"] == {("enphase_ev", "type:12345:cloud")}
     assert info["name"] == "Enphase Cloud"
-    site_info = helpers._site_device_info("12345")
-    assert site_info["identifiers"] == {("enphase_ev", "site:12345")}
 
 
 def test_evse_display_name_normalization_and_model_deduping() -> None:

--- a/tests/components/enphase_ev/test_sensor_additional_coverage.py
+++ b/tests/components/enphase_ev/test_sensor_additional_coverage.py
@@ -5297,12 +5297,11 @@ def test_cloud_sensor_device_info_falls_back_to_default_cloud_device(
     backoff = EnphaseSiteBackoffEndsSensor(coord)
 
     expected_identifiers = {("enphase_ev", f"type:{coord.site_id}:cloud")}
-    expected_site_identifiers = {("enphase_ev", f"site:{coord.site_id}")}
     assert site_energy.device_info["identifiers"] == expected_identifiers
     assert current_power.device_info["identifiers"] == expected_identifiers
     assert latency.device_info["identifiers"] == expected_identifiers
     assert last_error.device_info["identifiers"] == expected_identifiers
-    assert service_status.device_info["identifiers"] == expected_site_identifiers
+    assert service_status.device_info["identifiers"] == expected_identifiers
     assert backoff.device_info["identifiers"] == expected_identifiers
 
 
@@ -5422,6 +5421,7 @@ def test_site_service_status_sensor_reports_degraded_services(
     sensor = EnphaseSiteServiceStatusSensor(coord)
 
     assert sensor.native_value == "degraded"
+    assert sensor.icon == "mdi:cloud-alert"
     assert sensor.entity_category is EntityCategory.DIAGNOSTIC
     attrs = sensor.extra_state_attributes
     assert attrs["degraded_services"] == ["battery_status", "site_energy"]
@@ -5441,6 +5441,7 @@ def test_site_service_status_sensor_reports_unknown_for_invalid_metrics(
     sensor = EnphaseSiteServiceStatusSensor(coord)
 
     assert sensor.native_value == "unknown"
+    assert sensor.icon == "mdi:cloud-question"
     assert sensor.extra_state_attributes["degraded_services"] == []
     assert sensor.extra_state_attributes["metrics_available"] is False
 
@@ -5458,6 +5459,7 @@ def test_site_service_status_sensor_reports_ok_without_degraded_services(
     sensor = EnphaseSiteServiceStatusSensor(coord)
 
     assert sensor.native_value == "ok"
+    assert sensor.icon == "mdi:cloud-check"
     assert sensor.extra_state_attributes["degraded_services"] == []
 
 


### PR DESCRIPTION
## Summary

Fixes the v3.0.5 site service-status diagnostic sensor so it attaches to the existing Enphase Cloud device instead of creating a separate Enphase Site device.

Also adds state-aware icons for the Service Status sensor and bumps the integration manifest to `3.0.6`.

## Related Issues

Follow-up to #664.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check . && black custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev_306.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev_306.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev_306.coverage python -m coverage report -m --include=custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/device_info_helpers.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_service_translations.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

Results: full test suite passed with `3299 passed`. Targeted coverage stayed at 100% for `sensor.py` and `device_info_helpers.py`.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Service Status now uses the Enphase Cloud device info path, matching the other cloud diagnostic entities.
- Removed the now-unused site-level device helper.
- Service Status icon is state-aware: cloud-check, cloud-alert, or cloud-question.
