### PR TITLE
Prepare release 3.0.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## v3.0.8 - 2026-05-10
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- Added an options-flow toggle for degraded service repair issues so users can keep diagnostic sensor state without creating Repairs notifications for optional Enphase service degradation. (#674)
+
+### 🐛 Bug fixes
+- Treated temporary Enphase authentication blocks as retryable update failures with retry timing instead of reauth failures, allowing automatic polling to resume when the block expires. (#672)
+- Checked active authentication blocks before site-only refreshes so site-only entries also pause until the configured retry window expires. (#672)
+
+### 🔧 Improvements
+- Scoped optional degraded-service repair issue IDs per config entry and cleared legacy unscoped issues after upgrade to avoid collisions in multi-entry installs. (#674)
+
+### 🔄 Other changes
+- Bumped the integration manifest version to `3.0.8`.
+
 ## v3.0.7 - 2026-05-09
 
 ### 🚧 Breaking changes
@@ -9,7 +27,6 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ New features
 - Added a `clear_hems_auth_backoff` service to clear the Heat Pump/HEMS-only auth backoff without performing password login.
-- Added an options-flow toggle for degraded service repair issues so users can keep the diagnostic sensor state without creating Repairs notifications for optional Enphase service degradation.
 
 ### 🐛 Bug fixes
 - Isolated Heat Pump/HEMS auth failures behind a HEMS-only circuit breaker so they no longer trigger global stored-password refresh attempts or stop wallbox/battery polling. (#528)

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.0.7"
+  "version": "3.0.8"
 }


### PR DESCRIPTION
## Summary

Prepare release `3.0.8` by bumping the integration manifest version and adding a changelog entry for changes since `v3.0.7`.

## Related Issues

- #672
- #674

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release metadata update.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev/test_service_translations.py -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
```

Additional local metadata checks:

```bash
jq . custom_components/enphase_ev/manifest.json >/dev/null
git diff --check
```

Black and targeted coverage for touched Python modules were not run separately because this PR changes only `CHANGELOG.md` and `custom_components/enphase_ev/manifest.json`.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [ ] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Release prep only. No runtime behavior changed in this PR.