### PR TITLE
Derive heat pump power from site-today energy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### 🐛 Bug fixes
+- Derived Heat Pump power from the site-today heat-pump daily energy total instead of HEMS split energy, avoiding false `0 W` readings when the HEMS split remains flat. (#680)
+
 ## v3.0.9 - 2026-05-14
 
 ### 🚧 Breaking changes

--- a/custom_components/enphase_ev/heatpump_runtime.py
+++ b/custom_components/enphase_ev/heatpump_runtime.py
@@ -936,11 +936,25 @@ class HeatpumpRuntime:
         site_today_total_wh = self._site_today_heatpump_total_wh(site_today_payload)
         if site_today_total_wh is None:
             return None
-        site_today_timestamp = (
-            site_today_payload.get("timestamp")
-            if isinstance(site_today_payload, dict)
-            else None
-        )
+        site_today_timestamp = None
+        site_today_timestamp_source = None
+        if isinstance(site_today_payload, dict):
+            for key in ("last_report_date", "timestamp", "lastReportDate"):
+                if site_today_payload.get(key) is None:
+                    continue
+                site_today_timestamp = site_today_payload.get(key)
+                site_today_timestamp_source = key
+                break
+        if site_today_timestamp is None:
+            site_today_timestamp = dt_util.utcnow().isoformat()
+            site_today_timestamp_source = "coordinator_refresh"
+        first_stat = None
+        if isinstance(site_today_payload, dict):
+            stats = site_today_payload.get("stats")
+            if isinstance(stats, list):
+                first_stat = next(
+                    (item for item in stats if isinstance(item, dict)), None
+                )
         snapshot: dict[str, object] = {
             "device_uid": None,
             "device_name": None,
@@ -964,6 +978,15 @@ class HeatpumpRuntime:
                 else None
             ),
             "endpoint_timestamp": site_today_timestamp,
+            "sample_timestamp_source": site_today_timestamp_source,
+            "site_interval_seconds": (
+                first_stat.get("interval_length")
+                if isinstance(first_stat, dict)
+                else None
+            ),
+            "site_start_time": (
+                first_stat.get("start_time") if isinstance(first_stat, dict) else None
+            ),
             "split_endpoint_type": None,
             "split_endpoint_timestamp": None,
             "sampled_at_utc": (
@@ -1122,10 +1145,10 @@ class HeatpumpRuntime:
     def _record_heatpump_power_history_sample(self, snapshot: object) -> None:
         if not isinstance(snapshot, dict):
             return
-        energy_wh = coerce_optional_float(snapshot.get("split_daily_energy_wh"))
-        sample_utc = parse_inverter_last_report(
-            snapshot.get("split_endpoint_timestamp")
-        )
+        energy_wh = coerce_optional_float(snapshot.get("daily_energy_wh"))
+        sample_utc = parse_inverter_last_report(snapshot.get("sampled_at_utc"))
+        if sample_utc is None:
+            sample_utc = parse_inverter_last_report(snapshot.get("endpoint_timestamp"))
         if energy_wh is None or sample_utc is None:
             return
         device_uid = coerce_optional_text(snapshot.get("split_device_uid"))
@@ -1257,24 +1280,27 @@ class HeatpumpRuntime:
     ) -> dict[str, object] | None:
         if not isinstance(snapshot, dict):
             return None
-        if not self._heatpump_daily_split_available(snapshot):
-            return None
         device_uid = coerce_optional_text(snapshot.get("split_device_uid"))
         day_key = coerce_optional_text(snapshot.get("day_key"))
         runtime_mode = self._heatpump_runtime_mode(runtime_snapshot)
         is_idle = runtime_mode in {"IDLE", "OFF", "STOPPED", "STANDBY"}
-        current_energy_wh = coerce_optional_float(snapshot.get("split_daily_energy_wh"))
-        current_sample_utc = parse_inverter_last_report(
-            snapshot.get("split_endpoint_timestamp")
+        current_energy_wh = coerce_optional_float(snapshot.get("daily_energy_wh"))
+        current_split_energy_wh = coerce_optional_float(
+            snapshot.get("split_daily_energy_wh")
         )
+        current_sample_utc = parse_inverter_last_report(snapshot.get("sampled_at_utc"))
+        if current_sample_utc is None:
+            current_sample_utc = parse_inverter_last_report(
+                snapshot.get("endpoint_timestamp")
+            )
         previous_snapshot = getattr(self, "_heatpump_daily_consumption_previous", None)
         previous_energy_wh = (
-            coerce_optional_float(previous_snapshot.get("split_daily_energy_wh"))
+            coerce_optional_float(previous_snapshot.get("daily_energy_wh"))
             if isinstance(previous_snapshot, dict)
             else None
         )
-        previous_device_uid = (
-            coerce_optional_text(previous_snapshot.get("split_device_uid"))
+        previous_split_energy_wh = (
+            coerce_optional_float(previous_snapshot.get("split_daily_energy_wh"))
             if isinstance(previous_snapshot, dict)
             else None
         )
@@ -1283,19 +1309,22 @@ class HeatpumpRuntime:
             if isinstance(previous_snapshot, dict)
             else None
         )
-        previous_sample_utc = (
-            parse_inverter_last_report(
-                previous_snapshot.get("split_endpoint_timestamp")
+        previous_sample_utc = None
+        if isinstance(previous_snapshot, dict):
+            previous_sample_utc = parse_inverter_last_report(
+                previous_snapshot.get("sampled_at_utc")
             )
-            if isinstance(previous_snapshot, dict)
-            else None
-        )
+            if previous_sample_utc is None:
+                previous_sample_utc = parse_inverter_last_report(
+                    previous_snapshot.get("endpoint_timestamp")
+                )
         accepted_value = None
         rejected = False
         validation = "accepted_delta"
         window_s = None
         series_start_utc = None
         idle_high_delta_pending = False
+        power_source = "site_today_heatpump_delta"
 
         if current_energy_wh is None or current_sample_utc is None:
             if is_idle:
@@ -1308,7 +1337,6 @@ class HeatpumpRuntime:
             previous_energy_wh is None
             or previous_sample_utc is None
             or previous_day_key != day_key
-            or previous_device_uid != device_uid
         ):
             if is_idle:
                 accepted_value = 0.0
@@ -1411,8 +1439,13 @@ class HeatpumpRuntime:
                 else None
             ),
             "recommended": self._heatpump_power_candidate_is_recommended(device_uid),
-            "detail_count": 1 if current_energy_wh is not None else 0,
+            "detail_count": 1 if current_split_energy_wh is not None else 0,
             "reported_detail_value": (
+                round(current_split_energy_wh, 3)
+                if current_split_energy_wh is not None
+                else None
+            ),
+            "reported_daily_value": (
                 round(current_energy_wh, 3) if current_energy_wh is not None else None
             ),
             "accepted_value_w": (
@@ -1420,6 +1453,11 @@ class HeatpumpRuntime:
             ),
             "raw_value_w": round(raw_value, 3) if raw_value is not None else None,
             "previous_detail_value": (
+                round(previous_split_energy_wh, 3)
+                if previous_split_energy_wh is not None
+                else None
+            ),
+            "previous_daily_energy_wh": (
                 round(previous_energy_wh, 3) if previous_energy_wh is not None else None
             ),
             "window_seconds": round(window_s, 3) if window_s is not None else None,
@@ -1443,13 +1481,13 @@ class HeatpumpRuntime:
             "series_start_utc": (
                 series_start_utc.isoformat() if series_start_utc is not None else None
             ),
-            "endpoint_timestamp": snapshot.get("split_endpoint_timestamp"),
-            "endpoint_type": snapshot.get("split_endpoint_type"),
-            "source": (
-                f"hems_energy_consumption_delta:{self._debug_truncate_identifier(device_uid)}"
-                if device_uid
-                else "hems_energy_consumption_delta"
-            ),
+            "endpoint_timestamp": snapshot.get("endpoint_timestamp"),
+            "endpoint_type": snapshot.get("endpoint_type"),
+            "sample_timestamp_source": snapshot.get("sample_timestamp_source"),
+            "site_interval_seconds": snapshot.get("site_interval_seconds"),
+            "split_endpoint_timestamp": snapshot.get("split_endpoint_timestamp"),
+            "split_endpoint_type": snapshot.get("split_endpoint_type"),
+            "source": power_source,
         }
         return summary
 
