### PR TITLE
Throttle tariff refreshes

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -163,7 +163,7 @@ from .refresh_plan import (
     build_site_only_followup_plan,
 )
 from .refresh_runner import RefreshRunner
-from .tariff import TariffRuntime
+from .tariff import TARIFF_SUCCESS_TTL_S, TariffRuntime
 from .service_validation import raise_translated_service_validation
 from .state_models import (
     BatteryControlCapability,
@@ -971,7 +971,7 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 support_state_on_success=True,
             ),
             "tariff": EndpointFamilyPolicy(
-                success_ttl_s=None,
+                success_ttl_s=TARIFF_SUCCESS_TTL_S,
                 stale_after_s=86400.0,
                 failure_backoff_schedule_s=(60.0, 60.0, 60.0, 60.0),
                 max_backoff_s=60.0,

--- a/custom_components/enphase_ev/tariff.py
+++ b/custom_components/enphase_ev/tariff.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
 TARIFF_ENDPOINT_FAMILY = "tariff"
 TARIFF_DATED_RATES_ENDPOINT_FAMILY = "tariff_dated_rates"
+TARIFF_SUCCESS_TTL_S = 900.0
 TARIFF_BRANCH_KEYS = frozenset({"purchase", "buyback"})
 TARIFF_TYPE_IDS = frozenset({"flat", "tou", "tiered"})
 TARIFF_TYPE_KINDS = frozenset(

--- a/tests/components/enphase_ev/test_tariff.py
+++ b/tests/components/enphase_ev/test_tariff.py
@@ -8,6 +8,7 @@ import aiohttp
 import pytest
 from homeassistant.exceptions import ServiceValidationError
 
+from custom_components.enphase_ev import coordinator as coord_mod
 from custom_components.enphase_ev import sensor as sensor_mod
 from custom_components.enphase_ev.api import OptionalEndpointUnavailable
 from custom_components.enphase_ev.const import DOMAIN
@@ -23,6 +24,7 @@ from custom_components.enphase_ev.sensor import (
 from custom_components.enphase_ev.tariff import (
     TARIFF_DATED_RATES_ENDPOINT_FAMILY,
     TARIFF_ENDPOINT_FAMILY,
+    TARIFF_SUCCESS_TTL_S,
     TariffBillingUpdate,
     TariffRateLocator,
     TariffRateSnapshot,
@@ -2489,6 +2491,62 @@ def test_tariff_runtime_refresh_due_uses_endpoint_family_gate(
 
     assert TariffRuntime(coord).refresh_due() is True
     coord._endpoint_family_should_run.assert_called_once_with("tariff")  # noqa: SLF001
+
+
+@pytest.mark.asyncio
+async def test_tariff_runtime_success_throttles_followup_refreshes(
+    coordinator_factory,
+    monkeypatch,
+) -> None:
+    coord = coordinator_factory()
+    now = datetime(2026, 5, 17, 8, 45, tzinfo=timezone.utc)
+    monkeypatch.setattr(coord_mod.time, "monotonic", lambda: 1_000.0)
+    monkeypatch.setattr(coord_mod.dt_util, "utcnow", lambda: now)
+    coord.client.site_tariff_bundle = AsyncMock(
+        return_value=(
+            {
+                "anyBillPeriodStartDate": "2025-08-18",
+                "billingFrequency": "MONTH",
+                "billingIntervalValue": 1,
+            },
+            {
+                "currency": "$",
+                "purchase": {
+                    "typeKind": "single",
+                    "typeId": "flat",
+                    "seasons": [
+                        {
+                            "id": "default",
+                            "startMonth": "1",
+                            "endMonth": "12",
+                            "days": [
+                                {
+                                    "id": "week",
+                                    "days": [1, 2, 3, 4, 5, 6, 7],
+                                    "periods": [{"rate": "0.03"}],
+                                }
+                            ],
+                        }
+                    ],
+                },
+            },
+        )
+    )
+
+    await TariffRuntime(coord).async_refresh()
+
+    health = coord._endpoint_family_state(TARIFF_ENDPOINT_FAMILY)  # noqa: SLF001
+    assert health.next_retry_mono == pytest.approx(1_000.0 + TARIFF_SUCCESS_TTL_S)
+    assert health.next_retry_utc == now + coord_mod.timedelta(
+        seconds=TARIFF_SUCCESS_TTL_S
+    )
+    assert TariffRuntime(coord).refresh_due() is False
+
+    await TariffRuntime(coord).async_refresh()
+    coord.client.site_tariff_bundle.assert_awaited_once()
+
+    await TariffRuntime(coord).async_refresh(force=True)
+    assert coord.client.site_tariff_bundle.await_count == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Throttle successful tariff refreshes for 15 minutes so the non-realtime tariff endpoint is not called on every follow-up refresh cycle. This targets the measured local performance audit sample where tariff refresh took 2.442s during steady-state polling.

## Related Issues

None.

## Type of change

- [x] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/tariff.py tests/components/enphase_ev/test_tariff.py && ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm -v /Users/james/Documents/GitHub/ha-enphase-ev-charger/.git:/Users/james/Documents/GitHub/ha-enphase-ev-charger/.git ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/tariff.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest tests/components/enphase_ev -q"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest"
```

Additional focused checks run during development:

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_tariff.py::test_tariff_runtime_refreshes_snapshots tests/components/enphase_ev/test_tariff.py::test_tariff_runtime_success_throttles_followup_refreshes tests/components/enphase_ev/test_tariff.py::test_tariff_runtime_respects_endpoint_gate"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_tariff.py tests/components/enphase_ev/test_performance_audit_regressions.py"
```

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

- Local Home Assistant performance trace found tariff at 2.442s in a steady-state refresh sample.
- Tariff refresh remains force-refreshable after tariff writes.
- No user-facing strings or translations changed.
- `pre-commit` required mounting the parent repository Git metadata because this checkout is a Git worktree whose `.git` file points outside the Docker-mounted workspace.
