### PR TITLE
Prepare release v3.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,24 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+## v3.0.10 - 2026-05-17
+
+### 🚧 Breaking changes
+- None
+
+### ✨ New features
+- None
+
 ### 🐛 Bug fixes
-- Derived Heat Pump power from the site-today heat-pump daily energy total instead of HEMS split energy, avoiding false `0 W` readings when the HEMS split remains flat. (#680)
+- Reused the last successful EV charger status payload during transient network or DNS failures so charger entities can keep reporting recent state while diagnostics still track the outage. (#685)
+- Derived Heat Pump power from the site-today heat-pump daily energy total instead of HEMS split energy, avoiding false `0 W` readings when the HEMS split remains flat. (#684)
+
+### 🔧 Improvements
+- Throttled tariff refreshes after a successful read to reduce repeated Enphase cloud requests during steady polling. (#686)
+
+### 🔄 Other changes
+- Updated the API reference to document site-today heat-pump power derivation.
+- Bumped the integration manifest version to `3.0.10`.
 
 ## v3.0.9 - 2026-05-14
 

--- a/custom_components/enphase_ev/manifest.json
+++ b/custom_components/enphase_ev/manifest.json
@@ -18,5 +18,5 @@
   ],
   "quality_scale": "platinum",
   "requirements": [],
-  "version": "3.0.9"
+  "version": "3.0.10"
 }


### PR DESCRIPTION
## Summary

Prepare release v3.0.10 by bumping the integration manifest version and adding the v3.0.10 changelog section.

The changelog captures all changes since v3.0.9:
- reuse stale EV charger status during transient network or DNS failures
- derive Heat Pump power from site-today heat-pump daily energy
- throttle successful tariff refreshes to reduce cloud request volume

## Related Issues

Related PRs: #684, #685, #686.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [x] Documentation
- [ ] Refactor / tech debt
- [ ] Translation update
- [x] Other (describe below)

Release metadata update.

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check ."
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m json.tool custom_components/enphase_ev/manifest.json >/dev/null"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_manifest.py"
git diff --check
```

No Python source files changed, so Black and targeted Python-module coverage were not applicable.

## Checklist

- [x] I updated `CHANGELOG.md` for user-facing changes.
- [x] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [x] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

No diagnostics or screenshots; this PR only updates release metadata and changelog.