@@ -1505,25 +1543,6 @@ class HeatpumpRuntime:
         ):
             return
 
-        if self.coordinator._skip_hems_polling_due_to_auth_circuit(
-            endpoint="hems_energy_consumption"
-        ):
-            self._heatpump_mark_daily_consumption_stale(
-                now=now,
-                error="HEMS auth backoff active",
-            )
-            self._heatpump_mark_daily_split_stale(
-                now=now,
-                error="HEMS auth backoff active",
-            )
-            backoff_until = getattr(self.coordinator, "_hems_auth_backoff_until", None)
-            self._heatpump_daily_consumption_backoff_until = (
-                backoff_until or now + HEATPUMP_DAILY_CONSUMPTION_FAILURE_BACKOFF_S
-            )
-            self._heatpump_daily_consumption_cache_until = None
-            self._heatpump_daily_consumption_cache_key = marker
-            return
-
         split_fetcher = getattr(self.client, "hems_energy_consumption", None)
         site_today_fetcher = getattr(self.client, "pv_system_today", None)
         if not callable(site_today_fetcher):
@@ -1531,27 +1550,17 @@ class HeatpumpRuntime:
 
         split_payload: object = None
         split_error: str | None = None
+        skip_split_for_auth = self.coordinator._skip_hems_polling_due_to_auth_circuit(
+            endpoint="hems_energy_consumption"
+        )
+        if skip_split_for_auth:
+            split_error = "HEMS auth backoff active"
         try:
             site_today_payload = await self._async_call_refreshable_fetcher(
                 site_today_fetcher,
                 allow_reauth=False,
             )
         except Exception as err:  # noqa: BLE001
-            if self.coordinator._note_hems_auth_failure(
-                err,
-                endpoint="pv_system_today",
-            ):
-                self._heatpump_mark_daily_consumption_stale(
-                    now=now,
-                    error="HEMS auth backoff active",
-                )
-                self._heatpump_daily_consumption_backoff_until = (
-                    getattr(self.coordinator, "_hems_auth_backoff_until", None)
-                    or now + HEATPUMP_DAILY_CONSUMPTION_FAILURE_BACKOFF_S
-                )
-                self._heatpump_daily_consumption_cache_until = None
-                self._heatpump_daily_consumption_cache_key = marker
-                return
             error = (
                 redact_text(
                     err,
@@ -1570,11 +1579,7 @@ class HeatpumpRuntime:
             self._heatpump_daily_consumption_cache_key = marker
             return
 
-        if callable(
-            split_fetcher
-        ) and not self.coordinator._skip_hems_polling_due_to_auth_circuit(
-            endpoint="hems_energy_consumption"
-        ):
+        if callable(split_fetcher) and not skip_split_for_auth:
             try:
                 split_payload = await split_fetcher(
                     start_at=start_at,
@@ -1604,7 +1609,7 @@ class HeatpumpRuntime:
                     endpoint="hems_energy_consumption"
                 )
         elif callable(split_fetcher):
-            split_error = "HEMS auth backoff active"
+            split_error = split_error or "HEMS auth backoff active"
         else:
             split_error = "HEMS daily split endpoint unavailable"
 
@@ -1711,8 +1716,6 @@ class HeatpumpRuntime:
             and self._heatpump_daily_consumption_cache_key == marker
             and now < self._heatpump_daily_consumption_backoff_until
         ):
-            return False
-        if self.coordinator._hems_auth_circuit_active():
             return False
         fetcher = getattr(self.client, "pv_system_today", None)
         return callable(fetcher)
@@ -1847,34 +1850,6 @@ class HeatpumpRuntime:
             "recommended": self._heatpump_power_candidate_is_recommended(uid),
         }
 
-    def _mark_heatpump_power_auth_backoff(
-        self,
-        *,
-        now: float,
-        force: bool,
-    ) -> None:
-        """Mark heat-pump power stale while HEMS auth backoff is active."""
-
-        error = "HEMS auth backoff active"
-        self._heatpump_mark_power_stale(now=now, error=error)
-        self._heatpump_power_snapshot = {
-            "site_date": self._site_local_current_date(),
-            "force": force,
-            "outcome": "hems_auth_backoff",
-            "using_stale": bool(getattr(self, "_heatpump_power_using_stale", False)),
-            "last_success_utc": (
-                self._heatpump_power_last_success_utc.isoformat()
-                if isinstance(self._heatpump_power_last_success_utc, datetime)
-                else None
-            ),
-            "last_error": error,
-        }
-        backoff_until = getattr(self.coordinator, "_hems_auth_backoff_until", None)
-        self._heatpump_power_backoff_until = (
-            backoff_until or now + HEATPUMP_POWER_STALE_AFTER_S
-        )
-        self._heatpump_power_cache_until = None
-
     async def _async_refresh_heatpump_power(self, *, force: bool = False) -> None:
         now = time.monotonic()
         if not self.has_type("heatpump"):
@@ -1912,44 +1887,6 @@ class HeatpumpRuntime:
         if not force and self._heatpump_power_backoff_until is not None:
             if now < self._heatpump_power_backoff_until:
                 return
-
-        if self.coordinator._skip_hems_polling_due_to_auth_circuit(
-            endpoint="hems_power"
-        ):
-            self._mark_heatpump_power_auth_backoff(now=now, force=force)
-            return
-
-        await self._async_refresh_hems_support_preflight(force=force)
-        if self.coordinator._skip_hems_polling_due_to_auth_circuit(
-            endpoint="hems_power"
-        ):
-            self._mark_heatpump_power_auth_backoff(now=now, force=force)
-            return
-        if getattr(self.client, "hems_site_supported", None) is False:
-            error = "HEMS power endpoint unavailable for this site"
-            self._heatpump_mark_power_stale(
-                now=now,
-                error=error,
-            )
-            self._heatpump_power_snapshot = {
-                "site_date": self._site_local_current_date(),
-                "force": force,
-                "outcome": "unsupported_site",
-                "using_stale": bool(
-                    getattr(self, "_heatpump_power_using_stale", False)
-                ),
-                "last_success_utc": (
-                    self._heatpump_power_last_success_utc.isoformat()
-                    if isinstance(self._heatpump_power_last_success_utc, datetime)
-                    else None
-                ),
-                "last_error": error,
-            }
-            self._heatpump_power_cache_until = (
-                now + HEATPUMP_DAILY_CONSUMPTION_CACHE_TTL
-            )
-            self._heatpump_power_backoff_until = None
-            return
 
         site_date = self._site_local_current_date()
         previous_device_uid = self._heatpump_power_device_uid
