### PR TITLE
Refactor Enphase EV architecture

### DIFF
--- a/custom_components/enphase_ev/coordinator.py
+++ b/custom_components/enphase_ev/coordinator.py
@@ -53,7 +53,6 @@ from .const import (
     CONF_AUTH_REFRESH_SUSPENDED_UNTIL,
     CONF_COOKIE,
     DEFAULT_CHARGE_LEVEL_SETTING,
-    DEFAULT_NOMINAL_VOLTAGE,
     CONF_EAUTH,
     CONF_EMAIL,
     CONF_HEMS_AUTH_BACKOFF_UNTIL,
@@ -117,6 +116,7 @@ from .evse_runtime import (
     EvseRuntime,
     evse_power_is_actively_charging,
 )
+from .evse_power import build_evse_power_snapshot
 from .heatpump_runtime import HeatpumpRuntime
 from .inventory_runtime import CoordinatorTopologySnapshot, InventoryRuntime
 from .inventory_view import InventoryView
@@ -411,48 +411,9 @@ def _coerce_int_list(value: object) -> list[int] | None:
     return parsed or None
 
 
-def _power_parse_timestamp(raw: object) -> float | None:
-    if raw is None:
-        return None
-    if isinstance(raw, (int, float)):
-        try:
-            value = float(raw)
-        except Exception:
-            return None
-        if value > 10**12:
-            value = value / 1000.0
-        if value <= 0:
-            return None
-        try:
-            datetime.fromtimestamp(value, tz=_tz.utc)
-        except Exception:
-            return None
-        return value
-    if isinstance(raw, str):
-        stripped = raw.strip()
-        if not stripped:
-            return None
-        normalized = stripped.replace("[UTC]", "").replace("Z", "+00:00")
-        try:
-            dt_obj = datetime.fromisoformat(normalized)
-        except ValueError:
-            return None
-        if dt_obj.tzinfo is None:
-            dt_obj = dt_obj.replace(tzinfo=_tz.utc)
-        return dt_obj.astimezone(_tz.utc).timestamp()
-    return None
-
-
 def _power_as_float(raw: object) -> float | None:
     try:
         return float(raw)
-    except (TypeError, ValueError):
-        return None
-
-
-def _power_as_int(raw: object) -> int | None:
-    try:
-        return int(float(raw))
     except (TypeError, ValueError):
         return None
 
@@ -3288,294 +3249,6 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
                 return feature_flag_value, "feature_flag"
             return None, "unknown"
 
-        def _power_topology(entry: dict[str, object]) -> str:
-            phase_mode = entry.get("phase_mode")
-            if phase_mode is not None:
-                try:
-                    normalized = (
-                        str(phase_mode)
-                        .strip()
-                        .lower()
-                        .replace("-", "_")
-                        .replace(" ", "_")
-                    )
-                except Exception:  # noqa: BLE001
-                    normalized = ""
-                if normalized:
-                    if normalized in {"3", "3_phase", "three", "three_phase"}:
-                        return "three_phase"
-                    if normalized in {"split", "split_phase"}:
-                        return "split_phase"
-                    if normalized in {"1", "single", "single_phase"}:
-                        return "single_phase"
-            phase_count = _power_as_int(entry.get("phase_count"))
-            if phase_count is not None:
-                if phase_count >= 3:
-                    return "three_phase"
-                if phase_count == 1:
-                    return "single_phase"
-            return "unknown"
-
-        def _three_phase_multiplier(entry: dict[str, object]) -> float:
-            wiring = entry.get("wiring_configuration")
-            explicit_neutral = False
-            if isinstance(wiring, dict):
-                for raw in (*wiring.keys(), *wiring.values()):
-                    try:
-                        token = (
-                            str(raw).strip().lower().replace("-", "_").replace(" ", "_")
-                        )
-                    except Exception:  # noqa: BLE001
-                        continue
-                    if token in {"n", "neutral", "l1n", "l2n", "l3n", "ln"}:
-                        explicit_neutral = True
-                        break
-            return 3.0 if explicit_neutral else 1.7320508075688772
-
-        def _resolve_max_throughput(
-            entry: dict[str, object],
-        ) -> tuple[int, str, float | None, float, int, str, float]:
-            voltage = _power_as_float(entry.get("operating_v"))
-            if voltage is None or voltage <= 0:
-                voltage = _power_as_float(entry.get("nominal_v"))
-            if voltage is None or voltage <= 0:
-                voltage = float(
-                    getattr(self, "nominal_voltage", DEFAULT_NOMINAL_VOLTAGE)
-                )
-            topology = _power_topology(entry)
-            phase_multiplier = 1.0
-            for source, raw in (
-                ("session_charge_level", entry.get("session_charge_level")),
-                ("charging_level", entry.get("charging_level")),
-                ("max_amp", entry.get("max_amp")),
-                ("max_current", entry.get("max_current")),
-            ):
-                amps = _power_as_float(raw)
-                if amps is None or amps <= 0:
-                    continue
-                if topology == "three_phase":
-                    phase_multiplier = _three_phase_multiplier(entry)
-                unbounded = int(round(voltage * amps * phase_multiplier))
-                if unbounded <= 0:
-                    continue
-                bounded = min(unbounded, 19200)
-                return (
-                    bounded,
-                    source,
-                    amps,
-                    voltage,
-                    unbounded,
-                    topology,
-                    phase_multiplier,
-                )
-            return (19200, "static_default", None, voltage, 19200, topology, 1.0)
-
-        def _is_actually_charging(entry: dict[str, object]) -> bool:
-            if "actual_charging" in entry:
-                return bool(entry.get("actual_charging"))
-            return evse_power_is_actively_charging(
-                entry.get("connector_status"),
-                entry.get("charging"),
-                suspended_by_evse=entry.get("suspended_by_evse"),
-            )
-
-        def _known_previous_charging_state(
-            entry: dict[str, object] | None,
-        ) -> bool | None:
-            if not isinstance(entry, dict):
-                return None
-            if not any(
-                key in entry
-                for key in (
-                    "connector_status",
-                    "charging",
-                    "actual_charging",
-                    "suspended_by_evse",
-                )
-            ):
-                return None
-            return _is_actually_charging(entry)
-
-        def _build_evse_power_snapshot(
-            serial: str,
-            entry: dict[str, object],
-            previous_entry: dict[str, object] | None,
-        ) -> dict[str, object]:
-            previous = self.evse_state._evse_power_snapshots.get(serial, {})
-            (
-                max_watts,
-                max_source,
-                max_amps,
-                max_voltage,
-                max_unbounded,
-                max_topology,
-                max_phase_multiplier,
-            ) = _resolve_max_throughput(entry)
-            snapshot: dict[str, object] = {
-                "derived_power_max_throughput_w": max_watts,
-                "derived_power_max_throughput_unbounded_w": max_unbounded,
-                "derived_power_max_throughput_source": max_source,
-                "derived_power_max_throughput_amps": max_amps,
-                "derived_power_max_throughput_voltage": max_voltage,
-                "derived_power_max_throughput_topology": max_topology,
-                "derived_power_max_throughput_phase_multiplier": (max_phase_multiplier),
-            }
-
-            sample_ts = _power_parse_timestamp(entry.get("sampled_at_ts"))
-            if sample_ts is None:
-                sample_ts = _power_parse_timestamp(entry.get("sampled_at_utc"))
-            if sample_ts is None:
-                sample_ts = _power_parse_timestamp(entry.get("last_reported_at"))
-            sample_iso = (
-                datetime.fromtimestamp(sample_ts, tz=_tz.utc).isoformat()
-                if sample_ts is not None
-                else None
-            )
-            lifetime = _power_as_float(entry.get("lifetime_kwh"))
-            is_charging = _is_actually_charging(entry)
-            previous_is_charging = _known_previous_charging_state(previous_entry)
-
-            last_power_w = _power_as_int(previous.get("derived_power_w"))
-            if last_power_w is None:
-                last_power_w = 0
-            last_method = previous.get("derived_power_method")
-            if not isinstance(last_method, str):
-                last_method = "seeded"
-            last_window_s = _power_as_float(
-                previous.get("derived_power_window_seconds")
-            )
-            last_lifetime_kwh = _power_as_float(
-                previous.get("derived_last_lifetime_kwh")
-            )
-            last_energy_ts = _power_parse_timestamp(
-                previous.get("derived_last_energy_ts")
-            )
-            last_reset_at = _power_parse_timestamp(
-                previous.get("derived_last_reset_at")
-            )
-            prior_sample_ts = _power_parse_timestamp(
-                previous.get("derived_last_sample_ts")
-            )
-            lifetime_changed = (lifetime is None) != (last_lifetime_kwh is None) or (
-                lifetime is not None
-                and last_lifetime_kwh is not None
-                and abs(lifetime - last_lifetime_kwh) > 1e-9
-            )
-            if (
-                sample_ts is not None
-                and prior_sample_ts is not None
-                and sample_ts == prior_sample_ts
-                and not lifetime_changed
-            ):
-                snapshot.update(previous)
-                snapshot.update(
-                    {
-                        "derived_sampled_at_utc": sample_iso,
-                        "derived_last_sample_ts": sample_ts,
-                        "derived_power_max_throughput_w": max_watts,
-                        "derived_power_max_throughput_unbounded_w": max_unbounded,
-                        "derived_power_max_throughput_source": max_source,
-                        "derived_power_max_throughput_amps": max_amps,
-                        "derived_power_max_throughput_voltage": max_voltage,
-                        "derived_power_max_throughput_topology": max_topology,
-                        "derived_power_max_throughput_phase_multiplier": (
-                            max_phase_multiplier
-                        ),
-                    }
-                )
-                if not is_charging:
-                    snapshot["derived_power_w"] = 0
-                    snapshot["derived_power_method"] = "idle"
-                    snapshot["derived_power_window_seconds"] = None
-                self.evse_state._evse_power_snapshots[serial] = snapshot
-                return snapshot
-
-            snapshot.update(
-                {
-                    "derived_sampled_at_utc": sample_iso,
-                    "derived_last_sample_ts": sample_ts,
-                    "derived_last_lifetime_kwh": last_lifetime_kwh,
-                    "derived_last_energy_ts": last_energy_ts,
-                    "derived_last_reset_at": last_reset_at,
-                    "derived_power_w": last_power_w,
-                    "derived_power_window_seconds": last_window_s,
-                    "derived_power_method": last_method,
-                }
-            )
-
-            if previous_is_charging is False and is_charging:
-                snapshot["derived_power_w"] = 0
-                snapshot["derived_power_method"] = "seeded"
-                snapshot["derived_power_window_seconds"] = None
-                if lifetime is not None:
-                    snapshot["derived_last_lifetime_kwh"] = lifetime
-                if sample_ts is not None:
-                    snapshot["derived_last_energy_ts"] = sample_ts
-                self.evse_state._evse_power_snapshots[serial] = snapshot
-                return snapshot
-
-            if lifetime is None:
-                if not is_charging:
-                    snapshot["derived_power_w"] = 0
-                    snapshot["derived_power_method"] = "idle"
-                    snapshot["derived_power_window_seconds"] = None
-                self.evse_state._evse_power_snapshots[serial] = snapshot
-                return snapshot
-
-            if sample_ts is None:
-                snapshot["derived_last_lifetime_kwh"] = lifetime
-                self.evse_state._evse_power_snapshots[serial] = snapshot
-                return snapshot
-
-            if last_lifetime_kwh is None:
-                snapshot["derived_last_lifetime_kwh"] = lifetime
-                snapshot["derived_last_energy_ts"] = sample_ts
-                snapshot["derived_power_w"] = 0
-                snapshot["derived_power_method"] = "seeded"
-                snapshot["derived_power_window_seconds"] = None
-                self.evse_state._evse_power_snapshots[serial] = snapshot
-                return snapshot
-
-            delta_kwh = lifetime - last_lifetime_kwh
-            if delta_kwh < -0.25:
-                snapshot["derived_last_lifetime_kwh"] = lifetime
-                snapshot["derived_last_energy_ts"] = sample_ts
-                snapshot["derived_power_w"] = 0
-                snapshot["derived_power_method"] = "lifetime_reset"
-                snapshot["derived_power_window_seconds"] = None
-                snapshot["derived_last_reset_at"] = sample_ts
-                self.evse_state._evse_power_snapshots[serial] = snapshot
-                return snapshot
-
-            if not is_charging:
-                snapshot["derived_last_lifetime_kwh"] = lifetime
-                snapshot["derived_last_energy_ts"] = sample_ts
-                snapshot["derived_power_w"] = 0
-                snapshot["derived_power_method"] = "idle"
-                snapshot["derived_power_window_seconds"] = None
-                self.evse_state._evse_power_snapshots[serial] = snapshot
-                return snapshot
-
-            if delta_kwh <= 0.0005:
-                self.evse_state._evse_power_snapshots[serial] = snapshot
-                return snapshot
-
-            window_s = (
-                sample_ts - last_energy_ts
-                if last_energy_ts is not None and sample_ts > last_energy_ts
-                else 300.0
-            )
-            watts = int(round((delta_kwh * 3_600_000.0) / window_s))
-            if watts > max_watts:
-                watts = max_watts
-            snapshot["derived_power_w"] = watts
-            snapshot["derived_power_method"] = "lifetime_energy_window"
-            snapshot["derived_power_window_seconds"] = window_s
-            snapshot["derived_last_lifetime_kwh"] = lifetime
-            snapshot["derived_last_energy_ts"] = sample_ts
-            self.evse_state._evse_power_snapshots[serial] = snapshot
-            return snapshot
-
         for sn, obj in records:
             conn0 = (obj.get("connectors") or [{}])[0]
             previous_entry = None
@@ -4334,7 +4007,14 @@ class EnphaseCoordinator(DataUpdateCoordinator[dict]):
 
         for sn, cur in out.items():
             previous_entry = prev_data.get(sn) if isinstance(prev_data, dict) else None
-            cur.update(_build_evse_power_snapshot(sn, cur, previous_entry))
+            snapshot = build_evse_power_snapshot(
+                cur,
+                previous_entry if isinstance(previous_entry, dict) else None,
+                self.evse_state._evse_power_snapshots.get(sn, {}),
+                self.nominal_voltage,
+            )
+            self.evse_state._evse_power_snapshots[sn] = snapshot
+            cur.update(snapshot)
 
         # Attach session history using cached data, deferring expensive fetches when possible
         sessions_start = time.monotonic()

--- a/custom_components/enphase_ev/evse_power.py
+++ b/custom_components/enphase_ev/evse_power.py
@@ -1,0 +1,334 @@
+"""Pure EVSE power derivation helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone as _tz
+from typing import Mapping
+
+from .const import DEFAULT_NOMINAL_VOLTAGE
+from .evse_runtime import evse_power_is_actively_charging
+
+_MAX_THROUGHPUT_W = 19200
+_THREE_PHASE_LINE_TO_LINE_MULTIPLIER = 1.7320508075688772
+
+
+def _power_parse_timestamp(raw: object) -> float | None:
+    if raw is None:
+        return None
+    if isinstance(raw, (int, float)):
+        try:
+            value = float(raw)
+        except Exception:
+            return None
+        if value > 10**12:
+            value = value / 1000.0
+        if value <= 0:
+            return None
+        try:
+            datetime.fromtimestamp(value, tz=_tz.utc)
+        except Exception:
+            return None
+        return value
+    if isinstance(raw, str):
+        stripped = raw.strip()
+        if not stripped:
+            return None
+        normalized = stripped.replace("[UTC]", "").replace("Z", "+00:00")
+        try:
+            dt_obj = datetime.fromisoformat(normalized)
+        except ValueError:
+            return None
+        if dt_obj.tzinfo is None:
+            dt_obj = dt_obj.replace(tzinfo=_tz.utc)
+        return dt_obj.astimezone(_tz.utc).timestamp()
+    return None
+
+
+def _power_as_float(raw: object) -> float | None:
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _power_as_int(raw: object) -> int | None:
+    try:
+        return int(float(raw))
+    except (TypeError, ValueError):
+        return None
+
+
+def _power_topology(entry: Mapping[str, object]) -> str:
+    phase_mode = entry.get("phase_mode")
+    if phase_mode is not None:
+        try:
+            normalized = (
+                str(phase_mode).strip().lower().replace("-", "_").replace(" ", "_")
+            )
+        except Exception:  # noqa: BLE001
+            normalized = ""
+        if normalized:
+            if normalized in {"3", "3_phase", "three", "three_phase"}:
+                return "three_phase"
+            if normalized in {"split", "split_phase"}:
+                return "split_phase"
+            if normalized in {"1", "single", "single_phase"}:
+                return "single_phase"
+    phase_count = _power_as_int(entry.get("phase_count"))
+    if phase_count is not None:
+        if phase_count >= 3:
+            return "three_phase"
+        if phase_count == 1:
+            return "single_phase"
+    return "unknown"
+
+
+def _three_phase_multiplier(entry: Mapping[str, object]) -> float:
+    wiring = entry.get("wiring_configuration")
+    explicit_neutral = False
+    if isinstance(wiring, dict):
+        for raw in (*wiring.keys(), *wiring.values()):
+            try:
+                token = str(raw).strip().lower().replace("-", "_").replace(" ", "_")
+            except Exception:  # noqa: BLE001
+                continue
+            if token in {"n", "neutral", "l1n", "l2n", "l3n", "ln"}:
+                explicit_neutral = True
+                break
+    return 3.0 if explicit_neutral else _THREE_PHASE_LINE_TO_LINE_MULTIPLIER
+
+
+def _resolve_max_throughput(
+    entry: Mapping[str, object],
+    nominal_voltage: object = DEFAULT_NOMINAL_VOLTAGE,
+) -> tuple[int, str, float | None, float, int, str, float]:
+    voltage = _power_as_float(entry.get("operating_v"))
+    if voltage is None or voltage <= 0:
+        voltage = _power_as_float(entry.get("nominal_v"))
+    if voltage is None or voltage <= 0:
+        voltage = float(nominal_voltage)
+    topology = _power_topology(entry)
+    phase_multiplier = 1.0
+    for source, raw in (
+        ("session_charge_level", entry.get("session_charge_level")),
+        ("charging_level", entry.get("charging_level")),
+        ("max_amp", entry.get("max_amp")),
+        ("max_current", entry.get("max_current")),
+    ):
+        amps = _power_as_float(raw)
+        if amps is None or amps <= 0:
+            continue
+        if topology == "three_phase":
+            phase_multiplier = _three_phase_multiplier(entry)
+        unbounded = int(round(voltage * amps * phase_multiplier))
+        if unbounded <= 0:
+            continue
+        bounded = min(unbounded, _MAX_THROUGHPUT_W)
+        return (
+            bounded,
+            source,
+            amps,
+            voltage,
+            unbounded,
+            topology,
+            phase_multiplier,
+        )
+    return (
+        _MAX_THROUGHPUT_W,
+        "static_default",
+        None,
+        voltage,
+        _MAX_THROUGHPUT_W,
+        topology,
+        1.0,
+    )
+
+
+def _is_actually_charging(entry: Mapping[str, object]) -> bool:
+    if "actual_charging" in entry:
+        return bool(entry.get("actual_charging"))
+    return evse_power_is_actively_charging(
+        entry.get("connector_status"),
+        entry.get("charging"),
+        suspended_by_evse=entry.get("suspended_by_evse"),
+    )
+
+
+def _known_previous_charging_state(entry: Mapping[str, object] | None) -> bool | None:
+    if not isinstance(entry, Mapping):
+        return None
+    if not any(
+        key in entry
+        for key in (
+            "connector_status",
+            "charging",
+            "actual_charging",
+            "suspended_by_evse",
+        )
+    ):
+        return None
+    return _is_actually_charging(entry)
+
+
+def build_evse_power_snapshot(
+    current_entry: Mapping[str, object],
+    previous_entry: Mapping[str, object] | None,
+    previous_power_snapshot: Mapping[str, object] | None,
+    nominal_voltage: object = DEFAULT_NOMINAL_VOLTAGE,
+) -> dict[str, object]:
+    """Build the derived EVSE power/status snapshot for one charger entry."""
+
+    previous = previous_power_snapshot or {}
+    (
+        max_watts,
+        max_source,
+        max_amps,
+        max_voltage,
+        max_unbounded,
+        max_topology,
+        max_phase_multiplier,
+    ) = _resolve_max_throughput(current_entry, nominal_voltage)
+    snapshot: dict[str, object] = {
+        "derived_power_max_throughput_w": max_watts,
+        "derived_power_max_throughput_unbounded_w": max_unbounded,
+        "derived_power_max_throughput_source": max_source,
+        "derived_power_max_throughput_amps": max_amps,
+        "derived_power_max_throughput_voltage": max_voltage,
+        "derived_power_max_throughput_topology": max_topology,
+        "derived_power_max_throughput_phase_multiplier": max_phase_multiplier,
+    }
+
+    sample_ts = _power_parse_timestamp(current_entry.get("sampled_at_ts"))
+    if sample_ts is None:
+        sample_ts = _power_parse_timestamp(current_entry.get("sampled_at_utc"))
+    if sample_ts is None:
+        sample_ts = _power_parse_timestamp(current_entry.get("last_reported_at"))
+    sample_iso = (
+        datetime.fromtimestamp(sample_ts, tz=_tz.utc).isoformat()
+        if sample_ts is not None
+        else None
+    )
+    lifetime = _power_as_float(current_entry.get("lifetime_kwh"))
+    is_charging = _is_actually_charging(current_entry)
+    previous_is_charging = _known_previous_charging_state(previous_entry)
+
+    last_power_w = _power_as_int(previous.get("derived_power_w"))
+    if last_power_w is None:
+        last_power_w = 0
+    last_method = previous.get("derived_power_method")
+    if not isinstance(last_method, str):
+        last_method = "seeded"
+    last_window_s = _power_as_float(previous.get("derived_power_window_seconds"))
+    last_lifetime_kwh = _power_as_float(previous.get("derived_last_lifetime_kwh"))
+    last_energy_ts = _power_parse_timestamp(previous.get("derived_last_energy_ts"))
+    last_reset_at = _power_parse_timestamp(previous.get("derived_last_reset_at"))
+    prior_sample_ts = _power_parse_timestamp(previous.get("derived_last_sample_ts"))
+    lifetime_changed = (lifetime is None) != (last_lifetime_kwh is None) or (
+        lifetime is not None
+        and last_lifetime_kwh is not None
+        and abs(lifetime - last_lifetime_kwh) > 1e-9
+    )
+    if (
+        sample_ts is not None
+        and prior_sample_ts is not None
+        and sample_ts == prior_sample_ts
+        and not lifetime_changed
+    ):
+        snapshot.update(previous)
+        snapshot.update(
+            {
+                "derived_sampled_at_utc": sample_iso,
+                "derived_last_sample_ts": sample_ts,
+                "derived_power_max_throughput_w": max_watts,
+                "derived_power_max_throughput_unbounded_w": max_unbounded,
+                "derived_power_max_throughput_source": max_source,
+                "derived_power_max_throughput_amps": max_amps,
+                "derived_power_max_throughput_voltage": max_voltage,
+                "derived_power_max_throughput_topology": max_topology,
+                "derived_power_max_throughput_phase_multiplier": max_phase_multiplier,
+            }
+        )
+        if not is_charging:
+            snapshot["derived_power_w"] = 0
+            snapshot["derived_power_method"] = "idle"
+            snapshot["derived_power_window_seconds"] = None
+        return snapshot
+
+    snapshot.update(
+        {
+            "derived_sampled_at_utc": sample_iso,
+            "derived_last_sample_ts": sample_ts,
+            "derived_last_lifetime_kwh": last_lifetime_kwh,
+            "derived_last_energy_ts": last_energy_ts,
+            "derived_last_reset_at": last_reset_at,
+            "derived_power_w": last_power_w,
+            "derived_power_window_seconds": last_window_s,
+            "derived_power_method": last_method,
+        }
+    )
+
+    if previous_is_charging is False and is_charging:
+        snapshot["derived_power_w"] = 0
+        snapshot["derived_power_method"] = "seeded"
+        snapshot["derived_power_window_seconds"] = None
+        if lifetime is not None:
+            snapshot["derived_last_lifetime_kwh"] = lifetime
+        if sample_ts is not None:
+            snapshot["derived_last_energy_ts"] = sample_ts
+        return snapshot
+
+    if lifetime is None:
+        if not is_charging:
+            snapshot["derived_power_w"] = 0
+            snapshot["derived_power_method"] = "idle"
+            snapshot["derived_power_window_seconds"] = None
+        return snapshot
+
+    if sample_ts is None:
+        snapshot["derived_last_lifetime_kwh"] = lifetime
+        return snapshot
+
+    if last_lifetime_kwh is None:
+        snapshot["derived_last_lifetime_kwh"] = lifetime
+        snapshot["derived_last_energy_ts"] = sample_ts
+        snapshot["derived_power_w"] = 0
+        snapshot["derived_power_method"] = "seeded"
+        snapshot["derived_power_window_seconds"] = None
+        return snapshot
+
+    delta_kwh = lifetime - last_lifetime_kwh
+    if delta_kwh < -0.25:
+        snapshot["derived_last_lifetime_kwh"] = lifetime
+        snapshot["derived_last_energy_ts"] = sample_ts
+        snapshot["derived_power_w"] = 0
+        snapshot["derived_power_method"] = "lifetime_reset"
+        snapshot["derived_power_window_seconds"] = None
+        snapshot["derived_last_reset_at"] = sample_ts
+        return snapshot
+
+    if not is_charging:
+        snapshot["derived_last_lifetime_kwh"] = lifetime
+        snapshot["derived_last_energy_ts"] = sample_ts
+        snapshot["derived_power_w"] = 0
+        snapshot["derived_power_method"] = "idle"
+        snapshot["derived_power_window_seconds"] = None
+        return snapshot
+
+    if delta_kwh <= 0.0005:
+        return snapshot
+
+    window_s = (
+        sample_ts - last_energy_ts
+        if last_energy_ts is not None and sample_ts > last_energy_ts
+        else 300.0
+    )
+    watts = int(round((delta_kwh * 3_600_000.0) / window_s))
+    if watts > max_watts:
+        watts = max_watts
+    snapshot["derived_power_w"] = watts
+    snapshot["derived_power_method"] = "lifetime_energy_window"
+    snapshot["derived_power_window_seconds"] = window_s
+    snapshot["derived_last_lifetime_kwh"] = lifetime
+    snapshot["derived_last_energy_ts"] = sample_ts
+    return snapshot

--- a/custom_components/enphase_ev/evse_runtime.py
+++ b/custom_components/enphase_ev/evse_runtime.py
@@ -46,6 +46,7 @@ AUTH_SETTINGS_CACHE_TTL = 300.0
 CHARGE_MODE_CACHE_TTL = 300.0
 CHARGER_CONFIG_CACHE_TTL = 3600.0
 CHARGER_CONFIG_FAILURE_BACKOFF_S = 900.0
+EVSE_TOGGLE_PENDING_HOLD_S = 15.0
 EVSE_LOOKUP_CONCURRENCY = 5
 CHARGE_MODE_PREFERENCE_MAP: dict[str, str] = {
     "MANUAL": "MANUAL_CHARGING",
@@ -1411,6 +1412,65 @@ class EvseRuntime:
             False,
             now,
         )
+
+    def _set_evse_toggle_pending(self, attr_name: str, sn: str, enabled: bool) -> None:
+        pending = getattr(self.coordinator, attr_name, None)
+        if not isinstance(pending, dict):
+            pending = {}
+            setattr(self.coordinator, attr_name, pending)
+        pending[str(sn)] = (
+            bool(enabled),
+            time.monotonic() + EVSE_TOGGLE_PENDING_HOLD_S,
+        )
+
+    async def async_set_charge_mode(
+        self,
+        sn: str,
+        mode: str,
+        *,
+        previous_mode: str | None = None,
+    ) -> None:
+        sn_str = str(sn)
+        try:
+            await self.coordinator.client.set_charge_mode(
+                sn_str,
+                mode,
+                previous_mode=previous_mode,
+            )
+        except SchedulerUnavailable as err:
+            self.coordinator.note_scheduler_unavailable(err)
+            raise
+        self.coordinator.mark_scheduler_available()
+        self.set_charge_mode_cache(sn_str, mode)
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_green_battery_setting(self, sn: str, *, enabled: bool) -> None:
+        sn_str = str(sn)
+        try:
+            await self.coordinator.client.set_green_battery_setting(
+                sn_str, enabled=enabled
+            )
+        except SchedulerUnavailable as err:
+            self.coordinator.note_scheduler_unavailable(err)
+            raise
+        self.coordinator.mark_scheduler_available()
+        self.set_green_battery_cache(sn_str, enabled)
+        self._set_evse_toggle_pending("_green_battery_pending", sn_str, enabled)
+        await self.coordinator.async_request_refresh()
+
+    async def async_set_app_authentication(self, sn: str, *, enabled: bool) -> None:
+        sn_str = str(sn)
+        try:
+            await self.coordinator.client.set_app_authentication(
+                sn_str, enabled=enabled
+            )
+        except AuthSettingsUnavailable as err:
+            self.coordinator.note_auth_settings_unavailable(err)
+            raise
+        self.coordinator.mark_auth_settings_available()
+        self.set_app_auth_cache(sn_str, enabled)
+        self._set_evse_toggle_pending("_app_auth_pending", sn_str, enabled)
+        await self.coordinator.async_request_refresh()
 
     async def async_resolve_green_battery_settings(
         self, serials: Iterable[str]

--- a/custom_components/enphase_ev/select.py
+++ b/custom_components/enphase_ev/select.py
@@ -720,12 +720,10 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
         if previous_mode == mode:
             return
         try:
-            await self._coord.client.set_charge_mode(
+            await self._coord.evse_runtime.async_set_charge_mode(
                 self._sn, mode, previous_mode=previous_mode
             )
-            self._coord.mark_scheduler_available()
-        except SchedulerUnavailable as err:
-            self._coord.note_scheduler_unavailable(err)
+        except SchedulerUnavailable:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
                 translation_key="exceptions.scheduler_service_unavailable",
@@ -748,9 +746,6 @@ class ChargeModeSelect(EnphaseBaseEntity, SelectEntity):
                     translation_key="exceptions.schedule_required",
                 )
             raise
-        # Update cache immediately to reflect in UI while the scheduler catches up.
-        self._coord.set_charge_mode_cache(self._sn, mode)
-        await self._coord.async_request_refresh()
 
 
 class AcBatteryTargetStateOfChargeSelect(CoordinatorEntity, SelectEntity):

--- a/custom_components/enphase_ev/sensor.py
+++ b/custom_components/enphase_ev/sensor.py
@@ -67,6 +67,14 @@ from .runtime_helpers import (
     inventory_type_available as _type_available,
     inventory_type_device_info as _type_device_info,
 )
+from .sensor_registry import (
+    AC_BATTERY_ENTITY_UNIQUE_SUFFIXES as AC_BATTERY_ENTITY_UNIQUE_SUFFIXES,
+    AC_BATTERY_RETIRED_UNIQUE_SUFFIXES as AC_BATTERY_RETIRED_UNIQUE_SUFFIXES,
+    BATTERY_ENTITY_UNIQUE_SUFFIXES as BATTERY_ENTITY_UNIQUE_SUFFIXES,
+    BATTERY_RETIRED_UNIQUE_SUFFIXES as BATTERY_RETIRED_UNIQUE_SUFFIXES,
+    HISTORICAL_CHARGER_SENSOR_UNIQUE_SUFFIXES as HISTORICAL_CHARGER_SENSOR_UNIQUE_SUFFIXES,
+    EnphaseSensorRegistrySetup,
+)
 from .tariff import (
     current_tariff_rate_sensor_spec,
     next_billing_date,
@@ -91,45 +99,7 @@ CLOUD_ERROR_CODE_STATES: tuple[str, ...] = (
     "network_error",
 )
 SITE_SERVICE_STATUS_STATES: tuple[str, ...] = ("ok", "degraded", "unknown")
-BATTERY_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = (
-    "_charge_level",
-    "_status",
-    "_health",
-    "_cycle_count",
-)
-BATTERY_RETIRED_UNIQUE_SUFFIXES: tuple[str, ...] = (
-    "_last_reported",
-    "_last_reported_at",
-)
-AC_BATTERY_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = (
-    "_charge_level",
-    "_status",
-    "_power",
-    "_operating_mode",
-    "_cycle_count",
-    "_last_reported",
-)
-AC_BATTERY_RETIRED_UNIQUE_SUFFIXES: tuple[str, ...] = ("_last_reported_at",)
 CURRENT_POWER_CACHE_TTL_MULTIPLIER = 2
-HISTORICAL_CHARGER_SENSOR_UNIQUE_SUFFIXES: tuple[str, ...] = (
-    "_connector_reason",
-    "_session_miles",
-    "_plg_in_at",
-    "_plg_out_at",
-    "_schedule_type",
-    "_schedule_start",
-    "_schedule_end",
-    "_session_kwh",
-    "_charging_level",
-    "_session_duration",
-    "_phase_mode",
-    "_max_current",
-    "_min_amp",
-    "_max_amp",
-    "_connection",
-    "_reporting_interval",
-    "_ip_address",
-)
 SITE_LIFETIME_FLOW_BUCKET_LENGTH_KEYS: dict[str, tuple[str, ...]] = {
     "grid_import": ("import", "grid_home", "grid_battery"),
     "grid_export": ("solar_grid",),
@@ -303,331 +273,37 @@ async def async_setup_entry(
 ):
     coord: EnphaseCoordinator = get_runtime_data(entry).coordinator
     ent_reg = er.async_get(hass)
-    known_site_entity_keys: set[str] = set()
+    registry_setup = EnphaseSensorRegistrySetup(
+        ent_reg,
+        config_entry_id=entry.entry_id,
+        site_id=str(coord.site_id),
+    )
+    known_site_entity_keys = registry_setup.known_site_entity_keys
+    known_type_keys = registry_setup.known_type_keys
+    known_gateway_iq_router_keys = registry_setup.known_gateway_iq_router_keys
+    _gateway_iq_router_entity_key = registry_setup.gateway_iq_router_entity_key
+    _async_prune_removed_gateway_iq_router_entities = (
+        registry_setup.prune_removed_gateway_iq_router_entities
+    )
+    _async_remove_site_sensor_entity = registry_setup.remove_site_sensor_entity
+    _async_remove_type_sensor_entity = registry_setup.remove_type_sensor_entity
+    _site_sensor_entity_registered = registry_setup.site_sensor_entity_registered
+    _async_remove_site_sensor_entities_with_prefix = (
+        registry_setup.remove_site_sensor_entities_with_prefix
+    )
+    _async_prune_dry_contact_type_inventory_entities = (
+        registry_setup.prune_dry_contact_type_inventory_entities
+    )
+    _async_prune_blocked_type_inventory_entities = (
+        registry_setup.prune_blocked_type_inventory_entities
+    )
     known_serials: set[str] = set()
     known_storm_guard_serials: set[str] = set()
-    known_battery_serials: set[str] = set()
-    known_ac_battery_serials: set[str] = set()
-    known_inverter_serials: set[str] = set()
-    known_type_keys: set[str] = set()
-    known_gateway_iq_router_keys: set[str] = set()
-    battery_registry_pruned = False
-    ac_battery_registry_pruned = False
-    inverter_registry_pruned = False
     last_type_key_set: set[str] | None = None
     last_battery_serial_set: set[str] | None = None
     last_ac_battery_serial_set: set[str] | None = None
     last_charger_serial_set: set[str] | None = None
     last_inverter_serial_set: set[str] | None = None
-
-    def _site_sensor_unique_id(key: str) -> str:
-        return f"{DOMAIN}_site_{coord.site_id}_{key}"
-
-    def _type_sensor_unique_id(type_key: str) -> str:
-        return f"{DOMAIN}_site_{coord.site_id}_type_{type_key}_inventory"
-
-    def _gateway_iq_router_entity_key(router_key: str) -> str:
-        return f"gateway_iq_energy_router_{router_key}"
-
-    def _gateway_iq_router_key_from_unique_id(unique_id: object) -> str | None:
-        key = _gateway_clean_text(unique_id)
-        if not key:
-            return None
-        prefix = f"{DOMAIN}_site_{coord.site_id}_gateway_iq_energy_router_"
-        if not key.startswith(prefix):
-            return None
-        router_key = key[len(prefix) :]
-        return router_key or None
-
-    @callback
-    def _async_prune_removed_gateway_iq_router_entities(
-        current_router_keys: set[str],
-    ) -> None:
-        entities = getattr(ent_reg, "entities", None)
-        if not isinstance(entities, dict):
-            return
-        for reg_entry in list(entities.values()):
-            entry_domain = getattr(reg_entry, "domain", None)
-            if entry_domain is None:
-                entry_domain = reg_entry.entity_id.partition(".")[0]
-            if entry_domain != "sensor":
-                continue
-            entry_platform = getattr(reg_entry, "platform", None)
-            if entry_platform is not None and entry_platform != DOMAIN:
-                continue
-            entry_config_id = getattr(reg_entry, "config_entry_id", None)
-            if entry_config_id is not None and entry_config_id != entry.entry_id:
-                continue
-            router_key = _gateway_iq_router_key_from_unique_id(
-                getattr(reg_entry, "unique_id", None)
-            )
-            if not router_key or router_key in current_router_keys:
-                continue
-            ent_reg.async_remove(reg_entry.entity_id)
-            known_gateway_iq_router_keys.discard(router_key)
-            known_site_entity_keys.discard(_gateway_iq_router_entity_key(router_key))
-
-    @callback
-    def _async_remove_site_sensor_entity(key: str) -> None:
-        get_entity_id = getattr(ent_reg, "async_get_entity_id", None)
-        if not callable(get_entity_id):
-            return
-        entity_id = get_entity_id("sensor", DOMAIN, _site_sensor_unique_id(key))
-        if entity_id is None:
-            return
-        ent_reg.async_remove(entity_id)
-        known_site_entity_keys.discard(key)
-        router_prefix = "gateway_iq_energy_router_"
-        if key.startswith(router_prefix):
-            known_gateway_iq_router_keys.discard(key[len(router_prefix) :])
-
-    @callback
-    def _async_remove_type_sensor_entity(type_key: str) -> None:
-        get_entity_id = getattr(ent_reg, "async_get_entity_id", None)
-        if not callable(get_entity_id):
-            return
-        entity_id = get_entity_id(
-            "sensor",
-            DOMAIN,
-            _type_sensor_unique_id(type_key),
-        )
-        if entity_id is None:
-            return
-        ent_reg.async_remove(entity_id)
-        known_type_keys.discard(type_key)
-
-    def _site_sensor_entity_registered(key: str) -> bool:
-        get_entity_id = getattr(ent_reg, "async_get_entity_id", None)
-        if not callable(get_entity_id):
-            return False
-        return get_entity_id("sensor", DOMAIN, _site_sensor_unique_id(key)) is not None
-
-    def _entity_registry_values():
-        entities = getattr(ent_reg, "entities", None)
-        values = getattr(entities, "values", None)
-        if callable(values):
-            return values()
-        return ()
-
-    @callback
-    def _async_remove_site_sensor_entities_with_prefix(
-        prefix: str,
-    ) -> None:
-        unique_prefix = _site_sensor_unique_id(prefix)
-        for reg_entry in list(_entity_registry_values()):
-            entry_domain = getattr(reg_entry, "domain", None)
-            if entry_domain is None:
-                entry_domain = reg_entry.entity_id.partition(".")[0]
-            if entry_domain != "sensor":
-                continue
-            entry_platform = getattr(reg_entry, "platform", None)
-            if entry_platform is not None and entry_platform != DOMAIN:
-                continue
-            entry_config_id = getattr(reg_entry, "config_entry_id", None)
-            if entry_config_id is not None and entry_config_id != entry.entry_id:
-                continue
-            unique_id = _gateway_clean_text(getattr(reg_entry, "unique_id", None))
-            if not unique_id or not unique_id.startswith(unique_prefix):
-                continue
-            key = unique_id[len(f"{DOMAIN}_site_{coord.site_id}_") :]
-            ent_reg.async_remove(reg_entry.entity_id)
-            known_site_entity_keys.discard(key)
-
-    @callback
-    def _async_prune_dry_contact_type_inventory_entities() -> None:
-        entities = getattr(ent_reg, "entities", None)
-        if not isinstance(entities, dict):
-            return
-        unique_prefix = f"{DOMAIN}_site_{coord.site_id}_type_"
-        unique_suffix = "_inventory"
-        for reg_entry in list(entities.values()):
-            entry_domain = getattr(reg_entry, "domain", None)
-            if entry_domain is None:
-                entry_domain = reg_entry.entity_id.partition(".")[0]
-            if entry_domain != "sensor":
-                continue
-            entry_platform = getattr(reg_entry, "platform", None)
-            if entry_platform is not None and entry_platform != DOMAIN:
-                continue
-            entry_config_id = getattr(reg_entry, "config_entry_id", None)
-            if entry_config_id is not None and entry_config_id != entry.entry_id:
-                continue
-            unique_id = _gateway_clean_text(getattr(reg_entry, "unique_id", None))
-            type_key = None
-            if unique_id and unique_id.startswith(unique_prefix):
-                if not unique_id.endswith(unique_suffix):
-                    continue
-                type_key = unique_id[len(unique_prefix) : -len(unique_suffix)]
-            else:
-                entity_slug = reg_entry.entity_id.partition(".")[2]
-                if "drycontactloads" not in entity_slug or not entity_slug.endswith(
-                    "_inventory"
-                ):
-                    continue
-                type_key = "drycontactloads"
-            if not _is_dry_contact_type_key(type_key):
-                continue
-            ent_reg.async_remove(reg_entry.entity_id)
-            known_type_keys.discard(type_key)
-
-    @callback
-    def _async_prune_blocked_type_inventory_entities(
-        blocked_type_keys: set[str],
-    ) -> None:
-        entities = getattr(ent_reg, "entities", None)
-        if not isinstance(entities, dict) or not blocked_type_keys:
-            return
-        unique_prefix = f"{DOMAIN}_site_{coord.site_id}_type_"
-        unique_suffix = "_inventory"
-        for reg_entry in list(entities.values()):
-            entry_domain = getattr(reg_entry, "domain", None)
-            if entry_domain is None:
-                entry_domain = reg_entry.entity_id.partition(".")[0]
-            if entry_domain != "sensor":
-                continue
-            entry_platform = getattr(reg_entry, "platform", None)
-            if entry_platform is not None and entry_platform != DOMAIN:
-                continue
-            entry_config_id = getattr(reg_entry, "config_entry_id", None)
-            if entry_config_id is not None and entry_config_id != entry.entry_id:
-                continue
-            unique_id = _gateway_clean_text(getattr(reg_entry, "unique_id", None))
-            if not unique_id or not unique_id.startswith(unique_prefix):
-                continue
-            if not unique_id.endswith(unique_suffix):
-                continue
-            type_key = unique_id[len(unique_prefix) : -len(unique_suffix)]
-            if type_key not in blocked_type_keys:
-                continue
-            ent_reg.async_remove(reg_entry.entity_id)
-            known_type_keys.discard(type_key)
-
-    def _battery_sensor_unique_id(serial: str, suffix: str) -> str:
-        return f"{DOMAIN}_site_{coord.site_id}_battery_{serial}{suffix}"
-
-    def _battery_sensor_unique_ids(serial: str) -> tuple[str, ...]:
-        return tuple(
-            _battery_sensor_unique_id(serial, suffix)
-            for suffix in BATTERY_ENTITY_UNIQUE_SUFFIXES
-        )
-
-    def _battery_retired_sensor_unique_ids(serial: str) -> tuple[str, ...]:
-        return tuple(
-            _battery_sensor_unique_id(serial, suffix)
-            for suffix in BATTERY_RETIRED_UNIQUE_SUFFIXES
-        )
-
-    def _ac_battery_sensor_unique_id(serial: str, suffix: str) -> str:
-        return f"{DOMAIN}_site_{coord.site_id}_ac_battery_{serial}{suffix}"
-
-    def _ac_battery_sensor_unique_ids(serial: str) -> tuple[str, ...]:
-        return tuple(
-            _ac_battery_sensor_unique_id(serial, suffix)
-            for suffix in AC_BATTERY_ENTITY_UNIQUE_SUFFIXES
-        )
-
-    def _ac_battery_retired_sensor_unique_ids(serial: str) -> tuple[str, ...]:
-        return tuple(
-            _ac_battery_sensor_unique_id(serial, suffix)
-            for suffix in AC_BATTERY_RETIRED_UNIQUE_SUFFIXES
-        )
-
-    def _battery_serial_from_unique_id(unique_id: str) -> str | None:
-        unique_prefix = f"{DOMAIN}_site_{coord.site_id}_battery_"
-        if not unique_id.startswith(unique_prefix):
-            return None
-        if unique_id in {
-            f"{DOMAIN}_site_{coord.site_id}_battery_overall_status",
-            f"{DOMAIN}_site_{coord.site_id}_battery_last_reported",
-        }:
-            return None
-        for suffix in (
-            *BATTERY_ENTITY_UNIQUE_SUFFIXES,
-            *BATTERY_RETIRED_UNIQUE_SUFFIXES,
-        ):
-            if not unique_id.endswith(suffix):
-                continue
-            serial = unique_id[len(unique_prefix) : -len(suffix)]
-            if serial:
-                return serial
-            return None
-        return None
-
-    def _ac_battery_serial_from_unique_id(unique_id: str) -> str | None:
-        unique_prefix = f"{DOMAIN}_site_{coord.site_id}_ac_battery_"
-        if not unique_id.startswith(unique_prefix):
-            return None
-        if unique_id in {
-            f"{DOMAIN}_site_{coord.site_id}_ac_battery_overall_status",
-            f"{DOMAIN}_site_{coord.site_id}_ac_battery_last_reported",
-            f"{DOMAIN}_site_{coord.site_id}_ac_battery_power",
-        }:
-            return None
-        for suffix in (
-            *AC_BATTERY_ENTITY_UNIQUE_SUFFIXES,
-            *AC_BATTERY_RETIRED_UNIQUE_SUFFIXES,
-        ):
-            if not unique_id.endswith(suffix):
-                continue
-            serial = unique_id[len(unique_prefix) : -len(suffix)]
-            if serial:
-                return serial
-            return None
-        return None
-
-    def _inverter_lifetime_sensor_unique_id(serial: str) -> str:
-        return f"{DOMAIN}_inverter_{serial}_lifetime_energy"
-
-    def _legacy_gateway_connected_devices_unique_id() -> str:
-        return f"{DOMAIN}_site_{coord.site_id}_gateway_connected_devices"
-
-    def _legacy_microinverter_inventory_unique_id() -> str:
-        return f"{DOMAIN}_site_{coord.site_id}_type_microinverter_inventory"
-
-    @callback
-    def _async_prune_historical_charger_sensor_entities() -> None:
-        entities = getattr(ent_reg, "entities", None)
-        if not isinstance(entities, dict):
-            return
-        unique_prefix = f"{DOMAIN}_"
-        for reg_entry in list(entities.values()):
-            entry_domain = getattr(reg_entry, "domain", None)
-            if entry_domain is None:
-                entry_domain = reg_entry.entity_id.partition(".")[0]
-            if entry_domain != "sensor":
-                continue
-            entry_platform = getattr(reg_entry, "platform", None)
-            if entry_platform is not None and entry_platform != DOMAIN:
-                continue
-            entry_config_id = getattr(reg_entry, "config_entry_id", None)
-            if entry_config_id is not None and entry_config_id != entry.entry_id:
-                continue
-            unique_id = getattr(reg_entry, "unique_id", None)
-            if not isinstance(unique_id, str) or not unique_id.startswith(
-                unique_prefix
-            ):
-                continue
-            if not unique_id.endswith(HISTORICAL_CHARGER_SENSOR_UNIQUE_SUFFIXES):
-                continue
-            ent_reg.async_remove(reg_entry.entity_id)
-
-    @callback
-    def _async_prune_removed_site_entities() -> None:
-        get_entity_id = getattr(ent_reg, "async_get_entity_id", None)
-        if not callable(get_entity_id):
-            return
-        for unique_id in (
-            _legacy_gateway_connected_devices_unique_id(),
-            _legacy_microinverter_inventory_unique_id(),
-        ):
-            entity_id = get_entity_id(
-                "sensor",
-                DOMAIN,
-                unique_id,
-            )
-            if entity_id is not None:
-                ent_reg.async_remove(entity_id)
-        _async_remove_site_sensor_entity("battery_inactive_microinverters")
 
     @callback
     def _async_sync_site_entities() -> None:
@@ -1156,7 +832,6 @@ async def async_setup_entry(
 
     @callback
     def _async_sync_batteries() -> None:
-        nonlocal battery_registry_pruned
         site_has_battery = _site_has_battery(coord)
         if not site_has_battery or not _type_available(coord, "encharge"):
             current_serials: list[str] = []
@@ -1169,50 +844,14 @@ async def async_setup_entry(
             )
         current_set = set(current_serials)
 
-        if not battery_registry_pruned:
-            for reg_entry in list(ent_reg.entities.values()):
-                entry_domain = getattr(reg_entry, "domain", None)
-                if entry_domain is None:
-                    entry_domain = reg_entry.entity_id.partition(".")[0]
-                if entry_domain != "sensor":
-                    continue
-                entry_platform = getattr(reg_entry, "platform", None)
-                if entry_platform is not None and entry_platform != DOMAIN:
-                    continue
-                entry_config_id = getattr(reg_entry, "config_entry_id", None)
-                if entry_config_id is not None and entry_config_id != entry.entry_id:
-                    continue
-                unique_id = reg_entry.unique_id or ""
-                serial = _battery_serial_from_unique_id(unique_id)
-                if serial is None:
-                    continue
-                if any(
-                    unique_id.endswith(suffix)
-                    for suffix in BATTERY_RETIRED_UNIQUE_SUFFIXES
-                ):
-                    ent_reg.async_remove(reg_entry.entity_id)
-                    known_battery_serials.discard(serial)
-                    continue
-                if serial in current_set:
-                    continue
-                ent_reg.async_remove(reg_entry.entity_id)
-                known_battery_serials.discard(serial)
-            battery_registry_pruned = True
+        registry_setup.prune_battery_registry_once(current_set)
+        registry_setup.remove_missing_battery_entities(current_set)
 
-        removed_serials = known_battery_serials - current_set
-        for serial in removed_serials:
-            for unique_id in (
-                *_battery_sensor_unique_ids(serial),
-                *_battery_retired_sensor_unique_ids(serial),
-            ):
-                entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, unique_id)
-                if entity_id is not None:
-                    ent_reg.async_remove(entity_id)
-            known_battery_serials.discard(serial)
-
-        known_battery_serials.intersection_update(current_set)
-
-        serials = [sn for sn in current_serials if sn not in known_battery_serials]
+        serials = [
+            sn
+            for sn in current_serials
+            if sn not in registry_setup.known_battery_serials
+        ]
         if serials:
             entities: list[SensorEntity] = []
             for sn in serials:
@@ -1225,11 +864,10 @@ async def async_setup_entry(
                     ]
                 )
             async_add_entities(entities, update_before_add=False)
-            known_battery_serials.update(serials)
+            registry_setup.known_battery_serials.update(serials)
 
     @callback
     def _async_sync_ac_batteries() -> None:
-        nonlocal ac_battery_registry_pruned
         if not ac_battery_entities_available(coord):
             current_serials: list[str] = []
         else:
@@ -1241,50 +879,14 @@ async def async_setup_entry(
             )
         current_set = set(current_serials)
 
-        if not ac_battery_registry_pruned:
-            for reg_entry in list(ent_reg.entities.values()):
-                entry_domain = getattr(reg_entry, "domain", None)
-                if entry_domain is None:
-                    entry_domain = reg_entry.entity_id.partition(".")[0]
-                if entry_domain != "sensor":
-                    continue
-                entry_platform = getattr(reg_entry, "platform", None)
-                if entry_platform is not None and entry_platform != DOMAIN:
-                    continue
-                entry_config_id = getattr(reg_entry, "config_entry_id", None)
-                if entry_config_id is not None and entry_config_id != entry.entry_id:
-                    continue
-                unique_id = reg_entry.unique_id or ""
-                serial = _ac_battery_serial_from_unique_id(unique_id)
-                if serial is None:
-                    continue
-                if any(
-                    unique_id.endswith(suffix)
-                    for suffix in AC_BATTERY_RETIRED_UNIQUE_SUFFIXES
-                ):
-                    ent_reg.async_remove(reg_entry.entity_id)
-                    known_ac_battery_serials.discard(serial)
-                    continue
-                if serial in current_set:
-                    continue
-                ent_reg.async_remove(reg_entry.entity_id)
-                known_ac_battery_serials.discard(serial)
-            ac_battery_registry_pruned = True
+        registry_setup.prune_ac_battery_registry_once(current_set)
+        registry_setup.remove_missing_ac_battery_entities(current_set)
 
-        removed_serials = known_ac_battery_serials - current_set
-        for serial in removed_serials:
-            for unique_id in (
-                *_ac_battery_sensor_unique_ids(serial),
-                *_ac_battery_retired_sensor_unique_ids(serial),
-            ):
-                entity_id = ent_reg.async_get_entity_id("sensor", DOMAIN, unique_id)
-                if entity_id is not None:
-                    ent_reg.async_remove(entity_id)
-            known_ac_battery_serials.discard(serial)
-
-        known_ac_battery_serials.intersection_update(current_set)
-
-        serials = [sn for sn in current_serials if sn not in known_ac_battery_serials]
+        serials = [
+            sn
+            for sn in current_serials
+            if sn not in registry_setup.known_ac_battery_serials
+        ]
         if serials:
             entities: list[SensorEntity] = []
             for sn in serials:
@@ -1299,62 +901,29 @@ async def async_setup_entry(
                     ]
                 )
             async_add_entities(entities, update_before_add=False)
-            known_ac_battery_serials.update(serials)
+            registry_setup.known_ac_battery_serials.update(serials)
 
     @callback
     def _async_sync_inverters() -> None:
-        nonlocal inverter_registry_pruned
         current_serials = [
             sn for sn in getattr(coord, "iter_inverter_serials", lambda: [])() if sn
         ]
         current_set = set(current_serials)
 
-        if not inverter_registry_pruned:
-            unique_prefix = f"{DOMAIN}_inverter_"
-            unique_suffix = "_lifetime_energy"
-            for reg_entry in list(ent_reg.entities.values()):
-                entry_domain = getattr(reg_entry, "domain", None)
-                if entry_domain is None:
-                    entry_domain = reg_entry.entity_id.partition(".")[0]
-                if entry_domain != "sensor":
-                    continue
-                entry_platform = getattr(reg_entry, "platform", None)
-                if entry_platform is not None and entry_platform != DOMAIN:
-                    continue
-                entry_config_id = getattr(reg_entry, "config_entry_id", None)
-                if entry_config_id is not None and entry_config_id != entry.entry_id:
-                    continue
-                unique_id = reg_entry.unique_id or ""
-                if not (
-                    unique_id.startswith(unique_prefix)
-                    and unique_id.endswith(unique_suffix)
-                ):
-                    continue
-                serial = unique_id[len(unique_prefix) : -len(unique_suffix)]
-                if not serial or serial in current_set:
-                    continue
-                ent_reg.async_remove(reg_entry.entity_id)
-                known_inverter_serials.discard(serial)
-            inverter_registry_pruned = True
+        registry_setup.prune_inverter_registry_once(current_set)
+        registry_setup.remove_missing_inverter_entities(current_set)
 
-        removed_serials = known_inverter_serials - current_set
-        for serial in removed_serials:
-            entity_id = ent_reg.async_get_entity_id(
-                "sensor", DOMAIN, _inverter_lifetime_sensor_unique_id(serial)
-            )
-            if entity_id is not None:
-                ent_reg.async_remove(entity_id)
-            known_inverter_serials.discard(serial)
-
-        known_inverter_serials.intersection_update(current_set)
-
-        serials = [sn for sn in current_serials if sn not in known_inverter_serials]
+        serials = [
+            sn
+            for sn in current_serials
+            if sn not in registry_setup.known_inverter_serials
+        ]
         if serials:
             entities = [
                 EnphaseInverterLifetimeEnergySensor(coord, sn) for sn in serials
             ]
             async_add_entities(entities, update_before_add=False)
-            known_inverter_serials.update(serials)
+            registry_setup.known_inverter_serials.update(serials)
 
     @callback
     def _async_sync_topology() -> None:
@@ -1404,8 +973,8 @@ async def async_setup_entry(
     add_coordinator_listener = getattr(coord, "async_add_listener", None)
     if has_topology_listener and callable(add_coordinator_listener):
         entry.async_on_unload(add_coordinator_listener(_async_sync_topology))
-    _async_prune_historical_charger_sensor_entities()
-    _async_prune_removed_site_entities()
+    registry_setup.prune_historical_charger_sensor_entities()
+    registry_setup.prune_removed_site_entities()
     _async_sync_topology()
 
 

--- a/custom_components/enphase_ev/sensor_registry.py
+++ b/custom_components/enphase_ev/sensor_registry.py
@@ -1,0 +1,510 @@
+"""Entity registry helpers for Enphase sensor platform setup."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from .const import DOMAIN
+from .device_types import is_dry_contact_type_key
+from .runtime_helpers import coerce_optional_text as _clean_text
+
+BATTERY_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_charge_level",
+    "_status",
+    "_health",
+    "_cycle_count",
+)
+BATTERY_RETIRED_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_last_reported",
+    "_last_reported_at",
+)
+AC_BATTERY_ENTITY_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_charge_level",
+    "_status",
+    "_power",
+    "_operating_mode",
+    "_cycle_count",
+    "_last_reported",
+)
+AC_BATTERY_RETIRED_UNIQUE_SUFFIXES: tuple[str, ...] = ("_last_reported_at",)
+HISTORICAL_CHARGER_SENSOR_UNIQUE_SUFFIXES: tuple[str, ...] = (
+    "_connector_reason",
+    "_session_miles",
+    "_plg_in_at",
+    "_plg_out_at",
+    "_schedule_type",
+    "_schedule_start",
+    "_schedule_end",
+    "_session_kwh",
+    "_charging_level",
+    "_session_duration",
+    "_phase_mode",
+    "_max_current",
+    "_min_amp",
+    "_max_amp",
+    "_connection",
+    "_reporting_interval",
+    "_ip_address",
+)
+
+
+class EnphaseSensorRegistrySetup:
+    """Manage entity registry cleanup used by sensor setup."""
+
+    def __init__(self, ent_reg: Any, *, config_entry_id: str, site_id: str) -> None:
+        """Initialize the helper for one config entry."""
+
+        self._ent_reg = ent_reg
+        self._config_entry_id = config_entry_id
+        self._site_id = site_id
+        self.known_site_entity_keys: set[str] = set()
+        self.known_type_keys: set[str] = set()
+        self.known_gateway_iq_router_keys: set[str] = set()
+        self.known_battery_serials: set[str] = set()
+        self.known_ac_battery_serials: set[str] = set()
+        self.known_inverter_serials: set[str] = set()
+        self.battery_registry_pruned = False
+        self.ac_battery_registry_pruned = False
+        self.inverter_registry_pruned = False
+
+    def site_sensor_unique_id(self, key: str) -> str:
+        """Return the unique ID for a site-level sensor key."""
+
+        return f"{DOMAIN}_site_{self._site_id}_{key}"
+
+    def type_sensor_unique_id(self, type_key: str) -> str:
+        """Return the unique ID for a type inventory sensor."""
+
+        return f"{DOMAIN}_site_{self._site_id}_type_{type_key}_inventory"
+
+    @staticmethod
+    def gateway_iq_router_entity_key(router_key: str) -> str:
+        """Return the site entity key for an IQ Energy Router sensor."""
+
+        return f"gateway_iq_energy_router_{router_key}"
+
+    def battery_sensor_unique_id(self, serial: str, suffix: str) -> str:
+        """Return the unique ID for a per-storage-battery sensor."""
+
+        return f"{DOMAIN}_site_{self._site_id}_battery_{serial}{suffix}"
+
+    def battery_sensor_unique_ids(self, serial: str) -> tuple[str, ...]:
+        """Return active unique IDs for a per-storage-battery sensor set."""
+
+        return tuple(
+            self.battery_sensor_unique_id(serial, suffix)
+            for suffix in BATTERY_ENTITY_UNIQUE_SUFFIXES
+        )
+
+    def battery_retired_sensor_unique_ids(self, serial: str) -> tuple[str, ...]:
+        """Return retired unique IDs for a per-storage-battery sensor set."""
+
+        return tuple(
+            self.battery_sensor_unique_id(serial, suffix)
+            for suffix in BATTERY_RETIRED_UNIQUE_SUFFIXES
+        )
+
+    def ac_battery_sensor_unique_id(self, serial: str, suffix: str) -> str:
+        """Return the unique ID for a per-AC-battery sensor."""
+
+        return f"{DOMAIN}_site_{self._site_id}_ac_battery_{serial}{suffix}"
+
+    def ac_battery_sensor_unique_ids(self, serial: str) -> tuple[str, ...]:
+        """Return active unique IDs for a per-AC-battery sensor set."""
+
+        return tuple(
+            self.ac_battery_sensor_unique_id(serial, suffix)
+            for suffix in AC_BATTERY_ENTITY_UNIQUE_SUFFIXES
+        )
+
+    def ac_battery_retired_sensor_unique_ids(self, serial: str) -> tuple[str, ...]:
+        """Return retired unique IDs for a per-AC-battery sensor set."""
+
+        return tuple(
+            self.ac_battery_sensor_unique_id(serial, suffix)
+            for suffix in AC_BATTERY_RETIRED_UNIQUE_SUFFIXES
+        )
+
+    @staticmethod
+    def inverter_lifetime_sensor_unique_id(serial: str) -> str:
+        """Return the unique ID for a microinverter lifetime energy sensor."""
+
+        return f"{DOMAIN}_inverter_{serial}_lifetime_energy"
+
+    def remove_site_sensor_entity(self, key: str) -> None:
+        """Remove a site-level sensor entity by setup key."""
+
+        get_entity_id = getattr(self._ent_reg, "async_get_entity_id", None)
+        if not callable(get_entity_id):
+            return
+        entity_id = get_entity_id("sensor", DOMAIN, self.site_sensor_unique_id(key))
+        if entity_id is None:
+            return
+        self._ent_reg.async_remove(entity_id)
+        self.known_site_entity_keys.discard(key)
+        router_prefix = "gateway_iq_energy_router_"
+        if key.startswith(router_prefix):
+            self.known_gateway_iq_router_keys.discard(key[len(router_prefix) :])
+
+    def remove_type_sensor_entity(self, type_key: str) -> None:
+        """Remove a type inventory sensor entity by type key."""
+
+        get_entity_id = getattr(self._ent_reg, "async_get_entity_id", None)
+        if not callable(get_entity_id):
+            return
+        entity_id = get_entity_id(
+            "sensor",
+            DOMAIN,
+            self.type_sensor_unique_id(type_key),
+        )
+        if entity_id is None:
+            return
+        self._ent_reg.async_remove(entity_id)
+        self.known_type_keys.discard(type_key)
+
+    def site_sensor_entity_registered(self, key: str) -> bool:
+        """Return whether a site-level sensor entity is already registered."""
+
+        get_entity_id = getattr(self._ent_reg, "async_get_entity_id", None)
+        if not callable(get_entity_id):
+            return False
+        return (
+            get_entity_id("sensor", DOMAIN, self.site_sensor_unique_id(key)) is not None
+        )
+
+    def remove_site_sensor_entities_with_prefix(self, prefix: str) -> None:
+        """Remove site-level sensor entities with a unique ID prefix."""
+
+        unique_prefix = self.site_sensor_unique_id(prefix)
+        for reg_entry in list(self._entity_registry_values()):
+            if not self._registry_entry_matches_sensor(reg_entry):
+                continue
+            unique_id = _clean_text(getattr(reg_entry, "unique_id", None))
+            if not unique_id or not unique_id.startswith(unique_prefix):
+                continue
+            key = unique_id[len(f"{DOMAIN}_site_{self._site_id}_") :]
+            self._ent_reg.async_remove(reg_entry.entity_id)
+            self.known_site_entity_keys.discard(key)
+
+    def prune_removed_gateway_iq_router_entities(
+        self,
+        current_router_keys: set[str],
+    ) -> None:
+        """Remove IQ Energy Router sensors no longer present in inventory."""
+
+        entities = getattr(self._ent_reg, "entities", None)
+        if not isinstance(entities, dict):
+            return
+        for reg_entry in list(entities.values()):
+            if not self._registry_entry_matches_sensor(reg_entry):
+                continue
+            router_key = self._gateway_iq_router_key_from_unique_id(
+                getattr(reg_entry, "unique_id", None)
+            )
+            if not router_key or router_key in current_router_keys:
+                continue
+            self._ent_reg.async_remove(reg_entry.entity_id)
+            self.known_gateway_iq_router_keys.discard(router_key)
+            self.known_site_entity_keys.discard(
+                self.gateway_iq_router_entity_key(router_key)
+            )
+
+    def prune_dry_contact_type_inventory_entities(self) -> None:
+        """Remove retired dry contact type inventory sensors."""
+
+        entities = getattr(self._ent_reg, "entities", None)
+        if not isinstance(entities, dict):
+            return
+        unique_prefix = f"{DOMAIN}_site_{self._site_id}_type_"
+        unique_suffix = "_inventory"
+        for reg_entry in list(entities.values()):
+            if not self._registry_entry_matches_sensor(reg_entry):
+                continue
+            unique_id = _clean_text(getattr(reg_entry, "unique_id", None))
+            type_key = None
+            if unique_id and unique_id.startswith(unique_prefix):
+                if not unique_id.endswith(unique_suffix):
+                    continue
+                type_key = unique_id[len(unique_prefix) : -len(unique_suffix)]
+            else:
+                entity_slug = reg_entry.entity_id.partition(".")[2]
+                if "drycontactloads" not in entity_slug or not entity_slug.endswith(
+                    "_inventory"
+                ):
+                    continue
+                type_key = "drycontactloads"
+            if not is_dry_contact_type_key(type_key):
+                continue
+            self._ent_reg.async_remove(reg_entry.entity_id)
+            self.known_type_keys.discard(type_key)
+
+    def prune_blocked_type_inventory_entities(
+        self,
+        blocked_type_keys: set[str],
+    ) -> None:
+        """Remove type inventory sensors hidden by dedicated sensor support."""
+
+        entities = getattr(self._ent_reg, "entities", None)
+        if not isinstance(entities, dict) or not blocked_type_keys:
+            return
+        unique_prefix = f"{DOMAIN}_site_{self._site_id}_type_"
+        unique_suffix = "_inventory"
+        for reg_entry in list(entities.values()):
+            if not self._registry_entry_matches_sensor(reg_entry):
+                continue
+            unique_id = _clean_text(getattr(reg_entry, "unique_id", None))
+            if not unique_id or not unique_id.startswith(unique_prefix):
+                continue
+            if not unique_id.endswith(unique_suffix):
+                continue
+            type_key = unique_id[len(unique_prefix) : -len(unique_suffix)]
+            if type_key not in blocked_type_keys:
+                continue
+            self._ent_reg.async_remove(reg_entry.entity_id)
+            self.known_type_keys.discard(type_key)
+
+    def prune_historical_charger_sensor_entities(self) -> None:
+        """Remove retired per-charger sensor entities."""
+
+        entities = getattr(self._ent_reg, "entities", None)
+        if not isinstance(entities, dict):
+            return
+        unique_prefix = f"{DOMAIN}_"
+        for reg_entry in list(entities.values()):
+            if not self._registry_entry_matches_sensor(reg_entry):
+                continue
+            unique_id = getattr(reg_entry, "unique_id", None)
+            if not isinstance(unique_id, str) or not unique_id.startswith(
+                unique_prefix
+            ):
+                continue
+            if not unique_id.endswith(HISTORICAL_CHARGER_SENSOR_UNIQUE_SUFFIXES):
+                continue
+            self._ent_reg.async_remove(reg_entry.entity_id)
+
+    def prune_removed_site_entities(self) -> None:
+        """Remove legacy site-level sensor entities that no longer exist."""
+
+        get_entity_id = getattr(self._ent_reg, "async_get_entity_id", None)
+        if not callable(get_entity_id):
+            return
+        for unique_id in (
+            f"{DOMAIN}_site_{self._site_id}_gateway_connected_devices",
+            f"{DOMAIN}_site_{self._site_id}_type_microinverter_inventory",
+        ):
+            entity_id = get_entity_id(
+                "sensor",
+                DOMAIN,
+                unique_id,
+            )
+            if entity_id is not None:
+                self._ent_reg.async_remove(entity_id)
+        self.remove_site_sensor_entity("battery_inactive_microinverters")
+
+    def prune_battery_registry_once(self, current_set: set[str]) -> None:
+        """Prune stale storage battery registry entries after startup."""
+
+        if self.battery_registry_pruned:
+            return
+        for reg_entry in list(self._entity_registry_values()):
+            if not self._registry_entry_matches_sensor(reg_entry):
+                continue
+            unique_id = getattr(reg_entry, "unique_id", None) or ""
+            serial = self.battery_serial_from_unique_id(unique_id)
+            if serial is None:
+                continue
+            if any(
+                unique_id.endswith(suffix) for suffix in BATTERY_RETIRED_UNIQUE_SUFFIXES
+            ):
+                self._ent_reg.async_remove(reg_entry.entity_id)
+                self.known_battery_serials.discard(serial)
+                continue
+            if serial in current_set:
+                continue
+            self._ent_reg.async_remove(reg_entry.entity_id)
+            self.known_battery_serials.discard(serial)
+        self.battery_registry_pruned = True
+
+    def remove_missing_battery_entities(self, current_set: set[str]) -> None:
+        """Remove known storage battery entities no longer in the current set."""
+
+        removed_serials = self.known_battery_serials - current_set
+        for serial in removed_serials:
+            for unique_id in (
+                *self.battery_sensor_unique_ids(serial),
+                *self.battery_retired_sensor_unique_ids(serial),
+            ):
+                entity_id = self._async_get_sensor_entity_id(unique_id)
+                if entity_id is not None:
+                    self._ent_reg.async_remove(entity_id)
+            self.known_battery_serials.discard(serial)
+
+        self.known_battery_serials.intersection_update(current_set)
+
+    def prune_ac_battery_registry_once(self, current_set: set[str]) -> None:
+        """Prune stale AC battery registry entries after startup."""
+
+        if self.ac_battery_registry_pruned:
+            return
+        for reg_entry in list(self._entity_registry_values()):
+            if not self._registry_entry_matches_sensor(reg_entry):
+                continue
+            unique_id = getattr(reg_entry, "unique_id", None) or ""
+            serial = self.ac_battery_serial_from_unique_id(unique_id)
+            if serial is None:
+                continue
+            if any(
+                unique_id.endswith(suffix)
+                for suffix in AC_BATTERY_RETIRED_UNIQUE_SUFFIXES
+            ):
+                self._ent_reg.async_remove(reg_entry.entity_id)
+                self.known_ac_battery_serials.discard(serial)
+                continue
+            if serial in current_set:
+                continue
+            self._ent_reg.async_remove(reg_entry.entity_id)
+            self.known_ac_battery_serials.discard(serial)
+        self.ac_battery_registry_pruned = True
+
+    def remove_missing_ac_battery_entities(self, current_set: set[str]) -> None:
+        """Remove known AC battery entities no longer in the current set."""
+
+        removed_serials = self.known_ac_battery_serials - current_set
+        for serial in removed_serials:
+            for unique_id in (
+                *self.ac_battery_sensor_unique_ids(serial),
+                *self.ac_battery_retired_sensor_unique_ids(serial),
+            ):
+                entity_id = self._async_get_sensor_entity_id(unique_id)
+                if entity_id is not None:
+                    self._ent_reg.async_remove(entity_id)
+            self.known_ac_battery_serials.discard(serial)
+
+        self.known_ac_battery_serials.intersection_update(current_set)
+
+    def prune_inverter_registry_once(self, current_set: set[str]) -> None:
+        """Prune stale inverter registry entries after startup."""
+
+        if self.inverter_registry_pruned:
+            return
+        unique_prefix = f"{DOMAIN}_inverter_"
+        unique_suffix = "_lifetime_energy"
+        for reg_entry in list(self._entity_registry_values()):
+            if not self._registry_entry_matches_sensor(reg_entry):
+                continue
+            unique_id = getattr(reg_entry, "unique_id", None) or ""
+            if not (
+                isinstance(unique_id, str)
+                and unique_id.startswith(unique_prefix)
+                and unique_id.endswith(unique_suffix)
+            ):
+                continue
+            serial = unique_id[len(unique_prefix) : -len(unique_suffix)]
+            if not serial or serial in current_set:
+                continue
+            self._ent_reg.async_remove(reg_entry.entity_id)
+            self.known_inverter_serials.discard(serial)
+        self.inverter_registry_pruned = True
+
+    def remove_missing_inverter_entities(self, current_set: set[str]) -> None:
+        """Remove known inverter entities no longer in the current set."""
+
+        removed_serials = self.known_inverter_serials - current_set
+        for serial in removed_serials:
+            entity_id = self._async_get_sensor_entity_id(
+                self.inverter_lifetime_sensor_unique_id(serial)
+            )
+            if entity_id is not None:
+                self._ent_reg.async_remove(entity_id)
+            self.known_inverter_serials.discard(serial)
+
+        self.known_inverter_serials.intersection_update(current_set)
+
+    def battery_serial_from_unique_id(self, unique_id: object) -> str | None:
+        """Return a battery serial parsed from a known per-battery unique ID."""
+
+        if not isinstance(unique_id, str):
+            return None
+        unique_prefix = f"{DOMAIN}_site_{self._site_id}_battery_"
+        if not unique_id.startswith(unique_prefix):
+            return None
+        if unique_id in {
+            f"{DOMAIN}_site_{self._site_id}_battery_overall_status",
+            f"{DOMAIN}_site_{self._site_id}_battery_last_reported",
+        }:
+            return None
+        for suffix in (
+            *BATTERY_ENTITY_UNIQUE_SUFFIXES,
+            *BATTERY_RETIRED_UNIQUE_SUFFIXES,
+        ):
+            if not unique_id.endswith(suffix):
+                continue
+            serial = unique_id[len(unique_prefix) : -len(suffix)]
+            if serial:
+                return serial
+            return None
+        return None
+
+    def ac_battery_serial_from_unique_id(self, unique_id: object) -> str | None:
+        """Return an AC battery serial parsed from a known unique ID."""
+
+        if not isinstance(unique_id, str):
+            return None
+        unique_prefix = f"{DOMAIN}_site_{self._site_id}_ac_battery_"
+        if not unique_id.startswith(unique_prefix):
+            return None
+        if unique_id in {
+            f"{DOMAIN}_site_{self._site_id}_ac_battery_overall_status",
+            f"{DOMAIN}_site_{self._site_id}_ac_battery_last_reported",
+            f"{DOMAIN}_site_{self._site_id}_ac_battery_power",
+        }:
+            return None
+        for suffix in (
+            *AC_BATTERY_ENTITY_UNIQUE_SUFFIXES,
+            *AC_BATTERY_RETIRED_UNIQUE_SUFFIXES,
+        ):
+            if not unique_id.endswith(suffix):
+                continue
+            serial = unique_id[len(unique_prefix) : -len(suffix)]
+            if serial:
+                return serial
+            return None
+        return None
+
+    def _gateway_iq_router_key_from_unique_id(self, unique_id: object) -> str | None:
+        key = _clean_text(unique_id)
+        if not key:
+            return None
+        prefix = f"{DOMAIN}_site_{self._site_id}_gateway_iq_energy_router_"
+        if not key.startswith(prefix):
+            return None
+        router_key = key[len(prefix) :]
+        return router_key or None
+
+    def _entity_registry_values(self) -> Iterable[Any]:
+        entities = getattr(self._ent_reg, "entities", None)
+        values = getattr(entities, "values", None)
+        if callable(values):
+            return values()
+        return ()
+
+    def _registry_entry_matches_sensor(self, reg_entry: Any) -> bool:
+        entry_domain = getattr(reg_entry, "domain", None)
+        if entry_domain is None:
+            entry_domain = reg_entry.entity_id.partition(".")[0]
+        if entry_domain != "sensor":
+            return False
+        entry_platform = getattr(reg_entry, "platform", None)
+        if entry_platform is not None and entry_platform != DOMAIN:
+            return False
+        entry_config_id = getattr(reg_entry, "config_entry_id", None)
+        return not (
+            entry_config_id is not None and entry_config_id != self._config_entry_id
+        )
+
+    def _async_get_sensor_entity_id(self, unique_id: str) -> str | None:
+        get_entity_id = getattr(self._ent_reg, "async_get_entity_id", None)
+        if not callable(get_entity_id):
+            return None
+        return get_entity_id("sensor", DOMAIN, unique_id)

