### PR TITLE
Fix site-only coordinator updates

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -790,7 +790,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         super_kwargs = {
             "name": DOMAIN,
             "update_interval": timedelta(seconds=self._configured_slow_poll_interval),
-            "always_update": False,
+            "always_update": self.site_only or not self.serials,
         }
         if config_entry is not None:
             super_kwargs["config_entry"] = config_entry

--- a/tests/components/enphase_ev/test_coordinator_behavior.py
+++ b/tests/components/enphase_ev/test_coordinator_behavior.py
@@ -1179,6 +1179,43 @@ def test_publish_internal_state_update_copies_current_data(coordinator_factory) 
     coord.async_set_updated_data.assert_called_once_with(dict(coord.data))
 
 
+def test_site_only_coordinator_notifies_listeners_for_equal_payloads(
+    hass,
+    monkeypatch,
+) -> None:
+    from custom_components.enphase_ev import coordinator as coord_mod
+    from custom_components.enphase_ev.coordinator import EnphaseCoordinator
+
+    monkeypatch.setattr(
+        coord_mod, "async_get_clientsession", lambda *args, **kwargs: object()
+    )
+    monkeypatch.setattr(
+        coord_mod,
+        "async_call_later",
+        lambda *_args, **_kwargs: (lambda: None),
+    )
+    coord = EnphaseCoordinator(
+        hass,
+        {
+            CONF_SITE_ID: RANDOM_SITE_ID,
+            CONF_SERIALS: [],
+            CONF_EAUTH: "EAUTH",
+            CONF_COOKIE: "COOKIE",
+            CONF_SCAN_INTERVAL: 15,
+            CONF_SITE_ONLY: True,
+            CONF_INCLUDE_INVERTERS: True,
+        },
+    )
+    calls: list[dict | None] = []
+    unsub = coord.async_add_listener(lambda: calls.append(coord.data))
+
+    coord.async_set_updated_data({})
+    coord.async_set_updated_data({})
+    unsub()
+
+    assert calls == [{}, {}]
+
+
 def test_end_topology_refresh_batch_flushes_pending_refresh(
     coordinator_factory,
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #668.

Site-only entries return an empty coordinator payload while their useful state lives on coordinator/runtime fields. With `always_update=False`, Home Assistant could skip listener notifications after successful polls because the returned payload stayed `{}`, leaving site energy and battery/gateway entities stale until reload.

This changes site-only/no-serial coordinators to always notify listeners after successful refreshes, while keeping normal charger entries on equality-based updates. It also adds regression coverage for repeated equal payload publishes.

## Related Issues

Fixes #668.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_coordinator_behavior.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_behavior.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "git status --short && python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

The initial pre-commit attempt without the extra Git metadata mount failed before hooks ran because the Docker worktree `.git` file points to a host-only absolute gitdir path. The mounted rerun passed.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Issue diagnostics showed successful coordinator refreshes with fresh site-energy samples while site-only HA entities stayed stale after the first reload-time update. This points to listener notifications being skipped for equal `{}` coordinator payloads rather than a cloud fetch failure.
