### PR TITLE
Prepare release 3.0.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,26 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v3.0.9 - 2026-05-14
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
+### 🐛 Bug fixes
+- Preserved authentication refresh rejection streaks when stored-credential refresh attempts are rejected, keeping repeated temporary blocks on the intended suspension path. (#679)
+- Ensured site-only entries notify Home Assistant listeners after successful refreshes even when their coordinator payload remains empty, keeping site energy and battery/gateway entities from going stale. (#681)
+
+### 🔧 Improvements
+- Raised the minimum user-configurable polling cadence to 30 seconds for fast polling and 60 seconds for slow polling, and cached current-power samples for 60 seconds to reduce cloud request volume. (#676)
+- Simplified heat-pump power derivation to use HEMS daily-consumption deltas instead of the separate HEMS power timeseries flow, reducing endpoint fan-out and diagnostics noise. (#679)
+
 ### 🔄 Other changes
 - Added Home Assistant brand assets, including dark-theme icon and logo variants.
+- Documented the observed cloud request budget, minimum refresh cadence guidance, and HEMS auth diagnostics in the API reference.
+- Bumped the integration manifest version to `3.0.9`.
 
 ## v3.0.8 - 2026-05-10
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.0.8"
+  "version": "3.0.9"
 }

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -8,7 +8,7 @@ _This reference consolidates observed Enlighten mobile/web APIs across EV chargi
 - **Base URL:** `https://enlighten.enphaseenergy.com`
 - **Auth:** The current implementation is cookie-first. Login establishes an Enlighten session cookie jar, then the client best-effort fetches an access token from Entrez and adds endpoint-specific headers on top. Many read endpoints work with cookies plus `e-auth-token`; scheduler, HEMS, and timeseries families prefer or require `Authorization: Bearer <jwt>`. BatteryConfig is now the main exception: it follows the homeowner web app request shape instead of the bearer/e-auth/cookie overlay used elsewhere.
 - **Privacy:** Example identifiers, account details, LAN metadata, and credentials in this document use placeholders. Raw browser-export request headers often contain JWTs, cookies, email addresses, user IDs, LAN IPs, MAC addresses, and serial numbers; those values must be redacted before captures are shared or committed. When this spec lists "observed values", it intentionally preserves non-sensitive enum/flag values so newly seen behavior is not lost.
-- **Evidence date:** Implementation statements reflect `origin/main` at `beffcf8d`, synced locally on 2026-04-29. New browser/mobile captures should record the capture date, client surface, and endpoint family near the affected section.
+- **Evidence date:** Implementation statements reflect `origin/main` at `0c71ed03`, synced locally on 2026-05-12. New browser/mobile captures should record the capture date, client surface, and endpoint family near the affected section.
 - **Payload examples:** Examples should be minimal shape excerpts. Prefer fields that drive parsing, auth, controls, or diagnostics, and omit long arrays or app-shell metadata unless those details affect implementation.
 - **Path Variables:**
   - `<site_id>` - numeric site identifier
@@ -6202,6 +6202,7 @@ There is no single universal header set; the implementation varies headers by en
 - HTTP 401 — credentials expired or invalid.
 - HTTP 400/404/409/422 during control operations — validation failure or charger not ready/not plugged.
 - Rate limiting presents as HTTP 429.
+- Observed, non-official request budget: sustained cloud polling around or above roughly **600 requests/hour** (about **10 requests/minute**) appears to increase the risk of throttling, stale optional-service responses, or auth/session degradation. Treat this as a conservative operating ceiling, not an Enphase-published quota.
 
 ### 8.1 Cloud status codes (from the official v4 control API)
 Enphase’s public “EV Charger Control” reference (https://developer-v4.enphase.com/docs.html) documents the same backend actions behind a `/api/v4/systems/{system_id}/ev_charger/{serial_no}/…` surface. The status codes it lists match the JSON payloads observed on the cloud endpoints documented here. The most relevant responses are:
@@ -6221,11 +6222,29 @@ Enphase’s public “EV Charger Control” reference (https://developer-v4.enph
 
 When these conditions occur against the `/service/evse_controller/...` paths, the response often uses an analogous JSON envelope with `"status": "error"` and the same `message`/`details`.
 
-### 8.2 Implementation Diagnostics
+### 8.2 Runtime Request Budget and Minimum Refresh Cadence
+Observed behavior from issue `#528` and the request-volume follow-up `#667` indicates that optional endpoint families should be paced conservatively. The integration should optimize for stable, low-volume polling rather than app-like live refresh.
+
+Current implementation policy:
+- Keep ordinary slow coordinator polling at **60 seconds or slower** by default.
+- Keep temporary fast polling at **30 seconds or slower**, and reserve it for user actions or short-lived state transitions.
+- Do not poll low-volatility inventory/topology endpoints on every coordinator refresh. Current minimum cache windows include site-device inventory and system-dashboard detail fan-out at **600 seconds**, HEMS device inventory at **60 seconds**, heat-pump runtime state at **60 seconds**, and Storm Alert at **300 seconds**.
+- Derive heat-pump power from HEMS energy deltas on a slower cadence; current heat-pump power/daily energy refreshes use the HEMS daily-consumption cache window of **300 seconds**.
+- Endpoint failures must use stale data, endpoint-family cooldowns, or optional-service degradation before increasing polling pressure.
+- Optional HEMS/Heat Pump auth failures must not trigger global stored-password refresh. They are isolated behind the HEMS auth circuit and backoff so wallbox, battery, gateway, and other non-HEMS data can continue.
+- Temporary Enphase auth blocks should be treated as retryable update failures until the retry window expires, not as immediate Home Assistant reauth unless the user explicitly starts reauth.
+
+Minimum refresh guidance for new code:
+- Avoid adding any recurring cloud endpoint faster than **60 seconds** unless it is clearly tied to a user action, an active charging state, or a documented backend polling interval.
+- Avoid adding any optional diagnostic, inventory, or derived-energy endpoint faster than **300 seconds** unless freshness is required for an entity's primary state.
+- Account for fan-out endpoints as multiple effective requests. System-dashboard device details, HEMS discovery, and per-device energy endpoints can multiply request volume quickly even when the coordinator refresh interval looks safe.
+- Prefer diagnostics counters and endpoint-family `request_count` data over raw assumptions when tuning cadence on real sites.
+
+### 8.3 Implementation Diagnostics
 The integration exposes diagnostics and system-health data for endpoint behavior rather than raw API payloads.
 
 Implementation notes:
-- Diagnostics include multi-site health, endpoint-family cooldown/backoff state, payload health for EVSE summary/status, site-energy per-flow metadata, tariff health, heat-pump runtime diagnostics, and firmware catalog status.
+- Diagnostics include multi-site health, endpoint-family cooldown/backoff state and request counts, payload health for EVSE summary/status, site-energy per-flow metadata, tariff health, HEMS auth circuit state, heat-pump runtime diagnostics, and firmware catalog status.
 - Sensitive identifiers, tokens, cookies, LAN addresses, emails, and raw payload snippets are redacted or summarized before inclusion.
 
 ---


### PR DESCRIPTION
## Summary

Prepare release `3.0.9` by bumping the integration manifest version, promoting the accumulated changelog entries into the `v3.0.9` release section, and updating the API reference with the current request-budget and refresh-cadence guidance.

Includes changelog coverage for changes merged since `v3.0.8`, including the site-only coordinator listener fix from #681.

## Related Issues

Fixes #668 via included changelog coverage for #681.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release preparation: manifest version bump and release notes.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python scripts/validate_quality_scale.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

No changed Python module was introduced by this release-prep commit, so targeted Black and per-module coverage were not applicable.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [ ] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

Release prep only. This branch is based on `origin/main` after #681 was merged.