--- a/custom_components/enphase_ev/switch.py
+++ b/custom_components/enphase_ev/switch.py
@@ -48,7 +48,6 @@ from .service_validation import raise_translated_service_validation
 PARALLEL_UPDATES = 0
 _LOGGER = logging.getLogger(__name__)
 _AUTO_SUFFIX_RE = re.compile(r"^\d+$")
-_EVSE_TOGGLE_PENDING_HOLD_S = 15.0
 
 
 def _write_state_if_available(entity: SwitchEntity) -> None:
@@ -57,23 +56,6 @@ def _write_state_if_available(entity: SwitchEntity) -> None:
     if getattr(entity, "hass", None) is None or not getattr(entity, "entity_id", None):
         return
     entity.async_write_ha_state()
-
-
-def _set_evse_toggle_pending(
-    coord: EnphaseCoordinator, attr_name: str, serial: str, enabled: bool
-) -> None:
-    """Record a short-lived optimistic EVSE toggle target."""
-
-    # EVSE control endpoints can acknowledge before the status endpoint reflects
-    # the new value, so switches expose the requested target briefly.
-    pending = getattr(coord, attr_name, None)
-    if not isinstance(pending, dict):
-        pending = {}
-        setattr(coord, attr_name, pending)
-    pending[str(serial)] = (
-        bool(enabled),
-        time.monotonic() + _EVSE_TOGGLE_PENDING_HOLD_S,
-    )
 
 
 def _effective_evse_toggle_state(
@@ -1031,18 +1013,16 @@ class GreenBatterySwitch(EnphaseBaseEntity, SwitchEntity):
         return bool(effective)
 
     async def async_turn_on(self, **kwargs) -> None:
-        await self._coord.client.set_green_battery_setting(self._sn, enabled=True)
-        self._coord.set_green_battery_cache(self._sn, True)
-        _set_evse_toggle_pending(self._coord, "_green_battery_pending", self._sn, True)
+        await self._coord.evse_runtime.async_set_green_battery_setting(
+            self._sn, enabled=True
+        )
         _write_state_if_available(self)
-        await self._coord.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
-        await self._coord.client.set_green_battery_setting(self._sn, enabled=False)
-        self._coord.set_green_battery_cache(self._sn, False)
-        _set_evse_toggle_pending(self._coord, "_green_battery_pending", self._sn, False)
+        await self._coord.evse_runtime.async_set_green_battery_setting(
+            self._sn, enabled=False
+        )
         _write_state_if_available(self)
-        await self._coord.async_request_refresh()
 
 
 class AppAuthenticationSwitch(EnphaseBaseEntity, SwitchEntity):
@@ -1073,10 +1053,10 @@ class AppAuthenticationSwitch(EnphaseBaseEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs) -> None:
         try:
-            await self._coord.client.set_app_authentication(self._sn, enabled=True)
-            self._coord.mark_auth_settings_available()
-        except AuthSettingsUnavailable as err:
-            self._coord.note_auth_settings_unavailable(err)
+            await self._coord.evse_runtime.async_set_app_authentication(
+                self._sn, enabled=True
+            )
+        except AuthSettingsUnavailable:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
                 translation_key="exceptions.auth_settings_service_unavailable",
@@ -1085,17 +1065,14 @@ class AppAuthenticationSwitch(EnphaseBaseEntity, SwitchEntity):
                     "service is down."
                 ),
             )
