### PR TITLE
Prepare release 3.0.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,6 @@ on:
   push:
     branches:
       - main
-      - 'release/**'
     paths:
       - 'custom_components/**'
       - 'tests/components/enphase_ev/**'

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -26,7 +26,6 @@ on:
   push:
     branches:
       - main
-      - "release/**"
     paths:
       - "custom_components/enphase_ev/**/*.py"
       - "custom_components/enphase_ev/**/*.yaml"

--- a/.github/workflows/hassfest.yml
+++ b/.github/workflows/hassfest.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - main
-      - "release/**"
     paths:
       - "custom_components/**"
       - "quality_scale.yaml"

--- a/.github/workflows/quality-scale.yml
+++ b/.github/workflows/quality-scale.yml
@@ -19,7 +19,6 @@ on:
   push:
     branches:
       - main
-      - "release/**"
     paths:
       - "custom_components/enphase_ev/**"
       - "tests/components/enphase_ev/**"

--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - 'release/**'
   pull_request:
   schedule:
     - cron: "0 0 * * *"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## v3.0.6 - 2026-05-08
+## v3.0.7 - 2026-05-09
 
 ### 🚧 Breaking changes
 - None
@@ -11,14 +11,29 @@ All notable changes to this project will be documented in this file.
 - Added a `clear_hems_auth_backoff` service to clear the Heat Pump/HEMS-only auth backoff without performing password login.
 
 ### 🐛 Bug fixes
-- Attached the site service-status diagnostic sensor to the Enphase Cloud device instead of creating a separate Enphase Site device.
 - Isolated Heat Pump/HEMS auth failures behind a HEMS-only circuit breaker so they no longer trigger global stored-password refresh attempts or stop wallbox/battery polling. (#528)
 
 ### 🔧 Improvements
-- Added state-aware icons for the site service-status diagnostic sensor.
 - Added HEMS auth backoff diagnostics and a repair issue that explains how to pause or retry Heat Pump/HEMS polling. (#528)
 - Reduced baseline Enphase cloud request volume by lengthening low-volatility HEMS inventory, heat-pump state, Storm Alert, device inventory, and inverter production refresh windows. (#667)
 - Replaced the one-shot internal reload skip with counted reload suppression so token/cooldown persistence cannot recreate the coordinator during auth recovery.
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `3.0.7`.
+
+## v3.0.6 - 2026-05-08
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Attached the site service-status diagnostic sensor to the Enphase Cloud device instead of creating a separate Enphase Site device.
+
+### 🔧 Improvements
+- Added state-aware icons for the site service-status diagnostic sensor.
 
 ### 🔄 Other changes
 - Bumped the integration manifest version to `3.0.6`.

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.0.6"
+  "version": "3.0.7"
 }


### PR DESCRIPTION
## Summary

Prepare the 3.0.7 release by bumping the integration manifest version and adding changelog coverage for the changes merged since v3.0.6.

Prevent duplicate release-branch CI runs by limiting push-triggered validation workflows to `main`. Release branches are already covered by `pull_request` workflows, so this avoids running the same checks once for the branch push and again for the PR event.

## Related Issues

- #528
- #667

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release preparation and CI workflow maintenance.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m json.tool custom_components/enphase_ev/manifest.json >/tmp/enphase_manifest.json && python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python - <<'PY'
from pathlib import Path
import yaml
for path in sorted(Path('.github/workflows').glob('*.y*ml')):
    with path.open() as file:
        yaml.safe_load(file)
    print(path)
PY"
```

Targeted coverage was not run locally because the release prep does not change Python modules. The updated PR-side `targeted-coverage` check passed in GitHub Actions.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [x] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Observed duplicate runs on the first PR commit because `release/**` branches matched both `push` workflows and `pull_request` workflows. After removing `release/**` from the push triggers, the next commit only started PR-event validation runs for the release branch.