@@ -2010,7 +1947,7 @@ class HeatpumpRuntime:
             power_snapshot["outcome"] = "fetch_error"
             attempts = power_snapshot.setdefault("attempts", [])
             if isinstance(attempts, list):
-                attempts.append({"source": "hems_energy_consumption", "error": error})
+                attempts.append({"source": "site_today_heatpump", "error": error})
             self._heatpump_mark_power_stale(
                 now=now,
                 error=error,
@@ -2028,7 +1965,7 @@ class HeatpumpRuntime:
             return
 
         daily_last_error = coerce_optional_text(
-            getattr(self, "_heatpump_daily_split_last_error", None)
+            getattr(self, "_heatpump_daily_consumption_last_error", None)
         )
         power_summary = self._heatpump_power_summary_from_daily_snapshot(
             getattr(self, "_heatpump_daily_consumption", None),
@@ -2046,12 +1983,12 @@ class HeatpumpRuntime:
                 )
 
         if power_summary is None:
-            error = daily_last_error or "No usable HEMS daily-consumption payload"
+            error = daily_last_error or "No usable site today heat-pump payload"
             power_snapshot["last_error"] = error
             power_snapshot["outcome"] = "no_usable_payload"
             attempts = power_snapshot.setdefault("attempts", [])
             if isinstance(attempts, list) and error and not attempts:
-                attempts.append({"source": "hems_energy_consumption", "error": error})
+                attempts.append({"source": "site_today_heatpump", "error": error})
             self._heatpump_mark_power_stale(
                 now=now,
                 error=error,
@@ -2105,10 +2042,14 @@ class HeatpumpRuntime:
             else None
         )
         endpoint_timestamp = (
-            parse_inverter_last_report(snapshot.get("split_endpoint_timestamp"))
+            parse_inverter_last_report(snapshot.get("sampled_at_utc"))
             if isinstance(snapshot, dict)
             else None
         )
+        if endpoint_timestamp is None and isinstance(snapshot, dict):
+            endpoint_timestamp = parse_inverter_last_report(
+                snapshot.get("endpoint_timestamp")
+            )
         self._heatpump_power_w = float(power_summary.get("accepted_value_w") or 0.0)
         self._heatpump_power_sample_utc = endpoint_timestamp
         self._heatpump_power_start_utc = parse_inverter_last_report(
@@ -2116,9 +2057,8 @@ class HeatpumpRuntime:
         )
         self._heatpump_power_device_uid = device_uid
         self._heatpump_power_source = (
-            f"hems_energy_consumption_delta:{device_uid}"
-            if device_uid
-            else "hems_energy_consumption_delta"
+            coerce_optional_text(power_summary.get("source"))
+            or "site_today_heatpump_delta"
         )
         self._heatpump_power_raw_w = coerce_optional_float(
             power_summary.get("raw_value_w")
@@ -2136,21 +2076,20 @@ class HeatpumpRuntime:
         self._heatpump_power_backoff_until = None
         self._heatpump_power_last_error = daily_last_error
         self._heatpump_power_using_stale = bool(
-            getattr(self, "_heatpump_daily_split_using_stale", False)
+            getattr(self, "_heatpump_daily_consumption_using_stale", False)
         )
         self._heatpump_power_last_success_mono = getattr(
-            self, "_heatpump_daily_split_last_success_mono", now
+            self, "_heatpump_daily_consumption_last_success_mono", now
         )
         self._heatpump_power_last_success_utc = getattr(
-            self, "_heatpump_daily_split_last_success_utc", dt_util.utcnow()
+            self, "_heatpump_daily_consumption_last_success_utc", dt_util.utcnow()
         )
         self._heatpump_mark_known_present()
         self._record_heatpump_power_history_sample(snapshot)
         power_snapshot["selected_payload"] = dict(power_summary)
         power_snapshot["selected_source"] = (
-            f"hems_energy_consumption_delta:{self._debug_truncate_identifier(device_uid)}"
-            if device_uid
-            else "hems_energy_consumption_delta"
+            coerce_optional_text(power_summary.get("source"))
+            or "site_today_heatpump_delta"
         )
         power_snapshot["selected_sample_at_utc"] = (
             endpoint_timestamp.isoformat() if endpoint_timestamp is not None else None
@@ -2202,8 +2141,6 @@ class HeatpumpRuntime:
         if not force and self._heatpump_power_backoff_until is not None:
             if now < self._heatpump_power_backoff_until:
                 return False
-        if self.coordinator._hems_auth_circuit_active():
-            return False
         fetcher = getattr(self.client, "pv_system_today", None)
         return callable(fetcher)
 

--- a/docs/api/api_spec.md
+++ b/docs/api/api_spec.md
@@ -177,7 +177,7 @@ The integration currently implements these feature groups:
 - Auth and discovery: cookie login, MFA/resend handling, Entrez token bootstrap, site discovery, runtime auth refresh, and manual site-id fallback.
 - EV charging: status, summary, firmware details, feature flags, daily/lifetime EVSE energy, start/stop controls, charge-level configuration, and scheduler preference writes.
 - Site energy and inventory: latest power, today snapshot, lifetime energy, battery backup/grid eligibility, device inventory, microinverter inventory, live-stream capability flags, tariff reads/writes, dry contacts, and system dashboard summary/tree/details.
-- HEMS: inventory, heat-pump runtime state, HEMS daily energy split metadata, HEMS lifetime merge, and heat-pump power derivation from split deltas.
+- HEMS: inventory, heat-pump runtime state, HEMS daily energy split metadata, HEMS lifetime merge, and heat-pump power derivation from site-today heat-pump deltas.
 - Battery and BatteryConfig: site settings, profile/details, battery settings writes, ITC disclaimer acceptance, DTG/RBD/CFG controls, dry-contact parsing, schedules, validation/XSRF bootstrap, and AC Battery HTML runtime/control paths.
 - Firmware catalog and diagnostics: repository-managed runtime firmware catalog, endpoint health/backoff summaries, payload health, tariff health, heat-pump diagnostics, and redacted system-health output.
 
@@ -190,7 +190,7 @@ The implementation is intentionally tolerant of common Enphase wrapper and namin
 - Time values may be ISO strings, epoch seconds, or epoch milliseconds depending on endpoint family.
 - EVSE runtime payloads merge status, summary, firmware, feature flags, and EVSE timeseries by charger serial.
 - Site energy payloads preserve missing-vs-zero flow semantics and may derive grid/battery flows when direct arrays are absent.
-- HEMS inventory accepts router/gateway/heat-pump buckets across direct and nested shapes, skips retired members, and treats HEMS split energy as metadata unless today/lifetime site energy needs a fallback.
+- HEMS inventory accepts router/gateway/heat-pump buckets across direct and nested shapes, skips retired members, and treats HEMS split energy as metadata for daily heat-pump totals and derived heat-pump power.
 - BatteryConfig writes use endpoint-specific compatibility planning rather than a single universal header/body shape.
 
 ---
@@ -1000,7 +1000,7 @@ Observed structure:
 - `stats[0]` contains 96 quarter-hour buckets (`interval_length=900`) plus a `totals` object using the same metric names.
 - The payload co-locates energy-flow arrays, battery state, connection details, and internal logging strings in one response.
 - `heatpump` can be populated even when `production` and `evse` are all zero for the same day.
-- The integration treats this `heatpump` daily total as the authoritative displayed heat-pump energy. The HEMS `energy-consumption` endpoint is optional split metadata for source attribution and power derivation.
+- The integration treats this `heatpump` daily total as the authoritative displayed heat-pump energy and the source for derived heat-pump power. The HEMS `energy-consumption` endpoint is optional split metadata for diagnostics and source attribution.
 - `siteStatus="normal"` coexisted with `statusDetails.statusSeverity="warning"` in the observed capture.
 - `batteryConfig` mirrors several BatteryConfig-service concepts (`usage`, backup percentage, grid-mode settings, storm state) but adds internal class/ID fields and gateway-serial keyed maps.
 
@@ -4199,7 +4199,7 @@ Returns heat-pump consumption series as fixed-interval power buckets.
 Runtime status: not implemented. This endpoint was observed during API research but
 proved unreliable for heat-pump power in Home Assistant, so the integration does not
 call it and does not expose helper code for it. Current heat-pump power sensors derive
-watts from deltas in HEMS daily split energy (`/energy-consumption`) instead.
+watts from deltas in the site-today `heatpump` daily energy total instead.
 
 Example response shape (anonymized):
 ```json

--- a/tests/components/enphase_ev/test_heatpump_runtime.py
+++ b/tests/components/enphase_ev/test_heatpump_runtime.py
@@ -46,9 +46,13 @@ def _seed_previous_heatpump_daily_snapshot(
     timestamp: str,
     day_key: str,
     timezone_name: str,
+    daily_energy_wh: float | None = None,
     device_uid: str | None = "HP-1",
     device_name: str = "Waermepumpe",
 ) -> None:
+    if daily_energy_wh is None:
+        daily_energy_wh = energy_wh
+    parsed = parse_inverter_last_report(timestamp)
     coord._heatpump_daily_consumption = {  # noqa: SLF001
         "split_device_uid": device_uid,
         "split_device_name": device_name,
@@ -56,7 +60,7 @@ def _seed_previous_heatpump_daily_snapshot(
         "member_device_type": "HEAT_PUMP",
         "pairing_status": "PAIRED",
         "device_state": None,
-        "daily_energy_wh": energy_wh,
+        "daily_energy_wh": daily_energy_wh,
         "split_daily_energy_wh": energy_wh,
         "daily_solar_wh": 0.0,
         "daily_battery_wh": 0.0,
@@ -68,6 +72,9 @@ def _seed_previous_heatpump_daily_snapshot(
             if device_uid is not None
             else "hems_energy_consumption"
         ),
+        "endpoint_timestamp": timestamp,
+        "sampled_at_utc": parsed.isoformat() if parsed is not None else None,
+        "sample_timestamp_source": "last_report_date",
         "split_endpoint_type": "hems-device-details",
         "split_endpoint_timestamp": timestamp,
         "day_key": day_key,
@@ -82,18 +89,26 @@ def _heatpump_daily_snapshot(
     day_key: str = "2026-04-02",
     timezone_name: str = "UTC",
     device_uid: str | None = "HP-1",
+    daily_energy_wh: float | None = None,
 ) -> dict[str, object]:
+    if daily_energy_wh is None:
+        daily_energy_wh = energy_wh
+    parsed = parse_inverter_last_report(timestamp)
     return {
         "split_device_uid": device_uid,
         "member_device_type": "HEAT_PUMP",
         "pairing_status": "PAIRED",
         "device_state": None,
-        "daily_energy_wh": energy_wh,
+        "daily_energy_wh": daily_energy_wh,
         "split_daily_energy_wh": energy_wh,
         "daily_solar_wh": 0.0,
         "daily_battery_wh": 0.0,
         "daily_grid_wh": 0.0,
         "details": [energy_wh],
+        "endpoint_type": "pv_system_today",
+        "endpoint_timestamp": timestamp,
+        "sampled_at_utc": parsed.isoformat() if parsed is not None else None,
+        "sample_timestamp_source": "last_report_date",
         "split_endpoint_type": "hems-device-details",
         "split_endpoint_timestamp": timestamp,
         "day_key": day_key,
@@ -186,7 +201,7 @@ async def test_heatpump_runtime_state_stops_after_preflight_auth_failure(
 
 
 @pytest.mark.asyncio
-async def test_heatpump_power_stops_after_preflight_auth_failure(
+async def test_heatpump_power_continues_after_preflight_auth_failure(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory(serials=[])
@@ -196,19 +211,64 @@ async def test_heatpump_power_stops_after_preflight_auth_failure(
     coord.client.system_dashboard_summary = AsyncMock(  # type: ignore[method-assign]
         side_effect=api.Unauthorized()
     )
-    coord.client.pv_system_today = AsyncMock(side_effect=AssertionError("unused"))
+    coord.client.pv_system_today = AsyncMock(
+        return_value=_site_today_payload(100.0, timestamp="2026-04-05T00:05:00Z")
+    )
     coord.client.hems_energy_consumption = AsyncMock(
         side_effect=AssertionError("unused")
+    )
+    _seed_previous_heatpump_daily_snapshot(
+        coord,
+        energy_wh=90.0,
+        daily_energy_wh=90.0,
+        timestamp="2026-04-05T00:00:00Z",
+        day_key="2026-04-05",
+        timezone_name="UTC",
     )
 
     await runtime._async_refresh_heatpump_power(force=True)  # noqa: SLF001
 
-    coord.client.pv_system_today.assert_not_awaited()
+    coord.client.pv_system_today.assert_awaited_once_with(allow_reauth=False)
     coord.client.hems_energy_consumption.assert_not_awaited()
     assert coord._hems_auth_circuit_active() is True  # noqa: SLF001
-    assert coord.heatpump_power_last_error == "HEMS auth backoff active"
+    assert coord.heatpump_power_w == pytest.approx(120.0)
+    assert coord.heatpump_power_last_error is None
     assert (
-        coord._heatpump_power_snapshot["outcome"] == "hems_auth_backoff"
+        coord._heatpump_power_snapshot["outcome"] == "selected_sample"
+    )  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_heatpump_power_continues_when_hems_site_is_unsupported(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    runtime = coord.heatpump_runtime
+    _seed_heatpump_auth_test_topology(coord)
+    coord.client._hems_site_supported = False  # noqa: SLF001
+    coord.client.system_dashboard_summary = AsyncMock(side_effect=AssertionError)
+    coord.client.pv_system_today = AsyncMock(
+        return_value=_site_today_payload(100.0, timestamp="2026-04-05T00:05:00Z")
+    )
+    coord.client.hems_energy_consumption = AsyncMock(return_value=None)
+    _seed_previous_heatpump_daily_snapshot(
+        coord,
+        energy_wh=90.0,
+        daily_energy_wh=90.0,
+        timestamp="2026-04-05T00:00:00Z",
+        day_key="2026-04-05",
+        timezone_name="UTC",
+    )
+
+    await runtime._async_refresh_heatpump_power(force=True)  # noqa: SLF001
+
+    coord.client.system_dashboard_summary.assert_not_awaited()
+    coord.client.pv_system_today.assert_awaited_once_with(allow_reauth=False)
+    assert coord.heatpump_power_w == pytest.approx(120.0)
+    assert coord.heatpump_power_source == "site_today_heatpump_delta"
+    assert coord.heatpump_power_last_error is None
+    assert (
+        coord._heatpump_power_snapshot["outcome"] == "selected_sample"
     )  # noqa: SLF001
 
 
@@ -413,6 +473,115 @@ def test_heatpump_power_summary_smooths_idle_zero_from_history(
     assert summary["power_window_seconds"] == pytest.approx(1200.0)
     assert summary["power_validation"] == "smoothed_idle_delta"
     assert summary["smoothed"] is True
+
+
+def test_heatpump_power_summary_uses_daily_total_when_idle_split_is_flat(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_daily_consumption_previous = (  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=5899.0,
+            daily_energy_wh=5891.0,
+            timestamp="2026-05-15T20:20:08Z",
+        )
+    )
+
+    summary = runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=5899.0,
+            daily_energy_wh=5892.0,
+            timestamp="2026-05-15T20:26:23Z",
+        ),
+        runtime_snapshot={"heatpump_status": "IDLE"},
+    )
+
+    assert summary is not None
+    assert summary["reported_detail_value"] == pytest.approx(5899.0)
+    assert summary["previous_detail_value"] == pytest.approx(5899.0)
+    assert summary["daily_energy_wh"] == pytest.approx(5892.0)
+    assert summary["previous_daily_energy_wh"] == pytest.approx(5891.0)
+    assert summary["accepted_value_w"] == pytest.approx(9.6, abs=0.1)
+    assert summary["validation"] == "accepted_idle_delta"
+    assert summary["power_validation"] == "accepted_idle_delta"
+    assert summary["source"] == "site_today_heatpump_delta"
+    assert summary["rejected"] is False
+
+
+def test_heatpump_power_summary_rejects_high_daily_total_idle_delta(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_daily_consumption_previous = (  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=5899.0,
+            daily_energy_wh=5891.0,
+            timestamp="2026-05-15T20:20:08Z",
+        )
+    )
+
+    summary = runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=5899.0,
+            daily_energy_wh=5900.0,
+            timestamp="2026-05-15T20:26:23Z",
+        ),
+        runtime_snapshot={"heatpump_status": "IDLE"},
+    )
+
+    assert summary is not None
+    assert summary["accepted_value_w"] is None
+    assert summary["raw_value_w"] == pytest.approx(86.4, abs=0.1)
+    assert summary["validation"] == "rejected_idle_high_delta"
+    assert summary["source"] == "site_today_heatpump_delta"
+
+
+def test_heatpump_power_summary_uses_endpoint_timestamp_fallbacks(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    previous_snapshot = _heatpump_daily_snapshot(
+        energy_wh=10.0,
+        timestamp="2026-04-02T00:00:00Z",
+    )
+    previous_snapshot["sampled_at_utc"] = None
+    runtime._heatpump_daily_consumption_previous = previous_snapshot  # noqa: SLF001
+
+    summary = runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=11.0,
+            timestamp="2026-04-02T00:05:00Z",
+        ),
+        runtime_snapshot={"heatpump_status": "RUNNING"},
+    )
+
+    assert summary is not None
+    assert summary["accepted_value_w"] == pytest.approx(12.0)
+    assert summary["series_start_utc"] == "2026-04-02T00:00:00+00:00"
+
+
+def test_heatpump_power_summary_rejects_non_idle_repeated_sample(
+    coordinator_factory,
+) -> None:
+    runtime = coordinator_factory(serials=[]).heatpump_runtime
+    runtime._heatpump_daily_consumption_previous = (  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=10.0,
+            timestamp="2026-04-02T00:05:00Z",
+        )
+    )
+
+    summary = runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
+        _heatpump_daily_snapshot(
+            energy_wh=11.0,
+            timestamp="2026-04-02T00:05:00Z",
+        ),
+        runtime_snapshot={"heatpump_status": "RUNNING"},
+    )
+
+    assert summary is not None
+    assert summary["rejected"] is True
+    assert summary["validation"] == "repeated_sample"
 
 
 def test_heatpump_power_summary_smooths_idle_high_delta_from_history(
@@ -742,6 +911,9 @@ async def test_refresh_heatpump_power_records_rejected_idle_high_delta_history(
             },
         }
     )
+    coord.client.pv_system_today = AsyncMock(
+        return_value=_site_today_payload(105.0, timestamp="2026-04-02T00:05:00Z")
+    )
     _seed_previous_heatpump_daily_snapshot(
         coord,
         energy_wh=100.0,
@@ -1016,7 +1188,7 @@ async def test_heatpump_runtime_power_failure_logs_truncated_device_uid(
     )
     coord.heatpump_runtime._async_refresh_hems_support_preflight = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
     coord._devices_inventory_payload = {"curr_date_site": "2026-03-13"}  # noqa: SLF001
-    coord.client.hems_energy_consumption = AsyncMock(
+    coord.client.pv_system_today = AsyncMock(
         side_effect=RuntimeError("fetch failed for HP-1")
     )
 
@@ -1077,7 +1249,7 @@ async def test_heatpump_runtime_power_logs_fetch_plan_and_selection_summary(
         }
     )
     coord.client.pv_system_today = AsyncMock(
-        return_value=_site_today_payload(275.0, timestamp="2026-03-20T08:00:00Z")
+        return_value=_site_today_payload(550.0, timestamp="2026-03-13T00:05:00Z")
     )
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"device_uid": primary_uid, "heatpump_status": "RUNNING"}
@@ -1109,9 +1281,7 @@ async def test_heatpump_runtime_power_logs_fetch_plan_and_selection_summary(
     ]
     assert power_snapshot["previous_device_ref"] is None
     assert power_snapshot["outcome"] == "selected_sample"
-    assert (
-        power_snapshot["selected_source"] == "hems_energy_consumption_delta:DEVI...6789"
-    )
+    assert power_snapshot["selected_source"] == "site_today_heatpump_delta"
     assert power_snapshot["selected_payload"]["resolved_device_ref"] == "DEVI...6789"
     assert power_snapshot["selected_payload"]["accepted_value_w"] == pytest.approx(
         550.0
@@ -1136,6 +1306,7 @@ async def test_heatpump_runtime_power_logs_when_no_candidate_payload_is_usable(
         },
         ["heatpump"],
     )
+    coord.client.pv_system_today = AsyncMock(return_value=None)
     coord.client.hems_energy_consumption = AsyncMock(return_value=None)
 
     with caplog.at_level(logging.DEBUG):
@@ -1150,8 +1321,8 @@ async def test_heatpump_runtime_power_logs_when_no_candidate_payload_is_usable(
     assert power_snapshot["outcome"] == "no_usable_payload"
     assert power_snapshot["attempts"] == [
         {
-            "source": "hems_energy_consumption",
-            "error": "No usable HEMS daily split payload",
+            "source": "site_today_heatpump",
+            "error": "No usable site today heat-pump payload",
         }
     ]
 
@@ -1182,6 +1353,9 @@ async def test_heatpump_runtime_power_snapshot_handles_selected_payload_without_
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"heatpump_status": "RUNNING"}
     )
+    coord.client.pv_system_today = AsyncMock(
+        return_value=_site_today_payload(125.0, timestamp="2026-03-13T00:05:00Z")
+    )
     _seed_previous_heatpump_daily_snapshot(
         coord,
         device_uid=None,
@@ -1198,11 +1372,63 @@ async def test_heatpump_runtime_power_snapshot_handles_selected_payload_without_
 
     assert coord.heatpump_power_w == pytest.approx(125.0)
     assert coord.heatpump_power_device_uid is None
-    assert coord.heatpump_power_source == "hems_energy_consumption_delta"
+    assert coord.heatpump_power_source == "site_today_heatpump_delta"
     power_snapshot = coord.heatpump_runtime.heatpump_runtime_diagnostics()[
         "power_snapshot"
     ]
-    assert power_snapshot["selected_source"] == "hems_energy_consumption_delta"
+    assert power_snapshot["selected_source"] == "site_today_heatpump_delta"
+
+
+@pytest.mark.asyncio
+async def test_refresh_heatpump_power_uses_endpoint_timestamp_without_sampled_at(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory(serials=[])
+    coord._devices_inventory_payload = {"curr_date_site": "2026-04-02"}  # noqa: SLF001
+    coord.inventory_runtime._set_type_device_buckets(  # noqa: SLF001
+        {
+            "heatpump": {
+                "type_key": "heatpump",
+                "count": 1,
+                "devices": [{"device_type": "HEAT_PUMP", "device_uid": "HP-1"}],
+            }
+        },
+        ["heatpump"],
+    )
+    previous_snapshot = _heatpump_daily_snapshot(
+        energy_wh=10.0,
+        timestamp="2026-04-02T00:00:00Z",
+    )
+    current_snapshot = _heatpump_daily_snapshot(
+        energy_wh=11.0,
+        timestamp="2026-04-02T00:05:00Z",
+    )
+    current_snapshot["sampled_at_utc"] = None
+    coord.heatpump_runtime._heatpump_daily_consumption_previous = (  # noqa: SLF001
+        previous_snapshot
+    )
+    coord.heatpump_runtime._heatpump_runtime_state = {  # noqa: SLF001
+        "device_uid": "HP-1",
+        "heatpump_status": "RUNNING",
+    }
+
+    async def _set_daily_snapshot(*, force=False):
+        coord.heatpump_runtime._heatpump_daily_consumption = (
+            current_snapshot  # noqa: SLF001
+        )
+
+    coord.heatpump_runtime._async_refresh_hems_support_preflight = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
+    coord.heatpump_runtime._async_refresh_heatpump_runtime_state = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
+    coord.heatpump_runtime._async_refresh_heatpump_daily_consumption = _set_daily_snapshot  # type: ignore[method-assign]  # noqa: SLF001
+
+    await coord.heatpump_runtime._async_refresh_heatpump_power(
+        force=True
+    )  # noqa: SLF001
+
+    assert coord.heatpump_power_w == pytest.approx(12.0)
+    assert coord.heatpump_power_sample_utc == datetime(
+        2026, 4, 2, 0, 5, tzinfo=timezone.utc
+    )
 
 
 @pytest.mark.asyncio
@@ -1229,12 +1455,11 @@ async def test_heatpump_runtime_power_snapshot_redacts_identifier_bearing_errors
         ["heatpump"],
     )
 
-    async def _raise_fetch_error(
-        *, start_at=None, end_at=None, timezone=None, step=None
-    ):
+    async def _raise_fetch_error(*, allow_reauth=True):
         raise RuntimeError(f"fetch failed for {raw_uid} serial SERIAL-123456")
 
-    coord.client.hems_energy_consumption = _raise_fetch_error  # type: ignore[method-assign]
+    coord.client.pv_system_today = _raise_fetch_error  # type: ignore[method-assign]
+    coord.client.hems_energy_consumption = AsyncMock(return_value=None)
     coord.heatpump_runtime._async_refresh_hems_support_preflight = AsyncMock(return_value=None)  # type: ignore[assignment]  # noqa: SLF001
 
     await coord.heatpump_runtime._async_refresh_heatpump_power(
@@ -1555,12 +1780,13 @@ async def test_heatpump_runtime_diagnostics_and_refresh_edge_branches(
     coord.client._hems_site_supported = True  # noqa: SLF001
     coord.client.hems_energy_consumption = None
     await runtime.async_refresh_heatpump_power(force=True)
-    assert coord.heatpump_power_w is None
+    assert coord.heatpump_power_w == pytest.approx(0.0)
 
     coord.client.hems_energy_consumption = AsyncMock(return_value=None)
     await runtime.async_refresh_heatpump_power(force=True)
-    assert coord.heatpump_power_w is None
-    assert coord.heatpump_power_last_error == "No usable HEMS daily split payload"
+    assert coord.heatpump_power_w == pytest.approx(0.0)
+    assert coord.heatpump_power_source == "site_today_heatpump_delta"
+    assert coord.heatpump_power_last_error is None
 
     coord.client.hems_energy_consumption = AsyncMock(
         return_value={
@@ -1574,9 +1800,9 @@ async def test_heatpump_runtime_diagnostics_and_refresh_edge_branches(
         }
     )
     await runtime.async_refresh_heatpump_power(force=True)
-    assert coord.heatpump_power_w is None
-    assert coord.heatpump_power_last_error == "rejected_missing_energy_baseline"
-    assert coord.heatpump_power_sample_utc is None
+    assert coord.heatpump_power_w == pytest.approx(0.0)
+    assert coord.heatpump_power_last_error is None
+    assert coord.heatpump_power_sample_utc is not None
 
     class BadFloat:
         def __float__(self) -> float:
@@ -1772,29 +1998,43 @@ async def test_heatpump_runtime_skips_hems_polling_during_auth_circuit(
     )
     coord.client.system_dashboard_summary = AsyncMock(side_effect=AssertionError)
     coord.client.hems_heatpump_state = AsyncMock(side_effect=AssertionError)
-    coord.client.pv_system_today = AsyncMock(side_effect=AssertionError)
+    coord.client.pv_system_today = AsyncMock(
+        side_effect=[
+            _site_today_payload(100.0, timestamp="2026-04-05T00:05:00Z"),
+            _site_today_payload(110.0, timestamp="2026-04-05T00:10:00Z"),
+        ]
+    )
     coord.client.hems_energy_consumption = AsyncMock(side_effect=AssertionError)
     coord.client.heat_pump_events_json = AsyncMock(side_effect=AssertionError)
+    _seed_previous_heatpump_daily_snapshot(
+        coord,
+        energy_wh=90.0,
+        daily_energy_wh=90.0,
+        timestamp="2026-04-05T00:00:00Z",
+        day_key="2026-04-05",
+        timezone_name="UTC",
+    )
 
     await runtime._async_refresh_hems_support_preflight(force=True)  # noqa: SLF001
     await runtime.async_ensure_heatpump_runtime_diagnostics(force=True)
 
     coord.client.system_dashboard_summary.assert_not_awaited()
     coord.client.hems_heatpump_state.assert_not_awaited()
-    coord.client.pv_system_today.assert_not_awaited()
+    assert coord.client.pv_system_today.await_count == 2
     coord.client.hems_energy_consumption.assert_not_awaited()
     coord.client.heat_pump_events_json.assert_not_awaited()
     assert coord.heatpump_runtime_state_last_error == "HEMS auth backoff active"
-    assert coord.heatpump_daily_consumption_last_error == "HEMS auth backoff active"
-    assert coord.heatpump_power_last_error == "HEMS auth backoff active"
+    assert coord.heatpump_daily_consumption_last_error is None
+    assert runtime.heatpump_daily_split_last_error == "HEMS auth backoff active"
+    assert coord.heatpump_power_last_error is None
     assert (
-        coord._heatpump_power_snapshot["outcome"] == "hems_auth_backoff"
+        coord._heatpump_power_snapshot["outcome"] == "selected_sample"
     )  # noqa: SLF001
     assert (
         runtime._heatpump_events_payloads[0]["error"] == "HEMS auth backoff active"
     )  # noqa: SLF001
-    assert runtime.heatpump_daily_consumption_refresh_due(force=True) is False
-    assert runtime.heatpump_power_refresh_due(force=True) is False
+    assert runtime.heatpump_daily_consumption_refresh_due(force=True) is True
+    assert runtime.heatpump_power_refresh_due(force=True) is True
 
 
 @pytest.mark.asyncio
@@ -1818,11 +2058,10 @@ async def test_heatpump_runtime_isolates_hems_auth_failures(
     assert runtime.heatpump_daily_split_last_error == "HEMS auth backoff active"
 
     coord._clear_hems_auth_circuit(reset_failure_count=True)  # noqa: SLF001
-    calls = iter([False, True])
     monkeypatch.setattr(
         coord,
         "_skip_hems_polling_due_to_auth_circuit",
-        lambda *, endpoint: next(calls),
+        lambda *, endpoint: True,
     )
     coord.client.pv_system_today = AsyncMock(return_value=_site_today_payload(100.0))
     coord.client.hems_energy_consumption = AsyncMock(side_effect=AssertionError)
@@ -1890,6 +2129,9 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"device_uid": "HP-1", "heatpump_status": "RUNNING"}
     )
+    coord.client.pv_system_today = AsyncMock(
+        return_value=_site_today_payload(500.5, timestamp="2026-02-27T00:10:00Z")
+    )
     _seed_previous_heatpump_daily_snapshot(
         coord,
         energy_wh=458.7916666667,
@@ -1904,7 +2146,7 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
 
     assert coord.heatpump_power_w == pytest.approx(500.5)
     assert coord.heatpump_power_device_uid == "HP-1"
-    assert coord.heatpump_power_source == "hems_energy_consumption_delta:HP-1"
+    assert coord.heatpump_power_source == "site_today_heatpump_delta"
     assert coord.heatpump_power_start_utc == datetime(
         2026, 2, 27, 0, 5, tzinfo=timezone.utc
     )
@@ -1922,6 +2164,7 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
     assert first_call.kwargs["step"] == "P1D"
 
     coord._heatpump_power_cache_until = None  # noqa: SLF001
+    coord.client.pv_system_today = AsyncMock(side_effect=RuntimeError("boom"))
     coord.client.hems_energy_consumption = AsyncMock(side_effect=RuntimeError("boom"))
     await coord.heatpump_runtime._async_refresh_heatpump_power(
         force=True
@@ -1936,7 +2179,7 @@ async def test_refresh_heatpump_power_tracks_latest_valid_sample(
         force=True
     )  # noqa: SLF001
     assert coord.heatpump_power_w == pytest.approx(500.5)
-    assert coord.heatpump_power_source == "hems_energy_consumption_delta:HP-1"
+    assert coord.heatpump_power_source == "site_today_heatpump_delta"
     assert coord.heatpump_power_using_stale is True
     assert (
         coord.heatpump_power_last_error
@@ -1991,6 +2234,12 @@ async def test_refresh_heatpump_power_validates_energy_consumption_payload(
     )
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"device_uid": "HP-1", "heatpump_status": "IDLE"}
+    )
+    coord.client.pv_system_today = AsyncMock(
+        return_value=_site_today_payload(
+            55.0,
+            timestamp="2026-04-01T22:31:12.407610009Z",
+        )
     )
     _seed_previous_heatpump_daily_snapshot(
         coord,
@@ -2071,6 +2320,12 @@ async def test_refresh_heatpump_power_preserves_small_idle_value(
     )
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"device_uid": "HP-1", "heatpump_status": "IDLE"}
+    )
+    coord.client.pv_system_today = AsyncMock(
+        return_value=_site_today_payload(
+            4.0,
+            timestamp="2026-04-01T22:31:12.407610009Z",
+        )
     )
     _seed_previous_heatpump_daily_snapshot(
         coord,
@@ -2214,7 +2469,7 @@ async def test_heatpump_power_preserves_stale_sample_on_no_usable_payload(
     )
     coord._heatpump_power_w = 520.0  # noqa: SLF001
     coord._heatpump_power_device_uid = "HP-1"  # noqa: SLF001
-    coord._heatpump_power_source = "hems_energy_consumption_delta:HP-1"  # noqa: SLF001
+    coord._heatpump_power_source = "site_today_heatpump_delta"  # noqa: SLF001
     coord._heatpump_power_last_success_mono = time.monotonic() - 5  # noqa: SLF001
     coord._heatpump_power_last_success_utc = datetime(  # noqa: SLF001
         2026, 4, 5, 0, 0, tzinfo=timezone.utc
@@ -2477,7 +2732,7 @@ async def test_refresh_heatpump_daily_consumption_tracks_site_day(
 
 
 @pytest.mark.asyncio
-async def test_heatpump_daily_consumption_auth_failure_opens_hems_circuit(
+async def test_heatpump_daily_consumption_auth_failure_uses_local_backoff(
     coordinator_factory,
 ) -> None:
     coord = coordinator_factory(serials=[])
@@ -2504,9 +2759,10 @@ async def test_heatpump_daily_consumption_auth_failure_opens_hems_circuit(
 
     coord.client.pv_system_today.assert_awaited_once_with(allow_reauth=False)
     coord.client.hems_energy_consumption.assert_not_awaited()
-    assert coord._hems_auth_circuit_active() is True  # noqa: SLF001
-    assert coord.heatpump_daily_consumption_last_error == "HEMS auth backoff active"
+    assert coord._hems_auth_circuit_active() is False  # noqa: SLF001
+    assert coord.heatpump_daily_consumption_last_error == "Unauthorized"
     assert coord._heatpump_daily_consumption_cache_until is None  # noqa: SLF001
+    assert coord._heatpump_daily_consumption_backoff_until is not None  # noqa: SLF001
 
 
 def test_heatpump_daily_window_handles_dst_transition_day(
@@ -2636,29 +2892,30 @@ def test_heatpump_daily_helper_and_property_edge_cases(
         },
         _site_today_payload(10.0),
     )
-    assert snapshot == {
-        "device_uid": None,
-        "device_name": None,
-        "split_device_uid": "HP-2",
-        "split_device_name": "Backup",
-        "member_name": None,
-        "member_device_type": "ENERGY_METER",
-        "pairing_status": None,
-        "device_state": None,
-        "daily_energy_wh": pytest.approx(10.0),
-        "split_daily_energy_wh": pytest.approx(4.0),
-        "daily_solar_wh": pytest.approx(1.0),
-        "daily_battery_wh": pytest.approx(2.0),
-        "daily_grid_wh": pytest.approx(3.0),
-        "details": [4.0, "bad", None],
-        "source": "site_today_heatpump",
-        "split_source": "hems_energy_consumption:HP-2",
-        "endpoint_type": None,
-        "endpoint_timestamp": None,
-        "split_endpoint_type": None,
-        "split_endpoint_timestamp": None,
-        "sampled_at_utc": None,
-    }
+    assert snapshot["device_uid"] is None
+    assert snapshot["device_name"] is None
+    assert snapshot["split_device_uid"] == "HP-2"
+    assert snapshot["split_device_name"] == "Backup"
+    assert snapshot["member_name"] is None
+    assert snapshot["member_device_type"] == "ENERGY_METER"
+    assert snapshot["pairing_status"] is None
+    assert snapshot["device_state"] is None
+    assert snapshot["daily_energy_wh"] == pytest.approx(10.0)
+    assert snapshot["split_daily_energy_wh"] == pytest.approx(4.0)
+    assert snapshot["daily_solar_wh"] == pytest.approx(1.0)
+    assert snapshot["daily_battery_wh"] == pytest.approx(2.0)
+    assert snapshot["daily_grid_wh"] == pytest.approx(3.0)
+    assert snapshot["details"] == [4.0, "bad", None]
+    assert snapshot["source"] == "site_today_heatpump"
+    assert snapshot["split_source"] == "hems_energy_consumption:HP-2"
+    assert snapshot["endpoint_type"] is None
+    assert snapshot["endpoint_timestamp"] is not None
+    assert snapshot["sample_timestamp_source"] == "coordinator_refresh"
+    assert snapshot["site_interval_seconds"] is None
+    assert snapshot["site_start_time"] is None
+    assert snapshot["split_endpoint_type"] is None
+    assert snapshot["split_endpoint_timestamp"] is None
+    assert snapshot["sampled_at_utc"] is not None
     snapshot = coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
         {
             "data": {
@@ -2680,29 +2937,30 @@ def test_heatpump_daily_helper_and_property_edge_cases(
         },
         _site_today_payload(0.0),
     )
-    assert snapshot == {
-        "device_uid": None,
-        "device_name": None,
-        "split_device_uid": "HP-2",
-        "split_device_name": "Backup",
-        "member_name": None,
-        "member_device_type": "ENERGY_METER",
-        "pairing_status": None,
-        "device_state": None,
-        "daily_energy_wh": pytest.approx(0.0),
-        "split_daily_energy_wh": pytest.approx(0.0),
-        "daily_solar_wh": pytest.approx(0.0),
-        "daily_battery_wh": pytest.approx(0.0),
-        "daily_grid_wh": pytest.approx(0.0),
-        "details": [],
-        "source": "site_today_heatpump",
-        "split_source": "hems_energy_consumption:HP-2",
-        "endpoint_type": None,
-        "endpoint_timestamp": None,
-        "split_endpoint_type": None,
-        "split_endpoint_timestamp": None,
-        "sampled_at_utc": None,
-    }
+    assert snapshot["device_uid"] is None
+    assert snapshot["device_name"] is None
+    assert snapshot["split_device_uid"] == "HP-2"
+    assert snapshot["split_device_name"] == "Backup"
+    assert snapshot["member_name"] is None
+    assert snapshot["member_device_type"] == "ENERGY_METER"
+    assert snapshot["pairing_status"] is None
+    assert snapshot["device_state"] is None
+    assert snapshot["daily_energy_wh"] == pytest.approx(0.0)
+    assert snapshot["split_daily_energy_wh"] == pytest.approx(0.0)
+    assert snapshot["daily_solar_wh"] == pytest.approx(0.0)
+    assert snapshot["daily_battery_wh"] == pytest.approx(0.0)
+    assert snapshot["daily_grid_wh"] == pytest.approx(0.0)
+    assert snapshot["details"] == []
+    assert snapshot["source"] == "site_today_heatpump"
+    assert snapshot["split_source"] == "hems_energy_consumption:HP-2"
+    assert snapshot["endpoint_type"] is None
+    assert snapshot["endpoint_timestamp"] is not None
+    assert snapshot["sample_timestamp_source"] == "coordinator_refresh"
+    assert snapshot["site_interval_seconds"] is None
+    assert snapshot["site_start_time"] is None
+    assert snapshot["split_endpoint_type"] is None
+    assert snapshot["split_endpoint_timestamp"] is None
+    assert snapshot["sampled_at_utc"] is not None
     snapshot = coord.heatpump_runtime._build_heatpump_daily_consumption_snapshot(  # noqa: SLF001
         {"data": {"heat-pump": [{"device_uid": "HP-1", "consumption": ["bad"]}]}},
         _site_today_payload(10.0),
@@ -3002,12 +3260,14 @@ def test_heatpump_power_refresh_due_covers_cache_backoff_and_fetcher(
     assert (
         runtime._heatpump_power_summary_from_daily_snapshot(None) is None
     )  # noqa: SLF001
-    assert (
+    malformed_summary = (
         runtime._heatpump_power_summary_from_daily_snapshot(  # noqa: SLF001
             {"daily_energy_wh": 10.0}
         )
-        is None
     )
+    assert malformed_summary is not None
+    assert malformed_summary["rejected"] is True
+    assert malformed_summary["validation"] == "rejected_missing_energy_baseline"
 
     assert runtime.heatpump_daily_split_last_error is None
 
@@ -3307,6 +3567,12 @@ async def test_heatpump_runtime_power_and_diagnostics_paths(
     )
     coord.client.hems_heatpump_state = AsyncMock(
         return_value={"device_uid": "HP-CTRL", "heatpump_status": "RUNNING"}
+    )
+    coord.client.pv_system_today = AsyncMock(
+        side_effect=[
+            _site_today_payload(610.0, timestamp="2026-03-13T00:05:00Z"),
+            _site_today_payload(0.0, timestamp="2026-03-13T00:10:00Z"),
+        ]
     )
     _seed_previous_heatpump_daily_snapshot(
         coord,


### PR DESCRIPTION
## Summary

- Fixes #680 by deriving Heat Pump power from site-today `heatpump` daily energy deltas instead of HEMS daily split energy.
- Keep HEMS daily split data as optional metadata/diagnostics and avoid using HEMS auth/support state to block site-today power updates.
- Document the updated API behavior and add regression coverage for site-today timestamps, auth handling, and unsupported HEMS site paths.

## Related Issues

Fixes #680.
Related context: #528.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py && ruff check custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_heatpump_runtime.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/heatpump_runtime.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/heatpump_runtime.py tests/components/enphase_ev/test_heatpump_runtime.py && ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "git status --short --branch && python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
```

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The pre-commit command mounts the repository Git metadata because this Codex checkout is a Git worktree and Docker otherwise cannot resolve the host `.git/worktrees/...` path.