-        self._coord.set_app_auth_cache(self._sn, True)
-        _set_evse_toggle_pending(self._coord, "_app_auth_pending", self._sn, True)
         _write_state_if_available(self)
-        await self._coord.async_request_refresh()
 
     async def async_turn_off(self, **kwargs) -> None:
         try:
-            await self._coord.client.set_app_authentication(self._sn, enabled=False)
-            self._coord.mark_auth_settings_available()
-        except AuthSettingsUnavailable as err:
-            self._coord.note_auth_settings_unavailable(err)
+            await self._coord.evse_runtime.async_set_app_authentication(
+                self._sn, enabled=False
+            )
+        except AuthSettingsUnavailable:
             raise_translated_service_validation(
                 translation_domain=DOMAIN,
                 translation_key="exceptions.auth_settings_service_unavailable",
@@ -1104,10 +1081,7 @@ class AppAuthenticationSwitch(EnphaseBaseEntity, SwitchEntity):
                     "service is down."
                 ),
             )
-        self._coord.set_app_auth_cache(self._sn, False)
-        _set_evse_toggle_pending(self._coord, "_app_auth_pending", self._sn, False)
         _write_state_if_available(self)
-        await self._coord.async_request_refresh()
 
 
 class StormGuardEvseSwitch(EnphaseBaseEntity, SwitchEntity):

