### PR TITLE
Reuse stale status on transient network errors

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -495,6 +495,8 @@ class RefreshPipelineContext:
     first_refresh_followups_task: asyncio.Task[None] | None = None
     auth_refresh_rejected_count_at_start: int = 0
     status_used_stale: bool = False
+    status_stale_network_failure: bool = False
+    status_stale_dns_failure: bool = False
     fast_poll: bool = False
 
 
@@ -2529,6 +2531,13 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
     def _status_stale_window_s(self) -> float:
         return self.diagnostics.status_stale_window_s()
 
+    def _status_payload_reusable(self, *, first_refresh: bool) -> bool:
+        return (
+            not first_refresh
+            and isinstance(self._status_payload_cache, dict)
+            and self._payload_endpoint_reusable("status", self._status_stale_window_s())
+        )
+
     def payload_health_diagnostics(self) -> dict[str, object]:
         return self.diagnostics.payload_health_diagnostics()
 
@@ -2748,14 +2757,16 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         self._http_errors = 0
         self._payload_errors = 0
         self.diagnostics.clear_rate_limited_issue()
-        self.diagnostics.clear_network_issue()
-        self._network_errors = 0
+        if not getattr(context, "status_stale_network_failure", False):
+            self.diagnostics.clear_network_issue()
+            self._network_errors = 0
         self.diagnostics.clear_cloud_issue()
         self._backoff_until = None
         self._clear_backoff_timer()
         self._last_error = None
-        self.diagnostics.clear_dns_issue()
-        self._dns_failures = 0
+        if not getattr(context, "status_stale_dns_failure", False):
+            self.diagnostics.clear_dns_issue()
+            self._dns_failures = 0
         if not context.status_used_stale:
             self.last_success_utc = dt_util.utcnow()
             self.payload_using_stale = False
@@ -2996,12 +3007,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             raise ConfigEntryAuthFailed from err
         except OptionalEndpointUnavailable as err:
             reason = (str(err) or "EVSE status endpoint unavailable").strip()
