### PR TITLE
Fix auth block retry handling

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -2996,17 +2996,6 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         fallback_data = context.fallback_data
         first_refresh = context.first_refresh
 
-        if self.site_only or not self.serials:
-            return await self._async_run_site_only_refresh_pipeline(context)
-
-        # Handle backoff window
-        if self._backoff_until and time.monotonic() < self._backoff_until:
-            retry_after = max(0.0, self._backoff_until - time.monotonic())
-            raise UpdateFailed(
-                "In backoff due to rate limiting or server errors",
-                retry_after=retry_after,
-            )
-
         if self._auth_block_active():
             self._last_error = "auth_blocked"
             self.last_failure_utc = dt_util.utcnow()
@@ -3019,7 +3008,18 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self._http_errors = 0
             self._payload_errors = 0
             self.diagnostics.create_auth_block_issue()
-            raise ConfigEntryAuthFailed(self.last_failure_description)
+            raise self._auth_block_update_failed()
+
+        if self.site_only or not self.serials:
+            return await self._async_run_site_only_refresh_pipeline(context)
+
+        # Handle backoff window
+        if self._backoff_until and time.monotonic() < self._backoff_until:
+            retry_after = max(0.0, self._backoff_until - time.monotonic())
+            raise UpdateFailed(
+                "In backoff due to rate limiting or server errors",
+                retry_after=retry_after,
+            )
 
         if first_refresh:
             self._start_first_refresh_followups(context)
@@ -3045,9 +3045,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             raise
         except Unauthorized as err:
             if self._activate_auth_block_from_login_wall(err):
-                raise ConfigEntryAuthFailed(
-                    self._blocked_auth_failure_message()
-                ) from err
+                raise self._auth_block_update_failed() from err
             raise ConfigEntryAuthFailed from err
         except OptionalEndpointUnavailable as err:
             reason = (str(err) or "EVSE status endpoint unavailable").strip()
@@ -5073,6 +5071,25 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             )
         return "Enphase authentication is temporarily blocked; retry later."
 