--- a/tests/components/enphase_ev/test_evse_power.py
+++ b/tests/components/enphase_ev/test_evse_power.py
@@ -1,0 +1,303 @@
+from __future__ import annotations
+
+from datetime import datetime
+from datetime import timezone
+
+import pytest
+
+from custom_components.enphase_ev.evse_power import (
+    _power_parse_timestamp,
+    _power_topology,
+    _three_phase_multiplier,
+    build_evse_power_snapshot,
+)
+
+
+def test_build_evse_power_snapshot_seeds_lifetime_and_three_phase_max() -> None:
+    snapshot = build_evse_power_snapshot(
+        {
+            "phase_mode": "three phase",
+            "wiring_configuration": {"L1": "L1", "Neutral": "N"},
+            "operating_v": 230,
+            "session_charge_level": 32,
+            "sampled_at_ts": 1_700_000_000,
+            "lifetime_kwh": 10,
+            "charging": True,
+        },
+        None,
+        None,
+        240,
+    )
+
+    assert snapshot["derived_power_max_throughput_w"] == 19200
+    assert snapshot["derived_power_max_throughput_unbounded_w"] == 22080
+    assert snapshot["derived_power_max_throughput_source"] == "session_charge_level"
+    assert snapshot["derived_power_max_throughput_amps"] == pytest.approx(32.0)
+    assert snapshot["derived_power_max_throughput_voltage"] == pytest.approx(230.0)
+    assert snapshot["derived_power_max_throughput_topology"] == "three_phase"
+    assert snapshot["derived_power_max_throughput_phase_multiplier"] == pytest.approx(
+        3.0
+    )
+    assert snapshot["derived_last_lifetime_kwh"] == pytest.approx(10.0)
+    assert snapshot["derived_last_energy_ts"] == pytest.approx(1_700_000_000.0)
+    assert snapshot["derived_power_w"] == 0
+    assert snapshot["derived_power_method"] == "seeded"
+    assert snapshot["derived_power_window_seconds"] is None
+
+
+def test_build_evse_power_snapshot_calculates_lifetime_window_power() -> None:
+    snapshot = build_evse_power_snapshot(
+        {
+            "operating_v": 240,
+            "session_charge_level": 16,
+            "sampled_at_ts": 1_300,
+            "lifetime_kwh": 10.2,
+            "charging": True,
+        },
+        {"actual_charging": True},
+        {
+            "derived_last_lifetime_kwh": 10.0,
+            "derived_last_energy_ts": 1_000,
+            "derived_power_w": 111,
+            "derived_power_method": "previous",
+            "derived_power_window_seconds": 60,
+        },
+        240,
+    )
+
+    assert snapshot["derived_power_w"] == 2400
+    assert snapshot["derived_power_method"] == "lifetime_energy_window"
+    assert snapshot["derived_power_window_seconds"] == pytest.approx(300.0)
+    assert snapshot["derived_last_lifetime_kwh"] == pytest.approx(10.2)
+    assert snapshot["derived_last_energy_ts"] == pytest.approx(1_300.0)
+
+
+def test_build_evse_power_snapshot_caps_lifetime_window_power_at_max() -> None:
+    snapshot = build_evse_power_snapshot(
+        {
+            "operating_v": 240,
+            "session_charge_level": 16,
+            "sampled_at_ts": 1_300,
+            "lifetime_kwh": 11.0,
+            "charging": True,
+        },
+        {"actual_charging": True},
+        {
+            "derived_last_lifetime_kwh": 10.0,
+            "derived_last_energy_ts": 1_000,
+        },
+        240,
+    )
+
+    assert snapshot["derived_power_max_throughput_w"] == 3840
+    assert snapshot["derived_power_w"] == 3840
+
+
+def test_build_evse_power_snapshot_same_sample_preserves_previous_snapshot() -> None:
+    snapshot = build_evse_power_snapshot(
+        {
+            "sampled_at_ts": 1_000,
+            "lifetime_kwh": 5,
+            "charging": False,
+            "charging_level": 10,
+            "nominal_v": 230,
+        },
+        {"charging": True},
+        {
+            "derived_last_sample_ts": 1_000,
+            "derived_last_lifetime_kwh": 5,
+            "derived_power_w": 1234,
+            "derived_power_method": "lifetime_energy_window",
+            "derived_power_window_seconds": 300,
+            "custom_marker": "kept",
+        },
+        240,
+    )
+
+    assert snapshot["custom_marker"] == "kept"
+    assert snapshot["derived_power_w"] == 0
+    assert snapshot["derived_power_method"] == "idle"
+    assert snapshot["derived_power_window_seconds"] is None
+    assert snapshot["derived_power_max_throughput_w"] == 2300
+
+
+def test_build_evse_power_snapshot_seeds_on_known_idle_to_charging_transition() -> None:
+    snapshot = build_evse_power_snapshot(
+        {
+            "sampled_at_ts": 1_300,
+            "lifetime_kwh": 10.1,
+            "charging": True,
+        },
+        {"charging": False},
+        {
+            "derived_last_lifetime_kwh": 10.0,
+            "derived_last_energy_ts": 1_000,
+            "derived_power_w": 1200,
+            "derived_power_method": "lifetime_energy_window",
+        },
+        240,
+    )
+
+    assert snapshot["derived_power_w"] == 0
+    assert snapshot["derived_power_method"] == "seeded"
+    assert snapshot["derived_power_window_seconds"] is None
+    assert snapshot["derived_last_lifetime_kwh"] == pytest.approx(10.1)
+    assert snapshot["derived_last_energy_ts"] == pytest.approx(1_300.0)
+
+
+def test_build_evse_power_snapshot_handles_missing_lifetime_as_idle() -> None:
+    snapshot = build_evse_power_snapshot(
+        {"last_reported_at": "2024-01-01T00:00:00Z[UTC]", "charging": False},
+        None,
+        {"derived_power_w": 900, "derived_power_method": "previous"},
+        240,
+    )
+
+    assert snapshot["derived_sampled_at_utc"] == "2024-01-01T00:00:00+00:00"
+    assert snapshot["derived_power_w"] == 0
+    assert snapshot["derived_power_method"] == "idle"
+    assert snapshot["derived_power_window_seconds"] is None
+
+
+def test_build_evse_power_snapshot_marks_lifetime_sample_idle() -> None:
+    snapshot = build_evse_power_snapshot(
+        {"sampled_at_ts": 1_300, "lifetime_kwh": 10.2, "charging": False},
+        {"charging": True},
+        {
+            "derived_last_lifetime_kwh": 10.0,
+            "derived_last_energy_ts": 1_000,
+            "derived_power_w": 1200,
+        },
+        240,
+    )
+
+    assert snapshot["derived_last_lifetime_kwh"] == pytest.approx(10.2)
+    assert snapshot["derived_last_energy_ts"] == pytest.approx(1_300.0)
+    assert snapshot["derived_power_w"] == 0
+    assert snapshot["derived_power_method"] == "idle"
+    assert snapshot["derived_power_window_seconds"] is None
+
+
+def test_build_evse_power_snapshot_updates_lifetime_without_sample_time() -> None:
+    snapshot = build_evse_power_snapshot(
+        {"lifetime_kwh": 10.2, "charging": True},
+        {"charging": True},
+        {
+            "derived_last_lifetime_kwh": 10.0,
+            "derived_last_energy_ts": 1_000,
+            "derived_power_w": 1200,
+            "derived_power_method": "previous",
+            "derived_power_window_seconds": 300,
+        },
+        240,
+    )
+
+    assert snapshot["derived_last_lifetime_kwh"] == pytest.approx(10.2)
+    assert snapshot["derived_last_energy_ts"] == pytest.approx(1_000.0)
+    assert snapshot["derived_power_w"] == 1200
+    assert snapshot["derived_power_method"] == "previous"
+
+
+def test_build_evse_power_snapshot_ignores_previous_without_charging_state() -> None:
+    snapshot = build_evse_power_snapshot(
+        {"sampled_at_ts": 1_300, "lifetime_kwh": 10.2, "charging": True},
+        {"status": "unknown"},
+        {
+            "derived_last_lifetime_kwh": 10.0,
+            "derived_last_energy_ts": 1_000,
+        },
+        240,
+    )
+
+    assert snapshot["derived_power_method"] == "lifetime_energy_window"
+
+
+def test_build_evse_power_snapshot_detects_lifetime_reset() -> None:
+    snapshot = build_evse_power_snapshot(
+        {"sampled_at_ts": 1_300, "lifetime_kwh": 9.0, "charging": True},
+        {"charging": True},
+        {
+            "derived_last_lifetime_kwh": 10.0,
+            "derived_last_energy_ts": 1_000,
+            "derived_power_w": 1200,
+        },
+        240,
+    )
+
+    assert snapshot["derived_power_w"] == 0
+    assert snapshot["derived_power_method"] == "lifetime_reset"
+    assert snapshot["derived_power_window_seconds"] is None
+    assert snapshot["derived_last_reset_at"] == pytest.approx(1_300.0)
+
+
+def test_build_evse_power_snapshot_retains_previous_power_for_tiny_delta() -> None:
+    snapshot = build_evse_power_snapshot(
+        {"sampled_at_ts": 1_300, "lifetime_kwh": 10.0004, "charging": True},
+        {"charging": True},
+        {
+            "derived_last_lifetime_kwh": 10.0,
+            "derived_last_energy_ts": 1_000,
+            "derived_power_w": 1200,
+            "derived_power_method": "previous",
+            "derived_power_window_seconds": 300,
+        },
+        240,
+    )
+
+    assert snapshot["derived_power_w"] == 1200
+    assert snapshot["derived_power_method"] == "previous"
+    assert snapshot["derived_power_window_seconds"] == pytest.approx(300.0)
+
+
+def test_build_evse_power_snapshot_skips_tiny_unbounded_max_candidate() -> None:
+    snapshot = build_evse_power_snapshot(
+        {
+            "operating_v": 0.001,
+            "session_charge_level": 0.001,
+            "charging": True,
+        },
+        None,
+        None,
+        240,
+    )
+
+    assert snapshot["derived_power_max_throughput_w"] == 19200
+    assert snapshot["derived_power_max_throughput_source"] == "static_default"
+
+
+def test_evse_power_normalizes_topology_and_multiplier_edges() -> None:
+    class BadStr:
+        def __str__(self) -> str:
+            raise ValueError("boom")
+
+    assert _power_topology({"phase_mode": BadStr()}) == "unknown"
+    assert _power_topology({"phase_mode": "single-phase"}) == "single_phase"
+    assert _power_topology({"phase_mode": "split"}) == "split_phase"
+    assert _power_topology({"phase_count": 1}) == "single_phase"
+    assert _power_topology({"phase_count": 3}) == "three_phase"
+    assert _power_topology({"phase_count": 2}) == "unknown"
+    assert _three_phase_multiplier({"wiring_configuration": {BadStr(): "L1"}}) == (
+        pytest.approx(1.7320508075688772)
+    )
+    assert _three_phase_multiplier({"wiring_configuration": {"L1": "L1"}}) == (
+        pytest.approx(1.7320508075688772)
+    )
+    assert _three_phase_multiplier(
+        {"wiring_configuration": {"L1": "L1", "N": "N"}}
+    ) == (pytest.approx(3.0))
+
+
+def test_evse_power_parse_timestamp_variants() -> None:
+    class BadFloat(float):
+        def __float__(self) -> float:
+            raise ValueError("boom")
+
+    assert _power_parse_timestamp(BadFloat(1.0)) is None
+    assert _power_parse_timestamp(float("inf")) is None
+    assert _power_parse_timestamp(1_700_000_000_000) == pytest.approx(1_700_000_000)
+    assert _power_parse_timestamp(0) is None
+    assert _power_parse_timestamp("") is None
+    assert _power_parse_timestamp("bad") is None
+    assert _power_parse_timestamp([]) is None
+    expected = datetime(2024, 1, 1, tzinfo=timezone.utc).timestamp()
+    assert _power_parse_timestamp("2024-01-01T00:00:00") == pytest.approx(expected)