-            can_reuse_status = (
-                not first_refresh
-                and isinstance(self._status_payload_cache, dict)
-                and self._payload_endpoint_reusable(
-                    "status", self._status_stale_window_s()
-                )
+            can_reuse_status = self._status_payload_reusable(
+                first_refresh=first_refresh
             )
             _LOGGER.debug(
                 "EVSE status endpoint unavailable for site %s: %s",
@@ -3038,12 +3045,8 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
         except InvalidPayloadError as err:
             reason = (err.summary or str(err) or "Invalid JSON response").strip()
             signature = err.signature_dict()
-            can_reuse_status = (
-                not first_refresh
-                and isinstance(self._status_payload_cache, dict)
-                and self._payload_endpoint_reusable(
-                    "status", self._status_stale_window_s()
-                )
+            can_reuse_status = self._status_payload_reusable(
+                first_refresh=first_refresh
             )
             self._last_error = reason
             self.last_failure_endpoint = err.endpoint
@@ -3157,6 +3160,9 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             msg = redact_text(err, site_ids=(self.site_id,))
             if not msg:
                 msg = err.__class__.__name__
+            can_reuse_status = self._status_payload_reusable(
+                first_refresh=first_refresh
+            )
             self._last_error = msg
             self._network_errors += 1
             self._payload_errors = 0
@@ -3172,19 +3178,6 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             )
             if dns_failure:
                 self._dns_failures += 1
-            else:
-                self._dns_failures = 0
-                self.diagnostics.clear_dns_issue()
-            backoff_multiplier = 2 ** min(self._network_errors - 1, 3)
-            jitter = random.uniform(1.0, 2.5)
-            slow_floor = self._slow_interval_floor()
-            backoff = max(slow_floor, slow_floor * backoff_multiplier * jitter)
-            self._backoff_until = time.monotonic() + backoff
-            self._schedule_backoff_timer(backoff)
-            if self._network_errors >= 3:
-                self.diagnostics.report_network_issue()
-            if dns_failure and self._dns_failures >= 2:
-                self.diagnostics.report_dns_issue()
             now_utc = dt_util.utcnow()
             self.last_failure_utc = now_utc
             self.last_failure_status = None
@@ -3192,12 +3185,44 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
             self.last_failure_response = None
             self.last_failure_source = "network"
             self.last_failure_endpoint = None
-            self.payload_using_stale = False
-            self.payload_failure_kind = None
-            raise UpdateFailed(
-                f"Error communicating with API: {msg}",
-                retry_after=backoff,
-            )
+            if can_reuse_status:
+                self.payload_using_stale = True
+                self.payload_failure_kind = None
+                self._note_payload_endpoint_failure(
+                    "status",
+                    error=msg,
+                    signature=None,
+                    using_stale=True,
+                )
+                phase_timings["status_s"] = round(time.monotonic() - status_start, 3)
+                data = dict(self._status_payload_cache)
+                context.status_used_stale = True
+                context.status_stale_network_failure = True
+                context.status_stale_dns_failure = bool(
+                    dns_failure
+                    or self._dns_failures
+                    or getattr(self, "_dns_issue_reported", False)
+                )
+                if dns_failure and self._dns_failures >= 2:
+                    self.diagnostics.report_dns_issue()
+                status_refresh_succeeded = True
+            else:
+                backoff_multiplier = 2 ** min(self._network_errors - 1, 3)
+                jitter = random.uniform(1.0, 2.5)
+                slow_floor = self._slow_interval_floor()
+                backoff = max(slow_floor, slow_floor * backoff_multiplier * jitter)
+                self._backoff_until = time.monotonic() + backoff
+                self._schedule_backoff_timer(backoff)
+                if self._network_errors >= 3:
+                    self.diagnostics.report_network_issue()
+                if dns_failure and self._dns_failures >= 2:
+                    self.diagnostics.report_dns_issue()
+                self.payload_using_stale = False
+                self.payload_failure_kind = None
+                raise UpdateFailed(
+                    f"Error communicating with API: {msg}",
+                    retry_after=backoff,
+                )
         finally:
             if not status_refresh_succeeded:
                 await self._async_cancel_first_refresh_followups(context)

--- a/tests/components/enphase_ev/test_coordinator_additional_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_additional_coverage.py
@@ -1794,7 +1794,7 @@ async def test_async_update_data_network_dns_issue(
 
 
 @pytest.mark.asyncio
-async def test_async_update_data_network_error_clears_dns(
+async def test_async_update_data_network_error_keeps_existing_dns_issue(
     coordinator_factory, mock_issue_registry, monkeypatch
 ):
     coord = coordinator_factory()
@@ -1802,11 +1802,13 @@ async def test_async_update_data_network_error_clears_dns(
     coord._schedule_backoff_timer = MagicMock()
     coord._network_errors = 3
     coord._dns_issue_reported = True
+    coord._dns_failures = 2
 
     with pytest.raises(UpdateFailed):
         await coord._async_update_data()
 
-    assert coord._dns_issue_reported is False
+    assert coord._dns_issue_reported is True
+    assert coord._dns_failures == 2
 
 
 def test_sync_desired_charging_schedules_auto_resume(coordinator_factory, monkeypatch):

--- a/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
+++ b/tests/components/enphase_ev/test_coordinator_remaining_coverage.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -24,6 +25,9 @@ from custom_components.enphase_ev.coordinator import (
 from custom_components.enphase_ev.const import (
     CONF_COOKIE,
     DEFAULT_SLOW_POLL_INTERVAL,
+    DOMAIN,
+    ISSUE_DNS_RESOLUTION,
+    ISSUE_NETWORK_UNREACHABLE,
     OPT_FAST_POLL_INTERVAL,
     OPT_FAST_WHILE_STREAMING,
     OPT_SLOW_POLL_INTERVAL,
@@ -666,6 +670,128 @@ async def test_async_update_data_invalid_payload_reuses_cached_status_within_sta
         issue[1] == ISSUE_CLOUD_ERRORS for issue in mock_issue_registry.created
     )
     assert any(issue[1] == ISSUE_CLOUD_ERRORS for issue in mock_issue_registry.deleted)
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_network_error_reuses_cached_status_within_stale_window(
+    coordinator_factory,
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseSiteLastErrorCodeSensor
+
+    coord = coordinator_factory()
+    coord._has_successful_refresh = True
+    coord.data = {RANDOM_SERIAL: {"sn": RANDOM_SERIAL, "name": "Cached Charger"}}
+    coord._status_payload_cache = {
+        "evChargerData": [{"sn": RANDOM_SERIAL, "connectors": [{}]}],
+        "ts": "1700000123",
+    }
+    coord._mark_payload_endpoint_success(
+        "status",
+        success_mono=coord_mod.time.monotonic(),
+        success_utc=datetime.now(timezone.utc),
+    )
+    coord.client.status = AsyncMock(side_effect=asyncio.TimeoutError())
+    coord._schedule_backoff_timer = MagicMock()
+
+    result = await coord._async_update_data()
+
+    assert RANDOM_SERIAL in result
+    assert coord.payload_using_stale is True
+    assert coord.payload_failure_kind is None
+    assert coord.last_failure_source == "network"
+    assert EnphaseSiteLastErrorCodeSensor(coord).native_value == "network_error"
+    assert coord._network_errors == 1
+    assert coord._backoff_until is None
+    coord._schedule_backoff_timer.assert_not_called()
+    assert "total_s" in coord.phase_timings
+    assert coord._payload_health["status"]["using_stale"] is True  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_dns_error_reuses_stale_status_and_reports_dns_issue(
+    coordinator_factory,
+    mock_issue_registry,
+) -> None:
+    from custom_components.enphase_ev.sensor import EnphaseSiteLastErrorCodeSensor
+
+    coord = coordinator_factory()
+    coord._has_successful_refresh = True
+    coord.data = {RANDOM_SERIAL: {"sn": RANDOM_SERIAL, "name": "Cached Charger"}}
+    coord._status_payload_cache = {
+        "evChargerData": [{"sn": RANDOM_SERIAL, "connectors": [{}]}],
+        "ts": "1700000123",
+    }
+    coord._mark_payload_endpoint_success(
+        "status",
+        success_mono=coord_mod.time.monotonic(),
+        success_utc=datetime.now(timezone.utc),
+    )
+    coord.client.status = AsyncMock(
+        side_effect=aiohttp.ClientError("Temporary failure in name resolution")
+    )
+    coord._schedule_backoff_timer = MagicMock()
+
+    first_result = await coord._async_update_data()
+    second_result = await coord._async_update_data()
+
+    assert RANDOM_SERIAL in first_result
+    assert RANDOM_SERIAL in second_result
+    assert coord.payload_using_stale is True
+    assert coord.last_failure_source == "network"
+    assert EnphaseSiteLastErrorCodeSensor(coord).native_value == "dns_error"
+    assert coord._network_errors == 2
+    assert coord._dns_failures == 2
+    assert coord._backoff_until is None
+    coord._schedule_backoff_timer.assert_not_called()
+    assert any(
+        issue[1] == ISSUE_DNS_RESOLUTION for issue in mock_issue_registry.created
+    )
+    assert not any(
+        issue[1] == ISSUE_NETWORK_UNREACHABLE for issue in mock_issue_registry.created
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_update_data_stale_timeout_keeps_existing_dns_issue(
+    coordinator_factory,
+    mock_issue_registry,
+) -> None:
+    coord = coordinator_factory()
+    coord._has_successful_refresh = True
+    coord.data = {RANDOM_SERIAL: {"sn": RANDOM_SERIAL, "name": "Cached Charger"}}
+    coord._status_payload_cache = {
+        "evChargerData": [{"sn": RANDOM_SERIAL, "connectors": [{}]}],
+        "ts": "1700000123",
+    }
+    coord._mark_payload_endpoint_success(
+        "status",
+        success_mono=coord_mod.time.monotonic(),
+        success_utc=datetime.now(timezone.utc),
+    )
+    coord.client.status = AsyncMock(
+        side_effect=[
+            aiohttp.ClientError("Temporary failure in name resolution"),
+            aiohttp.ClientError("Temporary failure in name resolution"),
+            asyncio.TimeoutError(),
+        ]
+    )
+    coord._schedule_backoff_timer = MagicMock()
+
+    await coord._async_update_data()
+    await coord._async_update_data()
+    timeout_result = await coord._async_update_data()
+
+    assert RANDOM_SERIAL in timeout_result
+    assert coord.payload_using_stale is True
+    assert coord.last_failure_source == "network"
+    assert coord._network_errors == 3
+    assert coord._dns_failures == 2
+    assert coord._dns_issue_reported is True
+    assert coord._backoff_until is None
+    assert (DOMAIN, ISSUE_DNS_RESOLUTION) not in mock_issue_registry.deleted
+    assert not any(
+        issue[1] == ISSUE_NETWORK_UNREACHABLE for issue in mock_issue_registry.created
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/components/enphase_ev/test_rate_limit_and_switch_kick.py
+++ b/tests/components/enphase_ev/test_rate_limit_and_switch_kick.py
@@ -210,6 +210,7 @@ async def test_latency_ms_set_on_success_and_failure(hass, monkeypatch):
             raise asyncio.TimeoutError()
 
     coord.client = BadClient()
+    coord._status_payload_cache = None  # noqa: SLF001
     with pytest.raises(UpdateFailed):
         await coord._async_update_data()
     # latency should still be set in finally


### PR DESCRIPTION
## Summary

- Reuse a recent cached EVSE status payload for transient network and timeout failures while it remains inside the stale-status window.
- Preserve DNS repair diagnostics during stale fallback, and report the DNS repair after repeated DNS-resolution failures without also raising the generic network repair.
- Keep first-refresh and expired-stale-window network failures on the existing `UpdateFailed` backoff path.

Fixes #683.

## Related Issues

- #683

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_coordinator_additional_coverage.py tests/components/enphase_ev/test_coordinator_remaining_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_remaining_coverage.py::test_async_update_data_dns_error_reuses_stale_status_and_reports_dns_issue tests/components/enphase_ev/test_coordinator_remaining_coverage.py::test_async_update_data_stale_timeout_keeps_existing_dns_issue tests/components/enphase_ev/test_coordinator_additional_coverage.py::test_async_update_data_network_error_keeps_existing_dns_issue tests/components/enphase_ev/test_coordinator_additional_coverage.py::test_async_update_data_network_dns_issue"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_coordinator_remaining_coverage.py::test_async_update_data_network_error_reuses_cached_status_within_stale_window tests/components/enphase_ev/test_coordinator_remaining_coverage.py::test_async_update_data_invalid_payload_reuses_cached_status_within_stale_window tests/components/enphase_ev/test_coordinator_remaining_coverage.py::test_async_update_data_invalid_payload_fails_when_status_stale_window_expires tests/components/enphase_ev/test_coordinator_behavior.py::test_site_only_clears_issues_and_counters tests/components/enphase_ev/test_rate_limit_and_switch_kick.py::test_rate_limit_issue_created_on_repeated_429"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator.py tests/components/enphase_ev/test_coordinator_remaining_coverage.py tests/components/enphase_ev/test_coordinator_additional_coverage.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check tests/components/enphase_ev/test_rate_limit_and_switch_kick.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black tests/components/enphase_ev/test_rate_limit_and_switch_kick.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_rate_limit_and_switch_kick.py::test_latency_ms_set_on_success_and_failure"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q"
git diff --check
```

Coverage report: `custom_components/enphase_ev/coordinator.py` remained at 100%.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

The change is based on the diagnostics/logs from #683, where the charger data was otherwise usable but transient cloud/DNS/network failures made the status endpoint unavailable during refresh.