+    def _auth_block_retry_after_s(self) -> int | None:
+        """Return remaining auth-block seconds for coordinator retry scheduling."""
+
+        blocked_until = getattr(self, "_auth_blocked_until_utc", None)
+        if not isinstance(blocked_until, datetime):
+            return None
+        remaining = (blocked_until - dt_util.utcnow()).total_seconds()
+        if remaining <= 0:
+            return None
+        return max(1, int(remaining + 0.999))
+
+    def _auth_block_update_failed(self) -> UpdateFailed:
+        """Return a recoverable update failure while Enphase auth is blocked."""
+
+        return UpdateFailed(
+            self._blocked_auth_failure_message(),
+            retry_after=self._auth_block_retry_after_s(),
+        )
+
     async def _attempt_auto_refresh(self) -> bool:
         """Attempt to refresh authentication using stored credentials.
 
@@ -5123,7 +5140,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
         if self._auth_block_active():
             self.diagnostics.create_auth_block_issue()
-            raise ConfigEntryAuthFailed(self._blocked_auth_failure_message())
+            raise self._auth_block_update_failed()
 
         if self._unauth_errors >= 2:
             self.diagnostics.create_reauth_issue()

--- a/custom_components/enphase_ev/refresh_runner.py
+++ b/custom_components/enphase_ev/refresh_runner.py
@@ -86,9 +86,7 @@ class RefreshRunner:
             raise
         except EnphaseLoginWallUnauthorized as err:
             if self._coordinator._activate_auth_block_from_login_wall(err):
-                raise ConfigEntryAuthFailed(
-                    self._coordinator._blocked_auth_failure_message()
-                ) from err
+                raise self._coordinator._auth_block_update_failed() from err
             raise ConfigEntryAuthFailed from err
         except ConfigEntryAuthFailed:
             raise

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -2105,7 +2105,7 @@ async def test_handle_client_unauthorized_failure(monkeypatch, hass):
 async def test_handle_client_unauthorized_reports_auth_block_when_active(
     monkeypatch, hass
 ):
-    from homeassistant.exceptions import ConfigEntryAuthFailed
+    from homeassistant.helpers.update_coordinator import UpdateFailed
     from custom_components.enphase_ev import coordinator_diagnostics as diag_mod
 
     coord = _make_coordinator(hass, monkeypatch)
@@ -2128,7 +2128,7 @@ async def test_handle_client_unauthorized_reports_auth_block_when_active(
         raising=False,
     )
 
-    with pytest.raises(ConfigEntryAuthFailed, match="blocked"):
+    with pytest.raises(UpdateFailed, match="blocked"):
         await coord._handle_client_unauthorized()
 
     assert [issue_id for issue_id, _payload in created] == ["auth_blocked"]
@@ -2138,7 +2138,7 @@ async def test_handle_client_unauthorized_reports_auth_block_when_active(
 async def test_handle_client_unauthorized_reports_too_many_sessions_issue(
     monkeypatch, hass
 ):
-    from homeassistant.exceptions import ConfigEntryAuthFailed
+    from homeassistant.helpers.update_coordinator import UpdateFailed
     from custom_components.enphase_ev import coordinator_diagnostics as diag_mod
 
     coord = _make_coordinator(hass, monkeypatch)
@@ -2163,7 +2163,7 @@ async def test_handle_client_unauthorized_reports_too_many_sessions_issue(
         raising=False,
     )
 
-    with pytest.raises(ConfigEntryAuthFailed, match="blocked"):
+    with pytest.raises(UpdateFailed, match="blocked"):
         await coord._handle_client_unauthorized()
 
     assert [issue_id for issue_id, _payload in created] == ["too_many_active_sessions"]

--- a/tests/components/enphase_ev/test_coordinator_edge_cases.py
+++ b/tests/components/enphase_ev/test_coordinator_edge_cases.py
@@ -21,6 +21,7 @@ from custom_components.enphase_ev.const import (
     CONF_SCAN_INTERVAL,
     CONF_SERIALS,
     CONF_SITE_ID,
+    CONF_SITE_ONLY,
     CONF_SESSION_ID,
     AUTH_REFRESH_REJECTED_SUSPEND_THRESHOLD,
     DEFAULT_SLOW_POLL_INTERVAL,
@@ -2048,7 +2049,7 @@ async def test_activate_auth_block_from_login_wall_reuses_existing_block(hass):
 async def test_async_update_data_fails_fast_while_auth_blocked(monkeypatch, hass):
     from custom_components.enphase_ev import coordinator as coord_mod
     from custom_components.enphase_ev.coordinator import EnphaseCoordinator
-    from homeassistant.exceptions import ConfigEntryAuthFailed
+    from homeassistant.helpers.update_coordinator import UpdateFailed
 
     entry = _make_entry(hass)
     monkeypatch.setattr(
@@ -2064,10 +2065,47 @@ async def test_async_update_data_fails_fast_while_auth_blocked(monkeypatch, hass
     coord._auth_blocked_until_utc = datetime.now(timezone.utc) + timedelta(hours=1)
     coord._auth_block_reason = "login_wall_after_refresh_reject"
 
-    with pytest.raises(ConfigEntryAuthFailed, match="temporarily blocked"):
+    with pytest.raises(UpdateFailed, match="temporarily blocked") as exc_info:
         await coord._async_update_data()
 
+    assert 3590 <= exc_info.value.retry_after <= 3600
     coord.client.status.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_fails_fast_while_site_only_auth_blocked(
+    monkeypatch, hass
+):
+    from custom_components.enphase_ev import coordinator as coord_mod
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    entry = _make_entry(
+        hass,
+        {
+            CONF_SERIALS: [],
+            CONF_SITE_ONLY: True,
+            CONF_AUTH_BLOCKED_UNTIL: (
+                datetime.now(timezone.utc) + timedelta(hours=1)
+            ).isoformat(),
+            CONF_AUTH_BLOCK_REASON: "login_wall_after_refresh_reject",
+        },
+    )
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        coord_mod,
+        "async_call_later",
+        lambda *_args, **_kwargs: (lambda: None),
+    )
+    coord = EnphaseCoordinator(hass, entry.data, config_entry=entry)
+    coord.energy._async_refresh_site_energy = AsyncMock()  # noqa: SLF001
+
+    with pytest.raises(UpdateFailed, match="temporarily blocked") as exc_info:
+        await coord._async_update_data()
+
+    assert 3590 <= exc_info.value.retry_after <= 3600
+    coord.energy._async_refresh_site_energy.assert_not_awaited()  # noqa: SLF001
 
 
 @pytest.mark.asyncio
@@ -2077,7 +2115,7 @@ async def test_async_update_data_login_wall_during_refresh_cooldown_blocks(
     from custom_components.enphase_ev import coordinator as coord_mod
     from custom_components.enphase_ev.coordinator import EnphaseCoordinator
     from custom_components.enphase_ev.api import EnphaseLoginWallUnauthorized
-    from homeassistant.exceptions import ConfigEntryAuthFailed
+    from homeassistant.helpers.update_coordinator import UpdateFailed
 
     entry = _make_entry(hass)
     monkeypatch.setattr(
@@ -2103,11 +2141,12 @@ async def test_async_update_data_login_wall_during_refresh_cooldown_blocks(
         )
     )
 
-    with pytest.raises(ConfigEntryAuthFailed, match="temporarily blocked"):
+    with pytest.raises(UpdateFailed, match="temporarily blocked") as exc_info:
         await coord._async_update_data()
 
     assert coord._auth_block_reason == "login_wall_after_refresh_reject"
     assert coord._auth_blocked_until_utc is not None
+    assert 86390 <= exc_info.value.retry_after <= 86400
 
 
 @pytest.mark.asyncio
@@ -2205,6 +2244,15 @@ def test_blocked_auth_failure_message_handles_missing_timestamp():
     coord._auth_blocked_until_utc = None
 
     assert coord._blocked_auth_failure_message().endswith("retry later.")
+
+
+def test_auth_block_retry_after_returns_none_when_expired():
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    coord = _attach_evse_runtime(EnphaseCoordinator.__new__(EnphaseCoordinator))
+    coord._auth_blocked_until_utc = datetime.now(timezone.utc) - timedelta(seconds=1)
+
+    assert coord._auth_block_retry_after_s() is None
 
 
 def test_persist_tokens_updates_entry(hass, monkeypatch):

--- a/tests/components/enphase_ev/test_coordinator_redesign.py
+++ b/tests/components/enphase_ev/test_coordinator_redesign.py
@@ -998,14 +998,16 @@ def test_coordinator_lazily_creates_refresh_runner() -> None:
 
 
 @pytest.mark.asyncio
-async def test_refresh_runner_login_wall_raises_auth_failed_with_block_message(
+async def test_refresh_runner_login_wall_raises_update_failed_with_retry_after(
     coordinator_factory,
 ) -> None:
     from custom_components.enphase_ev.api import EnphaseLoginWallUnauthorized
+    from homeassistant.helpers.update_coordinator import UpdateFailed
 
     coord = coordinator_factory()
     coord._activate_auth_block_from_login_wall = MagicMock(return_value=True)  # type: ignore[method-assign]  # noqa: SLF001
     coord._blocked_auth_failure_message = MagicMock(return_value="blocked")  # type: ignore[method-assign]  # noqa: SLF001
+    coord._auth_block_retry_after_s = MagicMock(return_value=42)  # type: ignore[method-assign]  # noqa: SLF001
 
     async def _raise() -> None:
         raise EnphaseLoginWallUnauthorized(
@@ -1016,8 +1018,10 @@ async def test_refresh_runner_login_wall_raises_auth_failed_with_block_message(
             body_preview_redacted="<!DOCTYPE html>",
         )
 
-    with pytest.raises(ConfigEntryAuthFailed, match="blocked"):
+    with pytest.raises(UpdateFailed, match="blocked") as exc_info:
         await coord.refresh_runner.async_run_refresh_call("k", "label", _raise)
+
+    assert exc_info.value.retry_after == 42
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_init_module.py
+++ b/tests/components/enphase_ev/test_init_module.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, call
 
@@ -9,8 +10,9 @@ import voluptuous as vol
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ServiceValidationError
+from homeassistant.exceptions import ConfigEntryNotReady, ServiceValidationError
 from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.update_coordinator import UpdateFailed
 
 import custom_components.enphase_ev as enphase_init
 from custom_components.enphase_ev import (
@@ -44,9 +46,13 @@ from custom_components.enphase_ev import (
     async_unload_entry,
 )
 from custom_components.enphase_ev.const import (
+    CONF_AUTH_BLOCK_REASON,
+    CONF_AUTH_BLOCKED_UNTIL,
     CONF_INCLUDE_INVERTERS,
+    CONF_SERIALS,
     CONF_SELECTED_TYPE_KEYS,
     CONF_SITE_ID,
+    CONF_SITE_ONLY,
     ISSUE_AUTH_BLOCKED,
     ISSUE_TOO_MANY_ACTIVE_SESSIONS,
 )
@@ -506,6 +512,48 @@ async def test_async_setup_entry_updates_existing_device(
     )
     assert ev_type_device is None
     assert updated.via_device_id is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_auth_block_is_setup_not_ready_without_reauth(
+    hass: HomeAssistant, config_entry, monkeypatch
+) -> None:
+    """Startup auth blocks should retry setup instead of starting HA reauth."""
+
+    blocked_until = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    hass.config_entries.async_update_entry(
+        config_entry,
+        data={
+            **config_entry.data,
+            CONF_SERIALS: [],
+            CONF_SITE_ONLY: True,
+            CONF_AUTH_BLOCKED_UNTIL: blocked_until,
+            CONF_AUTH_BLOCK_REASON: "login_wall_after_refresh_reject",
+        },
+    )
+    object.__setattr__(
+        config_entry, "state", config_entries.ConfigEntryState.SETUP_IN_PROGRESS
+    )
+    start_reauth = Mock()
+    monkeypatch.setattr(config_entry, "async_start_reauth", start_reauth)
+    status = AsyncMock()
+    site_energy = AsyncMock()
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.coordinator.EnphaseEVClient.status",
+        status,
+    )
+    monkeypatch.setattr(
+        "custom_components.enphase_ev.energy.EnergyManager._async_refresh_site_energy",
+        site_energy,
+    )
+
+    with pytest.raises(ConfigEntryNotReady) as exc_info:
+        await async_setup_entry(hass, config_entry)
+
+    assert isinstance(exc_info.value.__cause__, UpdateFailed)
+    start_reauth.assert_not_called()
+    status.assert_not_awaited()
+    site_energy.assert_not_awaited()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes #671.

Temporary Enphase auth blocks were being raised as `ConfigEntryAuthFailed`, which moved Home Assistant into the reauthentication path and could prevent the coordinator from retrying automatically after the stored block expired. This changes active auth blocks to raise recoverable `UpdateFailed` with `retry_after`, applies the guard before site-only refreshes, and preserves true auth failures on the reauth path.

## Related Issues

Fixes #671

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_edge_cases.py::test_async_update_data_fails_fast_while_site_only_auth_blocked tests/components/enphase_ev/test_init_module.py::test_async_setup_entry_auth_block_is_setup_not_ready_without_reauth"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/refresh_runner.py tests/components/enphase_ev/test_coordinator_edge_cases.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_init_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/refresh_runner.py tests/components/enphase_ev/test_coordinator_edge_cases.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_init_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_edge_cases.py tests/components/enphase_ev/test_coordinator_behavior.py tests/components/enphase_ev/test_coordinator_redesign.py tests/components/enphase_ev/test_init_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/refresh_runner.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "git status -sb && python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The reporter log showed Home Assistant logging the temporary auth block as `could not authenticate`, confirming the integration was surfacing a temporary Enphase block through the durable reauth path. No screenshots attached.