--- a/tests/components/enphase_ev/test_evse_runtime.py
+++ b/tests/components/enphase_ev/test_evse_runtime.py
@@ -11,6 +11,7 @@ import pytest
 from homeassistant.exceptions import ServiceValidationError
 from homeassistant.util import dt as dt_util
 
+from custom_components.enphase_ev.api import SchedulerUnavailable
 from custom_components.enphase_ev.evse_runtime import (
     EVSE_LOOKUP_CONCURRENCY,
     FAST_TOGGLE_POLL_HOLD_S,
@@ -82,6 +83,38 @@ def test_evse_runtime_helper_paths(coordinator_factory) -> None:
         strict=False,
         enforce_mode="SCHEDULED_CHARGING",
     )
+
+
+@pytest.mark.asyncio
+async def test_evse_runtime_green_battery_write_rebuilds_pending_dict(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    runtime = coord.evse_runtime
+    coord._green_battery_pending = None  # noqa: SLF001
+    coord.client.set_green_battery_setting = AsyncMock(return_value={"status": "ok"})
+    coord.async_request_refresh = AsyncMock()
+
+    await runtime.async_set_green_battery_setting("EV1", enabled=True)
+
+    assert coord._green_battery_pending["EV1"][0] is True  # noqa: SLF001
+    coord.client.set_green_battery_setting.assert_awaited_once_with("EV1", enabled=True)
+    coord.async_request_refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_evse_runtime_green_battery_write_marks_scheduler_unavailable(
+    coordinator_factory,
+) -> None:
+    coord = coordinator_factory()
+    coord.client.set_green_battery_setting = AsyncMock(
+        side_effect=SchedulerUnavailable("down")
+    )
+
+    with pytest.raises(SchedulerUnavailable):
+        await coord.evse_runtime.async_set_green_battery_setting("EV1", enabled=True)
+
+    assert coord.scheduler_available is False
 
 
 def test_evse_runtime_battery_profile_charge_mode_preference_paths(

--- a/tests/components/enphase_ev/test_select_charge_mode.py
+++ b/tests/components/enphase_ev/test_select_charge_mode.py
@@ -47,6 +47,9 @@ async def test_charge_mode_select(hass, monkeypatch):
             return {"status": "accepted", "mode": mode}
 
     coord.client = StubClient()
+    coord.evse_runtime.async_set_charge_mode = AsyncMock(
+        wraps=coord.evse_runtime.async_set_charge_mode
+    )
 
     # Avoid exercising Debouncer / hass loop; stub refresh
     async def _noop():
@@ -59,6 +62,11 @@ async def test_charge_mode_select(hass, monkeypatch):
     assert sel.current_option == "Scheduled"
 
     await sel.async_select_option("Manual")
+    coord.evse_runtime.async_set_charge_mode.assert_awaited_once_with(
+        RANDOM_SERIAL,
+        "MANUAL_CHARGING",
+        previous_mode="SCHEDULED_CHARGING",
+    )
     # cache should update immediately
     assert coord._charge_mode_cache[RANDOM_SERIAL][0] == "MANUAL_CHARGING"
 

--- a/tests/components/enphase_ev/test_sensor_registry.py
+++ b/tests/components/enphase_ev/test_sensor_registry.py
@@ -1,0 +1,269 @@
+from __future__ import annotations
+
+from collections import Counter
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from custom_components.enphase_ev.const import DOMAIN
+from custom_components.enphase_ev.sensor_registry import EnphaseSensorRegistrySetup
+
+ENTRY_ID = "entry-id"
+SITE_ID = "site-id"
+
+
+class FakeRegistry:
+    def __init__(self, entities: dict[str, SimpleNamespace] | None = None) -> None:
+        self.entities = entities or {}
+        self.removed: list[str] = []
+
+    def async_get_entity_id(
+        self,
+        domain: str,
+        platform: str,
+        unique_id: str,
+    ) -> str | None:
+        for entity_id, entry in self.entities.items():
+            if (
+                domain == "sensor"
+                and platform == DOMAIN
+                and getattr(entry, "unique_id", None) == unique_id
+            ):
+                return entity_id
+        return None
+
+    def async_remove(self, entity_id: str) -> None:
+        self.removed.append(entity_id)
+
+
+def _entry(
+    entity_id: str,
+    unique_id: str,
+    *,
+    domain: str = "sensor",
+    platform: str = DOMAIN,
+    config_entry_id: str = ENTRY_ID,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        entity_id=entity_id,
+        unique_id=unique_id,
+        domain=domain,
+        platform=platform,
+        config_entry_id=config_entry_id,
+    )
+
+
+def _helper(registry: object) -> EnphaseSensorRegistrySetup:
+    return EnphaseSensorRegistrySetup(
+        registry,
+        config_entry_id=ENTRY_ID,
+        site_id=SITE_ID,
+    )
+
+
+def test_sensor_registry_serial_parsers_ignore_non_string_unique_ids() -> None:
+    helper = _helper(SimpleNamespace())
+
+    assert helper.battery_serial_from_unique_id(None) is None
+    assert helper.ac_battery_serial_from_unique_id(None) is None
+
+
+def test_sensor_registry_get_entity_id_without_registry_method() -> None:
+    helper = _helper(SimpleNamespace())
+
+    assert helper._async_get_sensor_entity_id("unique-id") is None
+
+
+def test_sensor_registry_prunes_gateway_and_type_inventory_entities() -> None:
+    registry = FakeRegistry(
+        {
+            "sensor.old_router": _entry(
+                "sensor.old_router",
+                f"{DOMAIN}_site_{SITE_ID}_gateway_iq_energy_router_old",
+            ),
+            "sensor.keep_router": _entry(
+                "sensor.keep_router",
+                f"{DOMAIN}_site_{SITE_ID}_gateway_iq_energy_router_keep",
+            ),
+            "sensor.wrong_entry_router": _entry(
+                "sensor.wrong_entry_router",
+                f"{DOMAIN}_site_{SITE_ID}_gateway_iq_energy_router_wrong_entry",
+                config_entry_id="other-entry",
+            ),
+            "sensor.dry_contact": _entry(
+                "sensor.dry_contact",
+                f"{DOMAIN}_site_{SITE_ID}_type_drycontactloads_inventory",
+            ),
+            "sensor.blocked_encharge": _entry(
+                "sensor.blocked_encharge",
+                f"{DOMAIN}_site_{SITE_ID}_type_encharge_inventory",
+            ),
+            "sensor.keep_type": _entry(
+                "sensor.keep_type",
+                f"{DOMAIN}_site_{SITE_ID}_type_envoy_inventory",
+            ),
+        }
+    )
+    helper = _helper(registry)
+    helper.known_gateway_iq_router_keys.update({"old", "keep"})
+    helper.known_site_entity_keys.update(
+        {
+            "gateway_iq_energy_router_old",
+            "gateway_iq_energy_router_keep",
+        }
+    )
+    helper.known_type_keys.update({"drycontactloads", "encharge", "envoy"})
+
+    helper.prune_removed_gateway_iq_router_entities({"keep"})
+    helper.prune_dry_contact_type_inventory_entities()
+    helper.prune_blocked_type_inventory_entities({"encharge"})
+
+    assert Counter(registry.removed) == Counter(
+        {
+            "sensor.old_router",
+            "sensor.dry_contact",
+            "sensor.blocked_encharge",
+        }
+    )
+    assert helper.known_gateway_iq_router_keys == {"keep"}
+    assert helper.known_site_entity_keys == {"gateway_iq_energy_router_keep"}
+    assert helper.known_type_keys == {"envoy"}
+
+
+def test_sensor_registry_prunes_historical_and_removed_site_entities() -> None:
+    registry = FakeRegistry(
+        {
+            "sensor.connector_reason": _entry(
+                "sensor.connector_reason",
+                f"{DOMAIN}_EV1_connector_reason",
+            ),
+            "sensor.keep_power": _entry(
+                "sensor.keep_power",
+                f"{DOMAIN}_EV1_power",
+            ),
+            "sensor.ignore_platform": _entry(
+                "sensor.ignore_platform",
+                f"{DOMAIN}_EV1_connector_reason",
+                platform="other",
+            ),
+            "sensor.gateway_connected_devices": _entry(
+                "sensor.gateway_connected_devices",
+                f"{DOMAIN}_site_{SITE_ID}_gateway_connected_devices",
+            ),
+            "sensor.microinverter_inventory": _entry(
+                "sensor.microinverter_inventory",
+                f"{DOMAIN}_site_{SITE_ID}_type_microinverter_inventory",
+            ),
+            "sensor.battery_inactive_microinverters": _entry(
+                "sensor.battery_inactive_microinverters",
+                f"{DOMAIN}_site_{SITE_ID}_battery_inactive_microinverters",
+            ),
+        }
+    )
+    helper = _helper(registry)
+    helper.known_site_entity_keys.add("battery_inactive_microinverters")
+
+    helper.prune_historical_charger_sensor_entities()
+    helper.prune_removed_site_entities()
+
+    assert Counter(registry.removed) == Counter(
+        {
+            "sensor.connector_reason",
+            "sensor.gateway_connected_devices",
+            "sensor.microinverter_inventory",
+            "sensor.battery_inactive_microinverters",
+        }
+    )
+    assert "battery_inactive_microinverters" not in helper.known_site_entity_keys
+
+
+def test_sensor_registry_prunes_battery_ac_battery_and_inverter_entities() -> None:
+    registry = FakeRegistry(
+        {
+            "sensor.battery_old_status": _entry(
+                "sensor.battery_old_status",
+                f"{DOMAIN}_site_{SITE_ID}_battery_OLD_status",
+            ),
+            "sensor.battery_retired_last_reported": _entry(
+                "sensor.battery_retired_last_reported",
+                f"{DOMAIN}_site_{SITE_ID}_battery_RETIRED_last_reported",
+            ),
+            "sensor.battery_keep_status": _entry(
+                "sensor.battery_keep_status",
+                f"{DOMAIN}_site_{SITE_ID}_battery_KEEP_status",
+            ),
+            "sensor.battery_missing_status": _entry(
+                "sensor.battery_missing_status",
+                f"{DOMAIN}_site_{SITE_ID}_battery_MISSING_status",
+            ),
+            "sensor.ac_battery_old_status": _entry(
+                "sensor.ac_battery_old_status",
+                f"{DOMAIN}_site_{SITE_ID}_ac_battery_ACOLD_status",
+            ),
+            "sensor.ac_battery_missing_power": _entry(
+                "sensor.ac_battery_missing_power",
+                f"{DOMAIN}_site_{SITE_ID}_ac_battery_ACMISSING_power",
+            ),
+            "sensor.inverter_old_lifetime": _entry(
+                "sensor.inverter_old_lifetime",
+                f"{DOMAIN}_inverter_INVOLD_lifetime_energy",
+            ),
+            "sensor.inverter_missing_lifetime": _entry(
+                "sensor.inverter_missing_lifetime",
+                f"{DOMAIN}_inverter_INVMISSING_lifetime_energy",
+            ),
+            "sensor.ignore_wrong_entry": _entry(
+                "sensor.ignore_wrong_entry",
+                f"{DOMAIN}_site_{SITE_ID}_battery_WRONG_status",
+                config_entry_id="other-entry",
+            ),
+        }
+    )
+    helper = _helper(registry)
+    helper.known_battery_serials.update({"KEEP", "MISSING"})
+    helper.known_ac_battery_serials.update({"ACKEEP", "ACMISSING"})
+    helper.known_inverter_serials.update({"INVKEEP", "INVMISSING"})
+
+    helper.prune_battery_registry_once({"KEEP"})
+    helper.remove_missing_battery_entities({"KEEP"})
+    helper.prune_ac_battery_registry_once({"ACKEEP"})
+    helper.remove_missing_ac_battery_entities({"ACKEEP"})
+    helper.prune_inverter_registry_once({"INVKEEP"})
+    helper.remove_missing_inverter_entities({"INVKEEP"})
+
+    assert Counter(registry.removed) == Counter(
+        {
+            "sensor.battery_old_status",
+            "sensor.battery_retired_last_reported",
+            "sensor.battery_missing_status",
+            "sensor.ac_battery_old_status",
+            "sensor.ac_battery_missing_power",
+            "sensor.inverter_old_lifetime",
+            "sensor.inverter_missing_lifetime",
+        }
+    )
+    assert helper.known_battery_serials == {"KEEP"}
+    assert helper.known_ac_battery_serials == {"ACKEEP"}
+    assert helper.known_inverter_serials == {"INVKEEP"}
+    assert helper.battery_registry_pruned is True
+    assert helper.ac_battery_registry_pruned is True
+    assert helper.inverter_registry_pruned is True
+
+
+def test_sensor_registry_remove_helpers_use_registry_lookup() -> None:
+    registry = SimpleNamespace(
+        async_get_entity_id=MagicMock(return_value="sensor.remove_me"),
+        async_remove=MagicMock(),
+    )
+    helper = _helper(registry)
+    helper.known_site_entity_keys.add("gateway_iq_energy_router_old")
+    helper.known_gateway_iq_router_keys.add("old")
+    helper.known_type_keys.add("envoy")
+
+    helper.remove_site_sensor_entity("gateway_iq_energy_router_old")
+    helper.remove_type_sensor_entity("envoy")
+
+    registry.async_remove.assert_any_call("sensor.remove_me")
+    assert registry.async_remove.call_count == 2
+    assert helper.known_site_entity_keys == set()
+    assert helper.known_gateway_iq_router_keys == set()
+    assert helper.known_type_keys == set()

--- a/tests/components/enphase_ev/test_switch_module.py
+++ b/tests/components/enphase_ev/test_switch_module.py
@@ -277,11 +277,7 @@ def test_switch_pending_helper_edge_paths() -> None:
     switch_mod._write_state_if_available(entity)
     entity.async_write_ha_state.assert_called_once()
 
-    coord = SimpleNamespace()
-    switch_mod._set_evse_toggle_pending(
-        coord, "_green_battery_pending", RANDOM_SERIAL, True
-    )
-    assert coord._green_battery_pending[RANDOM_SERIAL][0] is True  # noqa: SLF001
+    coord = SimpleNamespace(_green_battery_pending={})
 
     assert (
         switch_mod._effective_evse_toggle_state(
@@ -1506,20 +1502,32 @@ async def test_green_battery_switch_turn_on_off(coordinator_factory) -> None:
         {"green_battery_supported": True, "green_battery_enabled": False}
     )
     coord._green_battery_cache.clear()
+    coord.evse_runtime.async_set_green_battery_setting = AsyncMock(
+        wraps=coord.evse_runtime.async_set_green_battery_setting
+    )
     sw = GreenBatterySwitch(coord, RANDOM_SERIAL)
 
     await sw.async_turn_on()
+    coord.evse_runtime.async_set_green_battery_setting.assert_awaited_once_with(
+        RANDOM_SERIAL, enabled=True
+    )
     coord.client.set_green_battery_setting.assert_awaited_once_with(
         RANDOM_SERIAL, enabled=True
     )
     assert coord._green_battery_cache[RANDOM_SERIAL][0] is True
+    assert coord._green_battery_pending[RANDOM_SERIAL][0] is True
 
     await sw.async_turn_off()
+    assert coord.evse_runtime.async_set_green_battery_setting.await_count == 2
+    coord.evse_runtime.async_set_green_battery_setting.assert_awaited_with(
+        RANDOM_SERIAL, enabled=False
+    )
     assert coord.client.set_green_battery_setting.await_count == 2
     coord.client.set_green_battery_setting.assert_awaited_with(
         RANDOM_SERIAL, enabled=False
     )
     assert coord._green_battery_cache[RANDOM_SERIAL][0] is False
+    assert coord._green_battery_pending[RANDOM_SERIAL][0] is False
     assert coord.async_request_refresh.await_count == 2
 
 
@@ -1594,20 +1602,32 @@ def test_app_auth_switch_is_on_prefers_short_pending_override(
 async def test_app_auth_switch_turn_on_off(coordinator_factory) -> None:
     coord = coordinator_factory({"app_auth_supported": True, "app_auth_enabled": False})
     coord._auth_settings_cache.clear()
+    coord.evse_runtime.async_set_app_authentication = AsyncMock(
+        wraps=coord.evse_runtime.async_set_app_authentication
+    )
     sw = AppAuthenticationSwitch(coord, RANDOM_SERIAL)
 
     await sw.async_turn_on()
+    coord.evse_runtime.async_set_app_authentication.assert_awaited_once_with(
+        RANDOM_SERIAL, enabled=True
+    )
     coord.client.set_app_authentication.assert_awaited_once_with(
         RANDOM_SERIAL, enabled=True
     )
     assert coord._auth_settings_cache[RANDOM_SERIAL][0] is True
+    assert coord._app_auth_pending[RANDOM_SERIAL][0] is True
 
     await sw.async_turn_off()
+    assert coord.evse_runtime.async_set_app_authentication.await_count == 2
+    coord.evse_runtime.async_set_app_authentication.assert_awaited_with(
+        RANDOM_SERIAL, enabled=False
+    )
     assert coord.client.set_app_authentication.await_count == 2
     coord.client.set_app_authentication.assert_awaited_with(
         RANDOM_SERIAL, enabled=False
     )
     assert coord._auth_settings_cache[RANDOM_SERIAL][0] is False
+    assert coord._app_auth_pending[RANDOM_SERIAL][0] is False
     assert coord.async_request_refresh.await_count == 2
 
 


### PR DESCRIPTION
## Summary

Refactor the Enphase EV integration internals to reduce coordinator and entity responsibilities while preserving existing behavior.

- Move EVSE power derivation into a pure helper module and keep coordinator focused on refresh orchestration.
- Centralize EVSE charge-mode, green-battery, and app-authentication writes in `EvseRuntime`.
- Move sensor registry cleanup and unique-ID mechanics into `EnphaseSensorRegistrySetup`.
- Add direct unit coverage for EVSE power derivation and sensor registry pruning behavior.

## Related Issues

None.

## Type of change

- [ ] Bugfix
- [ ] Device support / compatibility
- [ ] New feature
- [ ] Documentation
- [x] Refactor / tech debt
- [ ] Translation update
- [ ] Other (describe below)

## Testing

```bash
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "ruff check custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/evse_power.py custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/select.py custom_components/enphase_ev/sensor.py custom_components/enphase_ev/sensor_registry.py custom_components/enphase_ev/switch.py tests/components/enphase_ev/test_evse_power.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_select_charge_mode.py tests/components/enphase_ev/test_sensor_registry.py tests/components/enphase_ev/test_switch_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "black --check custom_components/enphase_ev/coordinator.py custom_components/enphase_ev/evse_power.py custom_components/enphase_ev/evse_runtime.py custom_components/enphase_ev/select.py custom_components/enphase_ev/sensor.py custom_components/enphase_ev/sensor_registry.py custom_components/enphase_ev/switch.py tests/components/enphase_ev/test_evse_power.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_select_charge_mode.py tests/components/enphase_ev/test_sensor_registry.py tests/components/enphase_ev/test_switch_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "pytest -q tests/components/enphase_ev/test_sensor_registry.py tests/components/enphase_ev/test_evse_power.py tests/components/enphase_ev/test_evse_runtime.py tests/components/enphase_ev/test_select_charge_mode.py tests/components/enphase_ev/test_switch_module.py"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage erase && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage run -m pytest tests/components/enphase_ev -q && COVERAGE_FILE=/tmp/enphase_ev.coverage python -m coverage report -m --include=custom_components/enphase_ev/coordinator.py,custom_components/enphase_ev/evse_power.py,custom_components/enphase_ev/evse_runtime.py,custom_components/enphase_ev/select.py,custom_components/enphase_ev/sensor.py,custom_components/enphase_ev/sensor_registry.py,custom_components/enphase_ev/switch.py --fail-under=100"
docker compose -f devtools/docker/docker-compose.yml run --rm ha-dev bash -lc "python -m pre_commit run --all-files"
```

Coverage result: `3224 passed`; touched modules reported 100% coverage.

## Checklist

- [ ] I updated `CHANGELOG.md` for user-facing changes.
- [ ] I updated documentation (`README.md`, docs/) when behaviour or options changed.
- [ ] I verified translations (`custom_components/enphase_ev/translations/`) are complete and valid.
- [x] I ran targeted coverage for each touched Python module and confirmed 100% coverage.
- [ ] I reviewed GitHub Actions results (tests, hassfest, quality scale, validate).
- [x] I confirm this PR is scoped to a single logical change set.

## Diagnostics / Screenshots / Notes

This is an internal architecture refactor. No user-facing strings, translations, services, or documented behavior were changed.
